### PR TITLE
feat(ui): wire wizard steps 3-4 endpoints + schema discovery (APIC-P2-06)

### DIFF
--- a/apps/admin/e2e/1775-api-wizard-descriptor.spec.ts
+++ b/apps/admin/e2e/1775-api-wizard-descriptor.spec.ts
@@ -1,0 +1,113 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, type Route, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * APIC-P2-06 (#1775) — wizard steps 3–4: the endpoint descriptor builder and
+ * schema discovery. The descriptor + discover APIs are mocked (the live probe
+ * would need a reachable third-party host), so the test is deterministic and
+ * offline: add an endpoint, fetch a sample, accept the discovered fields.
+ */
+test('APIC-P2-06 — wizard endpoint builder + schema discovery', async ({ page }) => {
+  await loginAsAdmin(page);
+
+  const endpoints: Array<Record<string, unknown>> = [];
+
+  // Connection draft (step 1 → 2 persists it).
+  await page.route('**/api/connections', (route: Route) => {
+    if (route.request().method() === 'POST') {
+      return route.fulfill({
+        status: 201,
+        contentType: 'application/ld+json',
+        body: JSON.stringify({ id: 'conn-1', code: 'idosell', name: 'IdoSell', status: 'draft' }),
+      });
+    }
+    return route.fallback();
+  });
+
+  // RemoteEndpoint collection (GET) + create (POST).
+  await page.route('**/api/remote_endpoints*', (route: Route) => {
+    const method = route.request().method();
+    if (method === 'POST') {
+      const body = route.request().postDataJSON() as Record<string, unknown>;
+      const created = {
+        id: `ep-${endpoints.length + 1}`,
+        connectionId: 'conn-1',
+        role: body.role ?? 'read_list',
+        httpMethod: body.httpMethod ?? 'GET',
+        pathTemplate: body.pathTemplate ?? '/',
+        pagination: body.pagination ?? { strategy: 'none' },
+        recordSelector: body.recordSelector ?? null,
+      };
+      endpoints.push(created);
+      return route.fulfill({
+        status: 201,
+        contentType: 'application/ld+json',
+        body: JSON.stringify(created),
+      });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify({ member: endpoints, totalItems: endpoints.length }),
+    });
+  });
+
+  // Schema discovery.
+  await page.route('**/api/connections/*/discover', (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        fields: [
+          { path: '$.sku', dataType: 'string', sampleValue: 'A-1' },
+          { path: '$.price.amount', dataType: 'integer', sampleValue: '1999' },
+        ],
+        sampleRecord: { sku: 'A-1', price: { amount: 1999 } },
+        sampledRecords: 2,
+      }),
+    }),
+  );
+
+  // Accepted RemoteFields.
+  await page.route('**/api/remote_fields', (route: Route) =>
+    route.fulfill({
+      status: 201,
+      contentType: 'application/ld+json',
+      body: JSON.stringify({ id: 'field-1' }),
+    }),
+  );
+
+  await page.goto('/integrations/api-configurator/connections/new');
+
+  // Step 1 → persist draft → step 2 (test).
+  await page.getByLabel(/nazwa połączenia|connection name/i).fill('IdoSell');
+  await page.getByLabel(/^base url$/i).fill('https://api.idosell.com');
+  await page.getByRole('button', { name: /dalej|next/i }).click();
+  await expect(
+    page.getByRole('button', { name: /testuj połączenie|test connection/i }),
+  ).toBeVisible();
+
+  // Step 2 → step 3 (endpoints).
+  await page.getByRole('button', { name: /dalej|next/i }).click();
+  await expect(page.getByRole('button', { name: /dodaj endpoint|add endpoint/i })).toBeVisible();
+
+  // Add a read_list endpoint and see it land in the table.
+  await page.getByLabel(/^ścieżka$|^path$/i).fill('/products');
+  await page.getByRole('button', { name: /dodaj endpoint|add endpoint/i }).click();
+  await expect(page.getByText('/products')).toBeVisible();
+
+  // Step 3 → step 4 (schema discovery).
+  await page.getByRole('button', { name: /dalej|next/i }).click();
+  await page.getByRole('button', { name: /pobierz próbkę|fetch sample/i }).click();
+
+  // Discovered fields render; accept them.
+  await expect(page.getByText('$.sku')).toBeVisible();
+  await expect(page.getByText('$.price.amount')).toBeVisible();
+  await page.getByRole('button', { name: /zapisz pola|save fields/i }).click();
+  await expect(page.getByText(/pola zapisane|fields saved/i)).toBeVisible();
+
+  const a11y = await new AxeBuilder({ page }).analyze();
+  expect(a11y.violations).toEqual([]);
+});

--- a/apps/admin/src/features/api-configurator/consumer/wizard/ConnectionWizardPage.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/wizard/ConnectionWizardPage.tsx
@@ -9,6 +9,8 @@ import { cn } from '@/lib/utils';
 
 import { StepConnection } from './StepConnection';
 import { StepTest } from './StepTest';
+import { StepEndpoints } from './steps/StepEndpoints';
+import { StepSchema } from './steps/StepSchema';
 import { INITIAL_FORM, toConnectionInput, type WizardForm } from './types';
 
 const HUB = '/integrations/api-configurator/connections';
@@ -16,10 +18,11 @@ const HUB = '/integrations/api-configurator/connections';
 type StepState = 'done' | 'active' | 'pending';
 
 /**
- * APIC-P1-08 — the consumer connection wizard. Steps 1–2 (define + test) are
- * live; steps 3–4 (endpoints + schema discovery) are stubs that land with the
- * descriptor work in M2 (APIC-P2-06). The connection is persisted as a draft on
- * leaving step 1 so step 2 has an id to probe, and re-edits PATCH that draft.
+ * APIC-P1-08 / P2-06 — the consumer connection wizard. Step 1 defines the
+ * connection, step 2 tests it, step 3 builds the endpoint descriptors, step 4
+ * discovers the schema and accepts fields. The connection is persisted as a
+ * draft on leaving step 1 so the later steps have an id to attach to, and
+ * re-edits PATCH that draft.
  */
 export function ConnectionWizardPage() {
   const { t } = useTranslation();
@@ -42,7 +45,7 @@ export function ConnectionWizardPage() {
     {
       id: 'schema',
       label: t('api_configurator.wizard.step_schema'),
-      note: t('api_configurator.wizard.soon'),
+      note: t('api_configurator.wizard.schema.note'),
     },
   ];
 
@@ -191,16 +194,8 @@ export function ConnectionWizardPage() {
 
       {step === 0 ? <StepConnection form={form} set={set} /> : null}
       {step === 1 ? <StepTest form={form} connectionId={connectionId} /> : null}
-      {step === 2 || step === 3 ? (
-        <div className="rounded-2xl border border-dashed border-zinc-200 bg-white p-10 text-center">
-          <h2 className="text-[15px] font-semibold tracking-tight">
-            {t('api_configurator.wizard.stub_title')}
-          </h2>
-          <p className="mx-auto mt-1 max-w-md text-[13px] text-zinc-500">
-            {t('api_configurator.wizard.stub_desc')}
-          </p>
-        </div>
-      ) : null}
+      {step === 2 ? <StepEndpoints connectionId={connectionId} /> : null}
+      {step === 3 ? <StepSchema connectionId={connectionId} /> : null}
 
       {saveError !== null ? (
         <div className="rounded-xl border border-rose-200 bg-rose-50/60 p-3 text-[12.5px] text-rose-700">

--- a/apps/admin/src/features/api-configurator/consumer/wizard/ConnectionWizardPage.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/wizard/ConnectionWizardPage.tsx
@@ -208,7 +208,7 @@ export function ConnectionWizardPage() {
           {step === 0 ? t('app.cancel') : t('api_configurator.wizard.back')}
         </Button>
         <div className="flex-1" />
-        <div className="text-[12px] text-zinc-400">
+        <div className="text-[12px] text-zinc-500">
           {t('api_configurator.wizard.step_counter', { current: step + 1, total: steps.length })}
         </div>
         {isLast ? (

--- a/apps/admin/src/features/api-configurator/consumer/wizard/steps/StepEndpoints.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/wizard/steps/StepEndpoints.tsx
@@ -1,0 +1,192 @@
+import { useCreate, useDelete, useList } from '@refinedev/core';
+import { Plus, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+import {
+  type EndpointRole,
+  type HttpMethod,
+  MethodPill,
+  type PaginationKind,
+  PaginationPill,
+  RolePill,
+  Segmented,
+} from '../../../components/primitives';
+
+export interface RemoteEndpointRow {
+  id: string;
+  connectionId: string;
+  role: EndpointRole;
+  httpMethod: HttpMethod;
+  pathTemplate: string;
+  pagination: { strategy?: PaginationKind } & Record<string, unknown>;
+  recordSelector: string | null;
+}
+
+const ROLES: EndpointRole[] = ['read_list', 'read_one', 'write_create', 'write_update'];
+const METHODS: HttpMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
+const STRATEGIES: PaginationKind[] = ['none', 'offset', 'page', 'cursor', 'link_header'];
+
+/**
+ * APIC-P2-06 — wizard step 3: the endpoint (operation descriptor) builder. Lists
+ * the connection's RemoteEndpoints and adds/removes them against the P2-05 CRUD
+ * API. The schema-discovery step (4) samples one of these read endpoints.
+ */
+export function StepEndpoints({ connectionId }: { connectionId: string | null }) {
+  const { t } = useTranslation();
+  const { result, query } = useList<RemoteEndpointRow>({
+    resource: 'remote_endpoints',
+    filters:
+      connectionId === null ? [] : [{ field: 'connection', operator: 'eq', value: connectionId }],
+    queryOptions: { enabled: connectionId !== null },
+    pagination: { mode: 'off' },
+  });
+  const { mutate: create, mutation: createMutation } = useCreate();
+  const { mutate: remove } = useDelete();
+
+  const [role, setRole] = useState<EndpointRole>('read_list');
+  const [method, setMethod] = useState<HttpMethod>('GET');
+  const [path, setPath] = useState('/');
+  const [strategy, setStrategy] = useState<PaginationKind>('none');
+  const [selector, setSelector] = useState('$');
+
+  const endpoints = result.data;
+
+  function add(): void {
+    if (connectionId === null || path.trim() === '') {
+      return;
+    }
+    create(
+      {
+        resource: 'remote_endpoints',
+        values: {
+          connection: connectionId,
+          role,
+          httpMethod: method,
+          pathTemplate: path.trim(),
+          pagination: { strategy },
+          recordSelector: selector.trim() === '' ? null : selector.trim(),
+        },
+        successNotification: false,
+      },
+      { onSuccess: () => query.refetch() },
+    );
+  }
+
+  return (
+    <div className="soft-shadow space-y-4 rounded-2xl border border-zinc-200 bg-white p-6">
+      <table className="w-full text-[12.5px]">
+        <thead>
+          <tr className="text-[10px] uppercase tracking-wider text-zinc-400">
+            <th className="pb-1 text-left font-medium">{t('api_configurator.wizard.ep.role')}</th>
+            <th className="pb-1 text-left font-medium">{t('api_configurator.wizard.ep.method')}</th>
+            <th className="pb-1 text-left font-medium">{t('api_configurator.wizard.ep.path')}</th>
+            <th className="pb-1 text-left font-medium">
+              {t('api_configurator.wizard.ep.pagination')}
+            </th>
+            <th className="pb-1 text-left font-medium">
+              {t('api_configurator.wizard.ep.selector')}
+            </th>
+            <th className="pb-1" />
+          </tr>
+        </thead>
+        <tbody>
+          {endpoints.map((endpoint) => (
+            <tr key={endpoint.id} className="border-t border-zinc-100">
+              <td className="py-2">
+                <RolePill value={endpoint.role} />
+              </td>
+              <td className="py-2">
+                <MethodPill method={endpoint.httpMethod} />
+              </td>
+              <td className="py-2 font-mono text-zinc-800">{endpoint.pathTemplate}</td>
+              <td className="py-2">
+                <PaginationPill kind={endpoint.pagination?.strategy ?? 'none'} />
+              </td>
+              <td className="py-2 font-mono text-zinc-500">{endpoint.recordSelector ?? '—'}</td>
+              <td className="py-2 text-right">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  onClick={() =>
+                    remove(
+                      { resource: 'remote_endpoints', id: endpoint.id },
+                      { onSuccess: () => query.refetch() },
+                    )
+                  }
+                  aria-label={t('api_configurator.wizard.ep.remove', {
+                    path: endpoint.pathTemplate,
+                  })}
+                  className="text-zinc-400 hover:text-rose-600"
+                >
+                  <Trash2 className="size-4" aria-hidden="true" />
+                </Button>
+              </td>
+            </tr>
+          ))}
+          {endpoints.length === 0 && !query.isLoading ? (
+            <tr>
+              <td colSpan={6} className="py-4 text-center text-zinc-400">
+                {t('api_configurator.wizard.ep.empty')}
+              </td>
+            </tr>
+          ) : null}
+        </tbody>
+      </table>
+
+      <div className="space-y-3 rounded-xl border border-dashed border-zinc-200 p-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <Segmented
+            ariaLabel={t('api_configurator.wizard.ep.role')}
+            size="sm"
+            value={role}
+            onChange={setRole}
+            options={ROLES.map((r) => ({ value: r, label: r }))}
+          />
+          <Segmented
+            ariaLabel={t('api_configurator.wizard.ep.method')}
+            size="sm"
+            value={method}
+            onChange={setMethod}
+            options={METHODS.map((m) => ({ value: m, label: m }))}
+          />
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Input
+            value={path}
+            onChange={(e) => setPath(e.target.value)}
+            placeholder="/products"
+            aria-label={t('api_configurator.wizard.ep.path')}
+            className="h-9 max-w-xs font-mono"
+          />
+          <Segmented
+            ariaLabel={t('api_configurator.wizard.ep.pagination')}
+            size="sm"
+            value={strategy}
+            onChange={setStrategy}
+            options={STRATEGIES.map((s) => ({ value: s, label: s }))}
+          />
+          <Input
+            value={selector}
+            onChange={(e) => setSelector(e.target.value)}
+            placeholder="$.results"
+            aria-label={t('api_configurator.wizard.ep.selector')}
+            className="h-9 w-32 font-mono"
+          />
+          <Button
+            type="button"
+            onClick={add}
+            disabled={connectionId === null || createMutation.isPending}
+          >
+            <Plus className="mr-1 size-4" aria-hidden="true" />
+            {t('api_configurator.wizard.ep.add')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/api-configurator/consumer/wizard/steps/StepEndpoints.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/wizard/steps/StepEndpoints.tsx
@@ -80,7 +80,7 @@ export function StepEndpoints({ connectionId }: { connectionId: string | null })
     <div className="soft-shadow space-y-4 rounded-2xl border border-zinc-200 bg-white p-6">
       <table className="w-full text-[12.5px]">
         <thead>
-          <tr className="text-[10px] uppercase tracking-wider text-zinc-400">
+          <tr className="text-[10px] uppercase tracking-wider text-zinc-500">
             <th className="pb-1 text-left font-medium">{t('api_configurator.wizard.ep.role')}</th>
             <th className="pb-1 text-left font-medium">{t('api_configurator.wizard.ep.method')}</th>
             <th className="pb-1 text-left font-medium">{t('api_configurator.wizard.ep.path')}</th>
@@ -130,7 +130,7 @@ export function StepEndpoints({ connectionId }: { connectionId: string | null })
           ))}
           {endpoints.length === 0 && !query.isLoading ? (
             <tr>
-              <td colSpan={6} className="py-4 text-center text-zinc-400">
+              <td colSpan={6} className="py-4 text-center text-zinc-500">
                 {t('api_configurator.wizard.ep.empty')}
               </td>
             </tr>

--- a/apps/admin/src/features/api-configurator/consumer/wizard/steps/StepSchema.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/wizard/steps/StepSchema.tsx
@@ -147,13 +147,13 @@ export function StepSchema({ connectionId }: { connectionId: string | null }) {
       ) : null}
 
       {discovered === null ? (
-        <div className="rounded-xl border border-dashed border-zinc-200 px-5 py-10 text-center text-[13px] text-zinc-400">
+        <div className="rounded-xl border border-dashed border-zinc-200 px-5 py-10 text-center text-[13px] text-zinc-500">
           {t('api_configurator.wizard.schema.empty')}
         </div>
       ) : (
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1fr_1.1fr]">
           <div className="overflow-hidden rounded-xl border border-zinc-200">
-            <div className="border-b border-zinc-100 bg-zinc-50/60 px-3 py-2 text-[10.5px] font-medium uppercase tracking-wider text-zinc-400">
+            <div className="border-b border-zinc-100 bg-zinc-50/60 px-3 py-2 text-[10.5px] font-medium uppercase tracking-wider text-zinc-500">
               {t('api_configurator.wizard.schema.sample')}
             </div>
             <div className="p-3">
@@ -201,7 +201,7 @@ export function StepSchema({ connectionId }: { connectionId: string | null }) {
                   <div className="min-w-0 flex-1">
                     <div className="truncate font-mono text-[12px] text-zinc-800">{field.path}</div>
                     {field.sampleValue !== null ? (
-                      <div className="truncate font-mono text-[10.5px] text-zinc-400">
+                      <div className="truncate font-mono text-[10.5px] text-zinc-500">
                         {t('api_configurator.wizard.schema.field_sample', {
                           value: field.sampleValue,
                         })}

--- a/apps/admin/src/features/api-configurator/consumer/wizard/steps/StepSchema.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/wizard/steps/StepSchema.tsx
@@ -1,0 +1,235 @@
+import { useApiUrl, useCreate, useCustomMutation, useList } from '@refinedev/core';
+import { Check, Download } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+
+import { JsonView, Segmented } from '../../../components/primitives';
+import type { RemoteEndpointRow } from './StepEndpoints';
+
+interface DiscoveredField {
+  path: string;
+  dataType: string;
+  sampleValue: string | null;
+}
+
+interface DiscoverResult {
+  fields: DiscoveredField[];
+  sampleRecord: Record<string, unknown>;
+  sampledRecords: number;
+}
+
+/**
+ * APIC-P2-06 — wizard step 4: schema discovery. Samples a read endpoint through
+ * `POST /api/connections/{id}/discover`, lets the user accept the proposed
+ * fields, and persists the accepted ones as RemoteFields (P2-05 CRUD). Replaces
+ * hand-typing the remote schema.
+ */
+export function StepSchema({ connectionId }: { connectionId: string | null }) {
+  const { t } = useTranslation();
+  const apiUrl = useApiUrl();
+  const { result, query } = useList<RemoteEndpointRow>({
+    resource: 'remote_endpoints',
+    filters:
+      connectionId === null ? [] : [{ field: 'connection', operator: 'eq', value: connectionId }],
+    queryOptions: { enabled: connectionId !== null },
+    pagination: { mode: 'off' },
+  });
+  const { mutate: discover, mutation: discoverMutation } = useCustomMutation<DiscoverResult>();
+  const { mutateAsync: createField } = useCreate();
+
+  const readEndpoints = useMemo(
+    () => result.data.filter((endpoint) => endpoint.role.startsWith('read')),
+    [result.data],
+  );
+
+  const [endpointId, setEndpointId] = useState<string | null>(null);
+  const [discovered, setDiscovered] = useState<DiscoverResult | null>(null);
+  const [accepted, setAccepted] = useState<Set<string>>(new Set());
+  const [saved, setSaved] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const activeEndpoint = endpointId ?? readEndpoints[0]?.id ?? null;
+
+  function runDiscovery(): void {
+    if (connectionId === null || activeEndpoint === null) {
+      return;
+    }
+    setDiscovered(null);
+    setSaved(false);
+    discover(
+      {
+        url: `${apiUrl}/connections/${connectionId}/discover`,
+        method: 'post',
+        values: { endpoint: activeEndpoint },
+      },
+      {
+        onSuccess: ({ data }) => {
+          const payload = data as unknown as DiscoverResult;
+          setDiscovered(payload);
+          setAccepted(new Set(payload.fields.map((field) => field.path)));
+        },
+      },
+    );
+  }
+
+  async function acceptFields(): Promise<void> {
+    if (discovered === null || activeEndpoint === null) {
+      return;
+    }
+    setSaving(true);
+    try {
+      for (const field of discovered.fields) {
+        if (!accepted.has(field.path)) {
+          continue;
+        }
+        await createField({
+          resource: 'remote_fields',
+          values: {
+            endpoint: activeEndpoint,
+            path: field.path,
+            dataType: field.dataType,
+            sampleValue: field.sampleValue,
+          },
+          successNotification: false,
+        });
+      }
+      setSaved(true);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function toggle(path: string): void {
+    setAccepted((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+      return next;
+    });
+  }
+
+  return (
+    <div className="soft-shadow space-y-4 rounded-2xl border border-zinc-200 bg-white p-6">
+      <div className="flex flex-wrap items-center gap-3">
+        {readEndpoints.length > 0 ? (
+          <Segmented
+            ariaLabel={t('api_configurator.wizard.schema.endpoint')}
+            size="sm"
+            value={activeEndpoint ?? readEndpoints[0]?.id ?? ''}
+            onChange={setEndpointId}
+            options={readEndpoints.map((endpoint) => ({
+              value: endpoint.id,
+              label: endpoint.pathTemplate,
+            }))}
+          />
+        ) : null}
+        <Button
+          type="button"
+          onClick={runDiscovery}
+          disabled={connectionId === null || activeEndpoint === null || discoverMutation.isPending}
+        >
+          <Download className="mr-1.5 size-4" aria-hidden="true" />
+          {discoverMutation.isPending
+            ? t('api_configurator.wizard.schema.fetching')
+            : t('api_configurator.wizard.schema.fetch')}
+        </Button>
+      </div>
+
+      {readEndpoints.length === 0 && !query.isLoading ? (
+        <p className="text-[13px] text-zinc-500">
+          {t('api_configurator.wizard.schema.no_read_endpoint')}
+        </p>
+      ) : null}
+
+      {discovered === null ? (
+        <div className="rounded-xl border border-dashed border-zinc-200 px-5 py-10 text-center text-[13px] text-zinc-400">
+          {t('api_configurator.wizard.schema.empty')}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1fr_1.1fr]">
+          <div className="overflow-hidden rounded-xl border border-zinc-200">
+            <div className="border-b border-zinc-100 bg-zinc-50/60 px-3 py-2 text-[10.5px] font-medium uppercase tracking-wider text-zinc-400">
+              {t('api_configurator.wizard.schema.sample')}
+            </div>
+            <div className="p-3">
+              <JsonView value={discovered.sampleRecord} maxHeight={360} />
+            </div>
+          </div>
+          <div>
+            <div className="mb-2 flex items-center justify-between">
+              <div className="text-[12px] text-zinc-600">
+                {t('api_configurator.wizard.schema.accepted', {
+                  count: accepted.size,
+                  total: discovered.fields.length,
+                })}
+              </div>
+              <div className="flex items-center gap-1.5">
+                <button
+                  type="button"
+                  onClick={() => setAccepted(new Set(discovered.fields.map((field) => field.path)))}
+                  className="text-[11.5px] text-zinc-500 hover:text-zinc-900"
+                >
+                  {t('api_configurator.wizard.schema.all')}
+                </button>
+                <span className="text-zinc-300">·</span>
+                <button
+                  type="button"
+                  onClick={() => setAccepted(new Set())}
+                  className="text-[11.5px] text-zinc-500 hover:text-zinc-900"
+                >
+                  {t('api_configurator.wizard.schema.none')}
+                </button>
+              </div>
+            </div>
+            <div className="max-h-[340px] divide-y divide-zinc-50 overflow-y-auto rounded-xl border border-zinc-200">
+              {discovered.fields.map((field) => (
+                <label
+                  key={field.path}
+                  className="flex cursor-pointer items-center gap-3 px-3 py-2 hover:bg-zinc-50/70"
+                >
+                  <input
+                    type="checkbox"
+                    checked={accepted.has(field.path)}
+                    onChange={() => toggle(field.path)}
+                    className="size-4 rounded"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate font-mono text-[12px] text-zinc-800">{field.path}</div>
+                    {field.sampleValue !== null ? (
+                      <div className="truncate font-mono text-[10.5px] text-zinc-400">
+                        {t('api_configurator.wizard.schema.field_sample', {
+                          value: field.sampleValue,
+                        })}
+                      </div>
+                    ) : null}
+                  </div>
+                  <span className="shrink-0 rounded bg-zinc-100 px-1.5 py-0.5 font-mono text-[10.5px] text-zinc-600">
+                    {field.dataType}
+                  </span>
+                </label>
+              ))}
+            </div>
+            <div className="mt-3 flex items-center gap-3">
+              <Button type="button" onClick={acceptFields} disabled={saving || accepted.size === 0}>
+                <Check className="mr-1.5 size-4" aria-hidden="true" />
+                {saving
+                  ? t('api_configurator.wizard.schema.saving')
+                  : t('api_configurator.wizard.schema.accept', { count: accepted.size })}
+              </Button>
+              {saved ? (
+                <span className="text-[12.5px] text-emerald-600">
+                  {t('api_configurator.wizard.schema.saved')}
+                </span>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1817,7 +1817,33 @@
       "ssrf_passed": "URL passed SsrfGuard validation — public host, no redirects into private networks.",
       "sample_label": "Response · record sample",
       "stub_title": "Endpoints and schema discovery — coming soon",
-      "stub_desc": "Endpoint definitions (read/write) and automatic field discovery land in the next step of the epic (M2)."
+      "stub_desc": "Endpoint definitions (read/write) and automatic field discovery land in the next step of the epic (M2).",
+      "ep": {
+        "role": "Role",
+        "method": "Method",
+        "path": "Path",
+        "pagination": "Pagination",
+        "selector": "Record selector",
+        "add": "Add endpoint",
+        "remove": "Remove endpoint {{path}}",
+        "empty": "No endpoints — add a read/write operation below."
+      },
+      "schema": {
+        "note": "detect fields",
+        "endpoint": "Endpoint to sample",
+        "fetch": "Fetch sample",
+        "fetching": "Fetching…",
+        "no_read_endpoint": "Add a read endpoint in step 3 to discover fields.",
+        "empty": "Fetch a sample to discover and accept fields (Airbyte / Merge pattern).",
+        "sample": "Raw sample",
+        "accepted": "{{count}} of {{total}} fields accepted",
+        "all": "all",
+        "none": "none",
+        "field_sample": "sample: {{value}}",
+        "accept": "Save fields ({{count}})",
+        "saving": "Saving…",
+        "saved": "Fields saved"
+      }
     }
   },
   "api_profiles": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1865,7 +1865,33 @@
       "ssrf_passed": "URL przeszedł walidację SsrfGuard — publiczny host, brak przekierowań do sieci prywatnej.",
       "sample_label": "Odpowiedź · próbka rekordu",
       "stub_title": "Endpointy i wykrywanie schematu — wkrótce",
-      "stub_desc": "Definicja endpointów (read/write) oraz automatyczne wykrywanie pól dochodzą w kolejnym kroku epiku (M2)."
+      "stub_desc": "Definicja endpointów (read/write) oraz automatyczne wykrywanie pól dochodzą w kolejnym kroku epiku (M2).",
+      "ep": {
+        "role": "Rola",
+        "method": "Metoda",
+        "path": "Ścieżka",
+        "pagination": "Paginacja",
+        "selector": "Record selector",
+        "add": "Dodaj endpoint",
+        "remove": "Usuń endpoint {{path}}",
+        "empty": "Brak endpointów — dodaj operację read/write poniżej."
+      },
+      "schema": {
+        "note": "wykryj pola",
+        "endpoint": "Endpoint do próbkowania",
+        "fetch": "Pobierz próbkę",
+        "fetching": "Pobieranie…",
+        "no_read_endpoint": "Dodaj endpoint typu read w kroku 3, aby wykryć pola.",
+        "empty": "Pobierz próbkę, aby wykryć i zaakceptować pola (wzorzec Airbyte / Merge).",
+        "sample": "Surowa próbka",
+        "accepted": "{{count}} z {{total}} pól zaakceptowanych",
+        "all": "wszystkie",
+        "none": "żadne",
+        "field_sample": "próbka: {{value}}",
+        "accept": "Zapisz pola ({{count}})",
+        "saving": "Zapisywanie…",
+        "saved": "Pola zapisane"
+      }
     }
   },
   "api_profiles": {


### PR DESCRIPTION
## Cel

APIC-P2-06 — dokończenie kreatora połączenia: krok 3 (Endpointy) + krok 4 (Schema discovery). Zastępuje stuby kroków 3–4.

## Zakres

- **`StepEndpoints`** (krok 3) — builder descriptora operacji: tabela RemoteEndpointów (`RolePill`/`MethodPill`/`PaginationPill` + record selector), dodawanie (role/method `Segmented`, path, pagination strategy, selector → `POST /api/remote_endpoints`) i usuwanie (`DELETE`), scoped przez `?connection=` (filtr P2-05).
- **`StepSchema`** (krok 4) — schema discovery: wybór read endpointu, `Pobierz próbkę` → `POST /api/connections/{id}/discover`, render surowej próbki (`JsonView`) + lista wykrytych pól z checkboxami (all/none), `Zapisz pola` → `POST /api/remote_fields` per zaakceptowane pole.
- Refaktor `ConnectionWizardPage` (kroki 2/3 → live `StepEndpoints`/`StepSchema`); i18n `wizard.ep.*` + `wizard.schema.*` (pl + en).

## Testy / bramki

- `tsc -b --noEmit` ✅ · `biome check src e2e` (0 errors) ✅ · `vitest run` (5 plików / 17 testów) ✅ · `vite build` ✅
- **Playwright** `1775-...spec.ts`: login → kroki 1–2 → **krok 3** dodanie endpointu (mock CRUD, wiersz pojawia się) → **krok 4** `Pobierz próbkę` (mock discover) → render pól `$.sku`/`$.price.amount` → `Zapisz pola` (mock remote_fields) → „Pola zapisane" + **AxeBuilder** (0 violations). Descriptor/discover API mockowane (`page.route`) — live probe wymaga osiągalnego hosta zewnętrznego.

## Smoke test

`ships view, end-to-end nieprzetestowane na żywym tenantcie` — discover/CRUD są mockowane w E2E; realny round-trip do zewnętrznego API zależny od osiągalnego hosta (manualny smoke po seedzie realnego konektora). Backend ścieżki CI-zweryfikowane przez P2-05 ApiTestCase.

Refs #1775