### PR TITLE
feat(ui): API-configurator shared primitives library (APIC-P0-05)

### DIFF
--- a/apps/admin/src/features/api-configurator/components/primitives/__tests__/primitives.test.tsx
+++ b/apps/admin/src/features/api-configurator/components/primitives/__tests__/primitives.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { describe, expect, it } from 'vitest';
+
+import {
+  ApiToggle,
+  AuthBadge,
+  ConnStatusPill,
+  CoverageBar,
+  DirectionBadge,
+  DirToggle,
+  Field,
+  JsonView,
+  MethodPill,
+  PaginationPill,
+  RolePill,
+  SectionLabel,
+  SecurityNote,
+  Segmented,
+  TypeCompat,
+} from '..';
+
+expect.extend(toHaveNoViolations);
+
+function Demo() {
+  return (
+    <main>
+      <AuthBadge type="api_key" hint="X-Api-Key" />
+      <DirectionBadge dir="inbound" label="Inbound" />
+      <ConnStatusPill status="active" label="aktywne" />
+      <MethodPill method="GET" />
+      <RolePill value="read_list" />
+      <PaginationPill kind="cursor" />
+      <CoverageBar mapped={8} total={10} />
+      <TypeCompat ok title="Typy zgodne" />
+      <TypeCompat ok={false} title="Niezgodność typów" />
+      <JsonView value={{ sku: 'A-1', active: true, qty: 3, note: null }} />
+      <DirToggle value="inbound" onChange={() => {}} title="Zmień kierunek" />
+      <Segmented
+        ariaLabel="Kierunek"
+        value="inbound"
+        onChange={() => {}}
+        options={[
+          { value: 'inbound', label: 'Inbound' },
+          { value: 'outbound', label: 'Outbound' },
+        ]}
+      />
+      <ApiToggle on onChange={() => {}} ariaLabel="Wiązanie aktywne" />
+      <Field label="Base URL" hint="https" required>
+        <input aria-label="Base URL" />
+      </Field>
+      <SecurityNote tone="emerald">Ruch przez klienta SSRF-safe.</SecurityNote>
+      <SectionLabel>Endpointy</SectionLabel>
+    </main>
+  );
+}
+
+describe('api-configurator primitives', () => {
+  it('renders the semantic labels and tokens', () => {
+    render(<Demo />);
+    expect(screen.getByText('aktywne')).toBeInTheDocument();
+    expect(screen.getByText('GET')).toBeInTheDocument();
+    expect(screen.getByText('8/10 · 80%')).toBeInTheDocument();
+    expect(screen.getByText('cursor')).toBeInTheDocument();
+  });
+
+  it('has no axe violations', async () => {
+    const { container } = render(<Demo />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/admin/src/features/api-configurator/components/primitives/badges.tsx
+++ b/apps/admin/src/features/api-configurator/components/primitives/badges.tsx
@@ -1,0 +1,176 @@
+import { cn } from '@/lib/utils';
+
+/**
+ * APIC-P0-05 — shared badges/pills for the Konfigurator API screens, ported
+ * pixel-perfect from the `integracje/api-primitives.jsx` prototype. Enum props
+ * drive styling; user-facing text that is translatable (connection status,
+ * direction) is passed as a `label` prop so the screen owns i18n. Technical
+ * tokens (HTTP method, endpoint role, pagination, auth scheme) carry fixed
+ * labels — they are protocol terms, not UI copy.
+ */
+
+export type AuthType = 'none' | 'api_key' | 'bearer' | 'basic' | 'oauth2_token';
+
+const AUTH_STYLES: Record<AuthType, { label: string; cls: string }> = {
+  none: { label: 'Brak auth', cls: 'bg-zinc-100 text-zinc-600' },
+  api_key: { label: 'API key', cls: 'bg-sky-50 text-sky-700' },
+  bearer: { label: 'Bearer', cls: 'bg-violet-50 text-violet-700' },
+  basic: { label: 'Basic', cls: 'bg-amber-50 text-amber-800' },
+  oauth2_token: { label: 'OAuth 2.0', cls: 'bg-emerald-50 text-emerald-700' },
+};
+
+export function AuthBadge({ type, hint }: { type: AuthType; hint?: string }) {
+  const meta = AUTH_STYLES[type];
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded px-1.5 py-0.5 text-[10.5px] font-medium',
+        meta.cls,
+      )}
+    >
+      <svg
+        width="11"
+        height="11"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <rect x="4" y="11" width="16" height="10" rx="2" />
+        <path d="M8 11V8a4 4 0 1 1 8 0v3" />
+      </svg>
+      {meta.label}
+      {hint !== undefined && hint !== '' ? (
+        <span className="hidden font-mono text-[10px] opacity-70 xl:inline">· {hint}</span>
+      ) : null}
+    </span>
+  );
+}
+
+export type SyncDirection = 'inbound' | 'outbound' | 'bidirectional';
+
+const DIRECTION_STYLES: Record<SyncDirection, { arrow: string; cls: string }> = {
+  inbound: { arrow: '←', cls: 'bg-sky-50 text-sky-700' },
+  outbound: { arrow: '→', cls: 'bg-violet-50 text-violet-700' },
+  bidirectional: { arrow: '↔', cls: 'bg-emerald-50 text-emerald-700' },
+};
+
+export function DirectionBadge({
+  dir,
+  label,
+  size = 'sm',
+}: {
+  dir: SyncDirection;
+  label: string;
+  size?: 'sm' | 'md';
+}) {
+  const meta = DIRECTION_STYLES[dir];
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded font-medium',
+        size === 'sm' ? 'px-1.5 py-0.5 text-[10.5px]' : 'px-2 py-0.5 text-[11.5px]',
+        meta.cls,
+      )}
+    >
+      <span className="font-mono text-[12px] leading-none" aria-hidden>
+        {meta.arrow}
+      </span>
+      {label}
+    </span>
+  );
+}
+
+export type ConnectionStatus = 'active' | 'paused' | 'error' | 'draft';
+
+const STATUS_STYLES: Record<ConnectionStatus, { cls: string; dot: string; pulse: boolean }> = {
+  active: { cls: 'bg-emerald-50 text-emerald-700', dot: 'bg-emerald-500', pulse: true },
+  paused: { cls: 'bg-amber-50 text-amber-800', dot: 'bg-amber-500', pulse: false },
+  error: { cls: 'bg-rose-50 text-rose-700', dot: 'bg-rose-500', pulse: true },
+  draft: { cls: 'bg-zinc-100 text-zinc-600', dot: 'bg-zinc-400', pulse: false },
+};
+
+export function ConnStatusPill({ status, label }: { status: ConnectionStatus; label: string }) {
+  const meta = STATUS_STYLES[status];
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-[11.5px] font-medium',
+        meta.cls,
+      )}
+    >
+      <span
+        className={cn('h-1.5 w-1.5 rounded-full', meta.dot, meta.pulse && 'animate-pulse')}
+        aria-hidden
+      />
+      {label}
+    </span>
+  );
+}
+
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+const METHOD_STYLES: Record<HttpMethod, string> = {
+  GET: 'bg-emerald-50 text-emerald-700',
+  POST: 'bg-sky-50 text-sky-700',
+  PUT: 'bg-amber-50 text-amber-800',
+  PATCH: 'bg-violet-50 text-violet-700',
+  DELETE: 'bg-rose-50 text-rose-700',
+};
+
+export function MethodPill({ method }: { method: HttpMethod }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded px-1.5 py-0.5 font-mono text-[10.5px] font-semibold',
+        METHOD_STYLES[method],
+      )}
+    >
+      {method}
+    </span>
+  );
+}
+
+export type EndpointRole = 'read_list' | 'read_one' | 'write_create' | 'write_update';
+
+const ROLE_META: Record<EndpointRole, { txt: string; cls: string }> = {
+  read_list: { txt: 'read · list', cls: 'bg-sky-50 text-sky-700' },
+  read_one: { txt: 'read · one', cls: 'bg-sky-50 text-sky-700' },
+  write_create: { txt: 'write · create', cls: 'bg-violet-50 text-violet-700' },
+  write_update: { txt: 'write · update', cls: 'bg-violet-50 text-violet-700' },
+};
+
+export function RolePill({ value }: { value: EndpointRole }) {
+  const meta = ROLE_META[value];
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded px-1.5 py-0.5 font-mono text-[10.5px]',
+        meta.cls,
+      )}
+    >
+      {meta.txt}
+    </span>
+  );
+}
+
+export type PaginationKind = 'none' | 'offset' | 'page' | 'cursor' | 'link_header';
+
+const PAGINATION_LABELS: Record<PaginationKind, string> = {
+  none: 'bez paginacji',
+  offset: 'offset',
+  page: 'page',
+  cursor: 'cursor',
+  link_header: 'Link header',
+};
+
+export function PaginationPill({ kind }: { kind: PaginationKind }) {
+  return (
+    <span className="inline-flex items-center rounded bg-zinc-100 px-1.5 py-0.5 font-mono text-[10.5px] text-zinc-600">
+      {PAGINATION_LABELS[kind]}
+    </span>
+  );
+}

--- a/apps/admin/src/features/api-configurator/components/primitives/controls.tsx
+++ b/apps/admin/src/features/api-configurator/components/primitives/controls.tsx
@@ -1,0 +1,133 @@
+import { cn } from '@/lib/utils';
+
+import type { SyncDirection } from './badges';
+
+/**
+ * APIC-P0-05 — interactive controls for the Konfigurator API screens
+ * (`integracje/api-primitives.jsx`).
+ */
+
+const DIR_TOGGLE_ORDER: SyncDirection[] = ['inbound', 'bidirectional', 'outbound'];
+const DIR_TOGGLE_META: Record<SyncDirection, { arrow: string; cls: string }> = {
+  inbound: { arrow: '←', cls: 'text-sky-700 bg-sky-50 border-sky-200' },
+  bidirectional: { arrow: '↔', cls: 'text-emerald-700 bg-emerald-50 border-emerald-200' },
+  outbound: { arrow: '→', cls: 'text-violet-700 bg-violet-50 border-violet-200' },
+};
+
+export function DirToggle({
+  value,
+  onChange,
+  title,
+}: {
+  value: SyncDirection;
+  onChange: (next: SyncDirection) => void;
+  title: string;
+}) {
+  const meta = DIR_TOGGLE_META[value];
+  const cycle = () => {
+    const next =
+      DIR_TOGGLE_ORDER[(DIR_TOGGLE_ORDER.indexOf(value) + 1) % DIR_TOGGLE_ORDER.length] ??
+      'inbound';
+    onChange(next);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={cycle}
+      title={title}
+      aria-label={title}
+      className={cn(
+        'focus-ring grid h-6 w-7 place-items-center rounded-md border font-mono text-[13px] leading-none transition hover:brightness-95',
+        meta.cls,
+      )}
+    >
+      {meta.arrow}
+    </button>
+  );
+}
+
+export interface SegmentedOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+export function Segmented<T extends string>({
+  options,
+  value,
+  onChange,
+  size = 'md',
+  full = false,
+  ariaLabel,
+}: {
+  options: ReadonlyArray<SegmentedOption<T>>;
+  value: T;
+  onChange: (next: T) => void;
+  size?: 'sm' | 'md';
+  full?: boolean;
+  ariaLabel: string;
+}) {
+  // A segmented toggle: each option is an aria-pressed button (self-labelled
+  // by its text), so no container role is needed; `ariaLabel` becomes the
+  // group's tooltip.
+  return (
+    <div
+      title={ariaLabel}
+      className={cn(
+        'inline-flex items-center gap-0.5 rounded-xl bg-zinc-100 p-1',
+        full && 'w-full',
+      )}
+    >
+      {options.map((option) => {
+        const active = option.value === value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onChange(option.value)}
+            className={cn(
+              'whitespace-nowrap rounded-lg px-3 font-medium transition',
+              size === 'sm' ? 'h-7 text-[11.5px]' : 'h-9 text-[12.5px]',
+              full && 'flex-1',
+              active ? 'soft-shadow bg-white text-zinc-900' : 'text-zinc-500 hover:text-zinc-900',
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function ApiToggle({
+  on,
+  onChange,
+  ariaLabel,
+}: {
+  on: boolean;
+  onChange: (next: boolean) => void;
+  ariaLabel: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={on}
+      aria-label={ariaLabel}
+      onClick={() => onChange(!on)}
+      className={cn(
+        'focus-ring relative h-5 w-9 shrink-0 rounded-full transition',
+        on ? 'bg-zinc-900' : 'bg-zinc-200',
+      )}
+    >
+      <span
+        className={cn(
+          'absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition-all',
+          on ? 'left-[18px]' : 'left-0.5',
+        )}
+      />
+    </button>
+  );
+}

--- a/apps/admin/src/features/api-configurator/components/primitives/index.ts
+++ b/apps/admin/src/features/api-configurator/components/primitives/index.ts
@@ -1,0 +1,5 @@
+export * from './badges';
+export * from './controls';
+export * from './indicators';
+export * from './json-view';
+export * from './layout';

--- a/apps/admin/src/features/api-configurator/components/primitives/indicators.tsx
+++ b/apps/admin/src/features/api-configurator/components/primitives/indicators.tsx
@@ -1,0 +1,68 @@
+import { Check, TriangleAlert } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * APIC-P0-05 — mapping coverage bar + type-compatibility marker
+ * (`integracje/api-primitives.jsx`).
+ */
+export function CoverageBar({
+  mapped,
+  total,
+  width = 120,
+  ariaLabel,
+}: {
+  mapped: number;
+  total: number;
+  width?: number;
+  ariaLabel?: string;
+}) {
+  const pct = total > 0 ? Math.round((mapped / total) * 100) : 0;
+  const tone = pct >= 80 ? 'emerald' : pct >= 50 ? 'sky' : 'amber';
+  const barCls = { emerald: 'bg-emerald-500', sky: 'bg-sky-500', amber: 'bg-amber-500' }[tone];
+  const txtCls = { emerald: 'text-emerald-700', sky: 'text-sky-700', amber: 'text-amber-800' }[
+    tone
+  ];
+
+  return (
+    <div className="flex items-center gap-2.5">
+      <div
+        className="overflow-hidden rounded-full bg-zinc-100"
+        style={{ width, height: 7 }}
+        role="progressbar"
+        aria-label={ariaLabel ?? `${mapped}/${total}`}
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      >
+        <div
+          className={cn('h-full rounded-full transition-all', barCls)}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className={cn('num text-[11.5px] font-medium', txtCls)}>
+        {mapped}/{total} · {pct}%
+      </span>
+    </div>
+  );
+}
+
+export function TypeCompat({ ok, title }: { ok: boolean; title: string }) {
+  return ok ? (
+    <span
+      title={title}
+      className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-emerald-50 text-emerald-600"
+    >
+      <Check className="size-[11px]" strokeWidth={3} aria-hidden />
+      <span className="sr-only">{title}</span>
+    </span>
+  ) : (
+    <span
+      title={title}
+      className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-amber-50 text-amber-600"
+    >
+      <TriangleAlert className="size-[11px]" strokeWidth={2.4} aria-hidden />
+      <span className="sr-only">{title}</span>
+    </span>
+  );
+}

--- a/apps/admin/src/features/api-configurator/components/primitives/json-view.tsx
+++ b/apps/admin/src/features/api-configurator/components/primitives/json-view.tsx
@@ -1,0 +1,68 @@
+import { Fragment, type ReactNode } from 'react';
+
+import { cn } from '@/lib/utils';
+
+const TOKEN =
+  /("(?:\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(?:\s*:)?|\b(?:true|false)\b|\bnull\b|-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)/g;
+
+function classFor(token: string): string {
+  if (token.startsWith('"')) {
+    return /:\s*$/.test(token) ? 'text-zinc-500' : 'text-emerald-700';
+  }
+  if (token === 'true' || token === 'false') {
+    return 'text-violet-700';
+  }
+  if (token === 'null') {
+    return 'text-zinc-400';
+  }
+  return 'text-sky-700';
+}
+
+/**
+ * APIC-P0-05 — lightweight JSON viewer with syntax tinting
+ * (`integracje/api-primitives.jsx`). Tokenises into React spans rather than
+ * injecting HTML, so it stays XSS-safe (no `dangerouslySetInnerHTML`).
+ */
+export function JsonView({
+  value,
+  className,
+  maxHeight,
+}: {
+  value: unknown;
+  className?: string;
+  maxHeight?: number;
+}) {
+  const json = typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+
+  const parts: ReactNode[] = [];
+  let lastIndex = 0;
+  let key = 0;
+  for (const match of json.matchAll(TOKEN)) {
+    const start = match.index;
+    if (start > lastIndex) {
+      parts.push(<Fragment key={key++}>{json.slice(lastIndex, start)}</Fragment>);
+    }
+    const token = match[0];
+    parts.push(
+      <span key={key++} className={classFor(token)}>
+        {token}
+      </span>,
+    );
+    lastIndex = start + token.length;
+  }
+  if (lastIndex < json.length) {
+    parts.push(<Fragment key={key++}>{json.slice(lastIndex)}</Fragment>);
+  }
+
+  return (
+    <pre
+      className={cn(
+        'scrollbar-thin overflow-auto whitespace-pre font-mono text-[11.5px] leading-relaxed text-zinc-700',
+        className,
+      )}
+      style={maxHeight !== undefined ? { maxHeight } : undefined}
+    >
+      {parts}
+    </pre>
+  );
+}

--- a/apps/admin/src/features/api-configurator/components/primitives/layout.tsx
+++ b/apps/admin/src/features/api-configurator/components/primitives/layout.tsx
@@ -1,0 +1,81 @@
+import { Shield } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * APIC-P0-05 — small layout primitives (field wrapper, security callout,
+ * section label) for the Konfigurator API screens
+ * (`integracje/api-primitives.jsx`).
+ */
+export function Field({
+  label,
+  hint,
+  required = false,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  required?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div>
+      <div className="mb-1.5 flex items-center gap-1.5">
+        <span className="text-[11px] font-medium uppercase tracking-wider text-zinc-500">
+          {label}
+        </span>
+        {required ? <span className="text-[11px] text-rose-500">*</span> : null}
+        {hint !== undefined && hint !== '' ? (
+          <span className="text-[11px] normal-case tracking-normal text-zinc-400">· {hint}</span>
+        ) : null}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+type SecurityTone = 'emerald' | 'amber' | 'zinc';
+
+const SECURITY_STYLES: Record<SecurityTone, { box: string; icon: string }> = {
+  emerald: {
+    box: 'bg-emerald-50/70 border-emerald-200 text-emerald-900',
+    icon: 'text-emerald-600',
+  },
+  amber: { box: 'bg-amber-50/70 border-amber-200 text-amber-900', icon: 'text-amber-600' },
+  zinc: { box: 'bg-zinc-50 border-zinc-200 text-zinc-700', icon: 'text-zinc-500' },
+};
+
+export function SecurityNote({
+  children,
+  tone = 'emerald',
+  icon,
+}: {
+  children: ReactNode;
+  tone?: SecurityTone;
+  icon?: ReactNode;
+}) {
+  const meta = SECURITY_STYLES[tone];
+  return (
+    <div
+      className={cn('flex items-start gap-2.5 rounded-xl border px-3 py-2.5 text-[12px]', meta.box)}
+    >
+      <span className={cn('mt-px shrink-0', meta.icon)} aria-hidden>
+        {icon ?? <Shield className="size-4" />}
+      </span>
+      <div className="flex-1 leading-relaxed">{children}</div>
+    </div>
+  );
+}
+
+export function SectionLabel({ children, right }: { children: ReactNode; right?: ReactNode }) {
+  return (
+    <div className="mb-3 flex items-center gap-3">
+      <div className="text-[11px] font-medium uppercase tracking-wider text-zinc-400">
+        {children}
+      </div>
+      <div className="h-px flex-1 bg-zinc-100" />
+      {right}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Ports the ~18 shared primitives from `integracje/api-primitives.jsx` to typed, axe-clean React components for the Konfigurator API screens:

- **badges**: AuthBadge, DirectionBadge, ConnStatusPill, MethodPill, RolePill, PaginationPill (enum→styling; translatable text via `label` prop, so screens own i18n)
- **indicators**: CoverageBar (labelled progressbar), TypeCompat
- **json-view**: syntax-tinted viewer — tokenised into React spans (no `dangerouslySetInnerHTML`, XSS-safe)
- **controls**: DirToggle, Segmented (aria-pressed toggle group), ApiToggle (switch)
- **layout**: Field, SecurityNote, SectionLabel

## Smoke
**Ships standalone** — a component library with no live route yet; wired into screens in **P1-07** (hub) / **P1-08** (wizard), where the operator smoke-tests the integrated UI.

## Quality gates (local)
- typecheck (tsc) clean · Biome strict 0 · **Vitest render + jest-axe 0 violations (2/2)**.

Closes #1760

🤖 Generated with [Claude Code](https://claude.com/claude-code)