### PR TITLE
feat(integration): add Connection entity + RLS migration (APIC-P1-01)

### DIFF
--- a/apps/api/config/packages/doctrine.yaml
+++ b/apps/api/config/packages/doctrine.yaml
@@ -132,6 +132,12 @@ doctrine:
                 dir: '%kernel.project_dir%/src/ApiConfigurator/Infrastructure/Doctrine/Orm/Mapping'
                 prefix: 'App\ApiConfigurator\Domain\Entity'
                 alias: ApiConfigurator
+            Integration:
+                type: xml
+                is_bundle: false
+                dir: '%kernel.project_dir%/src/Integration/Generic/Infrastructure/Doctrine/Orm/Mapping'
+                prefix: 'App\Integration\Generic\Domain\Entity'
+                alias: Integration
             Import:
                 type: xml
                 is_bundle: false

--- a/apps/api/migrations/Version20260627100000.php
+++ b/apps/api/migrations/Version20260627100000.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * APIC-P1-01 (ADR-0022, epic APIC) — consumer-side `integration_connections`
+ * table: one external REST/JSON API connection per row, TenantScoped with
+ * Postgres RLS.
+ *
+ * Credentials live in two columns (`credentials_ciphertext` + key version),
+ * mirroring `tenant_agent_configs` / ADR-0017; the reversible-encryption write
+ * path + response masking land in APIC-P1-02.
+ *
+ * RLS follows the W1-1 FORCE pattern (Version20260617050000): a strict
+ * (fail-closed) tenant-isolation policy plus the super-admin break-glass
+ * bypass. Connections always run with a resolved tenant, so no pre-context
+ * relaxation is needed. The `NULLIF(current_setting(...), '')::uuid` cast keeps
+ * an empty GUC from raising `invalid input syntax for type uuid: ""`.
+ */
+final class Version20260627100000 extends AbstractMigration
+{
+    private const string TABLE = 'integration_connections';
+
+    public function getDescription(): string
+    {
+        return 'APIC-P1-01: add integration_connections (TenantScoped consumer connection) + FORCE RLS policies.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE integration_connections (
+                id UUID NOT NULL,
+                tenant_id UUID NOT NULL,
+                code VARCHAR(64) NOT NULL,
+                name VARCHAR(255) NOT NULL,
+                base_url VARCHAR(2048) NOT NULL,
+                auth_type VARCHAR(16) DEFAULT 'none' NOT NULL,
+                credentials_ciphertext TEXT DEFAULT NULL,
+                credentials_key_version INT DEFAULT NULL,
+                default_headers JSONB DEFAULT '{}' NOT NULL,
+                rate_limit_hint INT DEFAULT NULL,
+                status VARCHAR(16) DEFAULT 'draft' NOT NULL,
+                last_health_check_at TIMESTAMP(0) WITH TIME ZONE DEFAULT NULL,
+                created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+                updated_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+                PRIMARY KEY (id)
+            )
+            SQL);
+        $this->addSql('CREATE INDEX IDX_CB08B1B09033212A ON integration_connections (tenant_id)');
+        $this->addSql('CREATE INDEX integration_connections_tenant_status_idx ON integration_connections (tenant_id, status)');
+        $this->addSql('CREATE UNIQUE INDEX integration_connections_tenant_code_uniq ON integration_connections (tenant_id, code)');
+        $this->addSql(
+            'ALTER TABLE integration_connections ADD CONSTRAINT FK_CB08B1B09033212A '
+            .'FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE RESTRICT NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+
+        // ── Row-Level Security (W1-1 FORCE pattern) ───────────────────────
+        $predicate = "tenant_id = NULLIF(current_setting('app.current_tenant', true), '')::uuid";
+
+        $this->addSql(\sprintf('ALTER TABLE %s ENABLE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s FORCE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf(
+            'CREATE POLICY tenant_isolation_%s ON %s USING (%s) WITH CHECK (%s)',
+            self::TABLE,
+            self::TABLE,
+            $predicate,
+            $predicate,
+        ));
+        $this->addSql(\sprintf(
+            "CREATE POLICY super_admin_bypass_%s ON %s "
+            ."USING (current_setting('app.is_super_admin', true) = 'true') "
+            ."WITH CHECK (current_setting('app.is_super_admin', true) = 'true')",
+            self::TABLE,
+            self::TABLE,
+        ));
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(\sprintf('DROP POLICY IF EXISTS super_admin_bypass_%s ON %s', self::TABLE, self::TABLE));
+        $this->addSql(\sprintf('DROP POLICY IF EXISTS tenant_isolation_%s ON %s', self::TABLE, self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s NO FORCE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s DISABLE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql('DROP TABLE integration_connections');
+    }
+}

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -142,6 +142,9 @@ parameters:
               - src/Import/Domain/Entity/ImportSource.php
               - src/Import/Domain/Entity/ImportSourceLog.php
               - src/Import/Domain/Entity/ImportSchedule.php
+              # Integration/Generic (ADR-0022, epic APIC) — also extends
+              # AggregateRoot, same `?Tenant` write-window as the Import group.
+              - src/Integration/Generic/Domain/Entity/Connection.php
               - src/Import/Domain/Entity/ImportScheduleRun.php
               - src/Export/Domain/Entity/ExportSession.php
               - src/Export/Domain/Entity/ExportProfile.php

--- a/apps/api/src/Integration/Generic/Domain/Entity/Connection.php
+++ b/apps/api/src/Integration/Generic/Domain/Entity/Connection.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Entity;
+
+use App\Integration\Generic\Domain\Enum\AuthType;
+use App\Integration\Generic\Domain\Enum\ConnectionStatus;
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\AggregateRoot;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * A consumer-side connection to one external REST/JSON API (ADR-0022, epic APIC).
+ *
+ * Holds the transport definition — base URL, auth type, default headers, an
+ * optional rate hint — plus the reversibly-encrypted credentials needed to
+ * call the remote. The actual encryption-at-write + response masking lands in
+ * APIC-P1-02; this entity stores the already-produced ciphertext + master-key
+ * version in two columns, mirroring `TenantAgentConfig` / ADR-0017.
+ *
+ * `TenantScoped` + Postgres RLS isolate every connection to its tenant. Scheme
+ * (http/https) and SSRF-safe descriptor validation are enforced separately
+ * (APIC-P1-03/P1-04), not at this domain layer.
+ */
+class Connection extends AggregateRoot implements TenantScoped
+{
+    private Uuid $id;
+
+    private ?Tenant $tenant = null;
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 64)]
+    #[Assert\Regex(pattern: '/^[a-z0-9-]+$/', message: 'Code must contain only lowercase letters, digits, and dashes.')]
+    private string $code;
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    private string $name;
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 2048)]
+    private string $baseUrl;
+
+    private string $authType = AuthType::None->value;
+
+    /**
+     * Base64 of `nonce ‖ ciphertext ‖ tag`; null when `authType=none`. The
+     * write path (APIC-P1-02) produces this via the encryption service; it is
+     * never returned in API responses.
+     */
+    private ?string $credentialsCiphertext = null;
+
+    /** Master-key version used to produce the ciphertext (ADR-0017); null when no credentials. */
+    private ?int $credentialsKeyVersion = null;
+
+    /** @var array<string, string> */
+    private array $defaultHeaders = [];
+
+    #[Assert\Positive]
+    private ?int $rateLimitHint = null;
+
+    private string $status = ConnectionStatus::Draft->value;
+
+    private ?DateTimeImmutable $lastHealthCheckAt = null;
+
+    private DateTimeImmutable $createdAt;
+
+    private DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        string $code,
+        string $name,
+        string $baseUrl,
+        AuthType $authType = AuthType::None,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->code = $code;
+        $this->name = $name;
+        $this->baseUrl = $baseUrl;
+        $this->authType = $authType->value;
+        $this->createdAt = new DateTimeImmutable();
+        $this->updatedAt = $this->createdAt;
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant is already assigned and cannot be reassigned.');
+        }
+
+        $this->tenant = $tenant;
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+        $this->touch();
+    }
+
+    public function getBaseUrl(): string
+    {
+        return $this->baseUrl;
+    }
+
+    public function setBaseUrl(string $baseUrl): void
+    {
+        $this->baseUrl = $baseUrl;
+        $this->touch();
+    }
+
+    public function getAuthType(): AuthType
+    {
+        return AuthType::from($this->authType);
+    }
+
+    public function setAuthType(AuthType $authType): void
+    {
+        $this->authType = $authType->value;
+        $this->touch();
+    }
+
+    public function getCredentialsCiphertext(): ?string
+    {
+        return $this->credentialsCiphertext;
+    }
+
+    public function getCredentialsKeyVersion(): ?int
+    {
+        return $this->credentialsKeyVersion;
+    }
+
+    /**
+     * Stores an already-encrypted credential blob (ciphertext + key version)
+     * or clears it (both null). The encryption itself is owned by the write
+     * path (APIC-P1-02), never by this entity.
+     */
+    public function setCredentials(?string $ciphertext, ?int $keyVersion): void
+    {
+        $this->credentialsCiphertext = $ciphertext;
+        $this->credentialsKeyVersion = $keyVersion;
+        $this->touch();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getDefaultHeaders(): array
+    {
+        return $this->defaultHeaders;
+    }
+
+    /**
+     * @param array<string, string> $headers
+     */
+    public function setDefaultHeaders(array $headers): void
+    {
+        $this->defaultHeaders = $headers;
+        $this->touch();
+    }
+
+    public function getRateLimitHint(): ?int
+    {
+        return $this->rateLimitHint;
+    }
+
+    public function setRateLimitHint(?int $hint): void
+    {
+        $this->rateLimitHint = $hint;
+        $this->touch();
+    }
+
+    public function getStatus(): ConnectionStatus
+    {
+        return ConnectionStatus::from($this->status);
+    }
+
+    public function setStatus(ConnectionStatus $status): void
+    {
+        $this->status = $status->value;
+        $this->touch();
+    }
+
+    public function getLastHealthCheckAt(): ?DateTimeImmutable
+    {
+        return $this->lastHealthCheckAt;
+    }
+
+    /**
+     * Records the outcome of a connection test / health probe (APIC-P1-05):
+     * stamps the timestamp and updates the lifecycle status.
+     */
+    public function recordHealthCheck(DateTimeImmutable $at, ConnectionStatus $status): void
+    {
+        $this->lastHealthCheckAt = $at;
+        $this->status = $status->value;
+        $this->touch();
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    private function touch(): void
+    {
+        $this->updatedAt = new DateTimeImmutable();
+    }
+}

--- a/apps/api/src/Integration/Generic/Domain/Enum/AuthType.php
+++ b/apps/api/src/Integration/Generic/Domain/Enum/AuthType.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Enum;
+
+/**
+ * Authentication strategy a {@see \App\Integration\Generic\Domain\Entity\Connection}
+ * uses against the external API (ADR-0022, epic APIC).
+ *
+ * MVP scope covers static credential schemes only; full OAuth2
+ * authorization-code is a deferred §7 hook (APIC-P3-16).
+ */
+enum AuthType: string
+{
+    case None = 'none';
+    case ApiKey = 'api_key';
+    case Bearer = 'bearer';
+    case Basic = 'basic';
+    case Oauth2Token = 'oauth2_token';
+
+    /**
+     * Whether this scheme needs stored (reversibly-encrypted) credentials.
+     * `none` is the only credential-free scheme.
+     */
+    public function requiresCredentials(): bool
+    {
+        return self::None !== $this;
+    }
+}

--- a/apps/api/src/Integration/Generic/Domain/Enum/ConnectionStatus.php
+++ b/apps/api/src/Integration/Generic/Domain/Enum/ConnectionStatus.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Enum;
+
+/**
+ * Lifecycle state of a {@see \App\Integration\Generic\Domain\Entity\Connection}.
+ *
+ * `draft` is the initial state right after creation (before a successful
+ * connection test); `active`/`paused` are operator-controlled; `error` is set
+ * by the health check / sync runtime when the remote is unreachable or auth
+ * fails.
+ */
+enum ConnectionStatus: string
+{
+    case Draft = 'draft';
+    case Active = 'active';
+    case Paused = 'paused';
+    case Error = 'error';
+}

--- a/apps/api/src/Integration/Generic/Domain/Repository/ConnectionRepositoryInterface.php
+++ b/apps/api/src/Integration/Generic/Domain/Repository/ConnectionRepositoryInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Repository;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
+
+interface ConnectionRepositoryInterface
+{
+    public function save(Connection $connection): void;
+
+    public function remove(Connection $connection): void;
+
+    public function findById(Uuid $id): ?Connection;
+
+    public function findByCode(Tenant $tenant, string $code): ?Connection;
+
+    /**
+     * @return list<Connection>
+     */
+    public function findByTenant(Tenant $tenant): array;
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Orm/Mapping/Connection.orm.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Orm/Mapping/Connection.orm.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Integration\Generic\Domain\Entity\Connection"
+            table="integration_connections"
+            repository-class="App\Integration\Generic\Infrastructure\Doctrine\Repository\DoctrineConnectionRepository">
+
+        <unique-constraints>
+            <unique-constraint name="integration_connections_tenant_code_uniq" columns="tenant_id,code"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="integration_connections_tenant_status_idx" columns="tenant_id,status"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <field name="code" type="string" length="64"/>
+        <field name="name" type="string" length="255"/>
+        <field name="baseUrl" type="string" length="2048" column="base_url"/>
+        <field name="authType" type="string" length="16" column="auth_type">
+            <options>
+                <option name="default">none</option>
+            </options>
+        </field>
+        <field name="credentialsCiphertext" type="text" column="credentials_ciphertext" nullable="true"/>
+        <field name="credentialsKeyVersion" type="integer" column="credentials_key_version" nullable="true"/>
+        <field name="defaultHeaders" type="json" column="default_headers">
+            <options>
+                <option name="jsonb">true</option>
+                <option name="default">{}</option>
+            </options>
+        </field>
+        <field name="rateLimitHint" type="integer" column="rate_limit_hint" nullable="true"/>
+        <field name="status" type="string" length="16">
+            <options>
+                <option name="default">draft</option>
+            </options>
+        </field>
+        <field name="lastHealthCheckAt" type="datetimetz_immutable" column="last_health_check_at" nullable="true"/>
+        <field name="createdAt" type="datetimetz_immutable" column="created_at"/>
+        <field name="updatedAt" type="datetimetz_immutable" column="updated_at"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Repository/DoctrineConnectionRepository.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Repository/DoctrineConnectionRepository.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Doctrine\Repository;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Repository\ConnectionRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<Connection>
+ */
+class DoctrineConnectionRepository extends ServiceEntityRepository implements ConnectionRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Connection::class);
+    }
+
+    public function save(Connection $connection): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($connection);
+        $em->flush();
+    }
+
+    public function remove(Connection $connection): void
+    {
+        $em = $this->getEntityManager();
+        $em->remove($connection);
+        $em->flush();
+    }
+
+    public function findById(Uuid $id): ?Connection
+    {
+        return parent::find($id->toRfc4122());
+    }
+
+    public function findByCode(Tenant $tenant, string $code): ?Connection
+    {
+        return $this->findOneBy(['tenant' => $tenant, 'code' => $code]);
+    }
+
+    /**
+     * @return list<Connection>
+     */
+    public function findByTenant(Tenant $tenant): array
+    {
+        $qb = $this->createQueryBuilder('c')
+            ->where('c.tenant = :tenant')
+            ->orderBy('c.createdAt', 'DESC')
+            ->setParameter('tenant', $tenant);
+
+        /** @var list<Connection> $result */
+        $result = $qb->getQuery()->getResult();
+
+        return $result;
+    }
+}

--- a/apps/api/tests/Integration/Integration/Generic/ConnectionRepositoryTest.php
+++ b/apps/api/tests/Integration/Integration/Generic/ConnectionRepositoryTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Integration\Generic;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Enum\AuthType;
+use App\Integration\Generic\Domain\Repository\ConnectionRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * APIC-P1-01 — ConnectionRepository round-trip + 2-tenant cross-read = 0
+ * (Doctrine TenantFilter on the TenantScoped Connection entity; Postgres RLS
+ * is the defence-in-depth wall verified separately at the migration level).
+ */
+final class ConnectionRepositoryTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function savesAndFindsConnectionWithinTenant(): void
+    {
+        $alpha = $this->createTenant('alpha');
+        $this->activateTenantFilter($alpha);
+
+        $conn = new Connection('idosell', 'IdoSell PL', 'https://api.idosell.com', AuthType::ApiKey);
+        $conn->assignTenant($alpha);
+        $this->repo()->save($conn);
+
+        $found = $this->repo()->findByCode($alpha, 'idosell');
+        self::assertNotNull($found);
+        self::assertSame('idosell', $found->getCode());
+        self::assertSame(AuthType::ApiKey, $found->getAuthType());
+
+        self::assertCount(1, $this->repo()->findByTenant($alpha));
+    }
+
+    #[Test]
+    public function connectionsAreIsolatedAcrossTenants(): void
+    {
+        $alpha = $this->createTenant('alpha');
+        $beta = $this->createTenant('beta');
+
+        $this->activateTenantFilter($alpha);
+        $alphaConn = new Connection('idosell', 'IdoSell', 'https://api.idosell.com');
+        $alphaConn->assignTenant($alpha);
+        $this->repo()->save($alphaConn);
+
+        // Switch to beta: alpha's connection must be invisible.
+        $this->activateTenantFilter($beta);
+        self::assertCount(0, $this->repo()->findByTenant($alpha), 'beta context must not see alpha connections.');
+        self::assertNull($this->repo()->findByCode($alpha, 'idosell'));
+        self::assertCount(0, $this->repo()->findByTenant($beta));
+    }
+
+    private function repo(): ConnectionRepositoryInterface
+    {
+        return self::getContainer()->get(ConnectionRepositoryInterface::class);
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+
+    /**
+     * KernelTestCase has no HTTP request lifecycle, so the active tenant must
+     * be wired into the Doctrine filter manually after every context switch.
+     */
+    private function activateTenantFilter(Tenant $tenant): void
+    {
+        $this->tenantContext()->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function createTenant(string $code): Tenant
+    {
+        $tenant = new Tenant($code, ucfirst($code).' Tenant');
+        $em = $this->em();
+        $em->persist($tenant);
+        $em->flush();
+
+        return $tenant;
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Domain/Entity/ConnectionTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Domain/Entity/ConnectionTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Domain\Entity;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Enum\AuthType;
+use App\Integration\Generic\Domain\Enum\ConnectionStatus;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ConnectionTest extends TestCase
+{
+    #[Test]
+    public function newConnectionDefaultsToDraftWithoutCredentials(): void
+    {
+        $c = new Connection('idosell', 'IdoSell PL', 'https://api.idosell.com');
+
+        self::assertSame('idosell', $c->getCode());
+        self::assertSame('IdoSell PL', $c->getName());
+        self::assertSame('https://api.idosell.com', $c->getBaseUrl());
+        self::assertSame(AuthType::None, $c->getAuthType());
+        self::assertSame(ConnectionStatus::Draft, $c->getStatus());
+        self::assertSame([], $c->getDefaultHeaders());
+        self::assertNull($c->getCredentialsCiphertext());
+        self::assertNull($c->getCredentialsKeyVersion());
+        self::assertNull($c->getRateLimitHint());
+        self::assertNull($c->getLastHealthCheckAt());
+        self::assertNull($c->getTenant());
+    }
+
+    #[Test]
+    public function constructorAcceptsAuthType(): void
+    {
+        $c = new Connection('shopify', 'Shopify', 'https://x.myshopify.com', AuthType::Bearer);
+
+        self::assertSame(AuthType::Bearer, $c->getAuthType());
+    }
+
+    #[Test]
+    public function settersUpdateValues(): void
+    {
+        $c = $this->connection();
+        $c->setName('Renamed');
+        $c->setBaseUrl('https://new.example.com');
+        $c->setAuthType(AuthType::ApiKey);
+        $c->setStatus(ConnectionStatus::Active);
+        $c->setDefaultHeaders(['X-Trace' => '1']);
+        $c->setRateLimitHint(120);
+
+        self::assertSame('Renamed', $c->getName());
+        self::assertSame('https://new.example.com', $c->getBaseUrl());
+        self::assertSame(AuthType::ApiKey, $c->getAuthType());
+        self::assertSame(ConnectionStatus::Active, $c->getStatus());
+        self::assertSame(['X-Trace' => '1'], $c->getDefaultHeaders());
+        self::assertSame(120, $c->getRateLimitHint());
+    }
+
+    #[Test]
+    public function setCredentialsStoresAndClearsTheBlob(): void
+    {
+        $c = $this->connection();
+
+        $c->setCredentials('base64blob==', 3);
+        self::assertSame('base64blob==', $c->getCredentialsCiphertext());
+        self::assertSame(3, $c->getCredentialsKeyVersion());
+
+        $c->setCredentials(null, null);
+        self::assertNull($c->getCredentialsCiphertext());
+        self::assertNull($c->getCredentialsKeyVersion());
+    }
+
+    #[Test]
+    public function recordHealthCheckStampsTimestampAndStatus(): void
+    {
+        $c = $this->connection();
+        $at = new DateTimeImmutable('2026-06-27T10:00:00+00:00');
+
+        $c->recordHealthCheck($at, ConnectionStatus::Error);
+
+        self::assertEquals($at, $c->getLastHealthCheckAt());
+        self::assertSame(ConnectionStatus::Error, $c->getStatus());
+    }
+
+    #[Test]
+    public function assignTenantIsWriteOnce(): void
+    {
+        $c = $this->connection();
+        $c->assignTenant(new Tenant('alpha', 'Alpha'));
+        self::assertNotNull($c->getTenant());
+
+        $this->expectException(LogicException::class);
+        $c->assignTenant(new Tenant('beta', 'Beta'));
+    }
+
+    #[Test]
+    public function onlyNoneAuthTypeIsCredentialFree(): void
+    {
+        self::assertFalse(AuthType::None->requiresCredentials());
+        self::assertTrue(AuthType::ApiKey->requiresCredentials());
+        self::assertTrue(AuthType::Bearer->requiresCredentials());
+        self::assertTrue(AuthType::Basic->requiresCredentials());
+        self::assertTrue(AuthType::Oauth2Token->requiresCredentials());
+    }
+
+    private function connection(): Connection
+    {
+        return new Connection('idosell', 'IdoSell PL', 'https://api.idosell.com');
+    }
+}


### PR DESCRIPTION
## Summary
Consumer-side root of the API Configurator (ADR-0022, epic APIC): the `Connection` entity — one external REST/JSON API per row, TenantScoped with Postgres **FORCE RLS**.

## Backend
- `Connection` entity + `AuthType` (none/api_key/bearer/basic/oauth2_token) / `ConnectionStatus` (draft/active/paused/error) enums in `Integration/Generic/Domain`.
- Credentials stored as **ciphertext + key-version** columns (ADR-0017 shape, mirroring `TenantAgentConfig`). The reversible-encryption write path + response masking are **APIC-P1-02** (this ticket only persists an already-produced blob).
- `ConnectionRepositoryInterface` + Doctrine repo + XML mapping; registered as the `Integration` doctrine ORM mapping.
- Migration `Version20260627100000`: `integration_connections` (+ FK, 3 indexes) + ENABLE/FORCE RLS — strict tenant-isolation policy + super-admin bypass (W1-1 pattern, `NULLIF(current_setting('app.current_tenant',true),'')::uuid`).

## Quality gates (local)
- **PHPStan max**: 0 errors (new entity added to the `doctrine.associationType` `?Tenant` allowlist).
- **Deptrac**: 0 violations (entity reaches only Shared + Vendor).
- **PHP-CS-Fixer**: clean.
- **PHPUnit**: entity unit **7/7** + repository round-trip & **2-tenant cross-read=0** integration **2/2**, green locally.
- Migration applied on dev DB; verified `relrowsecurity=t, relforcerowsecurity=t` + both policies present.

No API surface yet (Connection CRUD is APIC-P1-06) → no OpenAPI change.

Closes #1761

🤖 Generated with [Claude Code](https://claude.com/claude-code)