### PR TITLE
feat(integration): RemoteEndpoint + RemoteField CRUD API + discover (APIC-P2-05)

### DIFF
--- a/apps/api/src/Identity/Infrastructure/Security/RemoteEndpointVoter.php
+++ b/apps/api/src/Identity/Infrastructure/Security/RemoteEndpointVoter.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Security;
+
+/**
+ * RBAC voter for the API Configurator `RemoteEndpoint` resource (APIC-P2-05).
+ * Reuses the legacy `integration` RbacMatrix resource — the same surface that
+ * gates Connection/ApiProfile management. The subject is named by its FQCN
+ * string (no cross-BC class import), keeping this Deptrac-clean.
+ */
+final class RemoteEndpointVoter extends AbstractRbacVoter
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function attributeMap(): array
+    {
+        return [
+            'READ' => 'read',
+            'CREATE' => 'write',
+            'UPDATE' => 'write',
+            'WRITE' => 'write',
+            'DELETE' => 'delete',
+        ];
+    }
+
+    protected function resource(): string
+    {
+        return 'integration';
+    }
+
+    protected function subjectClass(): string
+    {
+        return 'App\\Integration\\Generic\\Domain\\Entity\\RemoteEndpoint';
+    }
+}

--- a/apps/api/src/Identity/Infrastructure/Security/RemoteFieldVoter.php
+++ b/apps/api/src/Identity/Infrastructure/Security/RemoteFieldVoter.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Security;
+
+/**
+ * RBAC voter for the API Configurator `RemoteField` resource (APIC-P2-05).
+ * Reuses the legacy `integration` RbacMatrix resource. The subject is named by
+ * its FQCN string (no cross-BC class import), keeping this Deptrac-clean.
+ */
+final class RemoteFieldVoter extends AbstractRbacVoter
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function attributeMap(): array
+    {
+        return [
+            'READ' => 'read',
+            'CREATE' => 'write',
+            'UPDATE' => 'write',
+            'WRITE' => 'write',
+            'DELETE' => 'delete',
+        ];
+    }
+
+    protected function resource(): string
+    {
+        return 'integration';
+    }
+
+    protected function subjectClass(): string
+    {
+        return 'App\\Integration\\Generic\\Domain\\Entity\\RemoteField';
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Filter/RemoteEndpointConnectionFilter.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Filter/RemoteEndpointConnectionFilter.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\ApiPlatform\Filter;
+
+use ApiPlatform\Doctrine\Orm\Filter\FilterInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * `?connection={id}` on `/api/remote_endpoints` — scopes the descriptor list to
+ * one connection (APIC-P2-05). Tenant scoping still comes from the upstream
+ * Doctrine TenantFilter; this only adds the connection equality predicate.
+ */
+final class RemoteEndpointConnectionFilter implements FilterInterface
+{
+    private const string PARAMETER = 'connection';
+
+    public function apply(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $filters = $context['filters'] ?? [];
+        if (!\is_array($filters)) {
+            return;
+        }
+
+        $value = $filters[self::PARAMETER] ?? null;
+        if (!\is_string($value) || '' === $value) {
+            return;
+        }
+
+        $alias = $queryBuilder->getRootAliases()[0] ?? null;
+        if (null === $alias) {
+            return;
+        }
+
+        $parameter = $queryNameGenerator->generateParameterName('connectionId');
+        $queryBuilder
+            ->andWhere(\sprintf('%s.connection = :%s', $alias, $parameter))
+            ->setParameter($parameter, $value);
+    }
+
+    /**
+     * @param class-string $resourceClass
+     *
+     * @return array<string, array{property?: string, type?: string, required?: bool, description?: string, strategy?: string, is_collection?: bool}>
+     */
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            self::PARAMETER => [
+                'property' => 'connection',
+                'type' => 'string',
+                'required' => false,
+                'description' => 'Exact match on the parent Connection UUID (tenant-scoped).',
+                'strategy' => 'exact',
+            ],
+        ];
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Filter/RemoteFieldEndpointFilter.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Filter/RemoteFieldEndpointFilter.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\ApiPlatform\Filter;
+
+use ApiPlatform\Doctrine\Orm\Filter\FilterInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * `?endpoint={id}` on `/api/remote_fields` — scopes the field list to one
+ * endpoint (APIC-P2-05). Tenant scoping still comes from the upstream Doctrine
+ * TenantFilter; this only adds the endpoint equality predicate.
+ */
+final class RemoteFieldEndpointFilter implements FilterInterface
+{
+    private const string PARAMETER = 'endpoint';
+
+    public function apply(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $filters = $context['filters'] ?? [];
+        if (!\is_array($filters)) {
+            return;
+        }
+
+        $value = $filters[self::PARAMETER] ?? null;
+        if (!\is_string($value) || '' === $value) {
+            return;
+        }
+
+        $alias = $queryBuilder->getRootAliases()[0] ?? null;
+        if (null === $alias) {
+            return;
+        }
+
+        $parameter = $queryNameGenerator->generateParameterName('endpointId');
+        $queryBuilder
+            ->andWhere(\sprintf('%s.endpoint = :%s', $alias, $parameter))
+            ->setParameter($parameter, $value);
+    }
+
+    /**
+     * @param class-string $resourceClass
+     *
+     * @return array<string, array{property?: string, type?: string, required?: bool, description?: string, strategy?: string, is_collection?: bool}>
+     */
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            self::PARAMETER => [
+                'property' => 'endpoint',
+                'type' => 'string',
+                'required' => false,
+                'description' => 'Exact match on the parent RemoteEndpoint UUID (tenant-scoped).',
+                'strategy' => 'exact',
+            ],
+        ];
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/RemoteEndpoint.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/RemoteEndpoint.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns="https://api-platform.com/schema/metadata/resources-3.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata/resources-3.0
+                               https://api-platform.com/schema/metadata/resources-3.0.xsd">
+
+    <resource class="App\Integration\Generic\Domain\Entity\RemoteEndpoint"
+              shortName="RemoteEndpoint">
+
+        <normalizationContext>
+            <values>
+                <value name="groups">
+                    <values>
+                        <value>admin:read</value>
+                    </values>
+                </value>
+            </values>
+        </normalizationContext>
+
+        <!-- `?connection={id}` scopes the descriptor list to one connection (FE wizard). -->
+        <filters>
+            <filter>App\Integration\Generic\Infrastructure\ApiPlatform\Filter\RemoteEndpointConnectionFilter</filter>
+        </filters>
+
+        <operations>
+            <operation class="ApiPlatform\Metadata\GetCollection"
+                       uriTemplate="/remote_endpoints{._format}"
+                       security="is_granted('READ', 'App\\Integration\\Generic\\Domain\\Entity\\RemoteEndpoint')"/>
+
+            <operation class="ApiPlatform\Metadata\Get"
+                       uriTemplate="/remote_endpoints/{id}{._format}"
+                       security="is_granted('READ', object)"/>
+
+            <operation class="ApiPlatform\Metadata\Post"
+                       uriTemplate="/remote_endpoints{._format}"
+                       input="App\Integration\Generic\Infrastructure\ApiPlatform\Resource\RemoteEndpointInput"
+                       processor="App\Integration\Generic\Infrastructure\ApiPlatform\State\RemoteEndpointProcessor"
+                       security="is_granted('CREATE', 'App\\Integration\\Generic\\Domain\\Entity\\RemoteEndpoint')">
+                <denormalizationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>remote_endpoint:create</value>
+                            </values>
+                        </value>
+                    </values>
+                </denormalizationContext>
+            </operation>
+
+            <operation class="ApiPlatform\Metadata\Patch"
+                       uriTemplate="/remote_endpoints/{id}{._format}"
+                       input="App\Integration\Generic\Infrastructure\ApiPlatform\Resource\RemoteEndpointPatchInput"
+                       processor="App\Integration\Generic\Infrastructure\ApiPlatform\State\RemoteEndpointProcessor"
+                       security="is_granted('UPDATE', object)">
+                <denormalizationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>remote_endpoint:patch</value>
+                            </values>
+                        </value>
+                    </values>
+                </denormalizationContext>
+            </operation>
+
+            <operation class="ApiPlatform\Metadata\Delete"
+                       uriTemplate="/remote_endpoints/{id}{._format}"
+                       processor="App\Integration\Generic\Infrastructure\ApiPlatform\State\RemoteEndpointProcessor"
+                       security="is_granted('DELETE', object)"/>
+        </operations>
+    </resource>
+
+</resources>

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/RemoteEndpointInput.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/RemoteEndpointInput.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\ApiPlatform\Resource;
+
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * POST input for `/api/remote_endpoints` (APIC-P2-05). `connection` is the
+ * parent connection's UUID; the {@see \App\Integration\Generic\Infrastructure\ApiPlatform\State\RemoteEndpointProcessor}
+ * resolves it tenant-scoped and stamps the endpoint's tenant from it.
+ */
+final class RemoteEndpointInput
+{
+    #[Assert\NotBlank]
+    #[Groups(['remote_endpoint:create'])]
+    public string $connection = '';
+
+    #[Assert\Choice(choices: ['read_list', 'read_one', 'write_create', 'write_update'])]
+    #[Groups(['remote_endpoint:create'])]
+    public string $role = 'read_list';
+
+    #[Assert\Choice(choices: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'])]
+    #[Groups(['remote_endpoint:create'])]
+    public string $httpMethod = 'GET';
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 2048)]
+    #[Groups(['remote_endpoint:create'])]
+    public string $pathTemplate = '';
+
+    /**
+     * @var array<string, string>
+     */
+    #[Groups(['remote_endpoint:create'])]
+    public array $queryParams = [];
+
+    /**
+     * @var array<string, mixed>|null
+     */
+    #[Groups(['remote_endpoint:create'])]
+    public ?array $requestBodyTemplate = null;
+
+    /**
+     * @var array<string, mixed>
+     */
+    #[Groups(['remote_endpoint:create'])]
+    public array $pagination = ['strategy' => 'none'];
+
+    #[Assert\Length(max: 512)]
+    #[Groups(['remote_endpoint:create'])]
+    public ?string $recordSelector = null;
+
+    #[Assert\Choice(choices: ['json'])]
+    #[Groups(['remote_endpoint:create'])]
+    public string $responseFormat = 'json';
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/RemoteEndpointPatchInput.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/RemoteEndpointPatchInput.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\ApiPlatform\Resource;
+
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * PATCH (RFC 7396 merge) input for `/api/remote_endpoints/{id}` (APIC-P2-05).
+ * Every field is nullable — null means "leave unchanged". `connection` is
+ * immutable and omitted.
+ */
+final class RemoteEndpointPatchInput
+{
+    #[Assert\Choice(choices: ['read_list', 'read_one', 'write_create', 'write_update'])]
+    #[Groups(['remote_endpoint:patch'])]
+    public ?string $role = null;
+
+    #[Assert\Choice(choices: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'])]
+    #[Groups(['remote_endpoint:patch'])]
+    public ?string $httpMethod = null;
+
+    #[Assert\Length(max: 2048)]
+    #[Groups(['remote_endpoint:patch'])]
+    public ?string $pathTemplate = null;
+
+    /**
+     * @var array<string, string>|null
+     */
+    #[Groups(['remote_endpoint:patch'])]
+    public ?array $queryParams = null;
+
+    /**
+     * @var array<string, mixed>|null
+     */
+    #[Groups(['remote_endpoint:patch'])]
+    public ?array $requestBodyTemplate = null;
+
+    /**
+     * @var array<string, mixed>|null
+     */
+    #[Groups(['remote_endpoint:patch'])]
+    public ?array $pagination = null;
+
+    #[Assert\Length(max: 512)]
+    #[Groups(['remote_endpoint:patch'])]
+    public ?string $recordSelector = null;
+
+    #[Assert\Choice(choices: ['json'])]
+    #[Groups(['remote_endpoint:patch'])]
+    public ?string $responseFormat = null;
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/RemoteField.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/RemoteField.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns="https://api-platform.com/schema/metadata/resources-3.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata/resources-3.0
+                               https://api-platform.com/schema/metadata/resources-3.0.xsd">
+
+    <resource class="App\Integration\Generic\Domain\Entity\RemoteField"
+              shortName="RemoteField">
+
+        <normalizationContext>
+            <values>
+                <value name="groups">
+                    <values>
+                        <value>admin:read</value>
+                    </values>
+                </value>
+            </values>
+        </normalizationContext>
+
+        <!-- `?endpoint={id}` scopes the field list to one endpoint (FE mapping). -->
+        <filters>
+            <filter>App\Integration\Generic\Infrastructure\ApiPlatform\Filter\RemoteFieldEndpointFilter</filter>
+        </filters>
+
+        <operations>
+            <operation class="ApiPlatform\Metadata\GetCollection"
+                       uriTemplate="/remote_fields{._format}"
+                       security="is_granted('READ', 'App\\Integration\\Generic\\Domain\\Entity\\RemoteField')"/>
+
+            <operation class="ApiPlatform\Metadata\Get"
+                       uriTemplate="/remote_fields/{id}{._format}"
+                       security="is_granted('READ', object)"/>
+
+            <operation class="ApiPlatform\Metadata\Post"
+                       uriTemplate="/remote_fields{._format}"
+                       input="App\Integration\Generic\Infrastructure\ApiPlatform\Resource\RemoteFieldInput"
+                       processor="App\Integration\Generic\Infrastructure\ApiPlatform\State\RemoteFieldProcessor"
+                       security="is_granted('CREATE', 'App\\Integration\\Generic\\Domain\\Entity\\RemoteField')">
+                <denormalizationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>remote_field:create</value>
+                            </values>
+                        </value>
+                    </values>
+                </denormalizationContext>
+            </operation>
+
+            <operation class="ApiPlatform\Metadata\Patch"
+                       uriTemplate="/remote_fields/{id}{._format}"
+                       input="App\Integration\Generic\Infrastructure\ApiPlatform\Resource\RemoteFieldPatchInput"
+                       processor="App\Integration\Generic\Infrastructure\ApiPlatform\State\RemoteFieldProcessor"
+                       security="is_granted('UPDATE', object)">
+                <denormalizationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>remote_field:patch</value>
+                            </values>
+                        </value>
+                    </values>
+                </denormalizationContext>
+            </operation>
+
+            <operation class="ApiPlatform\Metadata\Delete"
+                       uriTemplate="/remote_fields/{id}{._format}"
+                       processor="App\Integration\Generic\Infrastructure\ApiPlatform\State\RemoteFieldProcessor"
+                       security="is_granted('DELETE', object)"/>
+        </operations>
+    </resource>
+
+</resources>

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/RemoteFieldInput.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/RemoteFieldInput.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\ApiPlatform\Resource;
+
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * POST input for `/api/remote_fields` (APIC-P2-05). `endpoint` is the parent
+ * endpoint's UUID; the {@see \App\Integration\Generic\Infrastructure\ApiPlatform\State\RemoteFieldProcessor}
+ * resolves it tenant-scoped and stamps the field's tenant from it.
+ */
+final class RemoteFieldInput
+{
+    #[Assert\NotBlank]
+    #[Groups(['remote_field:create'])]
+    public string $endpoint = '';
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 512)]
+    #[Groups(['remote_field:create'])]
+    public string $path = '';
+
+    #[Assert\Length(max: 255)]
+    #[Groups(['remote_field:create'])]
+    public ?string $label = null;
+
+    #[Assert\Choice(choices: ['string', 'integer', 'number', 'boolean', 'object', 'array', 'null'])]
+    #[Groups(['remote_field:create'])]
+    public string $dataType = 'string';
+
+    #[Assert\Length(max: 2048)]
+    #[Groups(['remote_field:create'])]
+    public ?string $sampleValue = null;
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/RemoteFieldPatchInput.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/RemoteFieldPatchInput.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\ApiPlatform\Resource;
+
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * PATCH (RFC 7396 merge) input for `/api/remote_fields/{id}` (APIC-P2-05).
+ * Every field is nullable — null means "leave unchanged". `endpoint` is
+ * immutable and omitted.
+ */
+final class RemoteFieldPatchInput
+{
+    #[Assert\Length(max: 512)]
+    #[Groups(['remote_field:patch'])]
+    public ?string $path = null;
+
+    #[Assert\Length(max: 255)]
+    #[Groups(['remote_field:patch'])]
+    public ?string $label = null;
+
+    #[Assert\Choice(choices: ['string', 'integer', 'number', 'boolean', 'object', 'array', 'null'])]
+    #[Groups(['remote_field:patch'])]
+    public ?string $dataType = null;
+
+    #[Assert\Length(max: 2048)]
+    #[Groups(['remote_field:patch'])]
+    public ?string $sampleValue = null;
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/State/RemoteEndpointProcessor.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/State/RemoteEndpointProcessor.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\ApiPlatform\State;
+
+use ApiPlatform\Metadata\DeleteOperationInterface;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\State\ProcessorInterface;
+use App\Integration\Generic\Application\Validation\DescriptorValidator;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\RemoteEndpoint;
+use App\Integration\Generic\Domain\Enum\RemoteEndpointRole;
+use App\Integration\Generic\Domain\Exception\InvalidDescriptorException;
+use App\Integration\Generic\Domain\Repository\ConnectionRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\RemoteEndpointRepositoryInterface;
+use App\Integration\Generic\Infrastructure\ApiPlatform\Resource\RemoteEndpointInput;
+use App\Integration\Generic\Infrastructure\ApiPlatform\Resource\RemoteEndpointPatchInput;
+use InvalidArgumentException;
+use LogicException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Write path for the `RemoteEndpoint` resource (APIC-P2-05). Resolves the
+ * parent connection tenant-scoped (a cross-tenant or missing id is a 404),
+ * validates the path template via the SSRF descriptor wall (APIC-P1-04 → 422),
+ * and persists. The tenant is stamped on persist by the listener.
+ *
+ * @implements ProcessorInterface<RemoteEndpointInput|RemoteEndpointPatchInput|RemoteEndpoint, RemoteEndpoint|null>
+ */
+final readonly class RemoteEndpointProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private ConnectionRepositoryInterface $connections,
+        private RemoteEndpointRepositoryInterface $endpoints,
+        private DescriptorValidator $descriptors,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     * @param array<string, mixed> $context
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): ?RemoteEndpoint
+    {
+        if ($operation instanceof DeleteOperationInterface) {
+            $this->endpoints->remove($this->require($uriVariables));
+
+            return null;
+        }
+
+        if ($operation instanceof Post) {
+            return $this->handlePost($data);
+        }
+
+        if ($operation instanceof Patch) {
+            return $this->handlePatch($data, $uriVariables);
+        }
+
+        throw new LogicException(\sprintf('RemoteEndpointProcessor cannot handle operation "%s".', $operation::class));
+    }
+
+    private function handlePost(mixed $data): RemoteEndpoint
+    {
+        if (!$data instanceof RemoteEndpointInput) {
+            throw new LogicException('RemoteEndpointProcessor expects RemoteEndpointInput on Post.');
+        }
+
+        $connection = $this->requireConnection($data->connection);
+        $this->validatePathTemplate($data->pathTemplate);
+
+        $endpoint = new RemoteEndpoint(
+            $connection,
+            RemoteEndpointRole::from($data->role),
+            $data->httpMethod,
+            $data->pathTemplate,
+        );
+        $endpoint->setQueryParams($data->queryParams);
+        $endpoint->setRequestBodyTemplate($data->requestBodyTemplate);
+        $endpoint->setPagination($data->pagination);
+        $endpoint->setRecordSelector($data->recordSelector);
+        $endpoint->setResponseFormat($data->responseFormat);
+
+        $this->endpoints->save($endpoint);
+
+        return $endpoint;
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     */
+    private function handlePatch(mixed $data, array $uriVariables): RemoteEndpoint
+    {
+        if (!$data instanceof RemoteEndpointPatchInput) {
+            throw new LogicException('RemoteEndpointProcessor expects RemoteEndpointPatchInput on Patch.');
+        }
+
+        $endpoint = $this->require($uriVariables);
+
+        if (null !== $data->role) {
+            $endpoint->setRole(RemoteEndpointRole::from($data->role));
+        }
+        if (null !== $data->httpMethod) {
+            $endpoint->setHttpMethod($data->httpMethod);
+        }
+        if (null !== $data->pathTemplate) {
+            $this->validatePathTemplate($data->pathTemplate);
+            $endpoint->setPathTemplate($data->pathTemplate);
+        }
+        if (null !== $data->queryParams) {
+            $endpoint->setQueryParams($data->queryParams);
+        }
+        if (null !== $data->requestBodyTemplate) {
+            $endpoint->setRequestBodyTemplate($data->requestBodyTemplate);
+        }
+        if (null !== $data->pagination) {
+            $endpoint->setPagination($data->pagination);
+        }
+        if (null !== $data->recordSelector) {
+            $endpoint->setRecordSelector($data->recordSelector);
+        }
+        if (null !== $data->responseFormat) {
+            $endpoint->setResponseFormat($data->responseFormat);
+        }
+
+        $this->endpoints->save($endpoint);
+
+        return $endpoint;
+    }
+
+    private function requireConnection(string $id): Connection
+    {
+        $connection = $this->connections->findById($this->parseId($id, 'connection'));
+        if (!$connection instanceof Connection) {
+            throw new NotFoundHttpException('Connection was not found.');
+        }
+
+        return $connection;
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     */
+    private function require(array $uriVariables): RemoteEndpoint
+    {
+        $raw = $uriVariables['id'] ?? null;
+        $id = $raw instanceof Uuid ? $raw : $this->parseId(\is_string($raw) ? $raw : '', 'id');
+
+        $endpoint = $this->endpoints->findById($id);
+        if (!$endpoint instanceof RemoteEndpoint) {
+            throw new NotFoundHttpException('RemoteEndpoint was not found.');
+        }
+
+        return $endpoint;
+    }
+
+    private function validatePathTemplate(string $pathTemplate): void
+    {
+        try {
+            $this->descriptors->assertValidPathTemplate($pathTemplate);
+        } catch (InvalidDescriptorException $exception) {
+            throw new UnprocessableEntityHttpException($exception->getMessage(), $exception);
+        }
+    }
+
+    private function parseId(string $raw, string $field): Uuid
+    {
+        if ('' === $raw) {
+            throw new NotFoundHttpException(\sprintf('Missing %s identifier.', $field));
+        }
+
+        try {
+            return Uuid::fromString($raw);
+        } catch (InvalidArgumentException) {
+            throw new NotFoundHttpException(\sprintf('Invalid %s identifier.', $field));
+        }
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/State/RemoteFieldProcessor.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/State/RemoteFieldProcessor.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\ApiPlatform\State;
+
+use ApiPlatform\Metadata\DeleteOperationInterface;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\State\ProcessorInterface;
+use App\Integration\Generic\Domain\Entity\RemoteEndpoint;
+use App\Integration\Generic\Domain\Entity\RemoteField;
+use App\Integration\Generic\Domain\Enum\RemoteFieldDataType;
+use App\Integration\Generic\Domain\Repository\RemoteEndpointRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\RemoteFieldRepositoryInterface;
+use App\Integration\Generic\Infrastructure\ApiPlatform\Resource\RemoteFieldInput;
+use App\Integration\Generic\Infrastructure\ApiPlatform\Resource\RemoteFieldPatchInput;
+use InvalidArgumentException;
+use LogicException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Write path for the `RemoteField` resource (APIC-P2-05). Resolves the parent
+ * endpoint tenant-scoped (a cross-tenant or missing id is a 404) and persists.
+ * The tenant is stamped on persist by the listener.
+ *
+ * @implements ProcessorInterface<RemoteFieldInput|RemoteFieldPatchInput|RemoteField, RemoteField|null>
+ */
+final readonly class RemoteFieldProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private RemoteEndpointRepositoryInterface $endpoints,
+        private RemoteFieldRepositoryInterface $fields,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     * @param array<string, mixed> $context
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): ?RemoteField
+    {
+        if ($operation instanceof DeleteOperationInterface) {
+            $this->fields->remove($this->require($uriVariables));
+
+            return null;
+        }
+
+        if ($operation instanceof Post) {
+            return $this->handlePost($data);
+        }
+
+        if ($operation instanceof Patch) {
+            return $this->handlePatch($data, $uriVariables);
+        }
+
+        throw new LogicException(\sprintf('RemoteFieldProcessor cannot handle operation "%s".', $operation::class));
+    }
+
+    private function handlePost(mixed $data): RemoteField
+    {
+        if (!$data instanceof RemoteFieldInput) {
+            throw new LogicException('RemoteFieldProcessor expects RemoteFieldInput on Post.');
+        }
+
+        $endpoint = $this->requireEndpoint($data->endpoint);
+
+        $field = new RemoteField($endpoint, $data->path, RemoteFieldDataType::from($data->dataType));
+        $field->setLabel($data->label);
+        $field->setSampleValue($data->sampleValue);
+
+        $this->fields->save($field);
+
+        return $field;
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     */
+    private function handlePatch(mixed $data, array $uriVariables): RemoteField
+    {
+        if (!$data instanceof RemoteFieldPatchInput) {
+            throw new LogicException('RemoteFieldProcessor expects RemoteFieldPatchInput on Patch.');
+        }
+
+        $field = $this->require($uriVariables);
+
+        if (null !== $data->path) {
+            $field->setPath($data->path);
+        }
+        if (null !== $data->label) {
+            $field->setLabel($data->label);
+        }
+        if (null !== $data->dataType) {
+            $field->setDataType(RemoteFieldDataType::from($data->dataType));
+        }
+        if (null !== $data->sampleValue) {
+            $field->setSampleValue($data->sampleValue);
+        }
+
+        $this->fields->save($field);
+
+        return $field;
+    }
+
+    private function requireEndpoint(string $id): RemoteEndpoint
+    {
+        $endpoint = $this->endpoints->findById($this->parseId($id, 'endpoint'));
+        if (!$endpoint instanceof RemoteEndpoint) {
+            throw new NotFoundHttpException('RemoteEndpoint was not found.');
+        }
+
+        return $endpoint;
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     */
+    private function require(array $uriVariables): RemoteField
+    {
+        $raw = $uriVariables['id'] ?? null;
+        $id = $raw instanceof Uuid ? $raw : $this->parseId(\is_string($raw) ? $raw : '', 'id');
+
+        $field = $this->fields->findById($id);
+        if (!$field instanceof RemoteField) {
+            throw new NotFoundHttpException('RemoteField was not found.');
+        }
+
+        return $field;
+    }
+
+    private function parseId(string $raw, string $field): Uuid
+    {
+        if ('' === $raw) {
+            throw new NotFoundHttpException(\sprintf('Missing %s identifier.', $field));
+        }
+
+        try {
+            return Uuid::fromString($raw);
+        } catch (InvalidArgumentException) {
+            throw new NotFoundHttpException(\sprintf('Invalid %s identifier.', $field));
+        }
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Serializer/RemoteEndpoint.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/Serializer/RemoteEndpoint.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping
+                                https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd">
+
+    <!-- Read projection for RemoteEndpoint (APIC-P2-05). -->
+    <class name="App\Integration\Generic\Domain\Entity\RemoteEndpoint">
+        <attribute name="id">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="connectionId">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="role">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="httpMethod">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="pathTemplate">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="queryParams">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="requestBodyTemplate">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="pagination">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="recordSelector">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="responseFormat">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="createdAt">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="updatedAt">
+            <group>admin:read</group>
+        </attribute>
+    </class>
+</serializer>

--- a/apps/api/src/Integration/Generic/Infrastructure/Serializer/RemoteField.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/Serializer/RemoteField.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping
+                                https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd">
+
+    <!-- Read projection for RemoteField (APIC-P2-05). -->
+    <class name="App\Integration\Generic\Domain\Entity\RemoteField">
+        <attribute name="id">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="endpointId">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="path">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="label">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="dataType">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="sampleValue">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="createdAt">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="updatedAt">
+            <group>admin:read</group>
+        </attribute>
+    </class>
+</serializer>

--- a/apps/api/src/Integration/Generic/Presentation/Controller/ConnectionDiscoverController.php
+++ b/apps/api/src/Integration/Generic/Presentation/Controller/ConnectionDiscoverController.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Presentation\Controller;
+
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Integration\Generic\Application\Discovery\SchemaDiscoveryService;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\RemoteEndpoint;
+use App\Integration\Generic\Domain\Exception\RemoteRequestFailedException;
+use App\Integration\Generic\Domain\Exception\SsrfBlockedException;
+use App\Integration\Generic\Domain\Repository\ConnectionRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\RemoteEndpointRepositoryInterface;
+use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * APIC-P2-05 (ADR-0022) — triggers schema discovery for one of a connection's
+ * read endpoints: samples its first page and returns the proposed fields.
+ *
+ * The connection and endpoint are resolved tenant-scoped (Postgres RLS), so a
+ * cross-tenant id is a 404; an endpoint that belongs to a different connection
+ * is also a 404. The `settings.integrations.manage` permission gates the
+ * action (firewall 401 + guard 403 + RLS 404). Proposals are not persisted —
+ * the wizard accepts/edits, then the RemoteField CRUD saves them.
+ */
+final class ConnectionDiscoverController
+{
+    public function __construct(
+        private readonly ConnectionRepositoryInterface $connections,
+        private readonly RemoteEndpointRepositoryInterface $endpoints,
+        private readonly SchemaDiscoveryService $discovery,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/connections/{id}/discover',
+        name: 'integration_connection_discover',
+        requirements: ['id' => '[0-9a-fA-F-]{36}'],
+        methods: ['POST'],
+    )]
+    #[RequiresPermission(module: 'settings.integrations', action: 'manage')]
+    public function __invoke(string $id, Request $request): JsonResponse
+    {
+        $connection = $this->requireConnection($id);
+        $endpoint = $this->requireEndpoint($request, $connection);
+
+        try {
+            $result = $this->discovery->discover($connection, $endpoint);
+        } catch (SsrfBlockedException|RemoteRequestFailedException $exception) {
+            // A blocked/unreachable remote is a user-side configuration problem,
+            // not a server error — surface it as 422 with the reason.
+            throw new UnprocessableEntityHttpException($exception->getMessage(), $exception);
+        }
+
+        $fields = array_map(
+            static fn ($field): array => [
+                'path' => $field->path,
+                'dataType' => $field->dataType->value,
+                'sampleValue' => $field->sampleValue,
+            ],
+            $result->fields,
+        );
+
+        return new JsonResponse([
+            'fields' => $fields,
+            'sampleRecord' => $result->sampleRecord,
+            'sampledRecords' => $result->sampledRecords,
+        ], Response::HTTP_OK);
+    }
+
+    private function requireConnection(string $id): Connection
+    {
+        try {
+            $connectionId = Uuid::fromString($id);
+        } catch (InvalidArgumentException) {
+            throw new NotFoundHttpException(\sprintf('Connection "%s" was not found.', $id));
+        }
+
+        $connection = $this->connections->findById($connectionId);
+        if (!$connection instanceof Connection) {
+            throw new NotFoundHttpException(\sprintf('Connection "%s" was not found.', $id));
+        }
+
+        return $connection;
+    }
+
+    private function requireEndpoint(Request $request, Connection $connection): RemoteEndpoint
+    {
+        $payload = json_decode($request->getContent(), true);
+        $rawId = \is_array($payload) ? ($payload['endpoint'] ?? null) : null;
+        if (!\is_string($rawId) || '' === $rawId) {
+            throw new UnprocessableEntityHttpException('Field "endpoint" (a RemoteEndpoint id) is required.');
+        }
+
+        try {
+            $endpointId = Uuid::fromString($rawId);
+        } catch (InvalidArgumentException) {
+            throw new NotFoundHttpException('RemoteEndpoint was not found.');
+        }
+
+        $endpoint = $this->endpoints->findById($endpointId);
+        if (!$endpoint instanceof RemoteEndpoint
+            || $endpoint->getConnectionId()->toRfc4122() !== $connection->getId()->toRfc4122()) {
+            throw new NotFoundHttpException('RemoteEndpoint was not found.');
+        }
+
+        return $endpoint;
+    }
+}

--- a/apps/api/tests/Api/Integration/Generic/RemoteDescriptorApiTest.php
+++ b/apps/api/tests/Api/Integration/Generic/RemoteDescriptorApiTest.php
@@ -1,0 +1,298 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Integration\Generic;
+
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Identity\Domain\Entity\User;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\ApiConfigurator\ApiConfiguratorApiTestCase;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * APIC-P2-05 — CRUD coverage for `/api/remote_endpoints` + `/api/remote_fields`
+ * and the `POST /api/connections/{id}/discover` trigger. Reuses the
+ * ApiConfigurator RBAC scaffold (super_admin + tenant_owner admin). The discover
+ * happy path is unit-covered (SchemaDiscoveryServiceTest); here the probe target
+ * is a loopback host so the SSRF wall makes the failure path deterministic and
+ * offline.
+ */
+final class RemoteDescriptorApiTest extends ApiConfiguratorApiTestCase
+{
+    private const string LD_JSON = 'application/ld+json';
+    private const string MERGE_PATCH = 'application/merge-patch+json';
+
+    #[Test]
+    public function postCreatesEndpoint(): void
+    {
+        $connectionId = $this->createConnection();
+
+        $body = $this->createEndpoint($connectionId, [
+            'role' => 'read_list',
+            'pathTemplate' => '/products',
+            'pagination' => ['strategy' => 'offset', 'limit' => 50],
+            'recordSelector' => '$.results',
+        ]);
+
+        self::assertResponseStatusCodeSame(201);
+        self::assertSame('read_list', $body['role'] ?? null);
+        self::assertSame('/products', $body['pathTemplate'] ?? null);
+        self::assertSame('$.results', $body['recordSelector'] ?? null);
+        self::assertSame($connectionId, $body['connectionId'] ?? null);
+    }
+
+    #[Test]
+    public function postEndpointRejectsSchemeInPathTemplate(): void
+    {
+        $connectionId = $this->createConnection();
+
+        $this->authenticatedClient()->request('POST', '/api/remote_endpoints', [
+            'headers' => ['content-type' => self::LD_JSON],
+            'body' => json_encode([
+                'connection' => $connectionId,
+                'role' => 'read_list',
+                'httpMethod' => 'GET',
+                'pathTemplate' => 'https://evil.example/products',
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(422);
+    }
+
+    #[Test]
+    public function postEndpointUnknownConnectionIs404(): void
+    {
+        $this->authenticatedClient()->request('POST', '/api/remote_endpoints', [
+            'headers' => ['content-type' => self::LD_JSON],
+            'body' => json_encode([
+                'connection' => '01234567-1234-7000-8000-000000000000',
+                'role' => 'read_list',
+                'httpMethod' => 'GET',
+                'pathTemplate' => '/products',
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    #[Test]
+    public function patchEndpointUpdatesRoleAndPath(): void
+    {
+        $connectionId = $this->createConnection();
+        $id = $this->createEndpoint($connectionId)['id'] ?? null;
+        \assert(\is_string($id));
+
+        $body = $this->authenticatedClient()->request('PATCH', '/api/remote_endpoints/'.$id, [
+            'headers' => ['content-type' => self::MERGE_PATCH],
+            'body' => json_encode(['role' => 'read_one', 'pathTemplate' => '/products/{id}'], JSON_THROW_ON_ERROR),
+        ])->toArray();
+
+        self::assertResponseStatusCodeSame(200);
+        self::assertSame('read_one', $body['role'] ?? null);
+        self::assertSame('/products/{id}', $body['pathTemplate'] ?? null);
+    }
+
+    #[Test]
+    public function deleteEndpointThenGetIs404(): void
+    {
+        $connectionId = $this->createConnection();
+        $id = $this->createEndpoint($connectionId)['id'] ?? null;
+        \assert(\is_string($id));
+
+        $client = $this->authenticatedClient();
+        $client->request('DELETE', '/api/remote_endpoints/'.$id);
+        self::assertResponseStatusCodeSame(204);
+
+        $client->request('GET', '/api/remote_endpoints/'.$id);
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    #[Test]
+    public function endpointsListIsScopedByConnection(): void
+    {
+        $first = $this->createConnection('alpha');
+        $second = $this->createConnection('beta');
+        $this->createEndpoint($first, ['pathTemplate' => '/a']);
+        $this->createEndpoint($second, ['pathTemplate' => '/b']);
+
+        $body = $this->authenticatedClient()
+            ->request('GET', '/api/remote_endpoints?connection='.$first)
+            ->toArray();
+
+        self::assertResponseStatusCodeSame(200);
+        self::assertSame(1, $body['totalItems'] ?? null);
+    }
+
+    #[Test]
+    public function postCreatesField(): void
+    {
+        $connectionId = $this->createConnection();
+        $endpointId = $this->createEndpoint($connectionId)['id'] ?? null;
+        \assert(\is_string($endpointId));
+
+        $body = $this->authenticatedClient()->request('POST', '/api/remote_fields', [
+            'headers' => ['content-type' => self::LD_JSON],
+            'body' => json_encode([
+                'endpoint' => $endpointId,
+                'path' => '$.price.amount',
+                'label' => 'Price',
+                'dataType' => 'integer',
+                'sampleValue' => '1999',
+            ], JSON_THROW_ON_ERROR),
+        ])->toArray(false);
+
+        self::assertResponseStatusCodeSame(201);
+        self::assertSame('$.price.amount', $body['path'] ?? null);
+        self::assertSame('integer', $body['dataType'] ?? null);
+        self::assertSame($endpointId, $body['endpointId'] ?? null);
+    }
+
+    #[Test]
+    public function fieldsListIsScopedByEndpoint(): void
+    {
+        $connectionId = $this->createConnection();
+        $endpointId = $this->createEndpoint($connectionId)['id'] ?? null;
+        \assert(\is_string($endpointId));
+        $this->createField($endpointId, '$.sku');
+        $this->createField($endpointId, '$.name');
+
+        $body = $this->authenticatedClient()
+            ->request('GET', '/api/remote_fields?endpoint='.$endpointId)
+            ->toArray();
+
+        self::assertResponseStatusCodeSame(200);
+        self::assertSame(2, $body['totalItems'] ?? null);
+    }
+
+    #[Test]
+    public function discoverRequiresEndpointField(): void
+    {
+        $connectionId = $this->createConnection();
+
+        $this->authenticatedClient()->request('POST', '/api/connections/'.$connectionId.'/discover', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => '{}',
+        ]);
+
+        self::assertResponseStatusCodeSame(422);
+    }
+
+    #[Test]
+    public function discoverUnknownConnectionIs404(): void
+    {
+        $this->authenticatedClient()->request('POST', '/api/connections/01234567-1234-7000-8000-000000000000/discover', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => '{"endpoint":"01234567-1234-7000-8000-000000000001"}',
+        ]);
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    #[Test]
+    public function discoverUnreachableEndpointIs422(): void
+    {
+        // Loopback base URL passes descriptor validation but the SSRF wall
+        // rejects it at fetch time → 422 (offline, deterministic).
+        $connectionId = $this->createConnection('local', 'http://127.0.0.1/api');
+        $endpointId = $this->createEndpoint($connectionId)['id'] ?? null;
+        \assert(\is_string($endpointId));
+
+        $this->authenticatedClient()->request('POST', '/api/connections/'.$connectionId.'/discover', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(['endpoint' => $endpointId], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(422);
+    }
+
+    #[Test]
+    public function unauthenticatedEndpointsListIs401(): void
+    {
+        static::createClient()->request('GET', '/api/remote_endpoints');
+        self::assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    #[Test]
+    public function limitedUserEndpointsListIs403(): void
+    {
+        $this->limitedClient()->request('GET', '/api/remote_endpoints');
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    private function createConnection(string $code = 'idosell', string $baseUrl = 'https://api.idosell.com'): string
+    {
+        $body = $this->authenticatedClient()->request('POST', '/api/connections', [
+            'headers' => ['content-type' => self::LD_JSON],
+            'body' => json_encode([
+                'code' => $code,
+                'name' => ucfirst($code),
+                'baseUrl' => $baseUrl,
+                'authType' => 'none',
+            ], JSON_THROW_ON_ERROR),
+        ])->toArray(false);
+
+        $id = $body['id'] ?? null;
+        \assert(\is_string($id));
+
+        return $id;
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     *
+     * @return array<array-key, mixed>
+     */
+    private function createEndpoint(string $connectionId, array $overrides = []): array
+    {
+        $payload = array_merge([
+            'connection' => $connectionId,
+            'role' => 'read_list',
+            'httpMethod' => 'GET',
+            'pathTemplate' => '/products',
+        ], $overrides);
+
+        return $this->authenticatedClient()->request('POST', '/api/remote_endpoints', [
+            'headers' => ['content-type' => self::LD_JSON],
+            'body' => json_encode($payload, JSON_THROW_ON_ERROR),
+        ])->toArray(false);
+    }
+
+    private function createField(string $endpointId, string $path): void
+    {
+        $this->authenticatedClient()->request('POST', '/api/remote_fields', [
+            'headers' => ['content-type' => self::LD_JSON],
+            'body' => json_encode([
+                'endpoint' => $endpointId,
+                'path' => $path,
+                'dataType' => 'string',
+            ], JSON_THROW_ON_ERROR),
+        ]);
+    }
+
+    private function limitedClient(): Client
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $email = 'limited@demo.localhost';
+        $stub = new User($tenant, $email, '', ['ROLE_USER']);
+        $user = new User($tenant, $email, $hasher->hashPassword($stub, 'changeme'), ['ROLE_USER']);
+        $em = $this->em();
+        $em->persist($user);
+        $em->flush();
+
+        $jwt = self::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+
+        $client = static::createClient();
+        $client->setDefaultOptions(['headers' => ['authorization' => 'Bearer '.$jwt]]);
+
+        return $client;
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -7055,6 +7055,988 @@
                 "x-cortex-permission": "object_type.read"
             }
         },
+        "/api/remote_endpoints": {
+            "get": {
+                "operationId": "api_remote_endpoints_get_collection",
+                "tags": [
+                    "RemoteEndpoint"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "RemoteEndpoint collection",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "description": "RemoteEndpoint.jsonld-admin.read collection.",
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/HydraCollectionBaseSchema"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "member"
+                                            ],
+                                            "properties": {
+                                                "member": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/RemoteEndpoint.jsonld-admin.read"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/RemoteEndpoint-admin.read"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Retrieves the collection of RemoteEndpoint resources.",
+                "description": "Retrieves the collection of RemoteEndpoint resources.",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "The collection page number",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        },
+                        "style": "form",
+                        "explode": true
+                    },
+                    {
+                        "name": "connection",
+                        "in": "query",
+                        "description": "Exact match on the parent Connection UUID (tenant-scoped).",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    }
+                ]
+            },
+            "post": {
+                "operationId": "api_remote_endpoints_post",
+                "tags": [
+                    "RemoteEndpoint"
+                ],
+                "responses": {
+                    "201": {
+                        "description": "RemoteEndpoint resource created",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RemoteEndpoint.jsonld-admin.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RemoteEndpoint-admin.read"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "422": {
+                        "description": "An error occurred",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Creates a RemoteEndpoint resource.",
+                "description": "Creates a RemoteEndpoint resource.",
+                "parameters": [],
+                "requestBody": {
+                    "description": "The new RemoteEndpoint resource",
+                    "content": {
+                        "application/ld+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RemoteEndpoint.RemoteEndpointInput-remote_endpoint.create"
+                            }
+                        },
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RemoteEndpoint.RemoteEndpointInput-remote_endpoint.create"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            }
+        },
+        "/api/remote_endpoints/{id}": {
+            "get": {
+                "operationId": "api_remote_endpoints_id_get",
+                "tags": [
+                    "RemoteEndpoint"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "RemoteEndpoint resource",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RemoteEndpoint.jsonld-admin.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RemoteEndpoint-admin.read"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Retrieves a RemoteEndpoint resource.",
+                "description": "Retrieves a RemoteEndpoint resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "RemoteEndpoint identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ]
+            },
+            "delete": {
+                "operationId": "api_remote_endpoints_id_delete",
+                "tags": [
+                    "RemoteEndpoint"
+                ],
+                "responses": {
+                    "204": {
+                        "description": "RemoteEndpoint resource deleted"
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Removes the RemoteEndpoint resource.",
+                "description": "Removes the RemoteEndpoint resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "RemoteEndpoint identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ]
+            },
+            "patch": {
+                "operationId": "api_remote_endpoints_id_patch",
+                "tags": [
+                    "RemoteEndpoint"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "RemoteEndpoint resource updated",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RemoteEndpoint.jsonld-admin.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RemoteEndpoint-admin.read"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "422": {
+                        "description": "An error occurred",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Updates the RemoteEndpoint resource.",
+                "description": "Updates the RemoteEndpoint resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "RemoteEndpoint identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "requestBody": {
+                    "description": "The updated RemoteEndpoint resource",
+                    "content": {
+                        "application/merge-patch+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RemoteEndpoint.RemoteEndpointPatchInput-remote_endpoint.patch.jsonMergePatch"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            }
+        },
+        "/api/remote_fields": {
+            "get": {
+                "operationId": "api_remote_fields_get_collection",
+                "tags": [
+                    "RemoteField"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "RemoteField collection",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "description": "RemoteField.jsonld-admin.read collection.",
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/HydraCollectionBaseSchema"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "member"
+                                            ],
+                                            "properties": {
+                                                "member": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/RemoteField.jsonld-admin.read"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/RemoteField-admin.read"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Retrieves the collection of RemoteField resources.",
+                "description": "Retrieves the collection of RemoteField resources.",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "The collection page number",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        },
+                        "style": "form",
+                        "explode": true
+                    },
+                    {
+                        "name": "endpoint",
+                        "in": "query",
+                        "description": "Exact match on the parent RemoteEndpoint UUID (tenant-scoped).",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    }
+                ]
+            },
+            "post": {
+                "operationId": "api_remote_fields_post",
+                "tags": [
+                    "RemoteField"
+                ],
+                "responses": {
+                    "201": {
+                        "description": "RemoteField resource created",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RemoteField.jsonld-admin.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RemoteField-admin.read"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "422": {
+                        "description": "An error occurred",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Creates a RemoteField resource.",
+                "description": "Creates a RemoteField resource.",
+                "parameters": [],
+                "requestBody": {
+                    "description": "The new RemoteField resource",
+                    "content": {
+                        "application/ld+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RemoteField.RemoteFieldInput-remote_field.create"
+                            }
+                        },
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RemoteField.RemoteFieldInput-remote_field.create"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            }
+        },
+        "/api/remote_fields/{id}": {
+            "get": {
+                "operationId": "api_remote_fields_id_get",
+                "tags": [
+                    "RemoteField"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "RemoteField resource",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RemoteField.jsonld-admin.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RemoteField-admin.read"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Retrieves a RemoteField resource.",
+                "description": "Retrieves a RemoteField resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "RemoteField identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ]
+            },
+            "delete": {
+                "operationId": "api_remote_fields_id_delete",
+                "tags": [
+                    "RemoteField"
+                ],
+                "responses": {
+                    "204": {
+                        "description": "RemoteField resource deleted"
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Removes the RemoteField resource.",
+                "description": "Removes the RemoteField resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "RemoteField identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ]
+            },
+            "patch": {
+                "operationId": "api_remote_fields_id_patch",
+                "tags": [
+                    "RemoteField"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "RemoteField resource updated",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RemoteField.jsonld-admin.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RemoteField-admin.read"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "422": {
+                        "description": "An error occurred",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Updates the RemoteField resource.",
+                "description": "Updates the RemoteField resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "RemoteField identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "requestBody": {
+                    "description": "The updated RemoteField resource",
+                    "content": {
+                        "application/merge-patch+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RemoteField.RemoteFieldPatchInput-remote_field.patch.jsonMergePatch"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            }
+        },
         "/api/admin/break-glass": {
             "post": {
                 "operationId": "api_admin_break_glass_post",
@@ -9847,6 +10829,45 @@
                 ],
                 "x-pim-source": "custom-route",
                 "x-cortex-permission": "channel.read"
+            }
+        },
+        "/api/connections/{id}/discover": {
+            "post": {
+                "operationId": "api_connections_id_discover_post",
+                "tags": [
+                    "connections"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api connections id discover",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "settings.integrations.manage"
             }
         },
         "/api/connections/{id}/test": {
@@ -19840,6 +20861,607 @@
                     }
                 ],
                 "description": "Generic template for every domain object kind in PIM (per ADR-009).\n\nPredefined kinds (`Product`, `Category`, `Asset`) seed as fixtures with\n`is_built_in=true` in #33 \u2014 they are platform-owned and protected from\ndeletion by `ObjectTypeService::delete`. Custom kinds (`Customer`,\n`Supplier`, `PriceList`, etc.) are unlocked in phase 2/3 via the\n`enable_custom_object_types` feature flag.\n\n`label_attribute_id` and `image_attribute_id` are nullable foreign keys\nto `attributes` \u2014 the convention is \"name\" \u2192 display label, \"main_image\"\n\u2192 image. Cross-ObjectType reference is technically possible but should\nbe paired with the junction; a validator that enforces this lands as a\nfollow-up after #34.\n\n`completeness_rules` is a JSONB payload stored verbatim. The Doctrine\nlistener that interprets it (e.g. `{required: ['sku', 'name'], weight:\n{sku: 2, name: 1}}`) and computes `Object.completeness_pct` is in #38.\n\n`schema_version` is a forward hook for export/import tooling planned\nfor phase 2 (when enterprise customers move definitions between\nenvironments) \u2014 set on every save, bumped manually when a schema-\nbreaking change to `completeness_rules` ships."
+            },
+            "RemoteEndpoint-admin.read": {
+                "type": "object",
+                "description": "One operation descriptor on an external API \u2014 the consumer-side analogue of\nan Airbyte stream (ADR-0022, epic APIC, ticket APIC-P2-01).\n\nA {@see Connection} owns many endpoints; each binds a {@see RemoteEndpointRole}\n(read_list / read_one / write_create / write_update) to an HTTP method, a\npath template, optional query params and a request-body template. The\n`pagination` envelope selects the paging strategy (none/offset/page/cursor/\nlink_header \u2014 implemented in APIC-P2-03); `recordSelector` is the JSONPath\nthat extracts records from a list response.\n\n`TenantScoped` + Postgres RLS isolate every endpoint to its tenant; the\ntenant always matches the parent connection's. The FK to Connection cascades\non delete, so removing a connection removes its descriptor.",
+                "properties": {
+                    "id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uuid"
+                    },
+                    "role": {
+                        "type": "string",
+                        "enum": [
+                            "read_list",
+                            "read_one",
+                            "write_create",
+                            "write_update"
+                        ]
+                    },
+                    "httpMethod": {
+                        "enum": [
+                            "GET",
+                            "POST",
+                            "PUT",
+                            "PATCH",
+                            "DELETE"
+                        ],
+                        "type": "string"
+                    },
+                    "pathTemplate": {
+                        "maxLength": 2048,
+                        "type": "string"
+                    },
+                    "queryParams": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "requestBodyTemplate": {
+                        "description": "Request-body template for write roles (placeholders resolved at sync\ntime); null for read roles.",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "additionalProperties": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "pagination": {
+                        "description": "Pagination envelope: `{strategy, ...params}`. Defaults to no paging; the\nconcrete strategies (offset/page/cursor/link_header) are read in\nAPIC-P2-03.",
+                        "default": {
+                            "strategy": "none"
+                        },
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "recordSelector": {
+                        "maxLength": 512,
+                        "description": "JSONPath that selects records from a list response (read_list); null otherwise.",
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "responseFormat": {
+                        "enum": [
+                            "json"
+                        ],
+                        "default": "json",
+                        "type": "string"
+                    },
+                    "createdAt": {
+                        "readOnly": true,
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updatedAt": {
+                        "readOnly": true,
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "connectionId": {
+                        "readOnly": true,
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                },
+                "required": [
+                    "httpMethod",
+                    "pathTemplate"
+                ]
+            },
+            "RemoteEndpoint.RemoteEndpointInput-remote_endpoint.create": {
+                "type": "object",
+                "description": "One operation descriptor on an external API \u2014 the consumer-side analogue of\nan Airbyte stream (ADR-0022, epic APIC, ticket APIC-P2-01).\n\nA {@see Connection} owns many endpoints; each binds a {@see RemoteEndpointRole}\n(read_list / read_one / write_create / write_update) to an HTTP method, a\npath template, optional query params and a request-body template. The\n`pagination` envelope selects the paging strategy (none/offset/page/cursor/\nlink_header \u2014 implemented in APIC-P2-03); `recordSelector` is the JSONPath\nthat extracts records from a list response.\n\n`TenantScoped` + Postgres RLS isolate every endpoint to its tenant; the\ntenant always matches the parent connection's. The FK to Connection cascades\non delete, so removing a connection removes its descriptor.",
+                "required": [
+                    "connection",
+                    "pathTemplate"
+                ],
+                "properties": {
+                    "connection": {
+                        "default": "",
+                        "type": "string"
+                    },
+                    "role": {
+                        "enum": [
+                            "read_list",
+                            "read_one",
+                            "write_create",
+                            "write_update"
+                        ],
+                        "default": "read_list",
+                        "type": "string"
+                    },
+                    "httpMethod": {
+                        "enum": [
+                            "GET",
+                            "POST",
+                            "PUT",
+                            "PATCH",
+                            "DELETE"
+                        ],
+                        "default": "GET",
+                        "type": "string"
+                    },
+                    "pathTemplate": {
+                        "maxLength": 2048,
+                        "default": "",
+                        "type": "string"
+                    },
+                    "queryParams": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "requestBodyTemplate": {
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "additionalProperties": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "pagination": {
+                        "default": {
+                            "strategy": "none"
+                        },
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "recordSelector": {
+                        "maxLength": 512,
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "responseFormat": {
+                        "enum": [
+                            "json"
+                        ],
+                        "default": "json",
+                        "type": "string"
+                    }
+                }
+            },
+            "RemoteEndpoint.RemoteEndpointPatchInput-remote_endpoint.patch.jsonMergePatch": {
+                "type": "object",
+                "description": "One operation descriptor on an external API \u2014 the consumer-side analogue of\nan Airbyte stream (ADR-0022, epic APIC, ticket APIC-P2-01).\n\nA {@see Connection} owns many endpoints; each binds a {@see RemoteEndpointRole}\n(read_list / read_one / write_create / write_update) to an HTTP method, a\npath template, optional query params and a request-body template. The\n`pagination` envelope selects the paging strategy (none/offset/page/cursor/\nlink_header \u2014 implemented in APIC-P2-03); `recordSelector` is the JSONPath\nthat extracts records from a list response.\n\n`TenantScoped` + Postgres RLS isolate every endpoint to its tenant; the\ntenant always matches the parent connection's. The FK to Connection cascades\non delete, so removing a connection removes its descriptor.",
+                "properties": {
+                    "role": {
+                        "enum": [
+                            "read_list",
+                            "read_one",
+                            "write_create",
+                            "write_update"
+                        ],
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "httpMethod": {
+                        "enum": [
+                            "GET",
+                            "POST",
+                            "PUT",
+                            "PATCH",
+                            "DELETE"
+                        ],
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "pathTemplate": {
+                        "maxLength": 2048,
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "queryParams": {
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "requestBodyTemplate": {
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "additionalProperties": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "pagination": {
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "additionalProperties": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "recordSelector": {
+                        "maxLength": 512,
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "responseFormat": {
+                        "enum": [
+                            "json"
+                        ],
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    }
+                }
+            },
+            "RemoteEndpoint.jsonld-admin.read": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/HydraItemBaseSchema"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "uuid"
+                            },
+                            "role": {
+                                "type": "string",
+                                "enum": [
+                                    "read_list",
+                                    "read_one",
+                                    "write_create",
+                                    "write_update"
+                                ]
+                            },
+                            "httpMethod": {
+                                "enum": [
+                                    "GET",
+                                    "POST",
+                                    "PUT",
+                                    "PATCH",
+                                    "DELETE"
+                                ],
+                                "type": "string"
+                            },
+                            "pathTemplate": {
+                                "maxLength": 2048,
+                                "type": "string"
+                            },
+                            "queryParams": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "string"
+                                }
+                            },
+                            "requestBodyTemplate": {
+                                "description": "Request-body template for write roles (placeholders resolved at sync\ntime); null for read roles.",
+                                "type": [
+                                    "object",
+                                    "null"
+                                ],
+                                "additionalProperties": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "pagination": {
+                                "description": "Pagination envelope: `{strategy, ...params}`. Defaults to no paging; the\nconcrete strategies (offset/page/cursor/link_header) are read in\nAPIC-P2-03.",
+                                "default": {
+                                    "strategy": "none"
+                                },
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "recordSelector": {
+                                "maxLength": 512,
+                                "description": "JSONPath that selects records from a list response (read_list); null otherwise.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "responseFormat": {
+                                "enum": [
+                                    "json"
+                                ],
+                                "default": "json",
+                                "type": "string"
+                            },
+                            "createdAt": {
+                                "readOnly": true,
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "updatedAt": {
+                                "readOnly": true,
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "connectionId": {
+                                "readOnly": true,
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        },
+                        "required": [
+                            "httpMethod",
+                            "pathTemplate"
+                        ]
+                    }
+                ],
+                "description": "One operation descriptor on an external API \u2014 the consumer-side analogue of\nan Airbyte stream (ADR-0022, epic APIC, ticket APIC-P2-01).\n\nA {@see Connection} owns many endpoints; each binds a {@see RemoteEndpointRole}\n(read_list / read_one / write_create / write_update) to an HTTP method, a\npath template, optional query params and a request-body template. The\n`pagination` envelope selects the paging strategy (none/offset/page/cursor/\nlink_header \u2014 implemented in APIC-P2-03); `recordSelector` is the JSONPath\nthat extracts records from a list response.\n\n`TenantScoped` + Postgres RLS isolate every endpoint to its tenant; the\ntenant always matches the parent connection's. The FK to Connection cascades\non delete, so removing a connection removes its descriptor."
+            },
+            "RemoteField-admin.read": {
+                "type": "object",
+                "description": "One field of an external API response \u2014 discovered from a sample or entered\nby hand (ADR-0022, epic APIC, ticket APIC-P2-02).\n\nA {@see RemoteEndpoint} owns many fields; each carries the JSONPath that\nlocates it within a record, a human label, the detected {@see RemoteFieldDataType}\nand a textual sample value. These are the left-hand side of the 1:1 field\nmapping (APIC-P2-07/08).\n\n`TenantScoped` + Postgres RLS isolate every field to its tenant; the tenant\nalways matches the parent endpoint's. The FK to RemoteEndpoint cascades on\ndelete.",
+                "properties": {
+                    "id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uuid"
+                    },
+                    "path": {
+                        "maxLength": 512,
+                        "type": "string"
+                    },
+                    "label": {
+                        "maxLength": 255,
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "dataType": {
+                        "type": "string",
+                        "enum": [
+                            "string",
+                            "integer",
+                            "number",
+                            "boolean",
+                            "object",
+                            "array",
+                            "null"
+                        ]
+                    },
+                    "sampleValue": {
+                        "maxLength": 2048,
+                        "description": "Textual sample value captured during discovery; null when none was seen.",
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "createdAt": {
+                        "readOnly": true,
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updatedAt": {
+                        "readOnly": true,
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "endpointId": {
+                        "readOnly": true,
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                },
+                "required": [
+                    "path"
+                ]
+            },
+            "RemoteField.RemoteFieldInput-remote_field.create": {
+                "type": "object",
+                "description": "One field of an external API response \u2014 discovered from a sample or entered\nby hand (ADR-0022, epic APIC, ticket APIC-P2-02).\n\nA {@see RemoteEndpoint} owns many fields; each carries the JSONPath that\nlocates it within a record, a human label, the detected {@see RemoteFieldDataType}\nand a textual sample value. These are the left-hand side of the 1:1 field\nmapping (APIC-P2-07/08).\n\n`TenantScoped` + Postgres RLS isolate every field to its tenant; the tenant\nalways matches the parent endpoint's. The FK to RemoteEndpoint cascades on\ndelete.",
+                "required": [
+                    "endpoint",
+                    "path"
+                ],
+                "properties": {
+                    "endpoint": {
+                        "default": "",
+                        "type": "string"
+                    },
+                    "path": {
+                        "maxLength": 512,
+                        "default": "",
+                        "type": "string"
+                    },
+                    "label": {
+                        "maxLength": 255,
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "dataType": {
+                        "enum": [
+                            "string",
+                            "integer",
+                            "number",
+                            "boolean",
+                            "object",
+                            "array",
+                            "null"
+                        ],
+                        "default": "string",
+                        "type": "string"
+                    },
+                    "sampleValue": {
+                        "maxLength": 2048,
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    }
+                }
+            },
+            "RemoteField.RemoteFieldPatchInput-remote_field.patch.jsonMergePatch": {
+                "type": "object",
+                "description": "One field of an external API response \u2014 discovered from a sample or entered\nby hand (ADR-0022, epic APIC, ticket APIC-P2-02).\n\nA {@see RemoteEndpoint} owns many fields; each carries the JSONPath that\nlocates it within a record, a human label, the detected {@see RemoteFieldDataType}\nand a textual sample value. These are the left-hand side of the 1:1 field\nmapping (APIC-P2-07/08).\n\n`TenantScoped` + Postgres RLS isolate every field to its tenant; the tenant\nalways matches the parent endpoint's. The FK to RemoteEndpoint cascades on\ndelete.",
+                "properties": {
+                    "path": {
+                        "maxLength": 512,
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "label": {
+                        "maxLength": 255,
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "dataType": {
+                        "enum": [
+                            "string",
+                            "integer",
+                            "number",
+                            "boolean",
+                            "object",
+                            "array",
+                            "null"
+                        ],
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "sampleValue": {
+                        "maxLength": 2048,
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    }
+                }
+            },
+            "RemoteField.jsonld-admin.read": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/HydraItemBaseSchema"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "uuid"
+                            },
+                            "path": {
+                                "maxLength": 512,
+                                "type": "string"
+                            },
+                            "label": {
+                                "maxLength": 255,
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "dataType": {
+                                "type": "string",
+                                "enum": [
+                                    "string",
+                                    "integer",
+                                    "number",
+                                    "boolean",
+                                    "object",
+                                    "array",
+                                    "null"
+                                ]
+                            },
+                            "sampleValue": {
+                                "maxLength": 2048,
+                                "description": "Textual sample value captured during discovery; null when none was seen.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "createdAt": {
+                                "readOnly": true,
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "updatedAt": {
+                                "readOnly": true,
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "endpointId": {
+                                "readOnly": true,
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        },
+                        "required": [
+                            "path"
+                        ]
+                    }
+                ],
+                "description": "One field of an external API response \u2014 discovered from a sample or entered\nby hand (ADR-0022, epic APIC, ticket APIC-P2-02).\n\nA {@see RemoteEndpoint} owns many fields; each carries the JSONPath that\nlocates it within a record, a human label, the detected {@see RemoteFieldDataType}\nand a textual sample value. These are the left-hand side of the 1:1 field\nmapping (APIC-P2-07/08).\n\n`TenantScoped` + Postgres RLS isolate every field to its tenant; the tenant\nalways matches the parent endpoint's. The FK to RemoteEndpoint cascades on\ndelete."
             }
         },
         "responses": {},
@@ -19921,6 +21543,14 @@
         {
             "name": "Connection",
             "description": "A consumer-side connection to one external REST/JSON API (ADR-0022, epic APIC).\n\nHolds the transport definition \u2014 base URL, auth type, default headers, an\noptional rate hint \u2014 plus the reversibly-encrypted credentials needed to\ncall the remote. The actual encryption-at-write + response masking lands in\nAPIC-P1-02; this entity stores the already-produced ciphertext + master-key\nversion in two columns, mirroring `TenantAgentConfig` / ADR-0017.\n\n`TenantScoped` + Postgres RLS isolate every connection to its tenant. Scheme\n(http/https) and SSRF-safe descriptor validation are enforced separately\n(APIC-P1-03/P1-04), not at this domain layer."
+        },
+        {
+            "name": "RemoteEndpoint",
+            "description": "One operation descriptor on an external API \u2014 the consumer-side analogue of\nan Airbyte stream (ADR-0022, epic APIC, ticket APIC-P2-01).\n\nA {@see Connection} owns many endpoints; each binds a {@see RemoteEndpointRole}\n(read_list / read_one / write_create / write_update) to an HTTP method, a\npath template, optional query params and a request-body template. The\n`pagination` envelope selects the paging strategy (none/offset/page/cursor/\nlink_header \u2014 implemented in APIC-P2-03); `recordSelector` is the JSONPath\nthat extracts records from a list response.\n\n`TenantScoped` + Postgres RLS isolate every endpoint to its tenant; the\ntenant always matches the parent connection's. The FK to Connection cascades\non delete, so removing a connection removes its descriptor."
+        },
+        {
+            "name": "RemoteField",
+            "description": "One field of an external API response \u2014 discovered from a sample or entered\nby hand (ADR-0022, epic APIC, ticket APIC-P2-02).\n\nA {@see RemoteEndpoint} owns many fields; each carries the JSONPath that\nlocates it within a record, a human label, the detected {@see RemoteFieldDataType}\nand a textual sample value. These are the left-hand side of the 1:1 field\nmapping (APIC-P2-07/08).\n\n`TenantScoped` + Postgres RLS isolate every field to its tenant; the tenant\nalways matches the parent endpoint's. The FK to RemoteEndpoint cascades on\ndelete."
         }
     ],
     "webhooks": {}


### PR DESCRIPTION
## Cel

APIC-P2-05 — endpointy edycji descriptora (RemoteEndpoint/RemoteField) + trigger schema discovery.

## Zakres

- **API Platform resources** dla `RemoteEndpoint` i `RemoteField`: GetCollection/Get/Post/Patch/Delete, serializer read-projection, denormalization groups create/patch.
- **Processory** (tenant-scoped): connection/endpoint rozwiązywane tenant-scoped → **404** cross-tenant/missing; pathTemplate walidowany przez SSRF descriptor wall (P1-04) → **422**; tenant stampowany na persist przez listener.
- **Filtry** `?connection={id}` (remote_endpoints) i `?endpoint={id}` (remote_fields) — scoping listy dla FE; tenant scoping nadal z TenantFilter.
- **Vot­ery** `RemoteEndpointVoter`/`RemoteFieldVoter` (Identity, resource `integration`, FQCN-string subject → Deptrac-clean).
- **`POST /api/connections/{id}/discover`** — uruchamia `SchemaDiscoveryService` dla wskazanego read endpointu (body `{endpoint}`); zwraca `{fields, sampleRecord, sampledRecords}`. Blocked/unreachable remote (SSRF/transport) → **422**, nie 500.
- **OpenAPI snapshot** zregenerowany — czysto addytywnie (+5 paths, +8 schemas; istniejące ścieżki byte-identical, 0 usuniętych).

## Testy / bramki (kontener api)

- **PHPStan max** ✅ · **Deptrac** 0 ✅ · **PHP-CS-Fixer** 0 ✅ · routing/DI zweryfikowane (`debug:router` + `cache:clear`).
- **PHPUnit** (Generic unit+integration regresja): **88/88** ✅.
- **`RemoteDescriptorApiTest`** (Layer 3, **CI-only** — lokalny JWT mint pada `bad decrypt`, wzorzec identyczny z CI-zielonym `ConnectionsApiTest`): CRUD endpointów/pól, 422 scheme-in-path, 404 unknown connection, filtr `?connection`/`?endpoint`, discover 422 (no endpoint) / 404 (unknown conn) / 422 (loopback → SSRF), 401/403.

Refs #1774