### PR TITLE
feat(ui): scaffold Konfigurator API shell with tab split (APIC-P0-04)

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -48,6 +48,18 @@ const ApiProfileShowPage = lazyPage(
   () => import('@/features/api-configurator/api-profiles/show'),
   'ApiProfileShowPage',
 );
+const KonfiguratorApiLayout = lazyPage(
+  () => import('@/features/api-configurator/layout/KonfiguratorApiLayout'),
+  'KonfiguratorApiLayout',
+);
+const ConnectionsHubPlaceholder = lazyPage(
+  () => import('@/features/api-configurator/consumer/ConnectionsHubPlaceholder'),
+  'ConnectionsHubPlaceholder',
+);
+const ApiMonitorPlaceholder = lazyPage(
+  () => import('@/features/api-configurator/monitor/ApiMonitorPlaceholder'),
+  'ApiMonitorPlaceholder',
+);
 const AssetsListPage = lazyPage(() => import('@/features/asset/assets/list'), 'AssetsListPage');
 const AssetShowPage = lazyPage(() => import('@/features/asset/assets/show'), 'AssetShowPage');
 const AttributeGroupCreatePage = lazyPage(
@@ -598,19 +610,32 @@ function App() {
                   </Route>
                   <Route path="/integrations/imports/new" element={<ImportWizardPage />} />
                   <Route path="/integrations/imports/:id" element={<ImportShowPage />} />
-                  <Route path="/integrations/api-configurator" element={<ApiProfilesListPage />} />
-                  <Route
-                    path="/integrations/api-configurator/create"
-                    element={<ApiProfileCreatePage />}
-                  />
-                  <Route
-                    path="/integrations/api-configurator/:id/edit"
-                    element={<ApiProfileEditPage />}
-                  />
-                  <Route
-                    path="/integrations/api-configurator/:id"
-                    element={<ApiProfileShowPage />}
-                  />
+                  <Route element={<KonfiguratorApiLayout />}>
+                    <Route
+                      path="/integrations/api-configurator"
+                      element={<ApiProfilesListPage />}
+                    />
+                    <Route
+                      path="/integrations/api-configurator/create"
+                      element={<ApiProfileCreatePage />}
+                    />
+                    <Route
+                      path="/integrations/api-configurator/connections"
+                      element={<ConnectionsHubPlaceholder />}
+                    />
+                    <Route
+                      path="/integrations/api-configurator/monitor"
+                      element={<ApiMonitorPlaceholder />}
+                    />
+                    <Route
+                      path="/integrations/api-configurator/:id/edit"
+                      element={<ApiProfileEditPage />}
+                    />
+                    <Route
+                      path="/integrations/api-configurator/:id"
+                      element={<ApiProfileShowPage />}
+                    />
+                  </Route>
                   <Route
                     path="/integrations"
                     element={<Navigate to="/integrations/imports/sessions" replace />}

--- a/apps/admin/src/features/api-configurator/consumer/ConnectionsHubPlaceholder.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/ConnectionsHubPlaceholder.tsx
@@ -1,0 +1,19 @@
+import { useTranslation } from 'react-i18next';
+
+/**
+ * APIC-P0-04 — empty placeholder for the consumer connections hub. Replaced by
+ * the live ConnectionCard grid in APIC-P1-07 (consumes `/api/connections`).
+ */
+export function ConnectionsHubPlaceholder() {
+  const { t } = useTranslation();
+  return (
+    <div className="rounded-2xl border border-dashed border-zinc-200 bg-white p-10 text-center">
+      <h2 className="text-[15px] font-semibold tracking-tight">
+        {t('api_configurator.shell.connections_soon_title')}
+      </h2>
+      <p className="mx-auto mt-1 max-w-md text-[13px] text-zinc-500">
+        {t('api_configurator.shell.connections_soon_desc')}
+      </p>
+    </div>
+  );
+}

--- a/apps/admin/src/features/api-configurator/layout/KonfiguratorApiLayout.tsx
+++ b/apps/admin/src/features/api-configurator/layout/KonfiguratorApiLayout.tsx
@@ -1,0 +1,46 @@
+import { useTranslation } from 'react-i18next';
+import { Outlet, useLocation, useNavigate } from 'react-router';
+
+import { PillTabs } from '@/components/ui-v2/pill-tabs';
+
+const BASE = '/integrations/api-configurator';
+
+type ShellTab = 'connections' | 'producer' | 'monitor';
+
+/**
+ * APIC-P0-04 — shared shell for the Konfigurator API area (ADR-0022). Mirrors
+ * the api-app.jsx prototype: a three-way split between the consumer side
+ * (Połączenia), the producer side (Moje API — the existing ApiProfile screens),
+ * and the sync Monitor. Pill tabs over an Outlet; the producer tab keeps the
+ * existing `/integrations/api-configurator` routes untouched, the consumer hub
+ * (P1-07) and monitor (P4-02) fill their placeholders next.
+ */
+export function KonfiguratorApiLayout() {
+  const { t } = useTranslation();
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+
+  const activeId: ShellTab = pathname.startsWith(`${BASE}/connections`)
+    ? 'connections'
+    : pathname.startsWith(`${BASE}/monitor`)
+      ? 'monitor'
+      : 'producer';
+
+  return (
+    <div className="space-y-5">
+      <PillTabs
+        ariaLabel={t('api_configurator.shell.tabs_aria')}
+        activeId={activeId}
+        onChange={(id) => {
+          void navigate(id === 'producer' ? BASE : `${BASE}/${id}`);
+        }}
+        items={[
+          { id: 'connections', label: t('api_configurator.shell.tabs.connections') },
+          { id: 'producer', label: t('api_configurator.shell.tabs.producer') },
+          { id: 'monitor', label: t('api_configurator.shell.tabs.monitor') },
+        ]}
+      />
+      <Outlet />
+    </div>
+  );
+}

--- a/apps/admin/src/features/api-configurator/layout/__tests__/KonfiguratorApiLayout.test.tsx
+++ b/apps/admin/src/features/api-configurator/layout/__tests__/KonfiguratorApiLayout.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { ConnectionsHubPlaceholder } from '../../consumer/ConnectionsHubPlaceholder';
+import { ApiMonitorPlaceholder } from '../../monitor/ApiMonitorPlaceholder';
+import { KonfiguratorApiLayout } from '../KonfiguratorApiLayout';
+
+expect.extend(toHaveNoViolations);
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route element={<KonfiguratorApiLayout />}>
+          <Route
+            path="/integrations/api-configurator/connections"
+            element={<ConnectionsHubPlaceholder />}
+          />
+          <Route
+            path="/integrations/api-configurator/monitor"
+            element={<ApiMonitorPlaceholder />}
+          />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('KonfiguratorApiLayout', () => {
+  it('renders the three shell tabs and the connections placeholder', () => {
+    renderAt('/integrations/api-configurator/connections');
+
+    expect(screen.getByRole('tab', { name: 'Połączenia' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Moje API' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Monitor' })).toBeInTheDocument();
+    expect(screen.getByText('Połączenia — wkrótce')).toBeInTheDocument();
+  });
+
+  it('routes the monitor tab to its placeholder', () => {
+    renderAt('/integrations/api-configurator/monitor');
+    expect(screen.getByText('Monitor synchronizacji — wkrótce')).toBeInTheDocument();
+  });
+
+  it('has no axe violations', async () => {
+    const { container } = renderAt('/integrations/api-configurator/connections');
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/admin/src/features/api-configurator/monitor/ApiMonitorPlaceholder.tsx
+++ b/apps/admin/src/features/api-configurator/monitor/ApiMonitorPlaceholder.tsx
@@ -1,0 +1,19 @@
+import { useTranslation } from 'react-i18next';
+
+/**
+ * APIC-P0-04 — empty placeholder for the sync Monitor. Replaced by the live run
+ * history + drill-down in APIC-P4-02.
+ */
+export function ApiMonitorPlaceholder() {
+  const { t } = useTranslation();
+  return (
+    <div className="rounded-2xl border border-dashed border-zinc-200 bg-white p-10 text-center">
+      <h2 className="text-[15px] font-semibold tracking-tight">
+        {t('api_configurator.shell.monitor_soon_title')}
+      </h2>
+      <p className="mx-auto mt-1 max-w-md text-[13px] text-zinc-500">
+        {t('api_configurator.shell.monitor_soon_desc')}
+      </p>
+    </div>
+  );
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1719,6 +1719,20 @@
       }
     }
   },
+  "api_configurator": {
+    "shell": {
+      "tabs_aria": "API Configurator sections",
+      "tabs": {
+        "connections": "Connections",
+        "producer": "My API",
+        "monitor": "Monitor"
+      },
+      "connections_soon_title": "Connections — coming soon",
+      "connections_soon_desc": "The list of external-API connections with their status and last sync will appear here. Creating and configuring connections lands in the next steps.",
+      "monitor_soon_title": "Sync monitor — coming soon",
+      "monitor_soon_desc": "Sync run history with per-record error drill-down."
+    }
+  },
   "api_profiles": {
     "list_title": "API Profiles",
     "list_subtitle": "Per-integrator presets — visible ObjectTypes, attributes, filters, webhooks.",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1767,6 +1767,20 @@
       }
     }
   },
+  "api_configurator": {
+    "shell": {
+      "tabs_aria": "Sekcje Konfiguratora API",
+      "tabs": {
+        "connections": "Połączenia",
+        "producer": "Moje API",
+        "monitor": "Monitor"
+      },
+      "connections_soon_title": "Połączenia — wkrótce",
+      "connections_soon_desc": "Tu pojawi się lista połączeń z zewnętrznymi API wraz ze statusem i ostatnią synchronizacją. Tworzenie i konfiguracja połączeń dochodzą w kolejnych krokach.",
+      "monitor_soon_title": "Monitor synchronizacji — wkrótce",
+      "monitor_soon_desc": "Historia uruchomień synchronizacji z drill-downem do błędów per rekord."
+    }
+  },
   "api_profiles": {
     "list_title": "Profile API",
     "list_subtitle": "Presety per integrator — widoczne typy obiektów, atrybuty, filtry, webhooki.",


### PR DESCRIPTION
## Summary
`KonfiguratorApiLayout` wraps the `/integrations/api-configurator` area with pill tabs — **Połączenia / Moje API / Monitor** — over an Outlet, mirroring the `api-app.jsx` prototype (ADR-0022).

- **Additive & low-risk**: the existing `ApiProfile` routes (Moje API) are nested **unchanged** — no internal-link / Refine-resource churn. Połączenia + Monitor are placeholders filled by **P1-07** (consumer hub on `/api/connections`) and **P4-02** (sync monitor).
- i18n pl/en keys under `api_configurator.shell`.

## Smoke (operator — SMOKE TEST RULE)
Ships the shell scaffold. **Requires your live smoke**: login → **Integracje → Konfigurator API** → confirm (a) the existing **Moje API** (ApiProfile) list still works under the tab bar, (b) **Połączenia** + **Monitor** tabs show placeholders, (c) tab navigation + active state, DevTools console clean.

## Quality gates (local)
- typecheck · Biome strict 0 · Vite build · **Vitest render + jest-axe 0 (3/3)**.

Closes #1759

🤖 Generated with [Claude Code](https://claude.com/claude-code)