### PR TITLE
feat(integration): SchemaDiscoveryService proposes RemoteFields (APIC-P2-04)

### DIFF
--- a/apps/api/src/Integration/Generic/Application/Discovery/DiscoveredField.php
+++ b/apps/api/src/Integration/Generic/Application/Discovery/DiscoveredField.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application\Discovery;
+
+use App\Integration\Generic\Domain\Enum\RemoteFieldDataType;
+
+/**
+ * A field proposed by {@see SchemaDiscoveryService} from a response sample
+ * (ADR-0022, epic APIC, ticket APIC-P2-04).
+ *
+ * It is a proposal, not a persisted {@see \App\Integration\Generic\Domain\Entity\RemoteField}:
+ * the wizard (APIC-P2-06) lets the user accept/edit before the CRUD endpoint
+ * (APIC-P2-05) saves the accepted ones.
+ */
+final readonly class DiscoveredField
+{
+    public function __construct(
+        public string $path,
+        public RemoteFieldDataType $dataType,
+        public ?string $sampleValue,
+    ) {
+    }
+}

--- a/apps/api/src/Integration/Generic/Application/Discovery/JsonFlattener.php
+++ b/apps/api/src/Integration/Generic/Application/Discovery/JsonFlattener.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application\Discovery;
+
+use App\Integration\Generic\Domain\Enum\RemoteFieldDataType;
+
+/**
+ * Flattens a decoded JSON record into a list of {@see DiscoveredField} dot paths
+ * (ADR-0022, epic APIC, ticket APIC-P2-04).
+ *
+ * Nested objects are walked recursively (`$.price.amount`); lists and scalars
+ * are leaves typed from the sampled value. A depth and field-count cap keep a
+ * pathological payload from exploding the proposal. Sample values are truncated
+ * — and since the only inputs are public list responses (never credentials),
+ * nothing sensitive is captured.
+ */
+final class JsonFlattener
+{
+    private const int MAX_DEPTH = 12;
+    private const int MAX_FIELDS = 500;
+    private const int SAMPLE_MAX_CHARS = 200;
+
+    /**
+     * @param array<array-key, mixed> $record
+     *
+     * @return list<DiscoveredField>
+     */
+    public function flatten(array $record, string $prefix = '$'): array
+    {
+        $fields = [];
+        $this->walk($record, $prefix, 0, $fields);
+
+        return $fields;
+    }
+
+    /**
+     * @param array<array-key, mixed> $node
+     * @param list<DiscoveredField>   $fields
+     */
+    private function walk(array $node, string $prefix, int $depth, array &$fields): void
+    {
+        foreach ($node as $key => $value) {
+            if (\count($fields) >= self::MAX_FIELDS) {
+                return;
+            }
+
+            $path = $prefix.'.'.$key;
+
+            if (\is_array($value) && [] !== $value && !array_is_list($value) && $depth < self::MAX_DEPTH) {
+                $this->walk($value, $path, $depth + 1, $fields);
+
+                continue;
+            }
+
+            $fields[] = new DiscoveredField($path, self::inferType($value), self::sample($value));
+        }
+    }
+
+    private static function inferType(mixed $value): RemoteFieldDataType
+    {
+        return match (true) {
+            \is_bool($value) => RemoteFieldDataType::Boolean,
+            \is_int($value) => RemoteFieldDataType::Integer,
+            \is_float($value) => RemoteFieldDataType::Number,
+            \is_string($value) => RemoteFieldDataType::String,
+            null === $value => RemoteFieldDataType::Null,
+            \is_array($value) && array_is_list($value) => RemoteFieldDataType::Array,
+            \is_array($value) => RemoteFieldDataType::Object,
+            default => RemoteFieldDataType::String,
+        };
+    }
+
+    private static function sample(mixed $value): ?string
+    {
+        if (null === $value) {
+            return null;
+        }
+        if (\is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+        if (\is_int($value) || \is_float($value) || \is_string($value)) {
+            return mb_substr((string) $value, 0, self::SAMPLE_MAX_CHARS);
+        }
+
+        $encoded = json_encode($value);
+
+        return false === $encoded ? null : mb_substr($encoded, 0, self::SAMPLE_MAX_CHARS);
+    }
+}

--- a/apps/api/src/Integration/Generic/Application/Discovery/SchemaDiscoveryResult.php
+++ b/apps/api/src/Integration/Generic/Application/Discovery/SchemaDiscoveryResult.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application\Discovery;
+
+/**
+ * The outcome of a schema discovery run (ADR-0022, epic APIC, ticket APIC-P2-04):
+ * the proposed fields plus the raw sample record they were inferred from (so the
+ * wizard can preview it side by side).
+ */
+final readonly class SchemaDiscoveryResult
+{
+    /**
+     * @param list<DiscoveredField>   $fields
+     * @param array<array-key, mixed> $sampleRecord
+     * @param int                     $sampledRecords number of records the sample page held
+     */
+    public function __construct(
+        public array $fields,
+        public array $sampleRecord,
+        public int $sampledRecords,
+    ) {
+    }
+
+    public static function empty(): self
+    {
+        return new self([], [], 0);
+    }
+}

--- a/apps/api/src/Integration/Generic/Application/Discovery/SchemaDiscoveryService.php
+++ b/apps/api/src/Integration/Generic/Application/Discovery/SchemaDiscoveryService.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application\Discovery;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\RemoteEndpoint;
+use App\Integration\Generic\Infrastructure\Http\Pagination\PaginatedFetcher;
+
+/**
+ * Proposes a schema for a read endpoint by sampling its first page (ADR-0022,
+ * epic APIC, ticket APIC-P2-04).
+ *
+ * It pulls one page through the SSRF-safe {@see PaginatedFetcher} (so a giant
+ * endpoint is never fully walked just to discover its shape), takes the first
+ * record, and flattens it into typed {@see DiscoveredField} proposals. The
+ * wizard (APIC-P2-06) lets the user accept/edit before the CRUD endpoint
+ * (APIC-P2-05) persists them. Only public list responses are sampled — no
+ * credentials ever flow into the result or logs.
+ */
+final readonly class SchemaDiscoveryService
+{
+    public function __construct(
+        private PaginatedFetcher $fetcher,
+        private JsonFlattener $flattener,
+    ) {
+    }
+
+    public function discover(Connection $connection, RemoteEndpoint $endpoint): SchemaDiscoveryResult
+    {
+        $page = $this->firstPage($connection, $endpoint);
+        $sample = $page[0] ?? null;
+
+        if (!\is_array($sample) || [] === $sample) {
+            return SchemaDiscoveryResult::empty();
+        }
+
+        return new SchemaDiscoveryResult(
+            $this->flattener->flatten($sample),
+            $sample,
+            \count($page),
+        );
+    }
+
+    /**
+     * @return list<array<array-key, mixed>>
+     */
+    private function firstPage(Connection $connection, RemoteEndpoint $endpoint): array
+    {
+        foreach ($this->fetcher->pages($connection, $endpoint) as $page) {
+            return $page;
+        }
+
+        return [];
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Application/Discovery/JsonFlattenerTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Application/Discovery/JsonFlattenerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Application\Discovery;
+
+use App\Integration\Generic\Application\Discovery\DiscoveredField;
+use App\Integration\Generic\Application\Discovery\JsonFlattener;
+use App\Integration\Generic\Domain\Enum\RemoteFieldDataType;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class JsonFlattenerTest extends TestCase
+{
+    private JsonFlattener $flattener;
+
+    protected function setUp(): void
+    {
+        $this->flattener = new JsonFlattener();
+    }
+
+    #[Test]
+    public function infersScalarTypesFromAFlatRecord(): void
+    {
+        $fields = $this->byPath([
+            'sku' => 'A-1',
+            'qty' => 7,
+            'price' => 19.99,
+            'active' => true,
+            'note' => null,
+        ]);
+
+        self::assertSame(RemoteFieldDataType::String, $fields['$.sku']->dataType);
+        self::assertSame('A-1', $fields['$.sku']->sampleValue);
+        self::assertSame(RemoteFieldDataType::Integer, $fields['$.qty']->dataType);
+        self::assertSame(RemoteFieldDataType::Number, $fields['$.price']->dataType);
+        self::assertSame(RemoteFieldDataType::Boolean, $fields['$.active']->dataType);
+        self::assertSame('true', $fields['$.active']->sampleValue);
+        self::assertSame(RemoteFieldDataType::Null, $fields['$.note']->dataType);
+        self::assertNull($fields['$.note']->sampleValue);
+    }
+
+    #[Test]
+    public function walksNestedObjectsIntoDotPaths(): void
+    {
+        $fields = $this->byPath([
+            'sku' => 'A-1',
+            'price' => ['amount' => 1999, 'currency' => 'PLN'],
+        ]);
+
+        self::assertArrayHasKey('$.price.amount', $fields);
+        self::assertArrayHasKey('$.price.currency', $fields);
+        self::assertSame(RemoteFieldDataType::Integer, $fields['$.price.amount']->dataType);
+        self::assertSame('PLN', $fields['$.price.currency']->sampleValue);
+        // The intermediate object itself is not emitted as a field.
+        self::assertArrayNotHasKey('$.price', $fields);
+    }
+
+    #[Test]
+    public function treatsListsAsArrayLeaves(): void
+    {
+        $fields = $this->byPath([
+            'tags' => ['new', 'sale'],
+            'empty' => [],
+        ]);
+
+        self::assertSame(RemoteFieldDataType::Array, $fields['$.tags']->dataType);
+        self::assertSame('["new","sale"]', $fields['$.tags']->sampleValue);
+        // An empty array is a leaf (no keys to recurse), typed as Array.
+        self::assertSame(RemoteFieldDataType::Array, $fields['$.empty']->dataType);
+    }
+
+    #[Test]
+    public function truncatesLongSampleValues(): void
+    {
+        $fields = $this->byPath(['blob' => str_repeat('x', 500)]);
+
+        self::assertNotNull($fields['$.blob']->sampleValue);
+        self::assertSame(200, mb_strlen($fields['$.blob']->sampleValue));
+    }
+
+    #[Test]
+    public function honoursACustomPrefix(): void
+    {
+        $fields = $this->flattener->flatten(['id' => 1], '$.data');
+
+        self::assertSame('$.data.id', $fields[0]->path);
+    }
+
+    /**
+     * @param array<array-key, mixed> $record
+     *
+     * @return array<string, DiscoveredField>
+     */
+    private function byPath(array $record): array
+    {
+        $byPath = [];
+        foreach ($this->flattener->flatten($record) as $field) {
+            $byPath[$field->path] = $field;
+        }
+
+        return $byPath;
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Application/Discovery/SchemaDiscoveryServiceTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Application/Discovery/SchemaDiscoveryServiceTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Application\Discovery;
+
+use App\Integration\Generic\Application\Discovery\JsonFlattener;
+use App\Integration\Generic\Application\Discovery\SchemaDiscoveryService;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\RemoteEndpoint;
+use App\Integration\Generic\Domain\Enum\RemoteEndpointRole;
+use App\Integration\Generic\Domain\Enum\RemoteFieldDataType;
+use App\Integration\Generic\Domain\GenericRestResponse;
+use App\Integration\Generic\Infrastructure\Http\Pagination\CursorPaginationStrategy;
+use App\Integration\Generic\Infrastructure\Http\Pagination\LinkHeaderPaginationStrategy;
+use App\Integration\Generic\Infrastructure\Http\Pagination\NonePaginationStrategy;
+use App\Integration\Generic\Infrastructure\Http\Pagination\OffsetPaginationStrategy;
+use App\Integration\Generic\Infrastructure\Http\Pagination\PagePaginationStrategy;
+use App\Integration\Generic\Infrastructure\Http\Pagination\PaginatedFetcher;
+use App\Integration\Generic\Infrastructure\Http\Pagination\PaginationStrategies;
+use App\Integration\Generic\Infrastructure\Http\RecordSelector;
+use App\Tests\Unit\Integration\Generic\Infrastructure\Http\Pagination\RecordingRequester;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class SchemaDiscoveryServiceTest extends TestCase
+{
+    #[Test]
+    public function proposesTypedFieldsFromTheFirstSampleRecord(): void
+    {
+        $body = json_encode([
+            'results' => [
+                ['sku' => 'A-1', 'price' => ['amount' => 1999], 'tags' => ['new']],
+                ['sku' => 'B-2', 'price' => ['amount' => 2999], 'tags' => []],
+            ],
+        ]);
+        $service = $this->service([new GenericRestResponse(200, [], (string) $body, 1, 64)]);
+
+        $result = $service->discover($this->connection(), $this->endpoint('$.results'));
+
+        $byPath = [];
+        foreach ($result->fields as $field) {
+            $byPath[$field->path] = $field;
+        }
+
+        self::assertSame(RemoteFieldDataType::String, $byPath['$.sku']->dataType);
+        self::assertSame(RemoteFieldDataType::Integer, $byPath['$.price.amount']->dataType);
+        self::assertSame(RemoteFieldDataType::Array, $byPath['$.tags']->dataType);
+        // Sample + count come from the first page.
+        self::assertSame('A-1', $result->sampleRecord['sku']);
+        self::assertSame(2, $result->sampledRecords);
+    }
+
+    #[Test]
+    public function returnsEmptyWhenTheSampleHasNoRecords(): void
+    {
+        $service = $this->service([new GenericRestResponse(200, [], '{"results":[]}', 1, 16)]);
+
+        $result = $service->discover($this->connection(), $this->endpoint('$.results'));
+
+        self::assertSame([], $result->fields);
+        self::assertSame([], $result->sampleRecord);
+        self::assertSame(0, $result->sampledRecords);
+    }
+
+    /**
+     * @param list<GenericRestResponse> $responses
+     */
+    private function service(array $responses): SchemaDiscoveryService
+    {
+        $strategies = new PaginationStrategies([
+            new NonePaginationStrategy(),
+            new OffsetPaginationStrategy(),
+            new PagePaginationStrategy(),
+            new CursorPaginationStrategy(new RecordSelector()),
+            new LinkHeaderPaginationStrategy(),
+        ]);
+        $fetcher = new PaginatedFetcher(new RecordingRequester($responses), new RecordSelector(), $strategies);
+
+        return new SchemaDiscoveryService($fetcher, new JsonFlattener());
+    }
+
+    private function connection(): Connection
+    {
+        return new Connection('idosell', 'IdoSell', 'https://api.example.com/v1');
+    }
+
+    private function endpoint(string $selector): RemoteEndpoint
+    {
+        $endpoint = new RemoteEndpoint($this->connection(), RemoteEndpointRole::ReadList, 'GET', '/products');
+        $endpoint->setPagination(['strategy' => 'none']);
+        $endpoint->setRecordSelector($selector);
+
+        return $endpoint;
+    }
+}


### PR DESCRIPTION
## Cel

APIC-P2-04 — wyeliminować ręczne wpisywanie schematu: fetch próbki → spłaszczenie JSON → propozycja pól `RemoteField`.

## Zakres (`src/Integration/Generic/Application/Discovery/`)

- **`SchemaDiscoveryService::discover(Connection, RemoteEndpoint)`** — pobiera **jedną stronę** przez `PaginatedFetcher` (giant endpoint nie jest w pełni przechodzony tylko po to, by poznać kształt), bierze pierwszy rekord, spłaszcza do propozycji.
- **`JsonFlattener`** — spłaszcza rekord do dot-path (`$.price.amount`); zagnieżdżone obiekty rekurencyjnie, listy/skalary jako liście z inferencją `RemoteFieldDataType`. Cap głębokości (12) + liczby pól (500) + truncate sample (200 zn.).
- **`DiscoveredField`** / **`SchemaDiscoveryResult`** DTO (propozycje, **nie** persystowane — akceptacja w FE P2-06, zapis w P2-05).

## Bezpieczeństwo (AC-3)

Próbkowane są wyłącznie publiczne odpowiedzi list/one; credentiale nigdy nie wchodzą do flattenera ani wyniku/logów (zapis przez SSRF-safe client; flatten działa tylko na response body).

## Testy / bramki (kontener api)

- **PHPStan max** ✅ · **Deptrac** 0 ✅ · **PHP-CS-Fixer** 0 ✅
- **PHPUnit** ✅ 7/7: `JsonFlattenerTest` (AC-1 inferencja skalarnych typów, AC-2 zagnieżdżone obiekty/tablice, truncate, custom prefix) + `SchemaDiscoveryServiceTest` (propozycje z pierwszej próbki przez realny fetcher + fake requester, empty gdy brak rekordów).

Refs #1773