### PR TITLE
feat(integration): add RemoteEndpoint entity + RLS migration (APIC-P2-01)

### DIFF
--- a/apps/api/migrations/Version20260628100000.php
+++ b/apps/api/migrations/Version20260628100000.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * APIC-P2-01 (ADR-0022, epic APIC) — consumer-side `integration_remote_endpoints`
+ * table: one operation descriptor (read_list/read_one/write_create/write_update)
+ * per row, owned by a {@see \App\Integration\Generic\Domain\Entity\Connection}.
+ *
+ * TenantScoped with the W1-1 FORCE RLS pattern (Version20260627100000): a
+ * fail-closed tenant-isolation policy plus the super-admin break-glass bypass.
+ * The FK to `integration_connections` cascades on delete, so removing a
+ * connection drops its descriptor; the tenant FK is RESTRICT.
+ */
+final class Version20260628100000 extends AbstractMigration
+{
+    private const string TABLE = 'integration_remote_endpoints';
+
+    public function getDescription(): string
+    {
+        return 'APIC-P2-01: add integration_remote_endpoints (TenantScoped operation descriptor) + FORCE RLS policies.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE integration_remote_endpoints (
+                id UUID NOT NULL,
+                tenant_id UUID NOT NULL,
+                connection_id UUID NOT NULL,
+                role VARCHAR(16) NOT NULL,
+                http_method VARCHAR(8) NOT NULL,
+                path_template VARCHAR(2048) NOT NULL,
+                query_params JSONB DEFAULT '{}' NOT NULL,
+                request_body_template JSONB DEFAULT NULL,
+                pagination JSONB NOT NULL,
+                record_selector VARCHAR(512) DEFAULT NULL,
+                response_format VARCHAR(16) DEFAULT 'json' NOT NULL,
+                created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+                updated_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+                PRIMARY KEY (id)
+            )
+            SQL);
+        $this->addSql('CREATE INDEX IDX_8614C85A9033212A ON integration_remote_endpoints (tenant_id)');
+        $this->addSql('CREATE INDEX IDX_8614C85ADD03F01 ON integration_remote_endpoints (connection_id)');
+        $this->addSql(
+            'CREATE INDEX integration_remote_endpoints_tenant_conn_idx '
+            .'ON integration_remote_endpoints (tenant_id, connection_id)'
+        );
+        $this->addSql(
+            'ALTER TABLE integration_remote_endpoints ADD CONSTRAINT FK_8614C85A9033212A '
+            .'FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE RESTRICT NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+        $this->addSql(
+            'ALTER TABLE integration_remote_endpoints ADD CONSTRAINT FK_8614C85ADD03F01 '
+            .'FOREIGN KEY (connection_id) REFERENCES integration_connections (id) '
+            .'ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+
+        // ── Row-Level Security (W1-1 FORCE pattern) ───────────────────────
+        $predicate = "tenant_id = NULLIF(current_setting('app.current_tenant', true), '')::uuid";
+
+        $this->addSql(\sprintf('ALTER TABLE %s ENABLE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s FORCE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf(
+            'CREATE POLICY tenant_isolation_%s ON %s USING (%s) WITH CHECK (%s)',
+            self::TABLE,
+            self::TABLE,
+            $predicate,
+            $predicate,
+        ));
+        $this->addSql(\sprintf(
+            "CREATE POLICY super_admin_bypass_%s ON %s "
+            ."USING (current_setting('app.is_super_admin', true) = 'true') "
+            ."WITH CHECK (current_setting('app.is_super_admin', true) = 'true')",
+            self::TABLE,
+            self::TABLE,
+        ));
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(\sprintf('DROP POLICY IF EXISTS super_admin_bypass_%s ON %s', self::TABLE, self::TABLE));
+        $this->addSql(\sprintf('DROP POLICY IF EXISTS tenant_isolation_%s ON %s', self::TABLE, self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s NO FORCE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s DISABLE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql('DROP TABLE integration_remote_endpoints');
+    }
+}

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -145,6 +145,7 @@ parameters:
               # Integration/Generic (ADR-0022, epic APIC) — also extends
               # AggregateRoot, same `?Tenant` write-window as the Import group.
               - src/Integration/Generic/Domain/Entity/Connection.php
+              - src/Integration/Generic/Domain/Entity/RemoteEndpoint.php
               - src/Import/Domain/Entity/ImportScheduleRun.php
               - src/Export/Domain/Entity/ExportSession.php
               - src/Export/Domain/Entity/ExportProfile.php

--- a/apps/api/src/Integration/Generic/Domain/Entity/RemoteEndpoint.php
+++ b/apps/api/src/Integration/Generic/Domain/Entity/RemoteEndpoint.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Entity;
+
+use App\Integration\Generic\Domain\Enum\RemoteEndpointRole;
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\AggregateRoot;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * One operation descriptor on an external API — the consumer-side analogue of
+ * an Airbyte stream (ADR-0022, epic APIC, ticket APIC-P2-01).
+ *
+ * A {@see Connection} owns many endpoints; each binds a {@see RemoteEndpointRole}
+ * (read_list / read_one / write_create / write_update) to an HTTP method, a
+ * path template, optional query params and a request-body template. The
+ * `pagination` envelope selects the paging strategy (none/offset/page/cursor/
+ * link_header — implemented in APIC-P2-03); `recordSelector` is the JSONPath
+ * that extracts records from a list response.
+ *
+ * `TenantScoped` + Postgres RLS isolate every endpoint to its tenant; the
+ * tenant always matches the parent connection's. The FK to Connection cascades
+ * on delete, so removing a connection removes its descriptor.
+ */
+class RemoteEndpoint extends AggregateRoot implements TenantScoped
+{
+    public const array HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
+
+    private Uuid $id;
+
+    private ?Tenant $tenant = null;
+
+    private Connection $connection;
+
+    private string $role;
+
+    #[Assert\NotBlank]
+    #[Assert\Choice(choices: self::HTTP_METHODS)]
+    private string $httpMethod;
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 2048)]
+    private string $pathTemplate;
+
+    /** @var array<string, string> */
+    private array $queryParams = [];
+
+    /**
+     * Request-body template for write roles (placeholders resolved at sync
+     * time); null for read roles.
+     *
+     * @var array<string, mixed>|null
+     */
+    private ?array $requestBodyTemplate = null;
+
+    /**
+     * Pagination envelope: `{strategy, ...params}`. Defaults to no paging; the
+     * concrete strategies (offset/page/cursor/link_header) are read in
+     * APIC-P2-03.
+     *
+     * @var array<string, mixed>
+     */
+    private array $pagination = ['strategy' => 'none'];
+
+    /** JSONPath that selects records from a list response (read_list); null otherwise. */
+    #[Assert\Length(max: 512)]
+    private ?string $recordSelector = null;
+
+    #[Assert\Choice(choices: ['json'])]
+    private string $responseFormat = 'json';
+
+    private DateTimeImmutable $createdAt;
+
+    private DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        Connection $connection,
+        RemoteEndpointRole $role,
+        string $httpMethod,
+        string $pathTemplate,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->connection = $connection;
+        $this->role = $role->value;
+        $this->httpMethod = $httpMethod;
+        $this->pathTemplate = $pathTemplate;
+        $this->createdAt = new DateTimeImmutable();
+        $this->updatedAt = $this->createdAt;
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant is already assigned and cannot be reassigned.');
+        }
+
+        $this->tenant = $tenant;
+    }
+
+    public function getConnection(): Connection
+    {
+        return $this->connection;
+    }
+
+    public function getConnectionId(): Uuid
+    {
+        return $this->connection->getId();
+    }
+
+    public function getRole(): RemoteEndpointRole
+    {
+        return RemoteEndpointRole::from($this->role);
+    }
+
+    public function setRole(RemoteEndpointRole $role): void
+    {
+        $this->role = $role->value;
+        $this->touch();
+    }
+
+    public function getHttpMethod(): string
+    {
+        return $this->httpMethod;
+    }
+
+    public function setHttpMethod(string $httpMethod): void
+    {
+        $this->httpMethod = $httpMethod;
+        $this->touch();
+    }
+
+    public function getPathTemplate(): string
+    {
+        return $this->pathTemplate;
+    }
+
+    public function setPathTemplate(string $pathTemplate): void
+    {
+        $this->pathTemplate = $pathTemplate;
+        $this->touch();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getQueryParams(): array
+    {
+        return $this->queryParams;
+    }
+
+    /**
+     * @param array<string, string> $queryParams
+     */
+    public function setQueryParams(array $queryParams): void
+    {
+        $this->queryParams = $queryParams;
+        $this->touch();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getRequestBodyTemplate(): ?array
+    {
+        return $this->requestBodyTemplate;
+    }
+
+    /**
+     * @param array<string, mixed>|null $requestBodyTemplate
+     */
+    public function setRequestBodyTemplate(?array $requestBodyTemplate): void
+    {
+        $this->requestBodyTemplate = $requestBodyTemplate;
+        $this->touch();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getPagination(): array
+    {
+        return $this->pagination;
+    }
+
+    /**
+     * @param array<string, mixed> $pagination
+     */
+    public function setPagination(array $pagination): void
+    {
+        $this->pagination = $pagination;
+        $this->touch();
+    }
+
+    public function getRecordSelector(): ?string
+    {
+        return $this->recordSelector;
+    }
+
+    public function setRecordSelector(?string $recordSelector): void
+    {
+        $this->recordSelector = $recordSelector;
+        $this->touch();
+    }
+
+    public function getResponseFormat(): string
+    {
+        return $this->responseFormat;
+    }
+
+    public function setResponseFormat(string $responseFormat): void
+    {
+        $this->responseFormat = $responseFormat;
+        $this->touch();
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    private function touch(): void
+    {
+        $this->updatedAt = new DateTimeImmutable();
+    }
+}

--- a/apps/api/src/Integration/Generic/Domain/Enum/RemoteEndpointRole.php
+++ b/apps/api/src/Integration/Generic/Domain/Enum/RemoteEndpointRole.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Enum;
+
+/**
+ * The role a {@see \App\Integration\Generic\Domain\Entity\RemoteEndpoint} plays
+ * in a sync — the consumer-side analogue of an Airbyte stream operation
+ * (ADR-0022, epic APIC).
+ *
+ * `read_*` endpoints pull from the remote (inbound sync); `write_*` endpoints
+ * push to it (outbound sync). The pairing is what lets one Connection both
+ * import and export against the same external API.
+ */
+enum RemoteEndpointRole: string
+{
+    case ReadList = 'read_list';
+    case ReadOne = 'read_one';
+    case WriteCreate = 'write_create';
+    case WriteUpdate = 'write_update';
+
+    /** Whether this role reads from the remote (inbound), as opposed to writing. */
+    public function isRead(): bool
+    {
+        return self::ReadList === $this || self::ReadOne === $this;
+    }
+}

--- a/apps/api/src/Integration/Generic/Domain/Repository/RemoteEndpointRepositoryInterface.php
+++ b/apps/api/src/Integration/Generic/Domain/Repository/RemoteEndpointRepositoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Repository;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\RemoteEndpoint;
+use App\Integration\Generic\Domain\Enum\RemoteEndpointRole;
+use Symfony\Component\Uid\Uuid;
+
+interface RemoteEndpointRepositoryInterface
+{
+    public function save(RemoteEndpoint $endpoint): void;
+
+    public function remove(RemoteEndpoint $endpoint): void;
+
+    public function findById(Uuid $id): ?RemoteEndpoint;
+
+    /**
+     * @return list<RemoteEndpoint>
+     */
+    public function findByConnection(Connection $connection): array;
+
+    public function findByConnectionAndRole(Connection $connection, RemoteEndpointRole $role): ?RemoteEndpoint;
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Orm/Mapping/RemoteEndpoint.orm.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Orm/Mapping/RemoteEndpoint.orm.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Integration\Generic\Domain\Entity\RemoteEndpoint"
+            table="integration_remote_endpoints"
+            repository-class="App\Integration\Generic\Infrastructure\Doctrine\Repository\DoctrineRemoteEndpointRepository">
+
+        <indexes>
+            <index name="integration_remote_endpoints_tenant_conn_idx" columns="tenant_id,connection_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <many-to-one field="connection" target-entity="App\Integration\Generic\Domain\Entity\Connection">
+            <join-column name="connection_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="role" type="string" length="16"/>
+        <field name="httpMethod" type="string" length="8" column="http_method"/>
+        <field name="pathTemplate" type="string" length="2048" column="path_template"/>
+        <field name="queryParams" type="json" column="query_params">
+            <options>
+                <option name="jsonb">true</option>
+                <option name="default">{}</option>
+            </options>
+        </field>
+        <field name="requestBodyTemplate" type="json" column="request_body_template" nullable="true">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+        <!-- No DB-level default: a non-empty JSONB default normalises with a
+             space (`{"strategy": "none"}`) and would perpetually drift against
+             Doctrine's expected DDL. The entity sets it in its constructor. -->
+        <field name="pagination" type="json" column="pagination">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+        <field name="recordSelector" type="string" length="512" column="record_selector" nullable="true"/>
+        <field name="responseFormat" type="string" length="16" column="response_format">
+            <options>
+                <option name="default">json</option>
+            </options>
+        </field>
+        <field name="createdAt" type="datetimetz_immutable" column="created_at"/>
+        <field name="updatedAt" type="datetimetz_immutable" column="updated_at"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Repository/DoctrineRemoteEndpointRepository.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Repository/DoctrineRemoteEndpointRepository.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Doctrine\Repository;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\RemoteEndpoint;
+use App\Integration\Generic\Domain\Enum\RemoteEndpointRole;
+use App\Integration\Generic\Domain\Repository\RemoteEndpointRepositoryInterface;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<RemoteEndpoint>
+ */
+class DoctrineRemoteEndpointRepository extends ServiceEntityRepository implements RemoteEndpointRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, RemoteEndpoint::class);
+    }
+
+    public function save(RemoteEndpoint $endpoint): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($endpoint);
+        $em->flush();
+    }
+
+    public function remove(RemoteEndpoint $endpoint): void
+    {
+        $em = $this->getEntityManager();
+        $em->remove($endpoint);
+        $em->flush();
+    }
+
+    public function findById(Uuid $id): ?RemoteEndpoint
+    {
+        return parent::find($id->toRfc4122());
+    }
+
+    /**
+     * @return list<RemoteEndpoint>
+     */
+    public function findByConnection(Connection $connection): array
+    {
+        $qb = $this->createQueryBuilder('e')
+            ->where('e.connection = :connection')
+            ->orderBy('e.createdAt', 'ASC')
+            ->setParameter('connection', $connection);
+
+        /** @var list<RemoteEndpoint> $result */
+        $result = $qb->getQuery()->getResult();
+
+        return $result;
+    }
+
+    public function findByConnectionAndRole(Connection $connection, RemoteEndpointRole $role): ?RemoteEndpoint
+    {
+        return $this->findOneBy(['connection' => $connection, 'role' => $role->value]);
+    }
+}

--- a/apps/api/tests/Integration/Integration/Generic/RemoteEndpointRepositoryTest.php
+++ b/apps/api/tests/Integration/Integration/Generic/RemoteEndpointRepositoryTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Integration\Generic;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\RemoteEndpoint;
+use App\Integration\Generic\Domain\Enum\AuthType;
+use App\Integration\Generic\Domain\Enum\RemoteEndpointRole;
+use App\Integration\Generic\Domain\Repository\ConnectionRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\RemoteEndpointRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * APIC-P2-01 — RemoteEndpointRepository round-trip + 2-tenant cross-read = 0
+ * (Doctrine TenantFilter on the TenantScoped RemoteEndpoint; Postgres RLS is
+ * the defence-in-depth wall verified at the migration level).
+ */
+final class RemoteEndpointRepositoryTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function savesAndFindsEndpointWithinTenant(): void
+    {
+        $alpha = $this->createTenant('alpha');
+        $this->activateTenantFilter($alpha);
+
+        $connection = $this->createConnection($alpha, 'idosell');
+        $endpoint = new RemoteEndpoint($connection, RemoteEndpointRole::ReadList, 'GET', '/products');
+        $endpoint->assignTenant($alpha);
+        $endpoint->setRecordSelector('$.results');
+        $endpoint->setQueryParams(['limit' => '100']);
+        $this->endpoints()->save($endpoint);
+
+        $found = $this->endpoints()->findById($endpoint->getId());
+        self::assertNotNull($found);
+        self::assertSame(RemoteEndpointRole::ReadList, $found->getRole());
+        self::assertSame('GET', $found->getHttpMethod());
+        self::assertSame('/products', $found->getPathTemplate());
+        self::assertSame('$.results', $found->getRecordSelector());
+        self::assertSame(['strategy' => 'none'], $found->getPagination());
+        self::assertSame($connection->getId()->toRfc4122(), $found->getConnectionId()->toRfc4122());
+
+        self::assertCount(1, $this->endpoints()->findByConnection($connection));
+        self::assertNotNull(
+            $this->endpoints()->findByConnectionAndRole($connection, RemoteEndpointRole::ReadList),
+        );
+    }
+
+    #[Test]
+    public function endpointsAreIsolatedAcrossTenants(): void
+    {
+        $alpha = $this->createTenant('alpha');
+        $beta = $this->createTenant('beta');
+
+        $this->activateTenantFilter($alpha);
+        $alphaConnection = $this->createConnection($alpha, 'idosell');
+        $alphaEndpoint = new RemoteEndpoint($alphaConnection, RemoteEndpointRole::ReadList, 'GET', '/products');
+        $alphaEndpoint->assignTenant($alpha);
+        $this->endpoints()->save($alphaEndpoint);
+
+        // Switch to beta: alpha's endpoint must be invisible through the
+        // Doctrine TenantFilter (DQL). `findById` is intentionally not asserted
+        // here — EntityManager::find() by PK serves from the identity map and
+        // bypasses SQL filters; cross-tenant PK reads are walled by Postgres RLS
+        // (verified at the migration level), not by the ORM filter.
+        $this->activateTenantFilter($beta);
+        self::assertCount(0, $this->endpoints()->findByConnection($alphaConnection));
+        self::assertNull(
+            $this->endpoints()->findByConnectionAndRole($alphaConnection, RemoteEndpointRole::ReadList),
+        );
+    }
+
+    private function endpoints(): RemoteEndpointRepositoryInterface
+    {
+        return self::getContainer()->get(RemoteEndpointRepositoryInterface::class);
+    }
+
+    private function connections(): ConnectionRepositoryInterface
+    {
+        return self::getContainer()->get(ConnectionRepositoryInterface::class);
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+
+    private function createConnection(Tenant $tenant, string $code): Connection
+    {
+        $connection = new Connection($code, ucfirst($code), 'https://api.example.com', AuthType::ApiKey);
+        $connection->assignTenant($tenant);
+        $this->connections()->save($connection);
+
+        return $connection;
+    }
+
+    /**
+     * KernelTestCase has no HTTP request lifecycle, so the active tenant must
+     * be wired into the Doctrine filter manually after every context switch.
+     */
+    private function activateTenantFilter(Tenant $tenant): void
+    {
+        $this->tenantContext()->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function createTenant(string $code): Tenant
+    {
+        $tenant = new Tenant($code, ucfirst($code).' Tenant');
+        $em = $this->em();
+        $em->persist($tenant);
+        $em->flush();
+
+        return $tenant;
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Domain/Entity/RemoteEndpointTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Domain/Entity/RemoteEndpointTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Domain\Entity;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\RemoteEndpoint;
+use App\Integration\Generic\Domain\Enum\RemoteEndpointRole;
+use App\Shared\Domain\Tenant;
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class RemoteEndpointTest extends TestCase
+{
+    #[Test]
+    public function newEndpointDefaultsToNoPagingJsonResponse(): void
+    {
+        $e = $this->endpoint();
+
+        self::assertSame(RemoteEndpointRole::ReadList, $e->getRole());
+        self::assertSame('GET', $e->getHttpMethod());
+        self::assertSame('/products', $e->getPathTemplate());
+        self::assertSame([], $e->getQueryParams());
+        self::assertNull($e->getRequestBodyTemplate());
+        self::assertSame(['strategy' => 'none'], $e->getPagination());
+        self::assertNull($e->getRecordSelector());
+        self::assertSame('json', $e->getResponseFormat());
+        self::assertNull($e->getTenant());
+    }
+
+    #[Test]
+    public function exposesItsParentConnection(): void
+    {
+        $connection = $this->connection();
+        $e = new RemoteEndpoint($connection, RemoteEndpointRole::ReadOne, 'GET', '/products/{id}');
+
+        self::assertSame($connection, $e->getConnection());
+        self::assertSame($connection->getId()->toRfc4122(), $e->getConnectionId()->toRfc4122());
+    }
+
+    #[Test]
+    public function settersUpdateValues(): void
+    {
+        $e = $this->endpoint();
+        $e->setRole(RemoteEndpointRole::WriteCreate);
+        $e->setHttpMethod('POST');
+        $e->setPathTemplate('/products');
+        $e->setQueryParams(['limit' => '50']);
+        $e->setRequestBodyTemplate(['sku' => '{{sku}}']);
+        $e->setPagination(['strategy' => 'cursor', 'cursorParam' => 'after']);
+        $e->setRecordSelector('$.data');
+        $e->setResponseFormat('json');
+
+        self::assertSame(RemoteEndpointRole::WriteCreate, $e->getRole());
+        self::assertSame('POST', $e->getHttpMethod());
+        self::assertSame(['limit' => '50'], $e->getQueryParams());
+        self::assertSame(['sku' => '{{sku}}'], $e->getRequestBodyTemplate());
+        self::assertSame(['strategy' => 'cursor', 'cursorParam' => 'after'], $e->getPagination());
+        self::assertSame('$.data', $e->getRecordSelector());
+    }
+
+    #[Test]
+    public function roleKnowsReadFromWrite(): void
+    {
+        self::assertTrue(RemoteEndpointRole::ReadList->isRead());
+        self::assertTrue(RemoteEndpointRole::ReadOne->isRead());
+        self::assertFalse(RemoteEndpointRole::WriteCreate->isRead());
+        self::assertFalse(RemoteEndpointRole::WriteUpdate->isRead());
+    }
+
+    #[Test]
+    public function assignTenantIsWriteOnce(): void
+    {
+        $e = $this->endpoint();
+        $e->assignTenant(new Tenant('alpha', 'Alpha'));
+        self::assertNotNull($e->getTenant());
+
+        $this->expectException(LogicException::class);
+        $e->assignTenant(new Tenant('beta', 'Beta'));
+    }
+
+    private function connection(): Connection
+    {
+        return new Connection('idosell', 'IdoSell PL', 'https://api.idosell.com');
+    }
+
+    private function endpoint(): RemoteEndpoint
+    {
+        return new RemoteEndpoint($this->connection(), RemoteEndpointRole::ReadList, 'GET', '/products');
+    }
+}


### PR DESCRIPTION
## Cel

APIC-P2-01 — descriptor operacji zewnętrznego API (konsumencki odpowiednik „stream" Airbyte). Pierwsza encja M2 (Descriptor + Mapping).

## Zakres

- **Encja `RemoteEndpoint`** (`TenantScoped`, extends `AggregateRoot`): `connection` (FK → Connection, **CASCADE** on delete), `role` (`read_list|read_one|write_create|write_update`), `httpMethod`, `pathTemplate`, `queryParams` (JSONB), `requestBodyTemplate` (JSONB, nullable), `pagination` (JSONB envelope `{strategy,…}`), `recordSelector` (JSONPath), `responseFormat` (`json`).
- **Enum `RemoteEndpointRole`** (+ `isRead()`).
- **Repozytorium** (interface + Doctrine impl): `findById`, `findByConnection`, `findByConnectionAndRole`.
- **Migracja `Version20260628100000`** — tabela `integration_remote_endpoints` + W1-1 **FORCE RLS** (tenant isolation + super-admin bypass), FK tenant RESTRICT / connection CASCADE.

## Decyzje

- `pagination` **bez DB-level default** — niepusty JSONB default normalizuje się w Postgresie ze spacją (`{"strategy": "none"}`) i wiecznie dryfuje względem oczekiwań Doctrine; default ustawia konstruktor encji. Zweryfikowane `schema:update --dump-sql` → **brak driftu**.
- Izolacja cross-tenant testowana przez metody DQL (TenantFilter); `findById` (PK → identity map) świadomie nie jest asercją izolacji — od tego jest Postgres RLS.

## Testy / bramki (uruchomione w kontenerze api)

- **PHPStan max** ✅ (po dodaniu encji do `doctrine.associationType` allowlist — ten sam `?Tenant` write-window co Connection/Import) · **Deptrac** 0 violations ✅ · **PHP-CS-Fixer** 0 ✅
- **PHPUnit** ✅ 7/7: `RemoteEndpointTest` (Layer 1 — domyślne wartości, parent connection, settery, role isRead, assignTenant write-once) + `RemoteEndpointRepositoryTest` (Layer 2 — round-trip + 2-tenant cross-read = 0).
- Migracja zaaplikowana + zrolowana lokalnie; `down()` czyści polityki RLS + tabelę.

Refs #1770