### PR TITLE
feat(integration): encrypt Connection credentials via BYOK cipher (APIC-P1-02)

### DIFF
--- a/apps/api/src/Integration/Generic/Application/ConnectionCredentialsCipher.php
+++ b/apps/api/src/Integration/Generic/Application/ConnectionCredentialsCipher.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Shared\Application\Crypto\EncryptedSecret;
+use App\Shared\Application\Crypto\EncryptionServiceInterface;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Reversible at-rest encryption for a {@see Connection}'s external-API
+ * credentials (APIC-P1-02, ADR-0022 / ADR-0017).
+ *
+ * Producer-side keys are HASHED (Argon2id) because PIM only verifies an
+ * incoming key; consumer-side credentials must be ENCRYPTED reversibly because
+ * the sync runtime has to decrypt them and replay them against the remote API.
+ * The two mechanisms deliberately coexist — see ADR-0022.
+ *
+ * The credential shape is a flat string→string map whose keys depend on the
+ * connection's {@see \App\Integration\Generic\Domain\Enum\AuthType}
+ * (e.g. `{header, value}` for api_key, `{user, pass}` for basic). The map is
+ * JSON-encoded, encrypted via the BYOK service, and persisted as the
+ * ciphertext + key-version columns. The GenericRestClient (APIC-P1-03) reads
+ * it back through {@see reveal()}; the credentials never leave the server in an
+ * API response (masking enforced where the resource is serialised, APIC-P1-06).
+ */
+final readonly class ConnectionCredentialsCipher
+{
+    public function __construct(
+        private EncryptionServiceInterface $encryption,
+    ) {
+    }
+
+    /**
+     * Encrypts the credential map and stores ciphertext + key version on the
+     * connection. An empty map clears any stored credentials (e.g. authType
+     * switched to `none`).
+     *
+     * @param array<string, string> $credentials
+     */
+    public function apply(Connection $connection, array $credentials): void
+    {
+        if ([] === $credentials) {
+            $connection->setCredentials(null, null);
+
+            return;
+        }
+
+        $secret = $this->encryption->encrypt(json_encode($credentials, JSON_THROW_ON_ERROR));
+        $connection->setCredentials($secret->ciphertext, $secret->version);
+    }
+
+    /**
+     * Decrypts the stored credentials back into the credential map. Returns an
+     * empty array when the connection has no stored credentials.
+     *
+     * @return array<string, string>
+     */
+    public function reveal(Connection $connection): array
+    {
+        $ciphertext = $connection->getCredentialsCiphertext();
+        $version = $connection->getCredentialsKeyVersion();
+
+        if (null === $ciphertext || null === $version) {
+            return [];
+        }
+
+        $plaintext = $this->encryption->decrypt(new EncryptedSecret($ciphertext, $version));
+
+        $decoded = json_decode($plaintext, true, 512, JSON_THROW_ON_ERROR);
+
+        $credentials = [];
+        if (\is_array($decoded)) {
+            foreach ($decoded as $key => $value) {
+                if (\is_string($key) && \is_string($value)) {
+                    $credentials[$key] = $value;
+                }
+            }
+        }
+
+        return $credentials;
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Application/ConnectionCredentialsCipherTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Application/ConnectionCredentialsCipherTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Application;
+
+use App\Integration\Generic\Application\ConnectionCredentialsCipher;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Enum\AuthType;
+use App\Shared\Application\Crypto\EncryptedSecret;
+use App\Shared\Application\Crypto\EncryptionServiceInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the cipher's own logic (map ↔ JSON ↔ stored columns, clear-on-empty,
+ * round-trip) with a deterministic fake encryption service. The AES-256-GCM
+ * primitive itself is covered by AesGcmEncryptionServiceTest (which skips on
+ * hosts without AES-NI); this suite must run everywhere, so it does not touch
+ * libsodium.
+ */
+final class ConnectionCredentialsCipherTest extends TestCase
+{
+    #[Test]
+    public function applyEncryptsAndStoresCiphertextWithVersion(): void
+    {
+        $cipher = new ConnectionCredentialsCipher($this->fakeEncryption());
+        $connection = $this->connection();
+
+        $cipher->apply($connection, ['header' => 'X-Api-Key', 'value' => 's3cr3t']);
+
+        self::assertSame(7, $connection->getCredentialsKeyVersion());
+        $ciphertext = $connection->getCredentialsCiphertext();
+        self::assertNotNull($ciphertext);
+        // The stored blob is not the raw secret value.
+        self::assertStringNotContainsString('s3cr3t', $ciphertext);
+    }
+
+    #[Test]
+    public function applyWithEmptyMapClearsStoredCredentials(): void
+    {
+        $cipher = new ConnectionCredentialsCipher($this->fakeEncryption());
+        $connection = $this->connection();
+        $cipher->apply($connection, ['token' => 'abc']);
+        self::assertNotNull($connection->getCredentialsCiphertext());
+
+        $cipher->apply($connection, []);
+
+        self::assertNull($connection->getCredentialsCiphertext());
+        self::assertNull($connection->getCredentialsKeyVersion());
+    }
+
+    #[Test]
+    public function revealRoundTripsTheCredentialMap(): void
+    {
+        $cipher = new ConnectionCredentialsCipher($this->fakeEncryption());
+        $connection = $this->connection();
+        $credentials = ['user' => 'alice', 'pass' => 'hunter2'];
+
+        $cipher->apply($connection, $credentials);
+
+        self::assertSame($credentials, $cipher->reveal($connection));
+    }
+
+    #[Test]
+    public function revealReturnsEmptyArrayWhenNoCredentialsStored(): void
+    {
+        $cipher = new ConnectionCredentialsCipher($this->fakeEncryption());
+
+        self::assertSame([], $cipher->reveal($this->connection()));
+    }
+
+    private function connection(): Connection
+    {
+        return new Connection('idosell', 'IdoSell PL', 'https://api.idosell.com', AuthType::ApiKey);
+    }
+
+    private function fakeEncryption(): EncryptionServiceInterface
+    {
+        return new class implements EncryptionServiceInterface {
+            public function encrypt(string $plaintext): EncryptedSecret
+            {
+                return new EncryptedSecret(base64_encode($plaintext), 7);
+            }
+
+            public function decrypt(EncryptedSecret $secret): string
+            {
+                $decoded = base64_decode($secret->ciphertext, true);
+
+                return false === $decoded ? '' : $decoded;
+            }
+
+            public function needsRotation(EncryptedSecret $secret): bool
+            {
+                return false;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
`ConnectionCredentialsCipher` — reversible at-rest encryption for a `Connection`'s external-API credentials (ADR-0022 / ADR-0017).

- `apply(Connection, array<string,string>)` JSON-encodes the credential map (shape per `AuthType`), encrypts it through the BYOK `EncryptionService`, and stores the **ciphertext + key-version** columns. Empty map clears stored credentials.
- `reveal(Connection): array<string,string>` decrypts back for the sync runtime (consumed by GenericRestClient, APIC-P1-03).
- Consumer credentials are encrypted **reversibly** (AES-256-GCM) — distinct from the producer-side Argon2id hash. Deliberate coexistence (ADR-0022).

## Świadome odejście (scope)
Response masking (secrets never returned by the API) moves to **APIC-P1-06**, where the `Connection` API resource + serialisation path are built. P1-02 has no endpoint to mask yet.

## Quality gates (local)
- PHPStan max: 0 · Deptrac: 0 · PHP-CS-Fixer: clean.
- Unit: cipher round-trip / clear-on-empty / ciphertext≠plaintext **4/4** with a deterministic fake EncryptionService (runs everywhere; the AES primitive is covered by `AesGcmEncryptionServiceTest`, which skips without AES-NI).

Closes #1762

🤖 Generated with [Claude Code](https://claude.com/claude-code)