### PR TITLE
feat(integration): ConnectionTester endpoint POST /connections/{id}/test (APIC-P1-05)

### DIFF
--- a/apps/api/src/Integration/Generic/Presentation/Controller/ConnectionTestController.php
+++ b/apps/api/src/Integration/Generic/Presentation/Controller/ConnectionTestController.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Presentation\Controller;
+
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Enum\ConnectionStatus;
+use App\Integration\Generic\Domain\Exception\RemoteRequestFailedException;
+use App\Integration\Generic\Domain\Exception\SsrfBlockedException;
+use App\Integration\Generic\Domain\Repository\ConnectionRepositoryInterface;
+use App\Integration\Generic\Infrastructure\Http\GenericRestClient;
+use DateTimeImmutable;
+use DateTimeInterface;
+use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * APIC-P1-05 (ADR-0022) — probes a connection's base URL through the SSRF-safe
+ * {@see GenericRestClient} and records the outcome on the entity.
+ *
+ * The probe response telemetry (status / latency / size / content-type /
+ * truncated sample) is returned with HTTP 200 even when the remote failed —
+ * the *test action* succeeded; its *result* lives in the body (`ok`). The
+ * connection is resolved tenant-scoped (Postgres RLS), so a cross-tenant id is
+ * a 404, and the `settings.integrations.manage` permission gates the action.
+ */
+final class ConnectionTestController
+{
+    private const int SAMPLE_MAX_CHARS = 2000;
+
+    public function __construct(
+        private readonly ConnectionRepositoryInterface $connections,
+        private readonly GenericRestClient $client,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/connections/{id}/test',
+        name: 'integration_connection_test',
+        requirements: ['id' => '[0-9a-fA-F-]{36}'],
+        methods: ['POST'],
+    )]
+    #[RequiresPermission(module: 'settings.integrations', action: 'manage')]
+    public function __invoke(string $id): JsonResponse
+    {
+        try {
+            $connectionId = Uuid::fromString($id);
+        } catch (InvalidArgumentException) {
+            throw new NotFoundHttpException(\sprintf('Connection "%s" was not found.', $id));
+        }
+
+        $connection = $this->connections->findById($connectionId);
+        if (!$connection instanceof Connection) {
+            throw new NotFoundHttpException(\sprintf('Connection "%s" was not found.', $id));
+        }
+
+        try {
+            $response = $this->client->request($connection, 'GET', $connection->getBaseUrl());
+        } catch (SsrfBlockedException|RemoteRequestFailedException $exception) {
+            return $this->finish($connection, ConnectionStatus::Error, [
+                'ok' => false,
+                'error' => $exception->getMessage(),
+            ]);
+        }
+
+        return $this->finish(
+            $connection,
+            $response->isSuccessful() ? ConnectionStatus::Active : ConnectionStatus::Error,
+            [
+                'ok' => $response->isSuccessful(),
+                'http_status' => $response->statusCode,
+                'latency_ms' => $response->durationMs,
+                'size_bytes' => $response->sizeBytes,
+                'content_type' => $response->contentType(),
+                'sample' => mb_substr($response->body, 0, self::SAMPLE_MAX_CHARS),
+            ],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function finish(Connection $connection, ConnectionStatus $status, array $payload): JsonResponse
+    {
+        $checkedAt = new DateTimeImmutable();
+        $connection->recordHealthCheck($checkedAt, $status);
+        $this->connections->save($connection);
+
+        $payload['status'] = $status->value;
+        $payload['checked_at'] = $checkedAt->format(DateTimeInterface::RFC3339_EXTENDED);
+
+        return new JsonResponse($payload, Response::HTTP_OK);
+    }
+}

--- a/apps/api/tests/Api/Integration/Generic/ConnectionTestApiTest.php
+++ b/apps/api/tests/Api/Integration/Generic/ConnectionTestApiTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Integration\Generic;
+
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Identity\Domain\Entity\User;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Enum\AuthType;
+use App\Integration\Generic\Domain\Enum\ConnectionStatus;
+use App\Integration\Generic\Domain\Repository\ConnectionRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\ApiConfigurator\ApiConfiguratorApiTestCase;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * APIC-P1-05 — POST /api/connections/{id}/test. Reuses the ApiConfigurator RBAC
+ * scaffold (super_admin + tenant_owner admin, PRD + legacy permissions). The
+ * probe target is a loopback host so the SSRF pre-filter rejects it before any
+ * network I/O — the test is deterministic and offline; the happy probe path is
+ * unit-covered in GenericRestClientTest.
+ */
+final class ConnectionTestApiTest extends ApiConfiguratorApiTestCase
+{
+    #[Test]
+    public function unauthenticatedRequestIs401(): void
+    {
+        $id = $this->seedConnection('idosell');
+
+        static::createClient()->request('POST', '/api/connections/'.$id.'/test');
+
+        self::assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    #[Test]
+    public function unknownConnectionIs404(): void
+    {
+        $this->authenticatedClient()->request('POST', '/api/connections/01234567-1234-7000-8000-000000000000/test');
+
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    #[Test]
+    public function userWithoutIntegrationsPermissionIs403(): void
+    {
+        $id = $this->seedConnection('idosell');
+
+        $this->limitedClient()->request('POST', '/api/connections/'.$id.'/test');
+
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    #[Test]
+    public function probeOfUnreachablePrivateHostReportsErrorAndRecordsHealth(): void
+    {
+        $id = $this->seedConnection('idosell');
+
+        $body = $this->authenticatedClient()
+            ->request('POST', '/api/connections/'.$id.'/test')
+            ->toArray();
+
+        self::assertFalse($body['ok'] ?? null);
+        self::assertSame(ConnectionStatus::Error->value, $body['status'] ?? null);
+        self::assertArrayHasKey('checked_at', $body);
+        self::assertArrayHasKey('error', $body);
+
+        $connection = $this->connectionRepo()->findByCode($this->demoTenant(), 'idosell');
+        self::assertNotNull($connection);
+        self::assertSame(ConnectionStatus::Error, $connection->getStatus());
+        self::assertNotNull($connection->getLastHealthCheckAt());
+    }
+
+    private function seedConnection(string $code): string
+    {
+        self::getContainer()->get(TenantContext::class)->set($this->demoTenant());
+
+        // Loopback target: rejected by the SSRF pre-filter before any I/O.
+        $connection = new Connection($code, ucfirst($code), 'https://127.0.0.1:9', AuthType::None);
+        $this->connectionRepo()->save($connection);
+
+        return $connection->getId()->toRfc4122();
+    }
+
+    private function connectionRepo(): ConnectionRepositoryInterface
+    {
+        return self::getContainer()->get(ConnectionRepositoryInterface::class);
+    }
+
+    private function demoTenant(): Tenant
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        return $tenant;
+    }
+
+    /**
+     * A real authenticated user that lacks `settings.integrations.manage`
+     * (ROLE_USER only, no RBAC roles) — exercises the 403 path.
+     */
+    private function limitedClient(): Client
+    {
+        $tenant = $this->demoTenant();
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $email = 'limited@demo.localhost';
+        $stub = new User($tenant, $email, '', ['ROLE_USER']);
+        $user = new User($tenant, $email, $hasher->hashPassword($stub, 'changeme'), ['ROLE_USER']);
+        $em = $this->em();
+        $em->persist($user);
+        $em->flush();
+
+        $jwt = self::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+
+        $client = static::createClient();
+        $client->setDefaultOptions(['headers' => ['authorization' => 'Bearer '.$jwt]]);
+
+        return $client;
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -9370,6 +9370,45 @@
                 "x-cortex-permission": "channel.read"
             }
         },
+        "/api/connections/{id}/test": {
+            "post": {
+                "operationId": "api_connections_id_test_post",
+                "tags": [
+                    "connections"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api connections id test",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "settings.integrations.manage"
+            }
+        },
         "/api/exports/columns": {
             "get": {
                 "operationId": "api_exports_columns_get",


### PR DESCRIPTION
## Summary
`POST /api/connections/{id}/test` — probes a connection's base URL through the SSRF-safe `GenericRestClient` and records the outcome (ADR-0022). Powers wizard step 2 (P1-08).

## Backend
- `ConnectionTestController` (`#[RequiresPermission(settings.integrations.manage)]`): resolves the connection **tenant-scoped** (RLS → 404 cross-tenant), probes, returns **200** with `{ok, http_status, latency_ms, size_bytes, content_type, sample, status, checked_at}`. SSRF/transport failure → `ok:false, status=error` (the action ran; result in the body). `recordHealthCheck` persists `lastHealthCheckAt` + status.
- No `User`-entity reach (Deptrac-clean): firewall (401) + permission guard (403) + RLS (404) gate it.
- OpenAPI snapshot regenerated (custom route auto-added).

## Quality gates
- PHPStan max 0 · Deptrac 0 · PHP-CS-Fixer clean · route registered (`debug:router`) · OpenAPI snapshot updated.
- **ApiTestCase (CI)**: 401 (unauth) · 403 (ROLE_USER lacks permission) · 404 (unknown) · SSRF-error probe path (loopback target → offline, records health=error). *Run in CI — local JWT mint is unavailable in this dev test-env.*

Closes #1765

🤖 Generated with [Claude Code](https://claude.com/claude-code)