### PR TITLE
feat(integration): exponential-backoff throttle handling for outbound calls (APIC-P1-09)

### DIFF
--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -328,6 +328,10 @@ services:
         arguments:
             $httpClient: '@generic.ssrf_safe_http_client'
 
+    # APIC-P1-09 — backoff policy needs the real blocking sleeper.
+    App\Integration\Generic\Application\Sleeper:
+        alias: App\Integration\Generic\Infrastructure\Http\RealSleeper
+
     # EXP-06 (#585) — async export worker. Same named-storage binding so
     # the handler can write the generated XLSX/CSV to MinIO under
     # `<tenant_id>/<session_id>.<format>` (PRD §11.1).

--- a/apps/api/src/Integration/Generic/Application/Sleeper.php
+++ b/apps/api/src/Integration/Generic/Application/Sleeper.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application;
+
+/**
+ * Port over PHP's blocking sleep, so the backoff policy
+ * ({@see \App\Integration\Generic\Infrastructure\Http\BackoffRestClient}) can
+ * be unit-tested without real wall-clock delays.
+ */
+interface Sleeper
+{
+    public function sleep(int $seconds): void;
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Http/BackoffRestClient.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Http/BackoffRestClient.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Http;
+
+use App\Integration\Generic\Application\Sleeper;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\GenericRestResponse;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Throttle-aware wrapper over {@see GenericRestClient} (APIC-P1-09, ADR-0022).
+ *
+ * Per CLAUDE.md §Throttling, exponential backoff is the ONLY rate-limiting
+ * mechanism in MVP — no leaky bucket, no shared Redis bucket state. On a 429
+ * (or 503) the wrapper waits `Retry-After` seconds (falling back to 2^attempt,
+ * capped at 60s) and retries, up to a small attempt budget; the final response
+ * is returned for the caller (sync runner) to dead-letter if still throttled.
+ *
+ * The per-tenant anti-abuse budget is enforced separately at the sync-trigger
+ * edge (the existing `integration_sync` limiter, 10/h/tenant), not per HTTP
+ * call — a per-call bucket would starve legitimate bulk syncs.
+ */
+final readonly class BackoffRestClient
+{
+    private const int MAX_ATTEMPTS = 5;
+    private const int MAX_BACKOFF_SECONDS = 60;
+
+    /** @var list<int> HTTP statuses that warrant a backoff + retry. */
+    private const array RETRYABLE_STATUSES = [429, 503];
+
+    public function __construct(
+        private GenericRestClient $client,
+        private Sleeper $sleeper,
+        private LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    /**
+     * @param array<string, string|int> $query
+     * @param array<string, string>     $headers
+     */
+    public function request(
+        Connection $connection,
+        string $method,
+        string $url,
+        array $query = [],
+        array $headers = [],
+        ?string $body = null,
+    ): GenericRestResponse {
+        $attempt = 0;
+        while (true) {
+            $response = $this->client->request($connection, $method, $url, $query, $headers, $body);
+
+            $isLastAttempt = $attempt >= self::MAX_ATTEMPTS - 1;
+            if ($isLastAttempt || !\in_array($response->statusCode, self::RETRYABLE_STATUSES, true)) {
+                return $response;
+            }
+
+            $delay = $this->backoffSeconds($response, $attempt);
+            $this->logger->info('External connection throttled; backing off.', [
+                'connection' => $connection->getCode(),
+                'status' => $response->statusCode,
+                'attempt' => $attempt + 1,
+                'delay_seconds' => $delay,
+            ]);
+            $this->sleeper->sleep($delay);
+            ++$attempt;
+        }
+    }
+
+    private function backoffSeconds(GenericRestResponse $response, int $attempt): int
+    {
+        $delay = $response->retryAfterSeconds() ?? (1 << $attempt);
+
+        return min($delay, self::MAX_BACKOFF_SECONDS);
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Http/RealSleeper.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Http/RealSleeper.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Http;
+
+use App\Integration\Generic\Application\Sleeper;
+
+final class RealSleeper implements Sleeper
+{
+    public function sleep(int $seconds): void
+    {
+        if ($seconds > 0) {
+            \sleep($seconds);
+        }
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Infrastructure/Http/BackoffRestClientTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Infrastructure/Http/BackoffRestClientTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Infrastructure\Http;
+
+use App\Integration\Generic\Application\ConnectionCredentialsCipher;
+use App\Integration\Generic\Application\Sleeper;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Enum\AuthType;
+use App\Integration\Generic\Infrastructure\Http\BackoffRestClient;
+use App\Integration\Generic\Infrastructure\Http\GenericRestClient;
+use App\Integration\Generic\Infrastructure\Http\SsrfGuard;
+use App\Shared\Application\Crypto\EncryptedSecret;
+use App\Shared\Application\Crypto\EncryptionServiceInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * Backoff policy exercised with a recording sleeper (no wall-clock) + a
+ * MockHttpClient queue and a literal public-IP URL so the real SsrfGuard
+ * passes offline.
+ */
+final class BackoffRestClientTest extends TestCase
+{
+    private const string PUBLIC_URL = 'https://93.184.216.34/products';
+
+    #[Test]
+    public function retriesOnceOn429ThenReturnsSuccess(): void
+    {
+        $sleeper = $this->recordingSleeper();
+        $client = $this->backoff([
+            new MockResponse('throttled', ['http_code' => 429]),
+            new MockResponse('{"ok":true}', ['http_code' => 200]),
+        ], $sleeper);
+
+        $response = $client->request($this->connection(), 'GET', self::PUBLIC_URL);
+
+        self::assertSame(200, $response->statusCode);
+        self::assertCount(1, $sleeper->delays);
+    }
+
+    #[Test]
+    public function exhaustsAttemptsAndReturnsTheLastThrottledResponse(): void
+    {
+        $sleeper = $this->recordingSleeper();
+        $client = $this->backoff(array_fill(0, 5, new MockResponse('throttled', ['http_code' => 429])), $sleeper);
+
+        $response = $client->request($this->connection(), 'GET', self::PUBLIC_URL);
+
+        self::assertSame(429, $response->statusCode);
+        // 5 attempts → 4 backoffs between them.
+        self::assertCount(4, $sleeper->delays);
+    }
+
+    #[Test]
+    public function respectsRetryAfterHeaderCappedAtSixtySeconds(): void
+    {
+        $sleeper = $this->recordingSleeper();
+        $client = $this->backoff([
+            new MockResponse('throttled', ['http_code' => 429, 'response_headers' => ['retry-after' => '120']]),
+            new MockResponse('{}', ['http_code' => 200]),
+        ], $sleeper);
+
+        $client->request($this->connection(), 'GET', self::PUBLIC_URL);
+
+        self::assertSame([60], $sleeper->delays);
+    }
+
+    #[Test]
+    public function fallsBackToExponentialDelayWhenNoRetryAfter(): void
+    {
+        $sleeper = $this->recordingSleeper();
+        $client = $this->backoff([
+            new MockResponse('throttled', ['http_code' => 429]),
+            new MockResponse('throttled', ['http_code' => 429]),
+            new MockResponse('{}', ['http_code' => 200]),
+        ], $sleeper);
+
+        $client->request($this->connection(), 'GET', self::PUBLIC_URL);
+
+        // 2^0, 2^1
+        self::assertSame([1, 2], $sleeper->delays);
+    }
+
+    #[Test]
+    public function doesNotRetrySuccessfulResponses(): void
+    {
+        $sleeper = $this->recordingSleeper();
+        $client = $this->backoff([new MockResponse('{}', ['http_code' => 200])], $sleeper);
+
+        $response = $client->request($this->connection(), 'GET', self::PUBLIC_URL);
+
+        self::assertSame(200, $response->statusCode);
+        self::assertSame([], $sleeper->delays);
+    }
+
+    /**
+     * @param list<MockResponse> $responses
+     */
+    private function backoff(array $responses, Sleeper $sleeper): BackoffRestClient
+    {
+        $generic = new GenericRestClient(new MockHttpClient($responses), new SsrfGuard(), $this->cipher());
+
+        return new BackoffRestClient($generic, $sleeper);
+    }
+
+    private function connection(): Connection
+    {
+        return new Connection('idosell', 'IdoSell', 'https://api.idosell.com', AuthType::None);
+    }
+
+    private function cipher(): ConnectionCredentialsCipher
+    {
+        return new ConnectionCredentialsCipher(new class implements EncryptionServiceInterface {
+            public function encrypt(string $plaintext): EncryptedSecret
+            {
+                return new EncryptedSecret(base64_encode($plaintext), 1);
+            }
+
+            public function decrypt(EncryptedSecret $secret): string
+            {
+                $decoded = base64_decode($secret->ciphertext, true);
+
+                return false === $decoded ? '' : $decoded;
+            }
+
+            public function needsRotation(EncryptedSecret $secret): bool
+            {
+                return false;
+            }
+        });
+    }
+
+    private function recordingSleeper(): RecordingSleeper
+    {
+        return new RecordingSleeper();
+    }
+}
+
+final class RecordingSleeper implements Sleeper
+{
+    /** @var list<int> */
+    public array $delays = [];
+
+    public function sleep(int $seconds): void
+    {
+        $this->delays[] = $seconds;
+    }
+}


### PR DESCRIPTION
## Summary
`BackoffRestClient` wraps `GenericRestClient`: on **429/503** it waits `Retry-After` seconds (fallback `2^attempt`, capped at **60s**) and retries up to a small attempt budget, returning the final response for the sync runner to dead-letter (ADR-0022).

Per **CLAUDE.md §Throttling**, exponential backoff is the ONLY rate-limit mechanism in MVP — no leaky bucket, no shared Redis bucket. The per-tenant anti-abuse budget is enforced at the **sync-trigger** edge (existing `integration_sync` limiter, 10/h/tenant), not per HTTP call (which would starve bulk syncs). Injectable `Sleeper` port keeps the policy unit-testable without wall-clock.

## Quality gates (local)
- PHPStan max 0 · Deptrac 0 · PHP-CS-Fixer clean · container compiles.
- Unit **5/5**: 429→200 retry · attempt exhaustion · Retry-After honoured + 60s cap · exponential fallback · no-retry-on-success.

Closes #1769

🤖 Generated with [Claude Code](https://claude.com/claude-code)