### PR TITLE
feat(integration): implement pagination strategies (APIC-P2-03)

### DIFF
--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -65,6 +65,11 @@ services:
         ApiPlatform\Doctrine\Orm\Filter\FilterInterface:
             tags: ['api_platform.filter']
 
+        # APIC-P2-03 — collect the consumer pagination drivers so
+        # PaginationStrategies can index them by name.
+        App\Integration\Generic\Infrastructure\Http\Pagination\PaginationStrategy:
+            tags: ['integration.pagination_strategy']
+
     App\:
         resource: '../src/'
 
@@ -331,6 +336,15 @@ services:
     # APIC-P1-09 — backoff policy needs the real blocking sleeper.
     App\Integration\Generic\Application\Sleeper:
         alias: App\Integration\Generic\Infrastructure\Http\RealSleeper
+
+    # APIC-P2-03 — consumers that want resilience (pagination, sync) depend on
+    # the RemoteRequester seam; bind it to the 429/503-retrying client.
+    App\Integration\Generic\Infrastructure\Http\RemoteRequester:
+        alias: App\Integration\Generic\Infrastructure\Http\BackoffRestClient
+
+    App\Integration\Generic\Infrastructure\Http\Pagination\PaginationStrategies:
+        arguments:
+            $strategies: !tagged_iterator integration.pagination_strategy
 
     # EXP-06 (#585) — async export worker. Same named-storage binding so
     # the handler can write the generated XLSX/CSV to MinIO under

--- a/apps/api/src/Integration/Generic/Domain/Enum/PaginationStrategyName.php
+++ b/apps/api/src/Integration/Generic/Domain/Enum/PaginationStrategyName.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Enum;
+
+/**
+ * The paging strategy a {@see \App\Integration\Generic\Domain\Entity\RemoteEndpoint}
+ * uses to walk a list response (ADR-0022, epic APIC, ticket APIC-P2-03).
+ *
+ * Stored as the `strategy` key of the endpoint's `pagination` JSONB envelope;
+ * the concrete drivers live in `Infrastructure/Http/Pagination`.
+ */
+enum PaginationStrategyName: string
+{
+    case None = 'none';
+    case Offset = 'offset';
+    case Page = 'page';
+    case Cursor = 'cursor';
+    case LinkHeader = 'link_header';
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Http/BackoffRestClient.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Http/BackoffRestClient.php
@@ -23,7 +23,7 @@ use Psr\Log\NullLogger;
  * edge (the existing `integration_sync` limiter, 10/h/tenant), not per HTTP
  * call — a per-call bucket would starve legitimate bulk syncs.
  */
-final readonly class BackoffRestClient
+final readonly class BackoffRestClient implements RemoteRequester
 {
     private const int MAX_ATTEMPTS = 5;
     private const int MAX_BACKOFF_SECONDS = 60;

--- a/apps/api/src/Integration/Generic/Infrastructure/Http/GenericRestClient.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Http/GenericRestClient.php
@@ -31,7 +31,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * status is returned on the {@see GenericRestResponse}, not thrown — only true
  * transport failures (DNS/TLS/timeout) and over-size responses raise.
  */
-final readonly class GenericRestClient
+final readonly class GenericRestClient implements RemoteRequester
 {
     private const int TIMEOUT_SECONDS = 30;
     private const int MAX_DURATION_SECONDS = 60;

--- a/apps/api/src/Integration/Generic/Infrastructure/Http/Pagination/CursorPaginationStrategy.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Http/Pagination/CursorPaginationStrategy.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Http\Pagination;
+
+use App\Integration\Generic\Domain\Enum\PaginationStrategyName;
+use App\Integration\Generic\Infrastructure\Http\RecordSelector;
+
+/**
+ * Opaque-cursor paging — the first page carries no cursor; each response embeds
+ * the next cursor at `cursorPath`, replayed as `?cursor=…` until it runs dry
+ * (ADR-0022, epic APIC, ticket APIC-P2-03).
+ */
+final readonly class CursorPaginationStrategy implements PaginationStrategy
+{
+    public function __construct(private RecordSelector $selector)
+    {
+    }
+
+    public function name(): PaginationStrategyName
+    {
+        return PaginationStrategyName::Cursor;
+    }
+
+    public function firstPage(PaginationConfig $config): PageRequest
+    {
+        return new PageRequest([$config->limitParam => $config->limit]);
+    }
+
+    public function nextPage(PaginationConfig $config, PageState $state): ?PageRequest
+    {
+        $cursor = $this->selector->value($state->decodedBody, $config->cursorPath);
+
+        if (!\is_string($cursor) && !\is_int($cursor)) {
+            return null;
+        }
+
+        $cursor = (string) $cursor;
+        if ('' === $cursor) {
+            return null;
+        }
+
+        return new PageRequest([$config->cursorParam => $cursor, $config->limitParam => $config->limit]);
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Http/Pagination/LinkHeaderPaginationStrategy.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Http/Pagination/LinkHeaderPaginationStrategy.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Http\Pagination;
+
+use App\Integration\Generic\Domain\Enum\PaginationStrategyName;
+
+/**
+ * RFC 8288 `Link` header paging — follow the `rel="next"` URL until the remote
+ * stops emitting one (GitHub/Shopify style) (ADR-0022, epic APIC, ticket
+ * APIC-P2-03).
+ */
+final class LinkHeaderPaginationStrategy implements PaginationStrategy
+{
+    public function name(): PaginationStrategyName
+    {
+        return PaginationStrategyName::LinkHeader;
+    }
+
+    public function firstPage(PaginationConfig $config): PageRequest
+    {
+        // The base URL drives the first call; the limit is a hint if the API honours it.
+        return new PageRequest([$config->limitParam => $config->limit]);
+    }
+
+    public function nextPage(PaginationConfig $config, PageState $state): ?PageRequest
+    {
+        $linkHeaders = $state->response->headers['link'] ?? [];
+        $next = self::findRel($linkHeaders, $config->linkRel);
+
+        return null === $next ? null : new PageRequest([], $next);
+    }
+
+    /**
+     * Parses `<url>; rel="next", <url>; rel="prev"` across one or more Link
+     * header values and returns the URL for the requested rel.
+     *
+     * @param list<string> $headers
+     */
+    private static function findRel(array $headers, string $rel): ?string
+    {
+        foreach ($headers as $header) {
+            foreach (explode(',', $header) as $part) {
+                if (1 !== preg_match('/<([^>]+)>\s*;\s*rel\s*=\s*"?([^";]+)"?/', $part, $matches)) {
+                    continue;
+                }
+                if (strtolower(trim($matches[2])) === strtolower($rel)) {
+                    return trim($matches[1]);
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Http/Pagination/NonePaginationStrategy.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Http/Pagination/NonePaginationStrategy.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Http\Pagination;
+
+use App\Integration\Generic\Domain\Enum\PaginationStrategyName;
+
+/**
+ * No paging — fetch the single page and stop (ADR-0022, epic APIC).
+ */
+final class NonePaginationStrategy implements PaginationStrategy
+{
+    public function name(): PaginationStrategyName
+    {
+        return PaginationStrategyName::None;
+    }
+
+    public function firstPage(PaginationConfig $config): PageRequest
+    {
+        return new PageRequest();
+    }
+
+    public function nextPage(PaginationConfig $config, PageState $state): ?PageRequest
+    {
+        return null;
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Http/Pagination/OffsetPaginationStrategy.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Http/Pagination/OffsetPaginationStrategy.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Http\Pagination;
+
+use App\Integration\Generic\Domain\Enum\PaginationStrategyName;
+
+/**
+ * Offset/limit paging — `?offset=0&limit=N`, `?offset=N&limit=N`, … until a
+ * short (or empty) page signals the end (ADR-0022, epic APIC, ticket APIC-P2-03).
+ */
+final class OffsetPaginationStrategy implements PaginationStrategy
+{
+    public function name(): PaginationStrategyName
+    {
+        return PaginationStrategyName::Offset;
+    }
+
+    public function firstPage(PaginationConfig $config): PageRequest
+    {
+        return new PageRequest([$config->offsetParam => 0, $config->limitParam => $config->limit]);
+    }
+
+    public function nextPage(PaginationConfig $config, PageState $state): ?PageRequest
+    {
+        // A page shorter than the limit (or empty) is the last one.
+        if ($state->recordCount < $config->limit) {
+            return null;
+        }
+
+        $nextOffset = ($state->pageIndex + 1) * $config->limit;
+
+        return new PageRequest([$config->offsetParam => $nextOffset, $config->limitParam => $config->limit]);
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Http/Pagination/PagePaginationStrategy.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Http/Pagination/PagePaginationStrategy.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Http\Pagination;
+
+use App\Integration\Generic\Domain\Enum\PaginationStrategyName;
+
+/**
+ * Page-number paging — `?page=1&limit=N`, `?page=2&limit=N`, … until a short
+ * (or empty) page signals the end (ADR-0022, epic APIC, ticket APIC-P2-03).
+ */
+final class PagePaginationStrategy implements PaginationStrategy
+{
+    public function name(): PaginationStrategyName
+    {
+        return PaginationStrategyName::Page;
+    }
+
+    public function firstPage(PaginationConfig $config): PageRequest
+    {
+        return new PageRequest([$config->pageParam => $config->startPage, $config->limitParam => $config->limit]);
+    }
+
+    public function nextPage(PaginationConfig $config, PageState $state): ?PageRequest
+    {
+        if ($state->recordCount < $config->limit) {
+            return null;
+        }
+
+        $nextPage = $config->startPage + $state->pageIndex + 1;
+
+        return new PageRequest([$config->pageParam => $nextPage, $config->limitParam => $config->limit]);
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Http/Pagination/PageRequest.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Http/Pagination/PageRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Http\Pagination;
+
+/**
+ * The next page to fetch as computed by a {@see PaginationStrategy} (ADR-0022,
+ * epic APIC, ticket APIC-P2-03).
+ *
+ * `query` carries the pagination params merged onto the endpoint's static query
+ * by the fetcher. `url`, when set (link_header), overrides the endpoint's base
+ * URL with the absolute next link the remote returned — it still passes the
+ * SSRF guard on the next request.
+ *
+ * @phpstan-type QueryParams array<string, string|int>
+ */
+final readonly class PageRequest
+{
+    /**
+     * @param array<string, string|int> $query
+     */
+    public function __construct(
+        public array $query = [],
+        public ?string $url = null,
+    ) {
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Http/Pagination/PageState.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Http/Pagination/PageState.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Http\Pagination;
+
+use App\Integration\Generic\Domain\GenericRestResponse;
+
+/**
+ * The outcome of the page just fetched, handed to {@see PaginationStrategy::nextPage()}
+ * to decide whether (and how) to advance (ADR-0022, epic APIC, ticket APIC-P2-03).
+ */
+final readonly class PageState
+{
+    /**
+     * @param int   $pageIndex   zero-based index of the page just fetched
+     * @param int   $recordCount records the selector extracted from it
+     * @param mixed $decodedBody the json_decode(..., true) body (for cursor lookups)
+     */
+    public function __construct(
+        public int $pageIndex,
+        public int $recordCount,
+        public GenericRestResponse $response,
+        public mixed $decodedBody,
+    ) {
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Http/Pagination/PaginatedFetcher.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Http/Pagination/PaginatedFetcher.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Http\Pagination;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\RemoteEndpoint;
+use App\Integration\Generic\Infrastructure\Http\RecordSelector;
+use App\Integration\Generic\Infrastructure\Http\RemoteRequester;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Walks a read endpoint page by page through the SSRF-safe requester, applying
+ * its descriptor's pagination strategy and record selector (ADR-0022, epic
+ * APIC, ticket APIC-P2-03).
+ *
+ * `pages()` is a generator, so a 50k-record pull never materialises in memory —
+ * the sync handler (APIC-P3-04) consumes one page at a time and clears the
+ * Doctrine unit of work between batches (FrankenPHP worker hygiene). A hard
+ * page cap guards against a misconfigured cursor/offset that never terminates;
+ * a non-2xx page ends the walk (the caller decides what a partial pull means).
+ */
+final readonly class PaginatedFetcher
+{
+    /** Infinite-loop guard: stop after this many pages regardless of strategy. */
+    public const int MAX_PAGES = 10_000;
+
+    public function __construct(
+        private RemoteRequester $requester,
+        private RecordSelector $recordSelector,
+        private PaginationStrategies $strategies,
+        private LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    /**
+     * Yields one batch of records per page, in order.
+     *
+     * @return iterable<int, list<array<array-key, mixed>>>
+     */
+    public function pages(Connection $connection, RemoteEndpoint $endpoint): iterable
+    {
+        $config = PaginationConfig::fromArray($endpoint->getPagination());
+        $strategy = $this->strategies->get($config->strategy);
+        $baseUrl = $this->buildUrl($connection, $endpoint);
+        $request = $strategy->firstPage($config);
+
+        for ($pageIndex = 0; null !== $request; ++$pageIndex) {
+            if ($pageIndex >= self::MAX_PAGES) {
+                $this->logger->warning('Pagination page cap reached; stopping walk.', [
+                    'connection' => $connection->getCode(),
+                    'endpoint' => $endpoint->getId()->toRfc4122(),
+                    'cap' => self::MAX_PAGES,
+                ]);
+                break;
+            }
+
+            $url = $request->url ?? $baseUrl;
+            $query = array_merge($endpoint->getQueryParams(), $request->query);
+
+            $response = $this->requester->request($connection, $endpoint->getHttpMethod(), $url, $query);
+            if (!$response->isSuccessful()) {
+                $this->logger->warning('External list page returned non-2xx; stopping walk.', [
+                    'connection' => $connection->getCode(),
+                    'endpoint' => $endpoint->getId()->toRfc4122(),
+                    'status' => $response->statusCode,
+                    'page' => $pageIndex,
+                ]);
+                break;
+            }
+
+            $decoded = json_decode($response->body, true);
+            $records = $this->recordSelector->records($decoded, $endpoint->getRecordSelector());
+
+            yield $records;
+
+            $request = $strategy->nextPage(
+                $config,
+                new PageState($pageIndex, \count($records), $response, $decoded),
+            );
+        }
+    }
+
+    /**
+     * Flattens {@see pages()} into a single record stream.
+     *
+     * @return iterable<int, array<array-key, mixed>>
+     */
+    public function records(Connection $connection, RemoteEndpoint $endpoint): iterable
+    {
+        foreach ($this->pages($connection, $endpoint) as $page) {
+            yield from $page;
+        }
+    }
+
+    private function buildUrl(Connection $connection, RemoteEndpoint $endpoint): string
+    {
+        $path = ltrim($endpoint->getPathTemplate(), '/');
+        if ('' === $path) {
+            return $connection->getBaseUrl();
+        }
+
+        return rtrim($connection->getBaseUrl(), '/').'/'.$path;
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Http/Pagination/PaginationConfig.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Http/Pagination/PaginationConfig.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Http\Pagination;
+
+use App\Integration\Generic\Domain\Enum\PaginationStrategyName;
+
+/**
+ * The parsed `pagination` envelope of a {@see \App\Integration\Generic\Domain\Entity\RemoteEndpoint}
+ * (ADR-0022, epic APIC, ticket APIC-P2-03).
+ *
+ * Every per-strategy knob carries a sensible default so a minimal
+ * `{"strategy":"offset"}` works out of the box. Unknown strategy values fall
+ * back to `none` (a single page) rather than erroring a sync.
+ */
+final readonly class PaginationConfig
+{
+    public function __construct(
+        public PaginationStrategyName $strategy,
+        public int $limit = 100,
+        public string $limitParam = 'limit',
+        public string $offsetParam = 'offset',
+        public string $pageParam = 'page',
+        public int $startPage = 1,
+        public string $cursorParam = 'cursor',
+        public string $cursorPath = '$.next_cursor',
+        public string $linkRel = 'next',
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $pagination
+     */
+    public static function fromArray(array $pagination): self
+    {
+        $strategy = PaginationStrategyName::tryFrom(self::str($pagination, 'strategy', 'none'))
+            ?? PaginationStrategyName::None;
+
+        return new self(
+            strategy: $strategy,
+            limit: self::int($pagination, 'limit', 100),
+            limitParam: self::str($pagination, 'limitParam', 'limit'),
+            offsetParam: self::str($pagination, 'offsetParam', 'offset'),
+            pageParam: self::str($pagination, 'pageParam', 'page'),
+            startPage: self::int($pagination, 'startPage', 1, 0),
+            cursorParam: self::str($pagination, 'cursorParam', 'cursor'),
+            cursorPath: self::str($pagination, 'cursorPath', '$.next_cursor'),
+            linkRel: self::str($pagination, 'linkRel', 'next'),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private static function str(array $data, string $key, string $default): string
+    {
+        $value = $data[$key] ?? null;
+
+        return \is_string($value) && '' !== $value ? $value : $default;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private static function int(array $data, string $key, int $default, int $min = 1): int
+    {
+        $value = $data[$key] ?? null;
+
+        return \is_int($value) && $value >= $min ? $value : $default;
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Http/Pagination/PaginationStrategies.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Http/Pagination/PaginationStrategies.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Http\Pagination;
+
+use App\Integration\Generic\Domain\Enum\PaginationStrategyName;
+use LogicException;
+
+/**
+ * Resolves a {@see PaginationStrategyName} to its driver (ADR-0022, epic APIC,
+ * ticket APIC-P2-03). The five MVP strategies are injected and indexed by name;
+ * an unknown name can never occur (the enum is closed), but the constructor
+ * fails loudly if a strategy is missing from the wiring.
+ */
+final class PaginationStrategies
+{
+    /** @var array<string, PaginationStrategy> */
+    private array $byName;
+
+    /**
+     * @param iterable<PaginationStrategy> $strategies
+     */
+    public function __construct(iterable $strategies)
+    {
+        $byName = [];
+        foreach ($strategies as $strategy) {
+            $byName[$strategy->name()->value] = $strategy;
+        }
+        $this->byName = $byName;
+    }
+
+    public function get(PaginationStrategyName $name): PaginationStrategy
+    {
+        return $this->byName[$name->value]
+            ?? throw new LogicException(\sprintf('No pagination strategy registered for "%s".', $name->value));
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Http/Pagination/PaginationStrategy.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Http/Pagination/PaginationStrategy.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Http\Pagination;
+
+use App\Integration\Generic\Domain\Enum\PaginationStrategyName;
+
+/**
+ * A driver that walks one external list endpoint (ADR-0022, epic APIC, ticket
+ * APIC-P2-03).
+ *
+ * `firstPage()` yields the params for page 1; `nextPage()` inspects the page
+ * just fetched and returns the next {@see PageRequest}, or null when the walk
+ * is complete. Strategies are pure — the {@see PaginatedFetcher} owns the HTTP,
+ * record extraction and the infinite-loop guard.
+ */
+interface PaginationStrategy
+{
+    public function name(): PaginationStrategyName;
+
+    public function firstPage(PaginationConfig $config): PageRequest;
+
+    public function nextPage(PaginationConfig $config, PageState $state): ?PageRequest;
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Http/RecordSelector.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Http/RecordSelector.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Http;
+
+/**
+ * Resolves a record selector against a decoded JSON body (ADR-0022, epic APIC,
+ * ticket APIC-P2-03).
+ *
+ * MVP supports the dot-path subset of JSONPath the wizard emits — `$` (root),
+ * `$.results`, `$.data.items`, or the bare `results` form. Full JSONPath
+ * (filters, wildcards, recursive descent) is a deferred §7 hook; the selector
+ * column is wide enough to grow into it without a migration.
+ *
+ * `records()` always yields a list of associative records: a list selector
+ * returns its rows, a single object is wrapped, anything else is empty.
+ * `value()` returns the raw node for scalar lookups (e.g. the next cursor).
+ */
+final class RecordSelector
+{
+    /**
+     * Extracts the list of records a read endpoint returns. Keys are
+     * `array-key` rather than `string` — JSON object keys decode to strings,
+     * but that cannot be proven from a `mixed` body, so the safe superset is
+     * declared and downstream lookups use the (string) field path regardless.
+     *
+     * @param mixed $decoded the json_decode(..., true) body
+     *
+     * @return list<array<array-key, mixed>>
+     */
+    public function records(mixed $decoded, ?string $selector): array
+    {
+        $node = $this->value($decoded, $selector);
+
+        if (!\is_array($node) || [] === $node) {
+            return [];
+        }
+
+        if (array_is_list($node)) {
+            return self::arrayRows($node);
+        }
+
+        // A single object response (read_one, or a list endpoint returning one record).
+        return [$node];
+    }
+
+    /**
+     * Keeps only the array elements of a list (skips scalar rows).
+     *
+     * @param list<mixed> $rows
+     *
+     * @return list<array<array-key, mixed>>
+     */
+    private static function arrayRows(array $rows): array
+    {
+        $records = [];
+        foreach ($rows as $row) {
+            if (\is_array($row)) {
+                $records[] = $row;
+            }
+        }
+
+        return $records;
+    }
+
+    /**
+     * Resolves a dot path to its raw node, or null when any segment is missing.
+     *
+     * @param mixed $decoded the json_decode(..., true) body
+     */
+    public function value(mixed $decoded, ?string $path): mixed
+    {
+        $segments = self::segments($path);
+        $node = $decoded;
+
+        foreach ($segments as $segment) {
+            if (!\is_array($node) || !\array_key_exists($segment, $node)) {
+                return null;
+            }
+            $node = $node[$segment];
+        }
+
+        return $node;
+    }
+
+    /**
+     * Splits `$.a.b` / `a.b` / `$` into path segments. Root (`$`, ``, null)
+     * yields no segments, so the whole body is returned.
+     *
+     * @return list<string>
+     */
+    private static function segments(?string $path): array
+    {
+        if (null === $path) {
+            return [];
+        }
+
+        $trimmed = ltrim(trim($path), '$');
+        $trimmed = ltrim($trimmed, '.');
+        if ('' === $trimmed) {
+            return [];
+        }
+
+        return array_values(array_filter(explode('.', $trimmed), static fn (string $s): bool => '' !== $s));
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Http/RemoteRequester.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Http/RemoteRequester.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Http;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Exception\RemoteRequestFailedException;
+use App\Integration\Generic\Domain\Exception\SsrfBlockedException;
+use App\Integration\Generic\Domain\GenericRestResponse;
+
+/**
+ * The narrow HTTP seam the consumer side depends on (ADR-0022, epic APIC).
+ *
+ * Both {@see GenericRestClient} (SSRF-safe transport + auth injection) and
+ * {@see BackoffRestClient} (429/503 retry on top) implement it. Callers that
+ * want resilience type-hint this interface; the service alias binds it to the
+ * backoff-wrapped client. Keeping the seam an interface also lets pagination
+ * and discovery be unit-tested with a fake, since the concrete clients are
+ * `final readonly`.
+ */
+interface RemoteRequester
+{
+    /**
+     * @param array<string, string|int> $query
+     * @param array<string, string>     $headers
+     *
+     * @throws SsrfBlockedException
+     * @throws RemoteRequestFailedException
+     */
+    public function request(
+        Connection $connection,
+        string $method,
+        string $url,
+        array $query = [],
+        array $headers = [],
+        ?string $body = null,
+    ): GenericRestResponse;
+}

--- a/apps/api/tests/Unit/Integration/Generic/Infrastructure/Http/Pagination/PaginatedFetcherTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Infrastructure/Http/Pagination/PaginatedFetcherTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Infrastructure\Http\Pagination;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\RemoteEndpoint;
+use App\Integration\Generic\Domain\Enum\RemoteEndpointRole;
+use App\Integration\Generic\Domain\GenericRestResponse;
+use App\Integration\Generic\Infrastructure\Http\Pagination\CursorPaginationStrategy;
+use App\Integration\Generic\Infrastructure\Http\Pagination\LinkHeaderPaginationStrategy;
+use App\Integration\Generic\Infrastructure\Http\Pagination\NonePaginationStrategy;
+use App\Integration\Generic\Infrastructure\Http\Pagination\OffsetPaginationStrategy;
+use App\Integration\Generic\Infrastructure\Http\Pagination\PagePaginationStrategy;
+use App\Integration\Generic\Infrastructure\Http\Pagination\PaginatedFetcher;
+use App\Integration\Generic\Infrastructure\Http\Pagination\PaginationStrategies;
+use App\Integration\Generic\Infrastructure\Http\RecordSelector;
+use App\Integration\Generic\Infrastructure\Http\RemoteRequester;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PaginatedFetcherTest extends TestCase
+{
+    #[Test]
+    public function offsetWalkAggregatesEveryPageUntilAShortOne(): void
+    {
+        $requester = $this->requester([
+            $this->jsonPage([['sku' => 'A'], ['sku' => 'B']]),
+            $this->jsonPage([['sku' => 'C'], ['sku' => 'D']]),
+            $this->jsonPage([['sku' => 'E']]),
+        ]);
+        $fetcher = $this->fetcher($requester);
+        $endpoint = $this->endpoint(['strategy' => 'offset', 'limit' => 2], '$');
+
+        $records = iterator_to_array($fetcher->records($this->connection(), $endpoint), false);
+
+        self::assertCount(5, $records);
+        self::assertSame(['A', 'B', 'C', 'D', 'E'], array_column($records, 'sku'));
+        // Three requests with advancing offsets, built off baseUrl + pathTemplate.
+        self::assertCount(3, $requester->calls);
+        self::assertSame('https://api.example.com/v1/products', $requester->calls[0]['url']);
+        self::assertSame(['offset' => 0, 'limit' => 2], $requester->calls[0]['query']);
+        self::assertSame(['offset' => 2, 'limit' => 2], $requester->calls[1]['query']);
+        self::assertSame(['offset' => 4, 'limit' => 2], $requester->calls[2]['query']);
+    }
+
+    #[Test]
+    public function recordSelectorExtractsFromAnEnvelope(): void
+    {
+        $requester = $this->requester([
+            new GenericRestResponse(200, [], (string) json_encode(['results' => [['id' => 1], ['id' => 2]]]), 1, 2),
+        ]);
+        $fetcher = $this->fetcher($requester);
+        $endpoint = $this->endpoint(['strategy' => 'none'], '$.results');
+
+        $records = iterator_to_array($fetcher->records($this->connection(), $endpoint), false);
+
+        self::assertSame([1, 2], array_column($records, 'id'));
+    }
+
+    #[Test]
+    public function staticQueryParamsRideAlongWithPagination(): void
+    {
+        $requester = $this->requester([$this->jsonPage([['id' => 1]])]);
+        $fetcher = $this->fetcher($requester);
+        $endpoint = $this->endpoint(['strategy' => 'offset', 'limit' => 50], '$');
+        $endpoint->setQueryParams(['locale' => 'pl']);
+
+        iterator_to_array($fetcher->records($this->connection(), $endpoint), false);
+
+        self::assertSame(['locale' => 'pl', 'offset' => 0, 'limit' => 50], $requester->calls[0]['query']);
+    }
+
+    #[Test]
+    public function aNonSuccessfulPageEndsTheWalk(): void
+    {
+        $requester = $this->requester([
+            $this->jsonPage([['id' => 1], ['id' => 2]]),
+            new GenericRestResponse(500, [], 'oops', 1, 4),
+        ]);
+        $fetcher = $this->fetcher($requester);
+        $endpoint = $this->endpoint(['strategy' => 'offset', 'limit' => 2], '$');
+
+        $records = iterator_to_array($fetcher->records($this->connection(), $endpoint), false);
+
+        // First page kept; the 500 stops the walk without yielding more.
+        self::assertCount(2, $records);
+        self::assertCount(2, $requester->calls);
+    }
+
+    #[Test]
+    public function loopGuardStopsAnEndlesslyAdvancingWalk(): void
+    {
+        // Every page is full → the offset strategy never short-circuits.
+        $requester = new RecordingRequester(default: new GenericRestResponse(200, [], '[{"id":1},{"id":2}]', 1, 8));
+        $fetcher = $this->fetcher($requester);
+        $endpoint = $this->endpoint(['strategy' => 'offset', 'limit' => 2], '$');
+
+        $pages = 0;
+        foreach ($fetcher->pages($this->connection(), $endpoint) as $_page) {
+            ++$pages;
+        }
+
+        self::assertSame(PaginatedFetcher::MAX_PAGES, $pages);
+        self::assertCount(PaginatedFetcher::MAX_PAGES, $requester->calls);
+    }
+
+    /**
+     * @param list<GenericRestResponse> $responses
+     */
+    private function requester(array $responses): RecordingRequester
+    {
+        return new RecordingRequester($responses);
+    }
+
+    private function fetcher(RemoteRequester $requester): PaginatedFetcher
+    {
+        $strategies = new PaginationStrategies([
+            new NonePaginationStrategy(),
+            new OffsetPaginationStrategy(),
+            new PagePaginationStrategy(),
+            new CursorPaginationStrategy(new RecordSelector()),
+            new LinkHeaderPaginationStrategy(),
+        ]);
+
+        return new PaginatedFetcher($requester, new RecordSelector(), $strategies);
+    }
+
+    private function connection(): Connection
+    {
+        return new Connection('idosell', 'IdoSell', 'https://api.example.com/v1');
+    }
+
+    /**
+     * @param array<string, mixed> $pagination
+     */
+    private function endpoint(array $pagination, string $selector): RemoteEndpoint
+    {
+        $endpoint = new RemoteEndpoint($this->connection(), RemoteEndpointRole::ReadList, 'GET', '/products');
+        $endpoint->setPagination($pagination);
+        $endpoint->setRecordSelector($selector);
+
+        return $endpoint;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $records
+     */
+    private function jsonPage(array $records): GenericRestResponse
+    {
+        return new GenericRestResponse(200, [], (string) json_encode($records), 1, 16);
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Infrastructure/Http/Pagination/PaginationStrategyTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Infrastructure/Http/Pagination/PaginationStrategyTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Infrastructure\Http\Pagination;
+
+use App\Integration\Generic\Domain\Enum\PaginationStrategyName;
+use App\Integration\Generic\Domain\GenericRestResponse;
+use App\Integration\Generic\Infrastructure\Http\Pagination\CursorPaginationStrategy;
+use App\Integration\Generic\Infrastructure\Http\Pagination\LinkHeaderPaginationStrategy;
+use App\Integration\Generic\Infrastructure\Http\Pagination\NonePaginationStrategy;
+use App\Integration\Generic\Infrastructure\Http\Pagination\OffsetPaginationStrategy;
+use App\Integration\Generic\Infrastructure\Http\Pagination\PagePaginationStrategy;
+use App\Integration\Generic\Infrastructure\Http\Pagination\PageState;
+use App\Integration\Generic\Infrastructure\Http\Pagination\PaginationConfig;
+use App\Integration\Generic\Infrastructure\Http\RecordSelector;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PaginationStrategyTest extends TestCase
+{
+    #[Test]
+    public function noneFetchesASinglePage(): void
+    {
+        $strategy = new NonePaginationStrategy();
+        $config = PaginationConfig::fromArray(['strategy' => 'none']);
+
+        self::assertSame(PaginationStrategyName::None, $strategy->name());
+        self::assertSame([], $strategy->firstPage($config)->query);
+        self::assertNull($strategy->nextPage($config, $this->state(0, 50)));
+    }
+
+    #[Test]
+    public function offsetAdvancesUntilAShortPage(): void
+    {
+        $strategy = new OffsetPaginationStrategy();
+        $config = PaginationConfig::fromArray(['strategy' => 'offset', 'limit' => 100]);
+
+        self::assertSame(['offset' => 0, 'limit' => 100], $strategy->firstPage($config)->query);
+        // Full page → next offset = (0+1)*100.
+        self::assertSame(['offset' => 100, 'limit' => 100], $strategy->nextPage($config, $this->state(0, 100))?->query);
+        // Second full page → next offset = (1+1)*100.
+        self::assertSame(['offset' => 200, 'limit' => 100], $strategy->nextPage($config, $this->state(1, 100))?->query);
+        // Short page ends the walk.
+        self::assertNull($strategy->nextPage($config, $this->state(2, 40)));
+    }
+
+    #[Test]
+    public function offsetRespectsCustomParamNames(): void
+    {
+        $strategy = new OffsetPaginationStrategy();
+        $config = PaginationConfig::fromArray([
+            'strategy' => 'offset',
+            'limit' => 25,
+            'offsetParam' => 'skip',
+            'limitParam' => 'take',
+        ]);
+
+        self::assertSame(['skip' => 0, 'take' => 25], $strategy->firstPage($config)->query);
+        self::assertSame(['skip' => 25, 'take' => 25], $strategy->nextPage($config, $this->state(0, 25))?->query);
+    }
+
+    #[Test]
+    public function pageIncrementsThePageNumber(): void
+    {
+        $strategy = new PagePaginationStrategy();
+        $config = PaginationConfig::fromArray(['strategy' => 'page', 'limit' => 50, 'startPage' => 1]);
+
+        self::assertSame(['page' => 1, 'limit' => 50], $strategy->firstPage($config)->query);
+        self::assertSame(['page' => 2, 'limit' => 50], $strategy->nextPage($config, $this->state(0, 50))?->query);
+        self::assertSame(['page' => 3, 'limit' => 50], $strategy->nextPage($config, $this->state(1, 50))?->query);
+        self::assertNull($strategy->nextPage($config, $this->state(2, 10)));
+    }
+
+    #[Test]
+    public function pageHonoursAZeroBasedStart(): void
+    {
+        $strategy = new PagePaginationStrategy();
+        $config = PaginationConfig::fromArray(['strategy' => 'page', 'limit' => 50, 'startPage' => 0]);
+
+        self::assertSame(['page' => 0, 'limit' => 50], $strategy->firstPage($config)->query);
+        self::assertSame(['page' => 1, 'limit' => 50], $strategy->nextPage($config, $this->state(0, 50))?->query);
+    }
+
+    #[Test]
+    public function cursorFollowsTheEmbeddedCursorUntilItRunsDry(): void
+    {
+        $strategy = new CursorPaginationStrategy(new RecordSelector());
+        $config = PaginationConfig::fromArray([
+            'strategy' => 'cursor',
+            'limit' => 100,
+            'cursorParam' => 'after',
+            'cursorPath' => '$.meta.next',
+        ]);
+
+        self::assertSame(['limit' => 100], $strategy->firstPage($config)->query);
+
+        $withCursor = new PageState(0, 100, $this->response(), ['meta' => ['next' => 'CUR-2']]);
+        self::assertSame(['after' => 'CUR-2', 'limit' => 100], $strategy->nextPage($config, $withCursor)?->query);
+
+        $noCursor = new PageState(1, 100, $this->response(), ['meta' => ['next' => null]]);
+        self::assertNull($strategy->nextPage($config, $noCursor));
+
+        $missing = new PageState(1, 100, $this->response(), ['data' => []]);
+        self::assertNull($strategy->nextPage($config, $missing));
+    }
+
+    #[Test]
+    public function linkHeaderFollowsRelNext(): void
+    {
+        $strategy = new LinkHeaderPaginationStrategy();
+        $config = PaginationConfig::fromArray(['strategy' => 'link_header']);
+
+        $withNext = new PageState(0, 100, $this->responseWithLink(
+            '<https://api.example.com/p?page=2>; rel="next", <https://api.example.com/p?page=9>; rel="last"',
+        ), []);
+        self::assertSame('https://api.example.com/p?page=2', $strategy->nextPage($config, $withNext)?->url);
+
+        $lastOnly = new PageState(1, 100, $this->responseWithLink(
+            '<https://api.example.com/p?page=1>; rel="prev"',
+        ), []);
+        self::assertNull($strategy->nextPage($config, $lastOnly));
+    }
+
+    private function state(int $pageIndex, int $recordCount): PageState
+    {
+        return new PageState($pageIndex, $recordCount, $this->response(), []);
+    }
+
+    private function response(): GenericRestResponse
+    {
+        return new GenericRestResponse(200, [], '[]', 5, 2);
+    }
+
+    private function responseWithLink(string $link): GenericRestResponse
+    {
+        return new GenericRestResponse(200, ['link' => [$link]], '[]', 5, 2);
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Infrastructure/Http/Pagination/RecordingRequester.php
+++ b/apps/api/tests/Unit/Integration/Generic/Infrastructure/Http/Pagination/RecordingRequester.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Infrastructure\Http\Pagination;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\GenericRestResponse;
+use App\Integration\Generic\Infrastructure\Http\RemoteRequester;
+
+/**
+ * Test double for {@see RemoteRequester}: replays a queue of canned responses
+ * and records each call's URL + query so pagination assertions can inspect how
+ * the walk drove the requests. When the queue drains it returns `$default`
+ * (or an empty page) — handy for the loop-guard case where every page is full.
+ */
+final class RecordingRequester implements RemoteRequester
+{
+    /** @var list<array{url: string, query: array<string, string|int>}> */
+    public array $calls = [];
+
+    /**
+     * @param list<GenericRestResponse> $queue
+     */
+    public function __construct(
+        private array $queue = [],
+        private ?GenericRestResponse $default = null,
+    ) {
+    }
+
+    public function request(
+        Connection $connection,
+        string $method,
+        string $url,
+        array $query = [],
+        array $headers = [],
+        ?string $body = null,
+    ): GenericRestResponse {
+        $this->calls[] = ['url' => $url, 'query' => $query];
+
+        return array_shift($this->queue)
+            ?? $this->default
+            ?? new GenericRestResponse(200, [], '[]', 1, 2);
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Infrastructure/Http/RecordSelectorTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Infrastructure/Http/RecordSelectorTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Infrastructure\Http;
+
+use App\Integration\Generic\Infrastructure\Http\RecordSelector;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class RecordSelectorTest extends TestCase
+{
+    private RecordSelector $selector;
+
+    protected function setUp(): void
+    {
+        $this->selector = new RecordSelector();
+    }
+
+    #[Test]
+    public function rootSelectorReturnsATopLevelList(): void
+    {
+        $body = [['sku' => 'A'], ['sku' => 'B']];
+
+        self::assertSame($body, $this->selector->records($body, '$'));
+        self::assertSame($body, $this->selector->records($body, null));
+    }
+
+    #[Test]
+    public function dottedSelectorDigsIntoTheEnvelope(): void
+    {
+        $body = ['results' => [['sku' => 'A'], ['sku' => 'B']]];
+
+        self::assertSame($body['results'], $this->selector->records($body, '$.results'));
+        self::assertSame($body['results'], $this->selector->records($body, 'results'));
+    }
+
+    #[Test]
+    public function nestedSelectorWalksMultipleSegments(): void
+    {
+        $body = ['data' => ['items' => [['id' => 1]]]];
+
+        self::assertSame([['id' => 1]], $this->selector->records($body, '$.data.items'));
+    }
+
+    #[Test]
+    public function singleObjectIsWrappedAsOneRecord(): void
+    {
+        $body = ['sku' => 'A', 'name' => 'Widget'];
+
+        self::assertSame([$body], $this->selector->records($body, '$'));
+    }
+
+    #[Test]
+    public function missingPathYieldsNoRecords(): void
+    {
+        self::assertSame([], $this->selector->records(['results' => []], '$.missing'));
+        self::assertSame([], $this->selector->records(null, '$.results'));
+        self::assertSame([], $this->selector->records('not json', '$'));
+    }
+
+    #[Test]
+    public function valueResolvesAScalarForCursorLookups(): void
+    {
+        $body = ['meta' => ['next_cursor' => 'abc123']];
+
+        self::assertSame('abc123', $this->selector->value($body, '$.meta.next_cursor'));
+        self::assertNull($this->selector->value($body, '$.meta.missing'));
+    }
+}


### PR DESCRIPTION
## Cel

APIC-P2-03 — sterowniki paginacji napędzane descriptorem endpointu. Iterator stron z `recordSelector` + guard nieskończonej pętli.

## Zakres

- **5 strategii** (`Infrastructure/Http/Pagination/`): `none`, `offset` (`?offset=&limit=`), `page` (`?page=&limit=`), `cursor` (next-cursor z body przez `cursorPath`), `link_header` (RFC 8288 `rel="next"`). Każda to czysty driver: `firstPage()` + `nextPage(state)` → `PageRequest|null`.
- **`PaginatedFetcher`** — generator chodzący po stronach przez `RemoteRequester` (SSRF-safe), ekstrakcja rekordów przez `RecordSelector`, **page cap** (`MAX_PAGES=10_000`) jako guard pętli; non-2xx kończy walk. Yielduje stronę naraz → 50k rekordów bez materializacji w pamięci (worker hygiene pod P3-04).
- **`RecordSelector`** — minimalny dot-path JSONPath (`$`, `$.results`, `$.data.items`); pełny JSONPath = deferred §7 hook.
- **`PaginationConfig`** VO (parsowanie envelope JSONB z defaultami), **`PageRequest`/`PageState`** VO, **`PaginationStrategies`** resolver (tagged iterator).
- **`RemoteRequester`** seam — `GenericRestClient` + `BackoffRestClient` implementują; alias wiąże interface → backoff (resilient path).

## Decyzje

- Strategie czyste/testowalne; HTTP + record-extraction + loop-guard żyją w fetcherze (separacja).
- `RecordSelector::records()` zwraca `list<array<array-key, mixed>>` — klucze obiektów JSON to stringi, ale tego nie da się udowodnić z `mixed` body; bezpieczny superset, lookupy i tak po (string) path.

## Testy / bramki (kontener api)

- **PHPStan max** ✅ · **Deptrac** 0 ✅ · **PHP-CS-Fixer** 0 ✅
- **PHPUnit** ✅ 18/18: `PaginationStrategyTest` (5 strategii — first/next, custom param names, zero-based start, cursor drain, Link parse), `RecordSelectorTest` (root/dotted/nested/single-object/missing/value), `PaginatedFetcherTest` (multi-page aggregation, envelope selector, static query ride-along, non-2xx stop, **loop guard = MAX_PAGES**). Pełny suite Generic: 75/75.
- DI zweryfikowane (`debug:container`): 5 strategii tagged, `RemoteRequester` → `BackoffRestClient`.

Refs #1772