### PR TITLE
feat(integration): add RemoteField entity + RLS migration (APIC-P2-02)

### DIFF
--- a/apps/api/migrations/Version20260628110000.php
+++ b/apps/api/migrations/Version20260628110000.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * APIC-P2-02 (ADR-0022, epic APIC) — consumer-side `integration_remote_fields`
+ * table: one discovered/manual field of an external API response per row, owned
+ * by a {@see \App\Integration\Generic\Domain\Entity\RemoteEndpoint}.
+ *
+ * TenantScoped with the W1-1 FORCE RLS pattern (Version20260628100000): a
+ * fail-closed tenant-isolation policy plus the super-admin break-glass bypass.
+ * The FK to `integration_remote_endpoints` cascades on delete; the tenant FK is
+ * RESTRICT.
+ */
+final class Version20260628110000 extends AbstractMigration
+{
+    private const string TABLE = 'integration_remote_fields';
+
+    public function getDescription(): string
+    {
+        return 'APIC-P2-02: add integration_remote_fields (TenantScoped response field) + FORCE RLS policies.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE integration_remote_fields (
+                id UUID NOT NULL,
+                tenant_id UUID NOT NULL,
+                endpoint_id UUID NOT NULL,
+                path VARCHAR(512) NOT NULL,
+                label VARCHAR(255) DEFAULT NULL,
+                data_type VARCHAR(16) NOT NULL,
+                sample_value VARCHAR(2048) DEFAULT NULL,
+                created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+                updated_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+                PRIMARY KEY (id)
+            )
+            SQL);
+        $this->addSql('CREATE INDEX IDX_2A62F69B9033212A ON integration_remote_fields (tenant_id)');
+        $this->addSql('CREATE INDEX IDX_2A62F69B21AF7E36 ON integration_remote_fields (endpoint_id)');
+        $this->addSql(
+            'CREATE INDEX integration_remote_fields_tenant_endpoint_idx '
+            .'ON integration_remote_fields (tenant_id, endpoint_id)'
+        );
+        $this->addSql(
+            'ALTER TABLE integration_remote_fields ADD CONSTRAINT FK_2A62F69B9033212A '
+            .'FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE RESTRICT NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+        $this->addSql(
+            'ALTER TABLE integration_remote_fields ADD CONSTRAINT FK_2A62F69B21AF7E36 '
+            .'FOREIGN KEY (endpoint_id) REFERENCES integration_remote_endpoints (id) '
+            .'ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+
+        // ── Row-Level Security (W1-1 FORCE pattern) ───────────────────────
+        $predicate = "tenant_id = NULLIF(current_setting('app.current_tenant', true), '')::uuid";
+
+        $this->addSql(\sprintf('ALTER TABLE %s ENABLE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s FORCE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf(
+            'CREATE POLICY tenant_isolation_%s ON %s USING (%s) WITH CHECK (%s)',
+            self::TABLE,
+            self::TABLE,
+            $predicate,
+            $predicate,
+        ));
+        $this->addSql(\sprintf(
+            "CREATE POLICY super_admin_bypass_%s ON %s "
+            ."USING (current_setting('app.is_super_admin', true) = 'true') "
+            ."WITH CHECK (current_setting('app.is_super_admin', true) = 'true')",
+            self::TABLE,
+            self::TABLE,
+        ));
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(\sprintf('DROP POLICY IF EXISTS super_admin_bypass_%s ON %s', self::TABLE, self::TABLE));
+        $this->addSql(\sprintf('DROP POLICY IF EXISTS tenant_isolation_%s ON %s', self::TABLE, self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s NO FORCE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s DISABLE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql('DROP TABLE integration_remote_fields');
+    }
+}

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -146,6 +146,7 @@ parameters:
               # AggregateRoot, same `?Tenant` write-window as the Import group.
               - src/Integration/Generic/Domain/Entity/Connection.php
               - src/Integration/Generic/Domain/Entity/RemoteEndpoint.php
+              - src/Integration/Generic/Domain/Entity/RemoteField.php
               - src/Import/Domain/Entity/ImportScheduleRun.php
               - src/Export/Domain/Entity/ExportSession.php
               - src/Export/Domain/Entity/ExportProfile.php

--- a/apps/api/src/Integration/Generic/Domain/Entity/RemoteField.php
+++ b/apps/api/src/Integration/Generic/Domain/Entity/RemoteField.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Entity;
+
+use App\Integration\Generic\Domain\Enum\RemoteFieldDataType;
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\AggregateRoot;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * One field of an external API response — discovered from a sample or entered
+ * by hand (ADR-0022, epic APIC, ticket APIC-P2-02).
+ *
+ * A {@see RemoteEndpoint} owns many fields; each carries the JSONPath that
+ * locates it within a record, a human label, the detected {@see RemoteFieldDataType}
+ * and a textual sample value. These are the left-hand side of the 1:1 field
+ * mapping (APIC-P2-07/08).
+ *
+ * `TenantScoped` + Postgres RLS isolate every field to its tenant; the tenant
+ * always matches the parent endpoint's. The FK to RemoteEndpoint cascades on
+ * delete.
+ */
+class RemoteField extends AggregateRoot implements TenantScoped
+{
+    private Uuid $id;
+
+    private ?Tenant $tenant = null;
+
+    private RemoteEndpoint $endpoint;
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 512)]
+    private string $path;
+
+    #[Assert\Length(max: 255)]
+    private ?string $label = null;
+
+    private string $dataType;
+
+    /** Textual sample value captured during discovery; null when none was seen. */
+    #[Assert\Length(max: 2048)]
+    private ?string $sampleValue = null;
+
+    private DateTimeImmutable $createdAt;
+
+    private DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        RemoteEndpoint $endpoint,
+        string $path,
+        RemoteFieldDataType $dataType = RemoteFieldDataType::String,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->endpoint = $endpoint;
+        $this->path = $path;
+        $this->dataType = $dataType->value;
+        $this->createdAt = new DateTimeImmutable();
+        $this->updatedAt = $this->createdAt;
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant is already assigned and cannot be reassigned.');
+        }
+
+        $this->tenant = $tenant;
+    }
+
+    public function getEndpoint(): RemoteEndpoint
+    {
+        return $this->endpoint;
+    }
+
+    public function getEndpointId(): Uuid
+    {
+        return $this->endpoint->getId();
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    public function setPath(string $path): void
+    {
+        $this->path = $path;
+        $this->touch();
+    }
+
+    public function getLabel(): ?string
+    {
+        return $this->label;
+    }
+
+    public function setLabel(?string $label): void
+    {
+        $this->label = $label;
+        $this->touch();
+    }
+
+    public function getDataType(): RemoteFieldDataType
+    {
+        return RemoteFieldDataType::from($this->dataType);
+    }
+
+    public function setDataType(RemoteFieldDataType $dataType): void
+    {
+        $this->dataType = $dataType->value;
+        $this->touch();
+    }
+
+    public function getSampleValue(): ?string
+    {
+        return $this->sampleValue;
+    }
+
+    public function setSampleValue(?string $sampleValue): void
+    {
+        $this->sampleValue = $sampleValue;
+        $this->touch();
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    private function touch(): void
+    {
+        $this->updatedAt = new DateTimeImmutable();
+    }
+}

--- a/apps/api/src/Integration/Generic/Domain/Enum/RemoteFieldDataType.php
+++ b/apps/api/src/Integration/Generic/Domain/Enum/RemoteFieldDataType.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Enum;
+
+/**
+ * The JSON data type of a {@see \App\Integration\Generic\Domain\Entity\RemoteField}
+ * as detected from a response sample (ADR-0022, epic APIC, ticket APIC-P2-02).
+ *
+ * Mirrors the JSON type system. The schema-discovery service (APIC-P2-04)
+ * infers it from sampled values; the mapping screen (APIC-P2-08/09) uses it to
+ * flag type compatibility against the target PIM attribute.
+ */
+enum RemoteFieldDataType: string
+{
+    case String = 'string';
+    case Integer = 'integer';
+    case Number = 'number';
+    case Boolean = 'boolean';
+    case Object = 'object';
+    case Array = 'array';
+    case Null = 'null';
+
+    /** Whether the type is a JSON scalar (not object/array/null). */
+    public function isScalar(): bool
+    {
+        return match ($this) {
+            self::String, self::Integer, self::Number, self::Boolean => true,
+            self::Object, self::Array, self::Null => false,
+        };
+    }
+}

--- a/apps/api/src/Integration/Generic/Domain/Repository/RemoteFieldRepositoryInterface.php
+++ b/apps/api/src/Integration/Generic/Domain/Repository/RemoteFieldRepositoryInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Repository;
+
+use App\Integration\Generic\Domain\Entity\RemoteEndpoint;
+use App\Integration\Generic\Domain\Entity\RemoteField;
+use Symfony\Component\Uid\Uuid;
+
+interface RemoteFieldRepositoryInterface
+{
+    public function save(RemoteField $field): void;
+
+    public function remove(RemoteField $field): void;
+
+    public function findById(Uuid $id): ?RemoteField;
+
+    /**
+     * @return list<RemoteField>
+     */
+    public function findByEndpoint(RemoteEndpoint $endpoint): array;
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Orm/Mapping/RemoteField.orm.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Orm/Mapping/RemoteField.orm.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Integration\Generic\Domain\Entity\RemoteField"
+            table="integration_remote_fields"
+            repository-class="App\Integration\Generic\Infrastructure\Doctrine\Repository\DoctrineRemoteFieldRepository">
+
+        <indexes>
+            <index name="integration_remote_fields_tenant_endpoint_idx" columns="tenant_id,endpoint_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <many-to-one field="endpoint" target-entity="App\Integration\Generic\Domain\Entity\RemoteEndpoint">
+            <join-column name="endpoint_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="path" type="string" length="512"/>
+        <field name="label" type="string" length="255" nullable="true"/>
+        <field name="dataType" type="string" length="16" column="data_type"/>
+        <field name="sampleValue" type="string" length="2048" column="sample_value" nullable="true"/>
+        <field name="createdAt" type="datetimetz_immutable" column="created_at"/>
+        <field name="updatedAt" type="datetimetz_immutable" column="updated_at"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Repository/DoctrineRemoteFieldRepository.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Repository/DoctrineRemoteFieldRepository.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Doctrine\Repository;
+
+use App\Integration\Generic\Domain\Entity\RemoteEndpoint;
+use App\Integration\Generic\Domain\Entity\RemoteField;
+use App\Integration\Generic\Domain\Repository\RemoteFieldRepositoryInterface;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<RemoteField>
+ */
+class DoctrineRemoteFieldRepository extends ServiceEntityRepository implements RemoteFieldRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, RemoteField::class);
+    }
+
+    public function save(RemoteField $field): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($field);
+        $em->flush();
+    }
+
+    public function remove(RemoteField $field): void
+    {
+        $em = $this->getEntityManager();
+        $em->remove($field);
+        $em->flush();
+    }
+
+    public function findById(Uuid $id): ?RemoteField
+    {
+        return parent::find($id->toRfc4122());
+    }
+
+    /**
+     * @return list<RemoteField>
+     */
+    public function findByEndpoint(RemoteEndpoint $endpoint): array
+    {
+        $qb = $this->createQueryBuilder('f')
+            ->where('f.endpoint = :endpoint')
+            ->orderBy('f.path', 'ASC')
+            ->setParameter('endpoint', $endpoint);
+
+        /** @var list<RemoteField> $result */
+        $result = $qb->getQuery()->getResult();
+
+        return $result;
+    }
+}

--- a/apps/api/tests/Integration/Integration/Generic/RemoteFieldRepositoryTest.php
+++ b/apps/api/tests/Integration/Integration/Generic/RemoteFieldRepositoryTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Integration\Generic;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\RemoteEndpoint;
+use App\Integration\Generic\Domain\Entity\RemoteField;
+use App\Integration\Generic\Domain\Enum\AuthType;
+use App\Integration\Generic\Domain\Enum\RemoteEndpointRole;
+use App\Integration\Generic\Domain\Enum\RemoteFieldDataType;
+use App\Integration\Generic\Domain\Repository\ConnectionRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\RemoteEndpointRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\RemoteFieldRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * APIC-P2-02 — RemoteFieldRepository round-trip + 2-tenant cross-read = 0
+ * (Doctrine TenantFilter on the TenantScoped RemoteField; Postgres RLS is the
+ * defence-in-depth wall verified at the migration level).
+ */
+final class RemoteFieldRepositoryTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function savesAndFindsFieldWithinTenant(): void
+    {
+        $alpha = $this->createTenant('alpha');
+        $this->activateTenantFilter($alpha);
+
+        $endpoint = $this->createEndpoint($alpha);
+        $field = new RemoteField($endpoint, '$.price', RemoteFieldDataType::Number);
+        $field->assignTenant($alpha);
+        $field->setLabel('Price');
+        $field->setSampleValue('19.99');
+        $this->fields()->save($field);
+
+        $found = $this->fields()->findById($field->getId());
+        self::assertNotNull($found);
+        self::assertSame('$.price', $found->getPath());
+        self::assertSame('Price', $found->getLabel());
+        self::assertSame(RemoteFieldDataType::Number, $found->getDataType());
+        self::assertSame('19.99', $found->getSampleValue());
+        self::assertSame($endpoint->getId()->toRfc4122(), $found->getEndpointId()->toRfc4122());
+
+        self::assertCount(1, $this->fields()->findByEndpoint($endpoint));
+    }
+
+    #[Test]
+    public function fieldsAreIsolatedAcrossTenants(): void
+    {
+        $alpha = $this->createTenant('alpha');
+        $beta = $this->createTenant('beta');
+
+        $this->activateTenantFilter($alpha);
+        $alphaEndpoint = $this->createEndpoint($alpha);
+        $alphaField = new RemoteField($alphaEndpoint, '$.sku', RemoteFieldDataType::String);
+        $alphaField->assignTenant($alpha);
+        $this->fields()->save($alphaField);
+
+        // Switch to beta: alpha's field is invisible through the Doctrine
+        // TenantFilter (DQL). `findById` (PK → identity map) bypasses SQL
+        // filters and is walled by Postgres RLS, not asserted here.
+        $this->activateTenantFilter($beta);
+        self::assertCount(0, $this->fields()->findByEndpoint($alphaEndpoint));
+    }
+
+    private function fields(): RemoteFieldRepositoryInterface
+    {
+        return self::getContainer()->get(RemoteFieldRepositoryInterface::class);
+    }
+
+    private function endpoints(): RemoteEndpointRepositoryInterface
+    {
+        return self::getContainer()->get(RemoteEndpointRepositoryInterface::class);
+    }
+
+    private function connections(): ConnectionRepositoryInterface
+    {
+        return self::getContainer()->get(ConnectionRepositoryInterface::class);
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+
+    private function createEndpoint(Tenant $tenant): RemoteEndpoint
+    {
+        $connection = new Connection('idosell', 'IdoSell', 'https://api.idosell.com', AuthType::ApiKey);
+        $connection->assignTenant($tenant);
+        $this->connections()->save($connection);
+
+        $endpoint = new RemoteEndpoint($connection, RemoteEndpointRole::ReadList, 'GET', '/products');
+        $endpoint->assignTenant($tenant);
+        $this->endpoints()->save($endpoint);
+
+        return $endpoint;
+    }
+
+    private function activateTenantFilter(Tenant $tenant): void
+    {
+        $this->tenantContext()->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function createTenant(string $code): Tenant
+    {
+        $tenant = new Tenant($code, ucfirst($code).' Tenant');
+        $em = $this->em();
+        $em->persist($tenant);
+        $em->flush();
+
+        return $tenant;
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Domain/Entity/RemoteFieldTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Domain/Entity/RemoteFieldTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Domain\Entity;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\RemoteEndpoint;
+use App\Integration\Generic\Domain\Entity\RemoteField;
+use App\Integration\Generic\Domain\Enum\RemoteEndpointRole;
+use App\Integration\Generic\Domain\Enum\RemoteFieldDataType;
+use App\Shared\Domain\Tenant;
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class RemoteFieldTest extends TestCase
+{
+    #[Test]
+    public function newFieldDefaultsToStringWithoutLabelOrSample(): void
+    {
+        $f = $this->field();
+
+        self::assertSame('$.sku', $f->getPath());
+        self::assertSame(RemoteFieldDataType::String, $f->getDataType());
+        self::assertNull($f->getLabel());
+        self::assertNull($f->getSampleValue());
+        self::assertNull($f->getTenant());
+    }
+
+    #[Test]
+    public function exposesItsParentEndpoint(): void
+    {
+        $endpoint = $this->endpoint();
+        $f = new RemoteField($endpoint, '$.id', RemoteFieldDataType::Integer);
+
+        self::assertSame($endpoint, $f->getEndpoint());
+        self::assertSame($endpoint->getId()->toRfc4122(), $f->getEndpointId()->toRfc4122());
+    }
+
+    #[Test]
+    public function settersUpdateValues(): void
+    {
+        $f = $this->field();
+        $f->setPath('$.price.amount');
+        $f->setLabel('Price');
+        $f->setDataType(RemoteFieldDataType::Number);
+        $f->setSampleValue('19.99');
+
+        self::assertSame('$.price.amount', $f->getPath());
+        self::assertSame('Price', $f->getLabel());
+        self::assertSame(RemoteFieldDataType::Number, $f->getDataType());
+        self::assertSame('19.99', $f->getSampleValue());
+    }
+
+    #[Test]
+    public function dataTypeKnowsScalarFromComposite(): void
+    {
+        self::assertTrue(RemoteFieldDataType::String->isScalar());
+        self::assertTrue(RemoteFieldDataType::Integer->isScalar());
+        self::assertTrue(RemoteFieldDataType::Number->isScalar());
+        self::assertTrue(RemoteFieldDataType::Boolean->isScalar());
+        self::assertFalse(RemoteFieldDataType::Object->isScalar());
+        self::assertFalse(RemoteFieldDataType::Array->isScalar());
+        self::assertFalse(RemoteFieldDataType::Null->isScalar());
+    }
+
+    #[Test]
+    public function assignTenantIsWriteOnce(): void
+    {
+        $f = $this->field();
+        $f->assignTenant(new Tenant('alpha', 'Alpha'));
+        self::assertNotNull($f->getTenant());
+
+        $this->expectException(LogicException::class);
+        $f->assignTenant(new Tenant('beta', 'Beta'));
+    }
+
+    private function endpoint(): RemoteEndpoint
+    {
+        $connection = new Connection('idosell', 'IdoSell PL', 'https://api.idosell.com');
+
+        return new RemoteEndpoint($connection, RemoteEndpointRole::ReadList, 'GET', '/products');
+    }
+
+    private function field(): RemoteField
+    {
+        return new RemoteField($this->endpoint(), '$.sku');
+    }
+}


### PR DESCRIPTION
## Cel

APIC-P2-02 — pole zewnętrznego API (wykryte z próbki lub ręczne). Lewa strona mapowania 1:1 (APIC-P2-07/08).

## Zakres

- **Encja `RemoteField`** (`TenantScoped`, extends `AggregateRoot`): `endpoint` (FK → RemoteEndpoint, **CASCADE** on delete), `path` (JSONPath), `label` (nullable), `dataType` (enum), `sampleValue` (nullable).
- **Enum `RemoteFieldDataType`** (`string|integer|number|boolean|object|array|null`, + `isScalar()`).
- **Repozytorium** (interface + Doctrine impl): `findById`, `findByEndpoint`.
- **Migracja `Version20260628110000`** — tabela `integration_remote_fields` + W1-1 **FORCE RLS**, FK tenant RESTRICT / endpoint CASCADE.

## Testy / bramki (uruchomione w kontenerze api)

- **PHPStan max** ✅ · **Deptrac** 0 violations ✅ · **PHP-CS-Fixer** 0 ✅
- **PHPUnit** ✅ 7/7: `RemoteFieldTest` (Layer 1 — defaults, parent endpoint, settery, isScalar, assignTenant write-once) + `RemoteFieldRepositoryTest` (Layer 2 — round-trip + 2-tenant cross-read = 0).
- Migracja zaaplikowana lokalnie; `schema:update --dump-sql` → brak driftu.

Refs #1771