### PR TITLE
feat(integration): expose Connection CRUD API (API Platform) (APIC-P1-06)

### DIFF
--- a/apps/api/config/packages/api_platform.yaml
+++ b/apps/api/config/packages/api_platform.yaml
@@ -15,6 +15,7 @@ api_platform:
             - '%kernel.project_dir%/src/Asset/Infrastructure/ApiPlatform/Resource'
             - '%kernel.project_dir%/src/ApiConfigurator/Infrastructure/ApiPlatform/Resource'
             - '%kernel.project_dir%/src/Import/Infrastructure/ApiPlatform/Resource'
+            - '%kernel.project_dir%/src/Integration/Generic/Infrastructure/ApiPlatform/Resource'
 
     # AP4 default content negotiation: JSON-LD (Hydra) for application use,
     # plain JSON kept available for tooling that does not understand

--- a/apps/api/config/packages/framework.yaml
+++ b/apps/api/config/packages/framework.yaml
@@ -18,6 +18,7 @@ framework:
                 - '%kernel.project_dir%/src/Asset/Infrastructure/Serializer'
                 - '%kernel.project_dir%/src/ApiConfigurator/Infrastructure/Serializer'
                 - '%kernel.project_dir%/src/Import/Infrastructure/Serializer'
+                - '%kernel.project_dir%/src/Integration/Generic/Infrastructure/Serializer'
 
     #esi: true
     #fragments: true

--- a/apps/api/src/Identity/Infrastructure/Security/ConnectionVoter.php
+++ b/apps/api/src/Identity/Infrastructure/Security/ConnectionVoter.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Security;
+
+/**
+ * RBAC voter for the API Configurator consumer `Connection` resource
+ * (APIC-P1-06). Reuses the legacy `integration` RbacMatrix resource — the same
+ * surface that gates ApiProfile/integration management. The subject is named by
+ * its FQCN string (no cross-BC class import), so this stays Deptrac-clean while
+ * living in the Identity security layer alongside the other resource voters.
+ */
+final class ConnectionVoter extends AbstractRbacVoter
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function attributeMap(): array
+    {
+        return [
+            'READ' => 'read',
+            'CREATE' => 'write',
+            'UPDATE' => 'write',
+            'WRITE' => 'write',
+            'DELETE' => 'delete',
+        ];
+    }
+
+    protected function resource(): string
+    {
+        return 'integration';
+    }
+
+    protected function subjectClass(): string
+    {
+        return 'App\\Integration\\Generic\\Domain\\Entity\\Connection';
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/Connection.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/Connection.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns="https://api-platform.com/schema/metadata/resources-3.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata/resources-3.0
+                               https://api-platform.com/schema/metadata/resources-3.0.xsd">
+
+    <resource class="App\Integration\Generic\Domain\Entity\Connection"
+              shortName="Connection">
+
+        <normalizationContext>
+            <values>
+                <value name="groups">
+                    <values>
+                        <value>admin:read</value>
+                    </values>
+                </value>
+            </values>
+        </normalizationContext>
+
+        <operations>
+            <operation class="ApiPlatform\Metadata\GetCollection"
+                       uriTemplate="/connections{._format}"
+                       security="is_granted('READ', 'App\\Integration\\Generic\\Domain\\Entity\\Connection')"/>
+
+            <operation class="ApiPlatform\Metadata\Get"
+                       uriTemplate="/connections/{id}{._format}"
+                       security="is_granted('READ', object)"/>
+
+            <operation class="ApiPlatform\Metadata\Post"
+                       uriTemplate="/connections{._format}"
+                       input="App\Integration\Generic\Infrastructure\ApiPlatform\Resource\ConnectionInput"
+                       processor="App\Integration\Generic\Infrastructure\ApiPlatform\State\ConnectionProcessor"
+                       security="is_granted('CREATE', 'App\\Integration\\Generic\\Domain\\Entity\\Connection')">
+                <denormalizationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>connection:create</value>
+                            </values>
+                        </value>
+                    </values>
+                </denormalizationContext>
+            </operation>
+
+            <operation class="ApiPlatform\Metadata\Patch"
+                       uriTemplate="/connections/{id}{._format}"
+                       input="App\Integration\Generic\Infrastructure\ApiPlatform\Resource\ConnectionPatchInput"
+                       processor="App\Integration\Generic\Infrastructure\ApiPlatform\State\ConnectionProcessor"
+                       security="is_granted('UPDATE', object)">
+                <denormalizationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>connection:patch</value>
+                            </values>
+                        </value>
+                    </values>
+                </denormalizationContext>
+            </operation>
+
+            <operation class="ApiPlatform\Metadata\Delete"
+                       uriTemplate="/connections/{id}{._format}"
+                       processor="App\Integration\Generic\Infrastructure\ApiPlatform\State\ConnectionProcessor"
+                       security="is_granted('DELETE', object)"/>
+        </operations>
+    </resource>
+</resources>

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/ConnectionInput.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/ConnectionInput.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\ApiPlatform\Resource;
+
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * POST input shape for `/api/connections` (APIC-P1-06). The setter-less,
+ * tenant-stamped {@see \App\Integration\Generic\Domain\Entity\Connection} is
+ * built by {@see \App\Integration\Generic\Infrastructure\ApiPlatform\State\ConnectionProcessor}.
+ *
+ * `credentials` is a write-only map (shape per authType) handed to the cipher;
+ * it carries no read group, so it can never be serialised back out.
+ */
+final class ConnectionInput
+{
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 64)]
+    #[Assert\Regex('/^[a-z0-9-]+$/')]
+    #[Groups(['connection:create'])]
+    public string $code = '';
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    #[Groups(['connection:create'])]
+    public string $name = '';
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 2048)]
+    #[Groups(['connection:create'])]
+    public string $baseUrl = '';
+
+    #[Assert\Choice(choices: ['none', 'api_key', 'bearer', 'basic', 'oauth2_token'])]
+    #[Groups(['connection:create'])]
+    public string $authType = 'none';
+
+    /**
+     * @var array<string, string>
+     */
+    #[Groups(['connection:create'])]
+    public array $credentials = [];
+
+    /**
+     * @var array<string, string>
+     */
+    #[Groups(['connection:create'])]
+    public array $defaultHeaders = [];
+
+    #[Assert\Positive]
+    #[Assert\LessThanOrEqual(100000)]
+    #[Groups(['connection:create'])]
+    public ?int $rateLimitHint = null;
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/ConnectionPatchInput.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/ConnectionPatchInput.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\ApiPlatform\Resource;
+
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * PATCH (RFC 7396 merge) input for `/api/connections/{id}` (APIC-P1-06). Every
+ * field is nullable — null means "leave unchanged". `code` is immutable and
+ * omitted. `status` accepts only the operator-controlled values
+ * (active/paused); draft/error are set by the system. `credentials` rotates the
+ * stored secret when present (empty map clears it).
+ */
+final class ConnectionPatchInput
+{
+    #[Assert\Length(max: 255)]
+    #[Groups(['connection:patch'])]
+    public ?string $name = null;
+
+    #[Assert\Length(max: 2048)]
+    #[Groups(['connection:patch'])]
+    public ?string $baseUrl = null;
+
+    #[Assert\Choice(choices: ['none', 'api_key', 'bearer', 'basic', 'oauth2_token'])]
+    #[Groups(['connection:patch'])]
+    public ?string $authType = null;
+
+    #[Assert\Choice(choices: ['active', 'paused'])]
+    #[Groups(['connection:patch'])]
+    public ?string $status = null;
+
+    /**
+     * @var array<string, string>|null
+     */
+    #[Groups(['connection:patch'])]
+    public ?array $credentials = null;
+
+    /**
+     * @var array<string, string>|null
+     */
+    #[Groups(['connection:patch'])]
+    public ?array $defaultHeaders = null;
+
+    #[Assert\Positive]
+    #[Assert\LessThanOrEqual(100000)]
+    #[Groups(['connection:patch'])]
+    public ?int $rateLimitHint = null;
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/State/ConnectionProcessor.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/State/ConnectionProcessor.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\ApiPlatform\State;
+
+use ApiPlatform\Metadata\DeleteOperationInterface;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\State\ProcessorInterface;
+use App\Integration\Generic\Application\ConnectionCredentialsCipher;
+use App\Integration\Generic\Application\Validation\DescriptorValidator;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Enum\AuthType;
+use App\Integration\Generic\Domain\Enum\ConnectionStatus;
+use App\Integration\Generic\Domain\Exception\InvalidDescriptorException;
+use App\Integration\Generic\Domain\Repository\ConnectionRepositoryInterface;
+use App\Integration\Generic\Infrastructure\ApiPlatform\Resource\ConnectionInput;
+use App\Integration\Generic\Infrastructure\ApiPlatform\Resource\ConnectionPatchInput;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use LogicException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Write path for the `Connection` resource (APIC-P1-06). Builds/updates the
+ * tenant-stamped aggregate from the input DTO, encrypts credentials via the
+ * BYOK cipher (APIC-P1-02) and validates the base URL via the SSRF descriptor
+ * wall (APIC-P1-04). The tenant is stamped on persist by the listener; the
+ * serializer never exposes the ciphertext columns.
+ *
+ * @implements ProcessorInterface<ConnectionInput|ConnectionPatchInput|Connection, Connection|null>
+ */
+final readonly class ConnectionProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private ConnectionRepositoryInterface $connections,
+        private ConnectionCredentialsCipher $cipher,
+        private DescriptorValidator $descriptors,
+        private TenantContext $tenantContext,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     * @param array<string, mixed> $context
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): ?Connection
+    {
+        if ($operation instanceof DeleteOperationInterface) {
+            $this->connections->remove($this->require($uriVariables));
+
+            return null;
+        }
+
+        if ($operation instanceof Post) {
+            return $this->handlePost($data);
+        }
+
+        if ($operation instanceof Patch) {
+            return $this->handlePatch($data, $uriVariables);
+        }
+
+        throw new LogicException(\sprintf('ConnectionProcessor cannot handle operation "%s".', $operation::class));
+    }
+
+    private function handlePost(mixed $data): Connection
+    {
+        if (!$data instanceof ConnectionInput) {
+            throw new LogicException('ConnectionProcessor expects ConnectionInput on Post.');
+        }
+
+        $tenant = $this->requireTenant();
+        if (null !== $this->connections->findByCode($tenant, $data->code)) {
+            throw new ConflictHttpException(\sprintf('Connection with code "%s" already exists for this tenant.', $data->code));
+        }
+
+        $this->validateBaseUrl($data->baseUrl);
+
+        $connection = new Connection($data->code, $data->name, $data->baseUrl, AuthType::from($data->authType));
+        $connection->setDefaultHeaders($data->defaultHeaders);
+        $connection->setRateLimitHint($data->rateLimitHint);
+        $this->cipher->apply($connection, $data->credentials);
+
+        $this->connections->save($connection);
+
+        return $connection;
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     */
+    private function handlePatch(mixed $data, array $uriVariables): Connection
+    {
+        if (!$data instanceof ConnectionPatchInput) {
+            throw new LogicException('ConnectionProcessor expects ConnectionPatchInput on Patch.');
+        }
+
+        $connection = $this->require($uriVariables);
+
+        if (null !== $data->name) {
+            $connection->setName($data->name);
+        }
+        if (null !== $data->baseUrl) {
+            $this->validateBaseUrl($data->baseUrl);
+            $connection->setBaseUrl($data->baseUrl);
+        }
+        if (null !== $data->authType) {
+            $connection->setAuthType(AuthType::from($data->authType));
+        }
+        if (null !== $data->status) {
+            $connection->setStatus(ConnectionStatus::from($data->status));
+        }
+        if (null !== $data->defaultHeaders) {
+            $connection->setDefaultHeaders($data->defaultHeaders);
+        }
+        if (null !== $data->rateLimitHint) {
+            $connection->setRateLimitHint($data->rateLimitHint);
+        }
+        if (null !== $data->credentials) {
+            $this->cipher->apply($connection, $data->credentials);
+        }
+
+        $this->connections->save($connection);
+
+        return $connection;
+    }
+
+    private function validateBaseUrl(string $baseUrl): void
+    {
+        try {
+            $this->descriptors->assertValidBaseUrl($baseUrl);
+        } catch (InvalidDescriptorException $exception) {
+            throw new UnprocessableEntityHttpException($exception->getMessage(), $exception);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     */
+    private function require(array $uriVariables): Connection
+    {
+        $connection = $this->connections->findById($this->idFromUriVariables($uriVariables));
+        if (!$connection instanceof Connection) {
+            throw new NotFoundHttpException('Connection was not found.');
+        }
+
+        return $connection;
+    }
+
+    private function requireTenant(): Tenant
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new LogicException('ConnectionProcessor requires an active tenant.');
+        }
+
+        return $tenant;
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     */
+    private function idFromUriVariables(array $uriVariables): Uuid
+    {
+        $raw = $uriVariables['id'] ?? null;
+        if ($raw instanceof Uuid) {
+            return $raw;
+        }
+        if (!\is_string($raw) || '' === $raw) {
+            throw new LogicException('ConnectionProcessor requires the {id} URI variable.');
+        }
+
+        return Uuid::fromString($raw);
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Serializer/Connection.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/Serializer/Connection.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping
+                                https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd">
+
+    <!--
+      Read projection for the Connection resource. The encrypted-credential
+      columns (credentialsCiphertext / credentialsKeyVersion) are deliberately
+      ABSENT, so secrets can never be serialised back out (APIC-P1-02/P1-06).
+    -->
+    <class name="App\Integration\Generic\Domain\Entity\Connection">
+        <attribute name="id">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="code">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="name">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="baseUrl">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="authType">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="defaultHeaders">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="rateLimitHint">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="status">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="lastHealthCheckAt">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="createdAt">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="updatedAt">
+            <group>admin:read</group>
+        </attribute>
+    </class>
+</serializer>

--- a/apps/api/tests/Api/Integration/Generic/ConnectionsApiTest.php
+++ b/apps/api/tests/Api/Integration/Generic/ConnectionsApiTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Integration\Generic;
+
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Identity\Domain\Entity\User;
+use App\Tests\Api\ApiConfigurator\ApiConfiguratorApiTestCase;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * APIC-P1-06 — CRUD coverage for `/api/connections` (ApiResource + processor +
+ * voter + serializer masking). Reuses the ApiConfigurator RBAC scaffold.
+ */
+final class ConnectionsApiTest extends ApiConfiguratorApiTestCase
+{
+    private const string LD_JSON = 'application/ld+json';
+    private const string MERGE_PATCH = 'application/merge-patch+json';
+
+    #[Test]
+    public function postCreatesConnectionAndNeverLeaksCredentials(): void
+    {
+        $body = $this->create('idosell', [
+            'authType' => 'api_key',
+            'credentials' => ['header' => 'X-Api-Key', 'value' => 's3cr3t'],
+            'rateLimitHint' => 120,
+        ]);
+
+        self::assertResponseStatusCodeSame(201);
+        self::assertSame('idosell', $body['code'] ?? null);
+        self::assertSame('api_key', $body['authType'] ?? null);
+        self::assertSame('draft', $body['status'] ?? null);
+        self::assertSame(120, $body['rateLimitHint'] ?? null);
+        // Secrets must never round-trip out.
+        self::assertArrayNotHasKey('credentials', $body);
+        self::assertArrayNotHasKey('credentialsCiphertext', $body);
+        self::assertArrayNotHasKey('credentialsKeyVersion', $body);
+    }
+
+    #[Test]
+    public function postRejectsDuplicateCode(): void
+    {
+        $this->create('idosell');
+        self::assertResponseStatusCodeSame(201);
+
+        $this->create('idosell');
+        self::assertResponseStatusCodeSame(409);
+    }
+
+    #[Test]
+    public function postRejectsInvalidCode(): void
+    {
+        $this->create('UPPER SPACES');
+        self::assertResponseStatusCodeSame(422);
+    }
+
+    #[Test]
+    public function postRejectsNonHttpBaseUrl(): void
+    {
+        $this->authenticatedClient()->request('POST', '/api/connections', [
+            'headers' => ['content-type' => self::LD_JSON],
+            'body' => json_encode([
+                'code' => 'badurl',
+                'name' => 'Bad URL',
+                'baseUrl' => 'file:///etc/passwd',
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(422);
+    }
+
+    #[Test]
+    public function patchUpdatesNameAndPausesConnection(): void
+    {
+        $id = $this->create('idosell')['id'] ?? null;
+        \assert(\is_string($id));
+
+        $client = $this->authenticatedClient();
+        $body = $client->request('PATCH', '/api/connections/'.$id, [
+            'headers' => ['content-type' => self::MERGE_PATCH],
+            'body' => json_encode(['name' => 'IdoSell PL', 'status' => 'paused'], JSON_THROW_ON_ERROR),
+        ])->toArray();
+
+        self::assertResponseStatusCodeSame(200);
+        self::assertSame('IdoSell PL', $body['name'] ?? null);
+        self::assertSame('paused', $body['status'] ?? null);
+    }
+
+    #[Test]
+    public function deleteRemovesConnection(): void
+    {
+        $id = $this->create('idosell')['id'] ?? null;
+        \assert(\is_string($id));
+
+        $client = $this->authenticatedClient();
+        $client->request('DELETE', '/api/connections/'.$id);
+        self::assertResponseStatusCodeSame(204);
+
+        $client->request('GET', '/api/connections/'.$id);
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    #[Test]
+    public function unauthenticatedRequestIs401(): void
+    {
+        static::createClient()->request('GET', '/api/connections');
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    #[Test]
+    public function userWithoutIntegrationsPermissionIs403(): void
+    {
+        $this->limitedClient()->request('GET', '/api/connections');
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     *
+     * @return array<array-key, mixed>
+     */
+    private function create(string $code, array $overrides = []): array
+    {
+        $payload = array_merge([
+            'code' => $code,
+            'name' => ucfirst($code),
+            'baseUrl' => 'https://api.idosell.com',
+            'authType' => 'none',
+        ], $overrides);
+
+        return $this->authenticatedClient()->request('POST', '/api/connections', [
+            'headers' => ['content-type' => self::LD_JSON],
+            'body' => json_encode($payload, JSON_THROW_ON_ERROR),
+        ])->toArray(false);
+    }
+
+    private function limitedClient(): Client
+    {
+        $tenant = $this->em()->getRepository(\App\Shared\Domain\Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof \App\Shared\Domain\Tenant);
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $email = 'limited@demo.localhost';
+        $stub = new User($tenant, $email, '', ['ROLE_USER']);
+        $user = new User($tenant, $email, $hasher->hashPassword($stub, 'changeme'), ['ROLE_USER']);
+        $em = $this->em();
+        $em->persist($user);
+        $em->flush();
+
+        $jwt = self::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+
+        $client = static::createClient();
+        $client->setDefaultOptions(['headers' => ['authorization' => 'Bearer '.$jwt]]);
+
+        return $client;
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -4713,6 +4713,485 @@
                 "x-cortex-permission": "channel.write"
             }
         },
+        "/api/connections": {
+            "get": {
+                "operationId": "api_connections_get_collection",
+                "tags": [
+                    "Connection"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Connection collection",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "description": "Connection.jsonld-admin.read collection.",
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/HydraCollectionBaseSchema"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "member"
+                                            ],
+                                            "properties": {
+                                                "member": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/Connection.jsonld-admin.read"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Connection-admin.read"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Retrieves the collection of Connection resources.",
+                "description": "Retrieves the collection of Connection resources.",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "The collection page number",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        },
+                        "style": "form",
+                        "explode": true
+                    }
+                ]
+            },
+            "post": {
+                "operationId": "api_connections_post",
+                "tags": [
+                    "Connection"
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Connection resource created",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Connection.jsonld-admin.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Connection-admin.read"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "422": {
+                        "description": "An error occurred",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Creates a Connection resource.",
+                "description": "Creates a Connection resource.",
+                "parameters": [],
+                "requestBody": {
+                    "description": "The new Connection resource",
+                    "content": {
+                        "application/ld+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Connection.ConnectionInput-connection.create"
+                            }
+                        },
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Connection.ConnectionInput-connection.create"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            }
+        },
+        "/api/connections/{id}": {
+            "get": {
+                "operationId": "api_connections_id_get",
+                "tags": [
+                    "Connection"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Connection resource",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Connection.jsonld-admin.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Connection-admin.read"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Retrieves a Connection resource.",
+                "description": "Retrieves a Connection resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Connection identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ]
+            },
+            "delete": {
+                "operationId": "api_connections_id_delete",
+                "tags": [
+                    "Connection"
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Connection resource deleted"
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Removes the Connection resource.",
+                "description": "Removes the Connection resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Connection identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ]
+            },
+            "patch": {
+                "operationId": "api_connections_id_patch",
+                "tags": [
+                    "Connection"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Connection resource updated",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Connection.jsonld-admin.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Connection-admin.read"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "422": {
+                        "description": "An error occurred",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Updates the Connection resource.",
+                "description": "Updates the Connection resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Connection identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "requestBody": {
+                    "description": "The updated Connection resource",
+                    "content": {
+                        "application/merge-patch+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Connection.ConnectionPatchInput-connection.patch.jsonMergePatch"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            }
+        },
         "/api/import-profiles": {
             "get": {
                 "operationId": "api_import-profiles_get_collection",
@@ -17052,6 +17531,298 @@
                 ],
                 "description": "Tenant-scoped sales / publication channel.\n\nExamples: `ecommerce_pl` (Polish webstore), `wholesale`, `b2b_export`.\nEach channel carries:\n\n  - a name (plain string) \u2014 what admins see in the UI. Internal-only,\n    never published to a destination, so it is intentionally single-language;\n  - an optional `category_tree_root_object_id` pointing at a\n    `CatalogObject` of `kind=category` \u2014 the root of the category tree\n    this channel publishes. Validation (\"the target must be a\n *     category\") lives in\n    {@see \\App\\Channel\\Infrastructure\\Doctrine\\EventListener\\ChannelCategoryRootValidator}.\n\nPer-channel attribute\u2192target-field mapping is not modelled here yet \u2014 it\nbelongs to the API integration configuration (Faza 1) and will be added\nwith the first real export integration."
             },
+            "Connection-admin.read": {
+                "type": "object",
+                "description": "A consumer-side connection to one external REST/JSON API (ADR-0022, epic APIC).\n\nHolds the transport definition \u2014 base URL, auth type, default headers, an\noptional rate hint \u2014 plus the reversibly-encrypted credentials needed to\ncall the remote. The actual encryption-at-write + response masking lands in\nAPIC-P1-02; this entity stores the already-produced ciphertext + master-key\nversion in two columns, mirroring `TenantAgentConfig` / ADR-0017.\n\n`TenantScoped` + Postgres RLS isolate every connection to its tenant. Scheme\n(http/https) and SSRF-safe descriptor validation are enforced separately\n(APIC-P1-03/P1-04), not at this domain layer.",
+                "properties": {
+                    "id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uuid"
+                    },
+                    "code": {
+                        "maxLength": 64,
+                        "pattern": "^([a-z0-9-]+)$",
+                        "type": "string"
+                    },
+                    "name": {
+                        "maxLength": 255,
+                        "type": "string"
+                    },
+                    "baseUrl": {
+                        "maxLength": 2048,
+                        "type": "string"
+                    },
+                    "authType": {
+                        "default": "none",
+                        "type": "string",
+                        "enum": [
+                            "none",
+                            "api_key",
+                            "bearer",
+                            "basic",
+                            "oauth2_token"
+                        ]
+                    },
+                    "defaultHeaders": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "rateLimitHint": {
+                        "minimum": 0,
+                        "exclusiveMinimum": 0,
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "status": {
+                        "default": "draft",
+                        "type": "string"
+                    },
+                    "lastHealthCheckAt": {
+                        "readOnly": true,
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "readOnly": true,
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updatedAt": {
+                        "readOnly": true,
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "required": [
+                    "code",
+                    "name",
+                    "baseUrl"
+                ]
+            },
+            "Connection.ConnectionInput-connection.create": {
+                "type": "object",
+                "description": "A consumer-side connection to one external REST/JSON API (ADR-0022, epic APIC).\n\nHolds the transport definition \u2014 base URL, auth type, default headers, an\noptional rate hint \u2014 plus the reversibly-encrypted credentials needed to\ncall the remote. The actual encryption-at-write + response masking lands in\nAPIC-P1-02; this entity stores the already-produced ciphertext + master-key\nversion in two columns, mirroring `TenantAgentConfig` / ADR-0017.\n\n`TenantScoped` + Postgres RLS isolate every connection to its tenant. Scheme\n(http/https) and SSRF-safe descriptor validation are enforced separately\n(APIC-P1-03/P1-04), not at this domain layer.",
+                "required": [
+                    "code",
+                    "name",
+                    "baseUrl"
+                ],
+                "properties": {
+                    "code": {
+                        "maxLength": 64,
+                        "pattern": "^([a-z0-9-]+)$",
+                        "default": "",
+                        "type": "string"
+                    },
+                    "name": {
+                        "maxLength": 255,
+                        "default": "",
+                        "type": "string"
+                    },
+                    "baseUrl": {
+                        "maxLength": 2048,
+                        "default": "",
+                        "type": "string"
+                    },
+                    "authType": {
+                        "enum": [
+                            "none",
+                            "api_key",
+                            "bearer",
+                            "basic",
+                            "oauth2_token"
+                        ],
+                        "default": "none",
+                        "type": "string"
+                    },
+                    "credentials": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "defaultHeaders": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "rateLimitHint": {
+                        "minimum": 0,
+                        "exclusiveMinimum": 0,
+                        "maximum": 100000,
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    }
+                }
+            },
+            "Connection.ConnectionPatchInput-connection.patch.jsonMergePatch": {
+                "type": "object",
+                "description": "A consumer-side connection to one external REST/JSON API (ADR-0022, epic APIC).\n\nHolds the transport definition \u2014 base URL, auth type, default headers, an\noptional rate hint \u2014 plus the reversibly-encrypted credentials needed to\ncall the remote. The actual encryption-at-write + response masking lands in\nAPIC-P1-02; this entity stores the already-produced ciphertext + master-key\nversion in two columns, mirroring `TenantAgentConfig` / ADR-0017.\n\n`TenantScoped` + Postgres RLS isolate every connection to its tenant. Scheme\n(http/https) and SSRF-safe descriptor validation are enforced separately\n(APIC-P1-03/P1-04), not at this domain layer.",
+                "properties": {
+                    "name": {
+                        "maxLength": 255,
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "baseUrl": {
+                        "maxLength": 2048,
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "authType": {
+                        "enum": [
+                            "none",
+                            "api_key",
+                            "bearer",
+                            "basic",
+                            "oauth2_token"
+                        ],
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "status": {
+                        "enum": [
+                            "active",
+                            "paused"
+                        ],
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "credentials": {
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "defaultHeaders": {
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "rateLimitHint": {
+                        "minimum": 0,
+                        "exclusiveMinimum": 0,
+                        "maximum": 100000,
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    }
+                }
+            },
+            "Connection.jsonld-admin.read": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/HydraItemBaseSchema"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "uuid"
+                            },
+                            "code": {
+                                "maxLength": 64,
+                                "pattern": "^([a-z0-9-]+)$",
+                                "type": "string"
+                            },
+                            "name": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "baseUrl": {
+                                "maxLength": 2048,
+                                "type": "string"
+                            },
+                            "authType": {
+                                "default": "none",
+                                "type": "string",
+                                "enum": [
+                                    "none",
+                                    "api_key",
+                                    "bearer",
+                                    "basic",
+                                    "oauth2_token"
+                                ]
+                            },
+                            "defaultHeaders": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "string"
+                                }
+                            },
+                            "rateLimitHint": {
+                                "minimum": 0,
+                                "exclusiveMinimum": 0,
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ]
+                            },
+                            "status": {
+                                "default": "draft",
+                                "type": "string"
+                            },
+                            "lastHealthCheckAt": {
+                                "readOnly": true,
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "date-time"
+                            },
+                            "createdAt": {
+                                "readOnly": true,
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "updatedAt": {
+                                "readOnly": true,
+                                "type": "string",
+                                "format": "date-time"
+                            }
+                        },
+                        "required": [
+                            "code",
+                            "name",
+                            "baseUrl"
+                        ]
+                    }
+                ],
+                "description": "A consumer-side connection to one external REST/JSON API (ADR-0022, epic APIC).\n\nHolds the transport definition \u2014 base URL, auth type, default headers, an\noptional rate hint \u2014 plus the reversibly-encrypted credentials needed to\ncall the remote. The actual encryption-at-write + response masking lands in\nAPIC-P1-02; this entity stores the already-produced ciphertext + master-key\nversion in two columns, mirroring `TenantAgentConfig` / ADR-0017.\n\n`TenantScoped` + Postgres RLS isolate every connection to its tenant. Scheme\n(http/https) and SSRF-safe descriptor validation are enforced separately\n(APIC-P1-03/P1-04), not at this domain layer."
+            },
             "ConstraintViolation": {
                 "type": "object",
                 "description": "Unprocessable entity",
@@ -19146,6 +19917,10 @@
         {
             "name": "ImportSource",
             "description": "VIEW-IMP-03 (#500) \u2014 connection config for incoming file feeds.\n\nLives alongside the profiles + sessions tables in the Import bundle.\nTenant-scoped + owner-scoped; the operator only sees the sources\nthey registered. `authRef` is a pointer to the Symfony Secrets Vault\n\u2014 credential plaintext never lands in the DB.\n\nPolling daemon is not part of V03 \u2014 only the schema, CRUD endpoints,\nand a manual `test-connection` probe land here. Auto-pickup of files\nmatching `filePattern` is scoped to the polling follow-up."
+        },
+        {
+            "name": "Connection",
+            "description": "A consumer-side connection to one external REST/JSON API (ADR-0022, epic APIC).\n\nHolds the transport definition \u2014 base URL, auth type, default headers, an\noptional rate hint \u2014 plus the reversibly-encrypted credentials needed to\ncall the remote. The actual encryption-at-write + response masking lands in\nAPIC-P1-02; this entity stores the already-produced ciphertext + master-key\nversion in two columns, mirroring `TenantAgentConfig` / ADR-0017.\n\n`TenantScoped` + Postgres RLS isolate every connection to its tenant. Scheme\n(http/https) and SSRF-safe descriptor validation are enforced separately\n(APIC-P1-03/P1-04), not at this domain layer."
         }
     ],
     "webhooks": {}


### PR DESCRIPTION
## Summary
Exposes the `Connection` resource via API Platform (ADR-0022) — the keystone the FE hub (P1-07) + wizard (P1-08) consume: list / get / create / update(+pause) / delete.

## Backend
- Resource XML (5 operations) + `ConnectionInput` / `ConnectionPatchInput` DTOs + `ConnectionProcessor` (lean direct-repo write path).
- Processor: encrypts credentials via `ConnectionCredentialsCipher` (P1-02), validates baseUrl via `DescriptorValidator` (P1-04 → **422**), enforces per-tenant code uniqueness (**409**). `status` patch = pause/activate.
- `ConnectionVoter` (legacy `integration` RbacMatrix resource; FQCN-string subject → **Deptrac-clean**).
- **Credential masking** — serializer whitelist omits `credentialsCiphertext`/`keyVersion`, so secrets are never serialised out (closes the masking deferred from P1-02).

## Quality gates
- PHPStan max 0 · Deptrac 0 · PHP-CS-Fixer clean · 5 CRUD routes registered (`debug:router`) · OpenAPI snapshot regenerated (+775).
- **ApiTestCase (CI)**: 201 (+ no-credential-leak) / 409 / 422 (bad code + non-http baseUrl) / 200 patch+pause / 204 delete→404 / 401 / 403. The **401 path passes locally** (kernel boots, resource/serializer/voter load); JWT-auth paths run in CI.

Closes #1766

🤖 Generated with [Claude Code](https://claude.com/claude-code)