### PR TITLE
feat(integration): validate connector descriptor (baseUrl + path template) (APIC-P1-04)

### DIFF
--- a/apps/api/src/Integration/Generic/Application/Validation/DescriptorValidator.php
+++ b/apps/api/src/Integration/Generic/Application/Validation/DescriptorValidator.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application\Validation;
+
+use App\Integration\Generic\Domain\Exception\InvalidDescriptorException;
+
+/**
+ * Config-time sanity check for user-defined connector descriptors (APIC-P1-04,
+ * ADR-0022). It is the first SSRF wall — it rejects obviously-abusable shapes
+ * before they are ever stored:
+ *
+ *  - base URL must be an absolute http(s) URL with a host (no `file://`,
+ *    `gopher://`, schemeless, …);
+ *  - an endpoint path template must stay relative to that base URL — it may
+ *    never embed its own scheme/host (`https://evil/…`) or be protocol-relative
+ *    (`//evil/…`), which would let a request target an arbitrary host and
+ *    bypass the connection's base URL entirely.
+ *
+ * It deliberately does NOT resolve hosts to IPs: config-time DNS is a TOCTOU
+ * trap and would be flaky. The authoritative per-request, per-redirect IP-range
+ * check lives in the SSRF-safe {@see \App\Integration\Generic\Infrastructure\Http\GenericRestClient}.
+ */
+final class DescriptorValidator
+{
+    /** @var list<string> */
+    private const array ALLOWED_SCHEMES = ['http', 'https'];
+
+    /**
+     * @throws InvalidDescriptorException
+     */
+    public function assertValidBaseUrl(string $baseUrl): void
+    {
+        $trimmed = trim($baseUrl);
+        if ('' === $trimmed) {
+            throw InvalidDescriptorException::baseUrl($baseUrl, 'must not be empty');
+        }
+
+        $parts = parse_url($trimmed);
+        if (false === $parts || !isset($parts['scheme'], $parts['host'])) {
+            throw InvalidDescriptorException::baseUrl($baseUrl, 'must be an absolute http(s) URL with a host');
+        }
+
+        if (!\in_array(strtolower($parts['scheme']), self::ALLOWED_SCHEMES, true)) {
+            throw InvalidDescriptorException::baseUrl($baseUrl, 'scheme must be http or https');
+        }
+    }
+
+    /**
+     * @throws InvalidDescriptorException
+     */
+    public function assertValidPathTemplate(string $pathTemplate): void
+    {
+        if (str_contains($pathTemplate, '://')) {
+            throw InvalidDescriptorException::pathTemplate($pathTemplate, 'must not embed a scheme/host');
+        }
+
+        if (str_starts_with($pathTemplate, '//')) {
+            throw InvalidDescriptorException::pathTemplate($pathTemplate, 'must not be protocol-relative');
+        }
+
+        if (str_contains($pathTemplate, '\\')) {
+            throw InvalidDescriptorException::pathTemplate($pathTemplate, 'must not contain backslashes');
+        }
+    }
+}

--- a/apps/api/src/Integration/Generic/Domain/Exception/InvalidDescriptorException.php
+++ b/apps/api/src/Integration/Generic/Domain/Exception/InvalidDescriptorException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Exception;
+
+use RuntimeException;
+
+/**
+ * Thrown when a connector descriptor (a connection's base URL or an endpoint's
+ * path template) fails the config-time sanity check (APIC-P1-04): non-http(s)
+ * scheme, missing host, or a path template that embeds a scheme/host and could
+ * override the base URL target (SSRF). The API layer maps it to a 422 Problem
+ * Details (APIC-P1-06). Runtime IP-range checks stay with the SSRF-safe client.
+ */
+final class InvalidDescriptorException extends RuntimeException
+{
+    public static function baseUrl(string $value, string $reason): self
+    {
+        return new self(\sprintf('Invalid connector base URL "%s": %s.', $value, $reason));
+    }
+
+    public static function pathTemplate(string $value, string $reason): self
+    {
+        return new self(\sprintf('Invalid endpoint path template "%s": %s.', $value, $reason));
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Application/Validation/DescriptorValidatorTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Application/Validation/DescriptorValidatorTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Application\Validation;
+
+use App\Integration\Generic\Application\Validation\DescriptorValidator;
+use App\Integration\Generic\Domain\Exception\InvalidDescriptorException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class DescriptorValidatorTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('validBaseUrls')]
+    public function acceptsAbsoluteHttpUrls(string $baseUrl): void
+    {
+        $this->expectNotToPerformAssertions();
+        new DescriptorValidator()->assertValidBaseUrl($baseUrl);
+    }
+
+    #[Test]
+    #[DataProvider('invalidBaseUrls')]
+    public function rejectsNonHttpOrSchemelessBaseUrls(string $baseUrl): void
+    {
+        $this->expectException(InvalidDescriptorException::class);
+        new DescriptorValidator()->assertValidBaseUrl($baseUrl);
+    }
+
+    #[Test]
+    #[DataProvider('validPaths')]
+    public function acceptsRelativePathTemplates(string $path): void
+    {
+        $this->expectNotToPerformAssertions();
+        new DescriptorValidator()->assertValidPathTemplate($path);
+    }
+
+    #[Test]
+    #[DataProvider('invalidPaths')]
+    public function rejectsPathTemplatesThatCanOverrideTheHost(string $path): void
+    {
+        $this->expectException(InvalidDescriptorException::class);
+        new DescriptorValidator()->assertValidPathTemplate($path);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function validBaseUrls(): iterable
+    {
+        yield 'https' => ['https://api.idosell.com'];
+        yield 'http with port + path' => ['http://api.example.com:8080/v2'];
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function invalidBaseUrls(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'file scheme' => ['file:///etc/passwd'];
+        yield 'gopher scheme' => ['gopher://evil/x'];
+        yield 'schemeless host' => ['api.example.com/v2'];
+        yield 'scheme without host' => ['https:///v2'];
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function validPaths(): iterable
+    {
+        yield 'leading slash' => ['/products/{id}'];
+        yield 'relative segment' => ['products'];
+        yield 'query template' => ['/products?since={cursor}'];
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function invalidPaths(): iterable
+    {
+        yield 'embedded scheme/host' => ['https://169.254.169.254/latest'];
+        yield 'protocol-relative' => ['//evil.example.com/x'];
+        yield 'backslash' => ['\\\\evil\\share'];
+    }
+}


### PR DESCRIPTION
## Summary
Config-time SSRF wall for user-defined connector descriptors (ADR-0022) — rejects abusable shapes before they are stored.

- `assertValidBaseUrl`: absolute **http(s)** URL with a host; rejects `file://`, schemeless, host-less.
- `assertValidPathTemplate`: must stay relative to the base URL — rejects embedded scheme/host (`https://evil/…`), protocol-relative (`//evil`), backslashes (host-override / SSRF).
- `InvalidDescriptorException` → 422 Problem Details where the resource is serialised (**APIC-P1-06**). Config-time DNS deliberately avoided (TOCTOU); runtime IP-range checks stay with `GenericRestClient`.

## Quality gates (local)
- PHPStan max 0 · Deptrac 0 · PHP-CS-Fixer clean · unit **13/13**.

Closes #1764

🤖 Generated with [Claude Code](https://claude.com/claude-code)