### PR TITLE
feat(integration): SSRF-safe GenericRestClient with auth injection (APIC-P1-03)

### DIFF
--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -316,6 +316,18 @@ services:
             $httpClient: '@import.ssrf_safe_http_client'
             $importsStorage: '@imports.storage'
 
+    # APIC-P1-03 (ADR-0022) — SSRF-safe HTTP client for the API Configurator
+    # consumer connector. Same NoPrivateNetworkHttpClient wrapper as imports:
+    # per-redirect peer-IP validation backing the cheap SsrfGuard pre-filter.
+    generic.ssrf_safe_http_client:
+        class: Symfony\Component\HttpClient\NoPrivateNetworkHttpClient
+        arguments:
+            - '@http_client'
+
+    App\Integration\Generic\Infrastructure\Http\GenericRestClient:
+        arguments:
+            $httpClient: '@generic.ssrf_safe_http_client'
+
     # EXP-06 (#585) — async export worker. Same named-storage binding so
     # the handler can write the generated XLSX/CSV to MinIO under
     # `<tenant_id>/<session_id>.<format>` (PRD §11.1).

--- a/apps/api/src/Integration/Generic/Domain/Exception/RemoteRequestFailedException.php
+++ b/apps/api/src/Integration/Generic/Domain/Exception/RemoteRequestFailedException.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Exception;
+
+use RuntimeException;
+use Throwable;
+
+/**
+ * Thrown when a request to an external connection fails at the transport level
+ * (DNS, TLS, connection refused, timeout) or the response exceeds the size cap
+ * (APIC-P1-03). A non-2xx HTTP status is NOT a failure — that is surfaced on
+ * {@see \App\Integration\Generic\Domain\GenericRestResponse}. The message never
+ * contains credentials.
+ */
+final class RemoteRequestFailedException extends RuntimeException
+{
+    public static function transport(string $reason, ?Throwable $previous = null): self
+    {
+        return new self(\sprintf('External request failed: %s', $reason), 0, $previous);
+    }
+
+    public static function responseTooLarge(int $limitBytes): self
+    {
+        return new self(\sprintf('External response exceeds the %d byte limit.', $limitBytes));
+    }
+}

--- a/apps/api/src/Integration/Generic/Domain/Exception/SsrfBlockedException.php
+++ b/apps/api/src/Integration/Generic/Domain/Exception/SsrfBlockedException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Exception;
+
+use RuntimeException;
+
+/**
+ * Thrown when an outbound URL is rejected by the SSRF pre-filter (APIC-P1-03):
+ * non-http(s) scheme, or a host resolving to a private / loopback / link-local
+ * / reserved address. The message never contains credentials.
+ */
+final class SsrfBlockedException extends RuntimeException
+{
+    public static function forUrl(string $url): self
+    {
+        return new self(\sprintf('Outbound URL "%s" rejected: non-public or unsupported host.', $url));
+    }
+}

--- a/apps/api/src/Integration/Generic/Domain/GenericRestResponse.php
+++ b/apps/api/src/Integration/Generic/Domain/GenericRestResponse.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain;
+
+/**
+ * The outcome of a single {@see \App\Integration\Generic\Infrastructure\Http\GenericRestClient}
+ * call (APIC-P1-03): the raw HTTP status, response headers, body, and the
+ * latency/size telemetry the connection tester (P1-05) and sync logs (P3-02)
+ * record. Error status codes (4xx/5xx) are surfaced here, not thrown — callers
+ * decide what a non-2xx means for their flow.
+ */
+final readonly class GenericRestResponse
+{
+    /**
+     * @param array<string, list<string>> $headers
+     */
+    public function __construct(
+        public int $statusCode,
+        public array $headers,
+        public string $body,
+        public int $durationMs,
+        public int $sizeBytes,
+    ) {
+    }
+
+    public function isSuccessful(): bool
+    {
+        return $this->statusCode >= 200 && $this->statusCode < 300;
+    }
+
+    public function contentType(): ?string
+    {
+        return $this->headers['content-type'][0] ?? null;
+    }
+
+    /**
+     * The `Retry-After` header value in seconds, when the remote signalled
+     * throttling (HTTP 429 / 503). Only the integer-seconds form is parsed;
+     * the HTTP-date form returns null (callers fall back to exponential
+     * backoff — APIC-P1-09).
+     */
+    public function retryAfterSeconds(): ?int
+    {
+        $value = $this->headers['retry-after'][0] ?? null;
+        if (null === $value || '' === $value || !ctype_digit($value)) {
+            return null;
+        }
+
+        return (int) $value;
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Http/GenericRestClient.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Http/GenericRestClient.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Http;
+
+use App\Integration\Generic\Application\ConnectionCredentialsCipher;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Enum\AuthType;
+use App\Integration\Generic\Domain\Exception\RemoteRequestFailedException;
+use App\Integration\Generic\Domain\Exception\SsrfBlockedException;
+use App\Integration\Generic\Domain\GenericRestResponse;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * The single HTTP transport for the consumer side of the API Configurator
+ * (APIC-P1-03, ADR-0022). Every external call goes through here so SSRF
+ * protection and credential injection are guaranteed and centralised.
+ *
+ * Two-layer SSRF defence: a cheap {@see SsrfGuard} pre-filter (reject obvious
+ * private/loopback/reserved targets before any I/O) on top of the injected
+ * `generic.ssrf_safe_http_client` — Symfony's `NoPrivateNetworkHttpClient`,
+ * which re-validates the actually-connected peer IP on every redirect hop
+ * (closing the DNS-rebinding + redirect-to-private gaps the pre-filter cannot).
+ *
+ * Credentials are decrypted on demand ({@see ConnectionCredentialsCipher}) and
+ * injected per {@see AuthType}; they are never written to logs. A non-2xx
+ * status is returned on the {@see GenericRestResponse}, not thrown — only true
+ * transport failures (DNS/TLS/timeout) and over-size responses raise.
+ */
+final readonly class GenericRestClient
+{
+    private const int TIMEOUT_SECONDS = 30;
+    private const int MAX_DURATION_SECONDS = 60;
+    private const int MAX_REDIRECTS = 3;
+    private const int MAX_BYTES = 8 * 1024 * 1024;
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private SsrfGuard $ssrfGuard,
+        private ConnectionCredentialsCipher $cipher,
+        private LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    /**
+     * @param array<string, string|int> $query
+     * @param array<string, string>     $headers extra per-request headers
+     *
+     * @throws SsrfBlockedException         when the URL fails the SSRF pre-filter
+     * @throws RemoteRequestFailedException on transport failure or over-size response
+     */
+    public function request(
+        Connection $connection,
+        string $method,
+        string $url,
+        array $query = [],
+        array $headers = [],
+        ?string $body = null,
+    ): GenericRestResponse {
+        if (!$this->ssrfGuard->isAllowed($url)) {
+            throw SsrfBlockedException::forUrl($url);
+        }
+
+        $options = [
+            'headers' => array_merge($connection->getDefaultHeaders(), $this->authHeaders($connection), $headers),
+            'timeout' => self::TIMEOUT_SECONDS,
+            'max_duration' => self::MAX_DURATION_SECONDS,
+            'max_redirects' => self::MAX_REDIRECTS,
+        ];
+        if ([] !== $query) {
+            $options['query'] = $query;
+        }
+        if (null !== $body) {
+            $options['body'] = $body;
+        }
+
+        $startedAt = microtime(true);
+        try {
+            $response = $this->httpClient->request($method, $url, $options);
+            $statusCode = $response->getStatusCode();
+            $responseHeaders = $response->getHeaders(false);
+
+            $payload = '';
+            $bytes = 0;
+            foreach ($this->httpClient->stream($response) as $chunk) {
+                $content = $chunk->getContent();
+                $bytes += \strlen($content);
+                if ($bytes > self::MAX_BYTES) {
+                    throw RemoteRequestFailedException::responseTooLarge(self::MAX_BYTES);
+                }
+                $payload .= $content;
+            }
+        } catch (TransportExceptionInterface $exception) {
+            $this->logger->warning('External connection request failed.', [
+                'connection' => $connection->getCode(),
+                'method' => $method,
+                'exception' => $exception->getMessage(),
+            ]);
+
+            throw RemoteRequestFailedException::transport($exception->getMessage(), $exception);
+        }
+
+        $durationMs = (int) round((microtime(true) - $startedAt) * 1000);
+
+        return new GenericRestResponse($statusCode, $responseHeaders, $payload, $durationMs, $bytes);
+    }
+
+    /**
+     * Builds the auth headers for the connection's scheme, decrypting the
+     * stored credentials on demand. Credentials are never logged.
+     *
+     * @return array<string, string>
+     */
+    private function authHeaders(Connection $connection): array
+    {
+        $credentials = $this->cipher->reveal($connection);
+
+        return match ($connection->getAuthType()) {
+            AuthType::None => [],
+            AuthType::ApiKey => isset($credentials['header'], $credentials['value'])
+                ? [$credentials['header'] => $credentials['value']]
+                : [],
+            AuthType::Bearer, AuthType::Oauth2Token => isset($credentials['token'])
+                ? ['Authorization' => 'Bearer '.$credentials['token']]
+                : [],
+            AuthType::Basic => isset($credentials['user'], $credentials['pass'])
+                ? ['Authorization' => 'Basic '.base64_encode($credentials['user'].':'.$credentials['pass'])]
+                : [],
+        };
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Http/SsrfGuard.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Http/SsrfGuard.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Http;
+
+use const DNS_AAAA;
+use const FILTER_FLAG_IPV4;
+use const FILTER_FLAG_IPV6;
+use const FILTER_FLAG_NO_PRIV_RANGE;
+use const FILTER_FLAG_NO_RES_RANGE;
+use const FILTER_VALIDATE_IP;
+
+/**
+ * APIC-P1-03 (ADR-0022) — cheap PRE-FILTER for server-side request forgery on
+ * user-defined external connections: rejects non-http(s) schemes and hosts that
+ * resolve to a non-public address BEFORE any request.
+ *
+ * It is NOT the sole defence — a one-shot pre-resolution cannot stop
+ * DNS-rebinding (the client re-resolves at connect time) nor a redirect to a
+ * private host. The authoritative connection-time + per-redirect peer-IP check
+ * is {@see \Symfony\Component\HttpClient\NoPrivateNetworkHttpClient}, which
+ * wraps the client injected into {@see GenericRestClient}
+ * (`generic.ssrf_safe_http_client` in services.yaml). This guard is the fast
+ * early reject; that client is the real backstop.
+ *
+ * Mirrors `App\Import\Application\Service\Media\SsrfGuard` — Deptrac forbids
+ * Integration → Import (no Import Contracts seam for it), so the connector owns
+ * its own copy. Rejected: private (RFC1918), loopback, link-local, reserved/ULA,
+ * carrier-grade NAT — the NO_PRIV_RANGE | NO_RES_RANGE filter flags cover them,
+ * with explicit literal guards as defence in depth.
+ */
+final class SsrfGuard
+{
+    public function isAllowed(string $url): bool
+    {
+        $parts = parse_url($url);
+        if (false === $parts || !isset($parts['scheme'], $parts['host'])) {
+            return false;
+        }
+        $scheme = strtolower($parts['scheme']);
+        if ('http' !== $scheme && 'https' !== $scheme) {
+            return false;
+        }
+
+        $host = $parts['host'];
+        // A bracketed/literal IP host bypasses DNS — validate it directly.
+        $literal = trim($host, '[]');
+        if (false !== filter_var($literal, FILTER_VALIDATE_IP)) {
+            return $this->isPublicIp($literal);
+        }
+
+        $ips = $this->resolve($host);
+        if ([] === $ips) {
+            return false; // unresolvable host → refuse rather than let the client try
+        }
+        foreach ($ips as $ip) {
+            if (!$this->isPublicIp($ip)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resolve(string $host): array
+    {
+        $ips = [];
+        $v4 = @gethostbynamel($host);
+        if (\is_array($v4)) {
+            $ips = $v4;
+        }
+        $aaaa = @dns_get_record($host, DNS_AAAA);
+        if (\is_array($aaaa)) {
+            foreach ($aaaa as $record) {
+                if (isset($record['ipv6']) && \is_string($record['ipv6'])) {
+                    $ips[] = $record['ipv6'];
+                }
+            }
+        }
+
+        return array_values(array_unique($ips));
+    }
+
+    private function isPublicIp(string $ip): bool
+    {
+        $flags = FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE;
+        if (str_contains($ip, ':')) {
+            // ::1 loopback + fc00::/7 ULA + fe80::/10 link-local are caught by
+            // the flags; reject anything that fails them.
+            return false !== filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | $flags);
+        }
+
+        $valid = filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | $flags);
+        if (false === $valid) {
+            return false;
+        }
+        // Defence in depth for ranges the flags miss on some libc builds.
+        $long = ip2long($ip);
+        if (false === $long) {
+            return false;
+        }
+        foreach ([['0.0.0.0', 8], ['127.0.0.0', 8], ['169.254.0.0', 16], ['10.0.0.0', 8], ['172.16.0.0', 12], ['192.168.0.0', 16], ['100.64.0.0', 10]] as [$net, $bits]) {
+            $mask = -1 << (32 - $bits);
+            if (($long & $mask) === (ip2long($net) & $mask)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Infrastructure/Http/GenericRestClientTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Infrastructure/Http/GenericRestClientTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Infrastructure\Http;
+
+use App\Integration\Generic\Application\ConnectionCredentialsCipher;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Enum\AuthType;
+use App\Integration\Generic\Domain\Exception\SsrfBlockedException;
+use App\Integration\Generic\Infrastructure\Http\GenericRestClient;
+use App\Integration\Generic\Infrastructure\Http\SsrfGuard;
+use App\Shared\Application\Crypto\EncryptedSecret;
+use App\Shared\Application\Crypto\EncryptionServiceInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * Uses Symfony's MockHttpClient (no network) + a literal public-IP URL so the
+ * real SsrfGuard passes without DNS. Asserts per-AuthType header injection, the
+ * SSRF pre-filter, and response parsing.
+ */
+final class GenericRestClientTest extends TestCase
+{
+    private const string PUBLIC_URL = 'https://93.184.216.34/products';
+
+    #[Test]
+    public function injectsApiKeyHeaderAndParsesResponse(): void
+    {
+        $mock = new MockResponse('{"items":[]}', [
+            'http_code' => 200,
+            'response_headers' => ['content-type' => 'application/json'],
+        ]);
+        $client = $this->client($mock);
+
+        $connection = new Connection('idosell', 'IdoSell', 'https://api.idosell.com', AuthType::ApiKey);
+        $this->cipher()->apply($connection, ['header' => 'X-Api-Key', 'value' => 's3cr3t']);
+
+        $response = $client->request($connection, 'GET', self::PUBLIC_URL);
+
+        self::assertSame(200, $response->statusCode);
+        self::assertTrue($response->isSuccessful());
+        self::assertSame('{"items":[]}', $response->body);
+        self::assertSame('application/json', $response->contentType());
+        self::assertContains('X-Api-Key: s3cr3t', $this->sentHeaders($mock));
+    }
+
+    #[Test]
+    public function injectsBearerHeader(): void
+    {
+        $mock = new MockResponse('{}', ['http_code' => 200]);
+        $client = $this->client($mock);
+
+        $connection = new Connection('shopify', 'Shopify', 'https://x.myshopify.com', AuthType::Bearer);
+        $this->cipher()->apply($connection, ['token' => 'abc123']);
+
+        $client->request($connection, 'GET', self::PUBLIC_URL);
+
+        self::assertContains('Authorization: Bearer abc123', $this->sentHeaders($mock));
+    }
+
+    #[Test]
+    public function noneAuthSendsNoAuthorizationHeader(): void
+    {
+        $mock = new MockResponse('{}', ['http_code' => 200]);
+        $client = $this->client($mock);
+
+        $connection = new Connection('open', 'Open API', 'https://api.open.com');
+
+        $client->request($connection, 'GET', self::PUBLIC_URL);
+
+        foreach ($this->sentHeaders($mock) as $header) {
+            self::assertStringStartsNotWith('Authorization:', $header);
+        }
+    }
+
+    #[Test]
+    public function rejectsPrivateTargetBeforeAnyRequest(): void
+    {
+        $client = $this->client(new MockResponse('{}'));
+        $connection = new Connection('open', 'Open API', 'https://api.open.com');
+
+        $this->expectException(SsrfBlockedException::class);
+        $client->request($connection, 'GET', 'https://127.0.0.1/admin');
+    }
+
+    #[Test]
+    public function surfacesRetryAfterOnThrottledResponse(): void
+    {
+        $mock = new MockResponse('rate limited', [
+            'http_code' => 429,
+            'response_headers' => ['retry-after' => '30'],
+        ]);
+        $client = $this->client($mock);
+        $connection = new Connection('open', 'Open API', 'https://api.open.com');
+
+        $response = $client->request($connection, 'GET', self::PUBLIC_URL);
+
+        self::assertSame(429, $response->statusCode);
+        self::assertFalse($response->isSuccessful());
+        self::assertSame(30, $response->retryAfterSeconds());
+    }
+
+    private function client(MockResponse $response): GenericRestClient
+    {
+        return new GenericRestClient(new MockHttpClient($response), new SsrfGuard(), $this->cipher());
+    }
+
+    private function cipher(): ConnectionCredentialsCipher
+    {
+        return new ConnectionCredentialsCipher(new class implements EncryptionServiceInterface {
+            public function encrypt(string $plaintext): EncryptedSecret
+            {
+                return new EncryptedSecret(base64_encode($plaintext), 1);
+            }
+
+            public function decrypt(EncryptedSecret $secret): string
+            {
+                $decoded = base64_decode($secret->ciphertext, true);
+
+                return false === $decoded ? '' : $decoded;
+            }
+
+            public function needsRotation(EncryptedSecret $secret): bool
+            {
+                return false;
+            }
+        });
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function sentHeaders(MockResponse $response): array
+    {
+        $headers = $response->getRequestOptions()['headers'] ?? [];
+        if (!\is_array($headers)) {
+            return [];
+        }
+
+        return array_values(array_filter($headers, 'is_string'));
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Infrastructure/Http/SsrfGuardTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Infrastructure/Http/SsrfGuardTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Infrastructure\Http;
+
+use App\Integration\Generic\Infrastructure\Http\SsrfGuard;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Uses literal-IP hosts only — `isAllowed()` validates them directly without
+ * DNS, so the suite is deterministic and network-free.
+ */
+final class SsrfGuardTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('publicUrls')]
+    public function allowsPublicHosts(string $url): void
+    {
+        self::assertTrue(new SsrfGuard()->isAllowed($url));
+    }
+
+    #[Test]
+    #[DataProvider('blockedUrls')]
+    public function blocksPrivateReservedAndUnsupportedUrls(string $url): void
+    {
+        self::assertFalse(new SsrfGuard()->isAllowed($url));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function publicUrls(): iterable
+    {
+        yield 'public ipv4' => ['https://93.184.216.34/products'];
+        yield 'google dns' => ['http://8.8.8.8/'];
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function blockedUrls(): iterable
+    {
+        yield 'loopback' => ['https://127.0.0.1/x'];
+        yield 'private 10/8' => ['https://10.0.0.5/x'];
+        yield 'private 192.168' => ['https://192.168.1.1/x'];
+        yield 'private 172.16' => ['https://172.16.0.9/x'];
+        yield 'link-local / cloud metadata' => ['https://169.254.169.254/latest/meta-data'];
+        yield 'carrier-grade nat' => ['https://100.64.0.1/x'];
+        yield 'ipv6 loopback' => ['https://[::1]/x'];
+        yield 'non-http scheme' => ['ftp://93.184.216.34/x'];
+        yield 'file scheme' => ['file:///etc/passwd'];
+        yield 'no host' => ['https:///x'];
+        yield 'garbage' => ['not a url at all'];
+    }
+}


### PR DESCRIPTION
## Summary
The single, SSRF-safe HTTP transport for the consumer connector (ADR-0022). Every external call routes through it, so SSRF defence + credential injection are centralised.

## Backend
- `GenericRestClient` wraps **`generic.ssrf_safe_http_client`** (Symfony `NoPrivateNetworkHttpClient` — re-validates the connected peer IP on every redirect hop) on top of a cheap **`SsrfGuard`** pre-filter (own copy — Deptrac forbids reaching the Import one).
- **Auth injected per `AuthType`** (api_key header / bearer / basic / oauth2_token), decrypting credentials on demand via `ConnectionCredentialsCipher`; **never logged**.
- Body streamed under an **8 MB cap**; timeout / max-duration / max-redirects set. Non-2xx surfaced on `GenericRestResponse` (+ `Retry-After` parse for P1-09); transport / over-size failures raise domain exceptions.

## Quality gates (local)
- PHPStan max: 0 · Deptrac: 0 · PHP-CS-Fixer: clean · container compiles (services.yaml).
- Unit **18/18, no network**: `SsrfGuard` (public allowed; loopback/private/link-local/cloud-metadata 169.254.169.254/CGNAT/ipv6/file:// blocked) + `GenericRestClient` via `MockHttpClient` (auth-per-type, SSRF pre-block, 429 Retry-After).

Closes #1763

🤖 Generated with [Claude Code](https://claude.com/claude-code)