### PR TITLE
feat(integration): add FieldMapping entity + versioned migration (APIC-P2-07)

### DIFF
--- a/apps/api/migrations/Version20260629100000.php
+++ b/apps/api/migrations/Version20260629100000.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * APIC-P2-07 (ADR-0022, epic APIC) — consumer-side `integration_field_mappings`
+ * table: one 1:1 `pimTarget ↔ remoteFieldPath` mapping per row, owned by a
+ * {@see \App\Integration\Generic\Domain\Entity\Connection}, versioned and
+ * reusable across sync bindings (the `binding_id` link stays loose — no FK —
+ * until SyncBinding lands in APIC-P3-01).
+ *
+ * TenantScoped with the W1-1 FORCE RLS pattern (Version20260628110000): a
+ * fail-closed tenant-isolation policy plus the super-admin break-glass bypass.
+ * The FK to `integration_connections` cascades on delete; the tenant FK is
+ * RESTRICT.
+ */
+final class Version20260629100000 extends AbstractMigration
+{
+    private const string TABLE = 'integration_field_mappings';
+
+    public function getDescription(): string
+    {
+        return 'APIC-P2-07: add integration_field_mappings (TenantScoped 1:1 mapping) + FORCE RLS policies.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE integration_field_mappings (
+                id UUID NOT NULL,
+                tenant_id UUID NOT NULL,
+                connection_id UUID NOT NULL,
+                binding_id UUID DEFAULT NULL,
+                pim_target VARCHAR(255) NOT NULL,
+                remote_field_path VARCHAR(512) NOT NULL,
+                direction VARCHAR(16) NOT NULL,
+                is_match_key BOOLEAN DEFAULT false NOT NULL,
+                version INT DEFAULT 1 NOT NULL,
+                created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+                updated_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+                PRIMARY KEY (id)
+            )
+            SQL);
+        $this->addSql('CREATE INDEX IDX_73B5789033212A ON integration_field_mappings (tenant_id)');
+        $this->addSql('CREATE INDEX IDX_73B578DD03F01 ON integration_field_mappings (connection_id)');
+        $this->addSql(
+            'CREATE INDEX integration_field_mappings_tenant_conn_idx '
+            .'ON integration_field_mappings (tenant_id, connection_id)'
+        );
+        $this->addSql(
+            'CREATE INDEX integration_field_mappings_tenant_binding_idx '
+            .'ON integration_field_mappings (tenant_id, binding_id)'
+        );
+        $this->addSql(
+            'ALTER TABLE integration_field_mappings ADD CONSTRAINT FK_73B5789033212A '
+            .'FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE RESTRICT NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+        $this->addSql(
+            'ALTER TABLE integration_field_mappings ADD CONSTRAINT FK_73B578DD03F01 '
+            .'FOREIGN KEY (connection_id) REFERENCES integration_connections (id) '
+            .'ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+
+        // ── Row-Level Security (W1-1 FORCE pattern) ───────────────────────
+        $predicate = "tenant_id = NULLIF(current_setting('app.current_tenant', true), '')::uuid";
+
+        $this->addSql(\sprintf('ALTER TABLE %s ENABLE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s FORCE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf(
+            'CREATE POLICY tenant_isolation_%s ON %s USING (%s) WITH CHECK (%s)',
+            self::TABLE,
+            self::TABLE,
+            $predicate,
+            $predicate,
+        ));
+        $this->addSql(\sprintf(
+            "CREATE POLICY super_admin_bypass_%s ON %s "
+            ."USING (current_setting('app.is_super_admin', true) = 'true') "
+            ."WITH CHECK (current_setting('app.is_super_admin', true) = 'true')",
+            self::TABLE,
+            self::TABLE,
+        ));
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(\sprintf('DROP POLICY IF EXISTS super_admin_bypass_%s ON %s', self::TABLE, self::TABLE));
+        $this->addSql(\sprintf('DROP POLICY IF EXISTS tenant_isolation_%s ON %s', self::TABLE, self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s NO FORCE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s DISABLE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql('DROP TABLE integration_field_mappings');
+    }
+}

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -147,6 +147,7 @@ parameters:
               - src/Integration/Generic/Domain/Entity/Connection.php
               - src/Integration/Generic/Domain/Entity/RemoteEndpoint.php
               - src/Integration/Generic/Domain/Entity/RemoteField.php
+              - src/Integration/Generic/Domain/Entity/FieldMapping.php
               - src/Import/Domain/Entity/ImportScheduleRun.php
               - src/Export/Domain/Entity/ExportSession.php
               - src/Export/Domain/Entity/ExportProfile.php

--- a/apps/api/src/Integration/Generic/Domain/Entity/FieldMapping.php
+++ b/apps/api/src/Integration/Generic/Domain/Entity/FieldMapping.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Entity;
+
+use App\Integration\Generic\Domain\Enum\MappingDirection;
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\AggregateRoot;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * A 1:1 mapping between a PIM target and a remote field path (ADR-0022, epic
+ * APIC, ticket APIC-P2-07).
+ *
+ * `pimTarget` names the PIM side — an attribute code or a system field
+ * (sku/name/status/category…); `remoteFieldPath` is the external JSONPath. The
+ * mapping belongs to a {@see Connection} and is versioned so it can be reused
+ * across sync bindings (the optional `bindingId` links it to a SyncBinding once
+ * that lands in APIC-P3-01 — kept loose here, no FK). `direction` and
+ * `isMatchKey` drive the sync engines: the match key identifies the row to
+ * upsert, the direction gates inbound/outbound application.
+ *
+ * `TenantScoped` + Postgres RLS isolate every mapping to its tenant. Type
+ * compatibility between the PIM target and the remote field is validated at the
+ * API edge (APIC-P2-08), not in this domain entity.
+ */
+class FieldMapping extends AggregateRoot implements TenantScoped
+{
+    private Uuid $id;
+
+    private ?Tenant $tenant = null;
+
+    private Connection $connection;
+
+    /** Loose link to a future SyncBinding (APIC-P3-01); no FK until it exists. */
+    private ?Uuid $bindingId = null;
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    private string $pimTarget;
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 512)]
+    private string $remoteFieldPath;
+
+    private string $direction = MappingDirection::Inbound->value;
+
+    private bool $isMatchKey = false;
+
+    #[Assert\Positive]
+    private int $version = 1;
+
+    private DateTimeImmutable $createdAt;
+
+    private DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        Connection $connection,
+        string $pimTarget,
+        string $remoteFieldPath,
+        MappingDirection $direction = MappingDirection::Inbound,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->connection = $connection;
+        $this->pimTarget = $pimTarget;
+        $this->remoteFieldPath = $remoteFieldPath;
+        $this->direction = $direction->value;
+        $this->createdAt = new DateTimeImmutable();
+        $this->updatedAt = $this->createdAt;
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant is already assigned and cannot be reassigned.');
+        }
+
+        $this->tenant = $tenant;
+    }
+
+    public function getConnection(): Connection
+    {
+        return $this->connection;
+    }
+
+    public function getConnectionId(): Uuid
+    {
+        return $this->connection->getId();
+    }
+
+    public function getBindingId(): ?Uuid
+    {
+        return $this->bindingId;
+    }
+
+    public function bindTo(?Uuid $bindingId): void
+    {
+        $this->bindingId = $bindingId;
+        $this->touch();
+    }
+
+    public function getPimTarget(): string
+    {
+        return $this->pimTarget;
+    }
+
+    public function setPimTarget(string $pimTarget): void
+    {
+        $this->pimTarget = $pimTarget;
+        $this->touch();
+    }
+
+    public function getRemoteFieldPath(): string
+    {
+        return $this->remoteFieldPath;
+    }
+
+    public function setRemoteFieldPath(string $remoteFieldPath): void
+    {
+        $this->remoteFieldPath = $remoteFieldPath;
+        $this->touch();
+    }
+
+    public function getDirection(): MappingDirection
+    {
+        return MappingDirection::from($this->direction);
+    }
+
+    public function setDirection(MappingDirection $direction): void
+    {
+        $this->direction = $direction->value;
+        $this->touch();
+    }
+
+    public function isMatchKey(): bool
+    {
+        return $this->isMatchKey;
+    }
+
+    public function setMatchKey(bool $isMatchKey): void
+    {
+        $this->isMatchKey = $isMatchKey;
+        $this->touch();
+    }
+
+    public function getVersion(): int
+    {
+        return $this->version;
+    }
+
+    /** Bumps the version when the mapping is edited so reuse can pin a revision. */
+    public function bumpVersion(): void
+    {
+        ++$this->version;
+        $this->touch();
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    private function touch(): void
+    {
+        $this->updatedAt = new DateTimeImmutable();
+    }
+}

--- a/apps/api/src/Integration/Generic/Domain/Enum/MappingDirection.php
+++ b/apps/api/src/Integration/Generic/Domain/Enum/MappingDirection.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Enum;
+
+/**
+ * The sync direction a {@see \App\Integration\Generic\Domain\Entity\FieldMapping}
+ * applies in (ADR-0022, epic APIC, ticket APIC-P2-07).
+ *
+ * `inbound` pulls the remote field into the PIM target, `outbound` pushes the
+ * PIM value to the remote, `both` does both (the conflict policy then decides
+ * the winner — APIC-P3-08).
+ */
+enum MappingDirection: string
+{
+    case Inbound = 'inbound';
+    case Outbound = 'outbound';
+    case Both = 'both';
+
+    /** Whether this mapping participates in an inbound (remote → PIM) sync. */
+    public function appliesInbound(): bool
+    {
+        return self::Inbound === $this || self::Both === $this;
+    }
+
+    /** Whether this mapping participates in an outbound (PIM → remote) sync. */
+    public function appliesOutbound(): bool
+    {
+        return self::Outbound === $this || self::Both === $this;
+    }
+}

--- a/apps/api/src/Integration/Generic/Domain/Repository/FieldMappingRepositoryInterface.php
+++ b/apps/api/src/Integration/Generic/Domain/Repository/FieldMappingRepositoryInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Repository;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\FieldMapping;
+use Symfony\Component\Uid\Uuid;
+
+interface FieldMappingRepositoryInterface
+{
+    public function save(FieldMapping $mapping): void;
+
+    public function remove(FieldMapping $mapping): void;
+
+    public function findById(Uuid $id): ?FieldMapping;
+
+    /**
+     * @return list<FieldMapping>
+     */
+    public function findByConnection(Connection $connection): array;
+
+    public function findByConnectionAndTarget(Connection $connection, string $pimTarget): ?FieldMapping;
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Orm/Mapping/FieldMapping.orm.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Orm/Mapping/FieldMapping.orm.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Integration\Generic\Domain\Entity\FieldMapping"
+            table="integration_field_mappings"
+            repository-class="App\Integration\Generic\Infrastructure\Doctrine\Repository\DoctrineFieldMappingRepository">
+
+        <indexes>
+            <index name="integration_field_mappings_tenant_conn_idx" columns="tenant_id,connection_id"/>
+            <index name="integration_field_mappings_tenant_binding_idx" columns="tenant_id,binding_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <many-to-one field="connection" target-entity="App\Integration\Generic\Domain\Entity\Connection">
+            <join-column name="connection_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="bindingId" type="uuid" column="binding_id" nullable="true"/>
+        <field name="pimTarget" type="string" length="255" column="pim_target"/>
+        <field name="remoteFieldPath" type="string" length="512" column="remote_field_path"/>
+        <field name="direction" type="string" length="16"/>
+        <field name="isMatchKey" type="boolean" column="is_match_key">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
+        <field name="version" type="integer">
+            <options>
+                <option name="default">1</option>
+            </options>
+        </field>
+        <field name="createdAt" type="datetimetz_immutable" column="created_at"/>
+        <field name="updatedAt" type="datetimetz_immutable" column="updated_at"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Repository/DoctrineFieldMappingRepository.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Repository/DoctrineFieldMappingRepository.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Doctrine\Repository;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\FieldMapping;
+use App\Integration\Generic\Domain\Repository\FieldMappingRepositoryInterface;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<FieldMapping>
+ */
+class DoctrineFieldMappingRepository extends ServiceEntityRepository implements FieldMappingRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, FieldMapping::class);
+    }
+
+    public function save(FieldMapping $mapping): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($mapping);
+        $em->flush();
+    }
+
+    public function remove(FieldMapping $mapping): void
+    {
+        $em = $this->getEntityManager();
+        $em->remove($mapping);
+        $em->flush();
+    }
+
+    public function findById(Uuid $id): ?FieldMapping
+    {
+        return parent::find($id->toRfc4122());
+    }
+
+    /**
+     * @return list<FieldMapping>
+     */
+    public function findByConnection(Connection $connection): array
+    {
+        $qb = $this->createQueryBuilder('m')
+            ->where('m.connection = :connection')
+            ->orderBy('m.pimTarget', 'ASC')
+            ->setParameter('connection', $connection);
+
+        /** @var list<FieldMapping> $result */
+        $result = $qb->getQuery()->getResult();
+
+        return $result;
+    }
+
+    public function findByConnectionAndTarget(Connection $connection, string $pimTarget): ?FieldMapping
+    {
+        return $this->findOneBy(['connection' => $connection, 'pimTarget' => $pimTarget]);
+    }
+}

--- a/apps/api/tests/Integration/Integration/Generic/FieldMappingRepositoryTest.php
+++ b/apps/api/tests/Integration/Integration/Generic/FieldMappingRepositoryTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Integration\Generic;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\FieldMapping;
+use App\Integration\Generic\Domain\Enum\AuthType;
+use App\Integration\Generic\Domain\Enum\MappingDirection;
+use App\Integration\Generic\Domain\Repository\ConnectionRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\FieldMappingRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * APIC-P2-07 — FieldMappingRepository round-trip + 2-tenant cross-read = 0
+ * (Doctrine TenantFilter on the TenantScoped FieldMapping; Postgres RLS is the
+ * defence-in-depth wall verified at the migration level).
+ */
+final class FieldMappingRepositoryTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function savesAndFindsMappingWithinTenant(): void
+    {
+        $alpha = $this->createTenant('alpha');
+        $this->activateTenantFilter($alpha);
+
+        $connection = $this->createConnection($alpha, 'idosell');
+        $mapping = new FieldMapping($connection, 'sku', '$.sku', MappingDirection::Both);
+        $mapping->assignTenant($alpha);
+        $mapping->setMatchKey(true);
+        $this->mappings()->save($mapping);
+
+        $found = $this->mappings()->findById($mapping->getId());
+        self::assertNotNull($found);
+        self::assertSame('sku', $found->getPimTarget());
+        self::assertSame('$.sku', $found->getRemoteFieldPath());
+        self::assertSame(MappingDirection::Both, $found->getDirection());
+        self::assertTrue($found->isMatchKey());
+        self::assertSame(1, $found->getVersion());
+
+        self::assertCount(1, $this->mappings()->findByConnection($connection));
+        self::assertNotNull($this->mappings()->findByConnectionAndTarget($connection, 'sku'));
+    }
+
+    #[Test]
+    public function mappingsAreIsolatedAcrossTenants(): void
+    {
+        $alpha = $this->createTenant('alpha');
+        $beta = $this->createTenant('beta');
+
+        $this->activateTenantFilter($alpha);
+        $alphaConnection = $this->createConnection($alpha, 'idosell');
+        $alphaMapping = new FieldMapping($alphaConnection, 'sku', '$.sku');
+        $alphaMapping->assignTenant($alpha);
+        $this->mappings()->save($alphaMapping);
+
+        // Switch to beta: alpha's mapping is invisible through the TenantFilter (DQL).
+        $this->activateTenantFilter($beta);
+        self::assertCount(0, $this->mappings()->findByConnection($alphaConnection));
+        self::assertNull($this->mappings()->findByConnectionAndTarget($alphaConnection, 'sku'));
+    }
+
+    private function mappings(): FieldMappingRepositoryInterface
+    {
+        return self::getContainer()->get(FieldMappingRepositoryInterface::class);
+    }
+
+    private function connections(): ConnectionRepositoryInterface
+    {
+        return self::getContainer()->get(ConnectionRepositoryInterface::class);
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+
+    private function createConnection(Tenant $tenant, string $code): Connection
+    {
+        $connection = new Connection($code, ucfirst($code), 'https://api.example.com', AuthType::ApiKey);
+        $connection->assignTenant($tenant);
+        $this->connections()->save($connection);
+
+        return $connection;
+    }
+
+    private function activateTenantFilter(Tenant $tenant): void
+    {
+        $this->tenantContext()->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function createTenant(string $code): Tenant
+    {
+        $tenant = new Tenant($code, ucfirst($code).' Tenant');
+        $em = $this->em();
+        $em->persist($tenant);
+        $em->flush();
+
+        return $tenant;
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Domain/Entity/FieldMappingTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Domain/Entity/FieldMappingTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Domain\Entity;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\FieldMapping;
+use App\Integration\Generic\Domain\Enum\MappingDirection;
+use App\Shared\Domain\Tenant;
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class FieldMappingTest extends TestCase
+{
+    #[Test]
+    public function newMappingDefaultsToInboundVersionOne(): void
+    {
+        $m = $this->mapping();
+
+        self::assertSame('sku', $m->getPimTarget());
+        self::assertSame('$.sku', $m->getRemoteFieldPath());
+        self::assertSame(MappingDirection::Inbound, $m->getDirection());
+        self::assertFalse($m->isMatchKey());
+        self::assertSame(1, $m->getVersion());
+        self::assertNull($m->getBindingId());
+        self::assertNull($m->getTenant());
+    }
+
+    #[Test]
+    public function exposesItsParentConnection(): void
+    {
+        $connection = $this->connection();
+        $m = new FieldMapping($connection, 'name', '$.name');
+
+        self::assertSame($connection, $m->getConnection());
+        self::assertSame($connection->getId()->toRfc4122(), $m->getConnectionId()->toRfc4122());
+    }
+
+    #[Test]
+    public function bumpVersionIncrementsForReuse(): void
+    {
+        $m = $this->mapping();
+        $m->bumpVersion();
+        $m->bumpVersion();
+
+        self::assertSame(3, $m->getVersion());
+    }
+
+    #[Test]
+    public function bindToLinksALooseSyncBinding(): void
+    {
+        $m = $this->mapping();
+        $bindingId = Uuid::v7();
+
+        $m->bindTo($bindingId);
+        self::assertSame($bindingId->toRfc4122(), $m->getBindingId()?->toRfc4122());
+
+        $m->bindTo(null);
+        self::assertNull($m->getBindingId());
+    }
+
+    #[Test]
+    public function settersUpdateValues(): void
+    {
+        $m = $this->mapping();
+        $m->setPimTarget('status');
+        $m->setRemoteFieldPath('$.state');
+        $m->setDirection(MappingDirection::Both);
+        $m->setMatchKey(true);
+
+        self::assertSame('status', $m->getPimTarget());
+        self::assertSame('$.state', $m->getRemoteFieldPath());
+        self::assertSame(MappingDirection::Both, $m->getDirection());
+        self::assertTrue($m->isMatchKey());
+    }
+
+    #[Test]
+    public function directionKnowsInboundAndOutbound(): void
+    {
+        self::assertTrue(MappingDirection::Inbound->appliesInbound());
+        self::assertFalse(MappingDirection::Inbound->appliesOutbound());
+        self::assertFalse(MappingDirection::Outbound->appliesInbound());
+        self::assertTrue(MappingDirection::Outbound->appliesOutbound());
+        self::assertTrue(MappingDirection::Both->appliesInbound());
+        self::assertTrue(MappingDirection::Both->appliesOutbound());
+    }
+
+    #[Test]
+    public function assignTenantIsWriteOnce(): void
+    {
+        $m = $this->mapping();
+        $m->assignTenant(new Tenant('alpha', 'Alpha'));
+        self::assertNotNull($m->getTenant());
+
+        $this->expectException(LogicException::class);
+        $m->assignTenant(new Tenant('beta', 'Beta'));
+    }
+
+    private function connection(): Connection
+    {
+        return new Connection('idosell', 'IdoSell PL', 'https://api.idosell.com');
+    }
+
+    private function mapping(): FieldMapping
+    {
+        return new FieldMapping($this->connection(), 'sku', '$.sku');
+    }
+}


### PR DESCRIPTION
## Cel

APIC-P2-07 — mapowanie 1:1 `pimTarget ↔ remoteFieldPath` (wersjonowane, reużywalne). Fundament pod FieldMapping API (P2-08) i SyncBinding (P3-01).

## Zakres

- **Encja `FieldMapping`** (`TenantScoped`, extends `AggregateRoot`): `connection` (FK → Connection, **CASCADE**), `bindingId` (luźny UUID, **bez FK** do czasu SyncBinding/P3-01), `pimTarget` (attr code / pole systemowe), `remoteFieldPath` (JSONPath), `direction` (enum), `isMatchKey` (bool), **`version`** (int, `bumpVersion()` dla reuse między wiązaniami).
- **Enum `MappingDirection`** (`inbound|outbound|both` + `appliesInbound()`/`appliesOutbound()`).
- **Repozytorium** (interface + Doctrine impl): `findById`, `findByConnection`, `findByConnectionAndTarget`.
- **Migracja `Version20260629100000`** — tabela `integration_field_mappings` + W1-1 **FORCE RLS**, indeksy (tenant,conn) i (tenant,binding), FK tenant RESTRICT / connection CASCADE.

## Testy / bramki (kontener api)

- **PHPStan max** ✅ · **Deptrac** 0 ✅ · **PHP-CS-Fixer** 0 ✅
- **PHPUnit** ✅ 9/9: `FieldMappingTest` (Layer 1 — defaults, parent connection, **bumpVersion** AC-2, bindTo, settery, direction applies, assignTenant write-once) + `FieldMappingRepositoryTest` (Layer 2 — round-trip + 2-tenant cross-read = 0).
- Migracja zaaplikowana lokalnie; `schema:update --dump-sql` → brak driftu.

Refs #1776