### PR TITLE
feat(integration): FieldMapping API + type-compat validation (APIC-P2-08)

### DIFF
--- a/apps/api/src/Identity/Infrastructure/Security/FieldMappingVoter.php
+++ b/apps/api/src/Identity/Infrastructure/Security/FieldMappingVoter.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Security;
+
+/**
+ * RBAC voter for the API Configurator `FieldMapping` resource (APIC-P2-08).
+ * Reuses the legacy `integration` RbacMatrix resource. The subject is named by
+ * its FQCN string (no cross-BC class import), keeping this Deptrac-clean.
+ */
+final class FieldMappingVoter extends AbstractRbacVoter
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function attributeMap(): array
+    {
+        return [
+            'READ' => 'read',
+            'CREATE' => 'write',
+            'UPDATE' => 'write',
+            'WRITE' => 'write',
+            'DELETE' => 'delete',
+        ];
+    }
+
+    protected function resource(): string
+    {
+        return 'integration';
+    }
+
+    protected function subjectClass(): string
+    {
+        return 'App\\Integration\\Generic\\Domain\\Entity\\FieldMapping';
+    }
+}

--- a/apps/api/src/Integration/Generic/Application/Mapping/MappingValidationResult.php
+++ b/apps/api/src/Integration/Generic/Application/Mapping/MappingValidationResult.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application\Mapping;
+
+/**
+ * The outcome of validating a connection's field mappings (ADR-0022, epic APIC,
+ * ticket APIC-P2-08): blocking errors (e.g. a missing match key for inbound)
+ * plus non-fatal type warnings. `isValid()` is true when there are no errors.
+ */
+final readonly class MappingValidationResult
+{
+    /**
+     * @param list<string>         $errors
+     * @param list<MappingWarning> $warnings
+     */
+    public function __construct(
+        public array $errors,
+        public array $warnings,
+    ) {
+    }
+
+    public function isValid(): bool
+    {
+        return [] === $this->errors;
+    }
+}

--- a/apps/api/src/Integration/Generic/Application/Mapping/MappingValidator.php
+++ b/apps/api/src/Integration/Generic/Application/Mapping/MappingValidator.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application\Mapping;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\FieldMapping;
+use App\Integration\Generic\Domain\Enum\RemoteFieldDataType;
+use App\Integration\Generic\Domain\Repository\FieldMappingRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\RemoteEndpointRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\RemoteFieldRepositoryInterface;
+
+/**
+ * Validates a connection's field mappings (ADR-0022, epic APIC, ticket APIC-P2-08).
+ *
+ * Two checks:
+ *  - **error** — an inbound (or both-way) sync needs at least one match key to
+ *    identify the row to upsert; without one the mapping set is invalid.
+ *  - **warning** — a 1:1 mapping is meant for scalars, so a composite (object/
+ *    array) remote field, or a path absent from the discovered schema, is
+ *    flagged but not blocked (minimal coercion, ADR-0016 decision 5).
+ *
+ * The PIM target's own type is not resolved here (that would reach into the
+ * Catalog context); the realistic, cross-context-free signal is the remote
+ * field's shape, which is what the warnings report.
+ */
+final readonly class MappingValidator
+{
+    public function __construct(
+        private FieldMappingRepositoryInterface $mappings,
+        private RemoteEndpointRepositoryInterface $endpoints,
+        private RemoteFieldRepositoryInterface $fields,
+    ) {
+    }
+
+    public function validate(Connection $connection): MappingValidationResult
+    {
+        $mappings = $this->mappings->findByConnection($connection);
+        $typesByPath = $this->discoveredTypes($connection);
+
+        return new MappingValidationResult(
+            $this->collectErrors($mappings),
+            $this->collectWarnings($mappings, $typesByPath),
+        );
+    }
+
+    /**
+     * @param list<FieldMapping> $mappings
+     *
+     * @return list<string>
+     */
+    private function collectErrors(array $mappings): array
+    {
+        $hasInbound = false;
+        $hasMatchKey = false;
+        foreach ($mappings as $mapping) {
+            if ($mapping->getDirection()->appliesInbound()) {
+                $hasInbound = true;
+            }
+            if ($mapping->isMatchKey()) {
+                $hasMatchKey = true;
+            }
+        }
+
+        $errors = [];
+        if ($hasInbound && !$hasMatchKey) {
+            $errors[] = 'Inbound sync requires at least one mapping marked as a match key.';
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param list<FieldMapping>                 $mappings
+     * @param array<string, RemoteFieldDataType> $typesByPath
+     *
+     * @return list<MappingWarning>
+     */
+    private function collectWarnings(array $mappings, array $typesByPath): array
+    {
+        $warnings = [];
+        foreach ($mappings as $mapping) {
+            $path = $mapping->getRemoteFieldPath();
+            $type = $typesByPath[$path] ?? null;
+
+            if (null === $type) {
+                $warnings[] = new MappingWarning(
+                    $mapping->getPimTarget(),
+                    $path,
+                    'Remote field path is not in the discovered schema; run discovery or check the path.',
+                );
+
+                continue;
+            }
+
+            if (!$type->isScalar()) {
+                $warnings[] = new MappingWarning(
+                    $mapping->getPimTarget(),
+                    $path,
+                    \sprintf('Remote field is %s; a 1:1 mapping to a scalar target may lose data.', $type->value),
+                );
+            }
+        }
+
+        return $warnings;
+    }
+
+    /**
+     * Builds the remoteFieldPath → dataType index from the connection's
+     * discovered fields (across all its endpoints).
+     *
+     * @return array<string, RemoteFieldDataType>
+     */
+    private function discoveredTypes(Connection $connection): array
+    {
+        $byPath = [];
+        foreach ($this->endpoints->findByConnection($connection) as $endpoint) {
+            foreach ($this->fields->findByEndpoint($endpoint) as $field) {
+                $byPath[$field->getPath()] = $field->getDataType();
+            }
+        }
+
+        return $byPath;
+    }
+}

--- a/apps/api/src/Integration/Generic/Application/Mapping/MappingWarning.php
+++ b/apps/api/src/Integration/Generic/Application/Mapping/MappingWarning.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application\Mapping;
+
+/**
+ * A non-fatal mapping issue surfaced by {@see MappingValidator} (ADR-0022, epic
+ * APIC, ticket APIC-P2-08) — e.g. a type that needs coercion or a path missing
+ * from the discovered schema. Per ADR-0016 decision 5 these are warnings, not
+ * errors: the 1:1 sync still runs with minimal coercion.
+ */
+final readonly class MappingWarning
+{
+    public function __construct(
+        public string $pimTarget,
+        public string $remoteFieldPath,
+        public string $message,
+    ) {
+    }
+}

--- a/apps/api/src/Integration/Generic/Domain/Entity/FieldMapping.php
+++ b/apps/api/src/Integration/Generic/Domain/Entity/FieldMapping.php
@@ -153,6 +153,15 @@ class FieldMapping extends AggregateRoot implements TenantScoped
         return $this->isMatchKey;
     }
 
+    /**
+     * Serializer-facing alias so the read projection exposes the flag as
+     * `isMatchKey` (mirrors the input DTO), per the ObjectType convention.
+     */
+    public function getIsMatchKey(): bool
+    {
+        return $this->isMatchKey;
+    }
+
     public function setMatchKey(bool $isMatchKey): void
     {
         $this->isMatchKey = $isMatchKey;

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Filter/FieldMappingConnectionFilter.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Filter/FieldMappingConnectionFilter.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\ApiPlatform\Filter;
+
+use ApiPlatform\Doctrine\Orm\Filter\FilterInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * `?connection={id}` on `/api/field_mappings` — scopes the mapping list to one
+ * connection (APIC-P2-08). Tenant scoping still comes from the upstream Doctrine
+ * TenantFilter; this only adds the connection equality predicate.
+ */
+final class FieldMappingConnectionFilter implements FilterInterface
+{
+    private const string PARAMETER = 'connection';
+
+    public function apply(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $filters = $context['filters'] ?? [];
+        if (!\is_array($filters)) {
+            return;
+        }
+
+        $value = $filters[self::PARAMETER] ?? null;
+        if (!\is_string($value) || '' === $value) {
+            return;
+        }
+
+        $alias = $queryBuilder->getRootAliases()[0] ?? null;
+        if (null === $alias) {
+            return;
+        }
+
+        $parameter = $queryNameGenerator->generateParameterName('connectionId');
+        $queryBuilder
+            ->andWhere(\sprintf('%s.connection = :%s', $alias, $parameter))
+            ->setParameter($parameter, $value);
+    }
+
+    /**
+     * @param class-string $resourceClass
+     *
+     * @return array<string, array{property?: string, type?: string, required?: bool, description?: string, strategy?: string, is_collection?: bool}>
+     */
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            self::PARAMETER => [
+                'property' => 'connection',
+                'type' => 'string',
+                'required' => false,
+                'description' => 'Exact match on the parent Connection UUID (tenant-scoped).',
+                'strategy' => 'exact',
+            ],
+        ];
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/FieldMapping.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/FieldMapping.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns="https://api-platform.com/schema/metadata/resources-3.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata/resources-3.0
+                               https://api-platform.com/schema/metadata/resources-3.0.xsd">
+
+    <resource class="App\Integration\Generic\Domain\Entity\FieldMapping"
+              shortName="FieldMapping">
+
+        <normalizationContext>
+            <values>
+                <value name="groups">
+                    <values>
+                        <value>admin:read</value>
+                    </values>
+                </value>
+            </values>
+        </normalizationContext>
+
+        <!-- `?connection={id}` scopes the mapping list to one connection (FE mapping screen). -->
+        <filters>
+            <filter>App\Integration\Generic\Infrastructure\ApiPlatform\Filter\FieldMappingConnectionFilter</filter>
+        </filters>
+
+        <operations>
+            <operation class="ApiPlatform\Metadata\GetCollection"
+                       uriTemplate="/field_mappings{._format}"
+                       security="is_granted('READ', 'App\\Integration\\Generic\\Domain\\Entity\\FieldMapping')"/>
+
+            <operation class="ApiPlatform\Metadata\Get"
+                       uriTemplate="/field_mappings/{id}{._format}"
+                       security="is_granted('READ', object)"/>
+
+            <operation class="ApiPlatform\Metadata\Post"
+                       uriTemplate="/field_mappings{._format}"
+                       input="App\Integration\Generic\Infrastructure\ApiPlatform\Resource\FieldMappingInput"
+                       processor="App\Integration\Generic\Infrastructure\ApiPlatform\State\FieldMappingProcessor"
+                       security="is_granted('CREATE', 'App\\Integration\\Generic\\Domain\\Entity\\FieldMapping')">
+                <denormalizationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>field_mapping:create</value>
+                            </values>
+                        </value>
+                    </values>
+                </denormalizationContext>
+            </operation>
+
+            <operation class="ApiPlatform\Metadata\Patch"
+                       uriTemplate="/field_mappings/{id}{._format}"
+                       input="App\Integration\Generic\Infrastructure\ApiPlatform\Resource\FieldMappingPatchInput"
+                       processor="App\Integration\Generic\Infrastructure\ApiPlatform\State\FieldMappingProcessor"
+                       security="is_granted('UPDATE', object)">
+                <denormalizationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>field_mapping:patch</value>
+                            </values>
+                        </value>
+                    </values>
+                </denormalizationContext>
+            </operation>
+
+            <operation class="ApiPlatform\Metadata\Delete"
+                       uriTemplate="/field_mappings/{id}{._format}"
+                       processor="App\Integration\Generic\Infrastructure\ApiPlatform\State\FieldMappingProcessor"
+                       security="is_granted('DELETE', object)"/>
+        </operations>
+    </resource>
+
+</resources>

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/FieldMappingInput.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/FieldMappingInput.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\ApiPlatform\Resource;
+
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * POST input for `/api/field_mappings` (APIC-P2-08). `connection` is the parent
+ * connection's UUID; the {@see \App\Integration\Generic\Infrastructure\ApiPlatform\State\FieldMappingProcessor}
+ * resolves it tenant-scoped and stamps the mapping's tenant from it.
+ */
+final class FieldMappingInput
+{
+    #[Assert\NotBlank]
+    #[Groups(['field_mapping:create'])]
+    public string $connection = '';
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    #[Groups(['field_mapping:create'])]
+    public string $pimTarget = '';
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 512)]
+    #[Groups(['field_mapping:create'])]
+    public string $remoteFieldPath = '';
+
+    #[Assert\Choice(choices: ['inbound', 'outbound', 'both'])]
+    #[Groups(['field_mapping:create'])]
+    public string $direction = 'inbound';
+
+    #[Groups(['field_mapping:create'])]
+    public bool $isMatchKey = false;
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/FieldMappingPatchInput.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/FieldMappingPatchInput.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\ApiPlatform\Resource;
+
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * PATCH (RFC 7396 merge) input for `/api/field_mappings/{id}` (APIC-P2-08).
+ * Every field is nullable — null means "leave unchanged". `connection` is
+ * immutable and omitted. Any applied change bumps the mapping version.
+ */
+final class FieldMappingPatchInput
+{
+    #[Assert\Length(max: 255)]
+    #[Groups(['field_mapping:patch'])]
+    public ?string $pimTarget = null;
+
+    #[Assert\Length(max: 512)]
+    #[Groups(['field_mapping:patch'])]
+    public ?string $remoteFieldPath = null;
+
+    #[Assert\Choice(choices: ['inbound', 'outbound', 'both'])]
+    #[Groups(['field_mapping:patch'])]
+    public ?string $direction = null;
+
+    #[Groups(['field_mapping:patch'])]
+    public ?bool $isMatchKey = null;
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/State/FieldMappingProcessor.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/State/FieldMappingProcessor.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\ApiPlatform\State;
+
+use ApiPlatform\Metadata\DeleteOperationInterface;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\State\ProcessorInterface;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\FieldMapping;
+use App\Integration\Generic\Domain\Enum\MappingDirection;
+use App\Integration\Generic\Domain\Repository\ConnectionRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\FieldMappingRepositoryInterface;
+use App\Integration\Generic\Infrastructure\ApiPlatform\Resource\FieldMappingInput;
+use App\Integration\Generic\Infrastructure\ApiPlatform\Resource\FieldMappingPatchInput;
+use InvalidArgumentException;
+use LogicException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Write path for the `FieldMapping` resource (APIC-P2-08). Resolves the parent
+ * connection tenant-scoped (a cross-tenant or missing id is a 404) and
+ * persists. Any applied change on a PATCH bumps the mapping version so reuse
+ * can pin a revision. The tenant is stamped on persist by the listener.
+ *
+ * @implements ProcessorInterface<FieldMappingInput|FieldMappingPatchInput|FieldMapping, FieldMapping|null>
+ */
+final readonly class FieldMappingProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private ConnectionRepositoryInterface $connections,
+        private FieldMappingRepositoryInterface $mappings,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     * @param array<string, mixed> $context
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): ?FieldMapping
+    {
+        if ($operation instanceof DeleteOperationInterface) {
+            $this->mappings->remove($this->require($uriVariables));
+
+            return null;
+        }
+
+        if ($operation instanceof Post) {
+            return $this->handlePost($data);
+        }
+
+        if ($operation instanceof Patch) {
+            return $this->handlePatch($data, $uriVariables);
+        }
+
+        throw new LogicException(\sprintf('FieldMappingProcessor cannot handle operation "%s".', $operation::class));
+    }
+
+    private function handlePost(mixed $data): FieldMapping
+    {
+        if (!$data instanceof FieldMappingInput) {
+            throw new LogicException('FieldMappingProcessor expects FieldMappingInput on Post.');
+        }
+
+        $connection = $this->requireConnection($data->connection);
+
+        $mapping = new FieldMapping(
+            $connection,
+            $data->pimTarget,
+            $data->remoteFieldPath,
+            MappingDirection::from($data->direction),
+        );
+        $mapping->setMatchKey($data->isMatchKey);
+
+        $this->mappings->save($mapping);
+
+        return $mapping;
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     */
+    private function handlePatch(mixed $data, array $uriVariables): FieldMapping
+    {
+        if (!$data instanceof FieldMappingPatchInput) {
+            throw new LogicException('FieldMappingProcessor expects FieldMappingPatchInput on Patch.');
+        }
+
+        $mapping = $this->require($uriVariables);
+        $changed = false;
+
+        if (null !== $data->pimTarget) {
+            $mapping->setPimTarget($data->pimTarget);
+            $changed = true;
+        }
+        if (null !== $data->remoteFieldPath) {
+            $mapping->setRemoteFieldPath($data->remoteFieldPath);
+            $changed = true;
+        }
+        if (null !== $data->direction) {
+            $mapping->setDirection(MappingDirection::from($data->direction));
+            $changed = true;
+        }
+        if (null !== $data->isMatchKey) {
+            $mapping->setMatchKey($data->isMatchKey);
+            $changed = true;
+        }
+
+        if ($changed) {
+            $mapping->bumpVersion();
+        }
+
+        $this->mappings->save($mapping);
+
+        return $mapping;
+    }
+
+    private function requireConnection(string $id): Connection
+    {
+        $connection = $this->connections->findById($this->parseId($id, 'connection'));
+        if (!$connection instanceof Connection) {
+            throw new NotFoundHttpException('Connection was not found.');
+        }
+
+        return $connection;
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     */
+    private function require(array $uriVariables): FieldMapping
+    {
+        $raw = $uriVariables['id'] ?? null;
+        $id = $raw instanceof Uuid ? $raw : $this->parseId(\is_string($raw) ? $raw : '', 'id');
+
+        $mapping = $this->mappings->findById($id);
+        if (!$mapping instanceof FieldMapping) {
+            throw new NotFoundHttpException('FieldMapping was not found.');
+        }
+
+        return $mapping;
+    }
+
+    private function parseId(string $raw, string $field): Uuid
+    {
+        if ('' === $raw) {
+            throw new NotFoundHttpException(\sprintf('Missing %s identifier.', $field));
+        }
+
+        try {
+            return Uuid::fromString($raw);
+        } catch (InvalidArgumentException) {
+            throw new NotFoundHttpException(\sprintf('Invalid %s identifier.', $field));
+        }
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Serializer/FieldMapping.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/Serializer/FieldMapping.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping
+                                https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd">
+
+    <!-- Read projection for FieldMapping (APIC-P2-08). -->
+    <class name="App\Integration\Generic\Domain\Entity\FieldMapping">
+        <attribute name="id">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="connectionId">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="bindingId">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="pimTarget">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="remoteFieldPath">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="direction">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="isMatchKey">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="version">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="createdAt">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="updatedAt">
+            <group>admin:read</group>
+        </attribute>
+    </class>
+</serializer>

--- a/apps/api/src/Integration/Generic/Presentation/Controller/ConnectionMappingValidateController.php
+++ b/apps/api/src/Integration/Generic/Presentation/Controller/ConnectionMappingValidateController.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Presentation\Controller;
+
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Integration\Generic\Application\Mapping\MappingValidator;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Repository\ConnectionRepositoryInterface;
+use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * APIC-P2-08 (ADR-0022) — validates a connection's field mappings: returns the
+ * blocking errors (e.g. a missing match key for inbound) and the non-fatal type
+ * warnings so the mapping screen can surface them before a sync runs.
+ *
+ * The connection is resolved tenant-scoped (Postgres RLS), so a cross-tenant id
+ * is a 404; `settings.integrations.manage` gates the action. Always HTTP 200 —
+ * the *validation ran*; whether the mappings are valid lives in the body.
+ */
+final class ConnectionMappingValidateController
+{
+    public function __construct(
+        private readonly ConnectionRepositoryInterface $connections,
+        private readonly MappingValidator $validator,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/connections/{id}/mappings/validate',
+        name: 'integration_connection_mappings_validate',
+        requirements: ['id' => '[0-9a-fA-F-]{36}'],
+        methods: ['POST'],
+    )]
+    #[RequiresPermission(module: 'settings.integrations', action: 'manage')]
+    public function __invoke(string $id): JsonResponse
+    {
+        $connection = $this->requireConnection($id);
+        $result = $this->validator->validate($connection);
+
+        return new JsonResponse([
+            'valid' => $result->isValid(),
+            'errors' => $result->errors,
+            'warnings' => array_map(
+                static fn ($warning): array => [
+                    'pimTarget' => $warning->pimTarget,
+                    'remoteFieldPath' => $warning->remoteFieldPath,
+                    'message' => $warning->message,
+                ],
+                $result->warnings,
+            ),
+        ], Response::HTTP_OK);
+    }
+
+    private function requireConnection(string $id): Connection
+    {
+        try {
+            $connectionId = Uuid::fromString($id);
+        } catch (InvalidArgumentException) {
+            throw new NotFoundHttpException(\sprintf('Connection "%s" was not found.', $id));
+        }
+
+        $connection = $this->connections->findById($connectionId);
+        if (!$connection instanceof Connection) {
+            throw new NotFoundHttpException(\sprintf('Connection "%s" was not found.', $id));
+        }
+
+        return $connection;
+    }
+}

--- a/apps/api/tests/Api/Integration/Generic/FieldMappingApiTest.php
+++ b/apps/api/tests/Api/Integration/Generic/FieldMappingApiTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Integration\Generic;
+
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Identity\Domain\Entity\User;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\ApiConfigurator\ApiConfiguratorApiTestCase;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * APIC-P2-08 — CRUD coverage for `/api/field_mappings` plus the
+ * `POST /api/connections/{id}/mappings/validate` trigger (match-key rule +
+ * type warnings). Reuses the ApiConfigurator RBAC scaffold.
+ */
+final class FieldMappingApiTest extends ApiConfiguratorApiTestCase
+{
+    private const string LD_JSON = 'application/ld+json';
+    private const string MERGE_PATCH = 'application/merge-patch+json';
+
+    #[Test]
+    public function postCreatesMapping(): void
+    {
+        $connectionId = $this->createConnection();
+
+        $body = $this->createMapping($connectionId, [
+            'pimTarget' => 'sku',
+            'remoteFieldPath' => '$.sku',
+            'direction' => 'both',
+            'isMatchKey' => true,
+        ]);
+
+        self::assertResponseStatusCodeSame(201);
+        self::assertSame('sku', $body['pimTarget'] ?? null);
+        self::assertSame('$.sku', $body['remoteFieldPath'] ?? null);
+        self::assertSame('both', $body['direction'] ?? null);
+        self::assertTrue($body['isMatchKey'] ?? null);
+        self::assertSame(1, $body['version'] ?? null);
+        self::assertSame($connectionId, $body['connectionId'] ?? null);
+    }
+
+    #[Test]
+    public function patchBumpsVersion(): void
+    {
+        $connectionId = $this->createConnection();
+        $id = $this->createMapping($connectionId)['id'] ?? null;
+        \assert(\is_string($id));
+
+        $body = $this->authenticatedClient()->request('PATCH', '/api/field_mappings/'.$id, [
+            'headers' => ['content-type' => self::MERGE_PATCH],
+            'body' => json_encode(['direction' => 'outbound'], JSON_THROW_ON_ERROR),
+        ])->toArray();
+
+        self::assertResponseStatusCodeSame(200);
+        self::assertSame('outbound', $body['direction'] ?? null);
+        self::assertSame(2, $body['version'] ?? null);
+    }
+
+    #[Test]
+    public function deleteMappingThenGetIs404(): void
+    {
+        $connectionId = $this->createConnection();
+        $id = $this->createMapping($connectionId)['id'] ?? null;
+        \assert(\is_string($id));
+
+        $client = $this->authenticatedClient();
+        $client->request('DELETE', '/api/field_mappings/'.$id);
+        self::assertResponseStatusCodeSame(204);
+
+        $client->request('GET', '/api/field_mappings/'.$id);
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    #[Test]
+    public function mappingsListIsScopedByConnection(): void
+    {
+        $first = $this->createConnection('alpha');
+        $second = $this->createConnection('beta');
+        $this->createMapping($first, ['pimTarget' => 'sku', 'remoteFieldPath' => '$.sku']);
+        $this->createMapping($second, ['pimTarget' => 'name', 'remoteFieldPath' => '$.name']);
+
+        $body = $this->authenticatedClient()
+            ->request('GET', '/api/field_mappings?connection='.$first)
+            ->toArray();
+
+        self::assertResponseStatusCodeSame(200);
+        self::assertSame(1, $body['totalItems'] ?? null);
+    }
+
+    #[Test]
+    public function validateFlagsInboundWithoutMatchKey(): void
+    {
+        $connectionId = $this->createConnection();
+        $this->createMapping($connectionId, [
+            'pimTarget' => 'name',
+            'remoteFieldPath' => '$.name',
+            'direction' => 'inbound',
+            'isMatchKey' => false,
+        ]);
+
+        $body = $this->authenticatedClient()
+            ->request('POST', '/api/connections/'.$connectionId.'/mappings/validate', [
+                'headers' => ['content-type' => 'application/json'],
+                'body' => '{}',
+            ])
+            ->toArray();
+
+        self::assertResponseStatusCodeSame(200);
+        self::assertFalse($body['valid'] ?? null);
+        self::assertNotEmpty($body['errors'] ?? []);
+    }
+
+    #[Test]
+    public function validatePassesWithAMatchKey(): void
+    {
+        $connectionId = $this->createConnection();
+        $this->createMapping($connectionId, [
+            'pimTarget' => 'sku',
+            'remoteFieldPath' => '$.sku',
+            'direction' => 'inbound',
+            'isMatchKey' => true,
+        ]);
+
+        $body = $this->authenticatedClient()
+            ->request('POST', '/api/connections/'.$connectionId.'/mappings/validate', [
+                'headers' => ['content-type' => 'application/json'],
+                'body' => '{}',
+            ])
+            ->toArray();
+
+        self::assertResponseStatusCodeSame(200);
+        self::assertTrue($body['valid'] ?? null);
+    }
+
+    #[Test]
+    public function validateUnknownConnectionIs404(): void
+    {
+        $this->authenticatedClient()->request(
+            'POST',
+            '/api/connections/01234567-1234-7000-8000-000000000000/mappings/validate',
+            ['headers' => ['content-type' => 'application/json'], 'body' => '{}'],
+        );
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    #[Test]
+    public function unauthenticatedListIs401(): void
+    {
+        static::createClient()->request('GET', '/api/field_mappings');
+        self::assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    #[Test]
+    public function limitedUserListIs403(): void
+    {
+        $this->limitedClient()->request('GET', '/api/field_mappings');
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    private function createConnection(string $code = 'idosell'): string
+    {
+        $body = $this->authenticatedClient()->request('POST', '/api/connections', [
+            'headers' => ['content-type' => self::LD_JSON],
+            'body' => json_encode([
+                'code' => $code,
+                'name' => ucfirst($code),
+                'baseUrl' => 'https://api.idosell.com',
+                'authType' => 'none',
+            ], JSON_THROW_ON_ERROR),
+        ])->toArray(false);
+
+        $id = $body['id'] ?? null;
+        \assert(\is_string($id));
+
+        return $id;
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     *
+     * @return array<array-key, mixed>
+     */
+    private function createMapping(string $connectionId, array $overrides = []): array
+    {
+        $payload = array_merge([
+            'connection' => $connectionId,
+            'pimTarget' => 'sku',
+            'remoteFieldPath' => '$.sku',
+            'direction' => 'inbound',
+            'isMatchKey' => false,
+        ], $overrides);
+
+        return $this->authenticatedClient()->request('POST', '/api/field_mappings', [
+            'headers' => ['content-type' => self::LD_JSON],
+            'body' => json_encode($payload, JSON_THROW_ON_ERROR),
+        ])->toArray(false);
+    }
+
+    private function limitedClient(): Client
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $email = 'limited@demo.localhost';
+        $stub = new User($tenant, $email, '', ['ROLE_USER']);
+        $user = new User($tenant, $email, $hasher->hashPassword($stub, 'changeme'), ['ROLE_USER']);
+        $em = $this->em();
+        $em->persist($user);
+        $em->flush();
+
+        $jwt = self::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+
+        $client = static::createClient();
+        $client->setDefaultOptions(['headers' => ['authorization' => 'Bearer '.$jwt]]);
+
+        return $client;
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Application/Mapping/MappingValidatorTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Application/Mapping/MappingValidatorTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Application\Mapping;
+
+use App\Integration\Generic\Application\Mapping\MappingValidator;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\FieldMapping;
+use App\Integration\Generic\Domain\Entity\RemoteEndpoint;
+use App\Integration\Generic\Domain\Entity\RemoteField;
+use App\Integration\Generic\Domain\Enum\MappingDirection;
+use App\Integration\Generic\Domain\Enum\RemoteEndpointRole;
+use App\Integration\Generic\Domain\Enum\RemoteFieldDataType;
+use App\Integration\Generic\Domain\Repository\FieldMappingRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\RemoteEndpointRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\RemoteFieldRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class MappingValidatorTest extends TestCase
+{
+    private Connection $connection;
+    private RemoteEndpoint $endpoint;
+
+    protected function setUp(): void
+    {
+        $this->connection = new Connection('idosell', 'IdoSell', 'https://api.idosell.com');
+        $this->endpoint = new RemoteEndpoint(
+            $this->connection,
+            RemoteEndpointRole::ReadList,
+            'GET',
+            '/products',
+        );
+    }
+
+    #[Test]
+    public function inboundWithoutMatchKeyIsAnError(): void
+    {
+        $mapping = new FieldMapping($this->connection, 'sku', '$.sku', MappingDirection::Inbound);
+
+        $result = $this->validate([$mapping], [$this->field('$.sku', RemoteFieldDataType::String)]);
+
+        self::assertFalse($result->isValid());
+        self::assertCount(1, $result->errors);
+        self::assertStringContainsString('match key', $result->errors[0]);
+    }
+
+    #[Test]
+    public function inboundWithMatchKeyIsValid(): void
+    {
+        $matchKey = new FieldMapping($this->connection, 'sku', '$.sku', MappingDirection::Inbound);
+        $matchKey->setMatchKey(true);
+        $name = new FieldMapping($this->connection, 'name', '$.name', MappingDirection::Inbound);
+
+        $result = $this->validate(
+            [$matchKey, $name],
+            [$this->field('$.sku', RemoteFieldDataType::String), $this->field('$.name', RemoteFieldDataType::String)],
+        );
+
+        self::assertTrue($result->isValid());
+        self::assertSame([], $result->warnings);
+    }
+
+    #[Test]
+    public function outboundOnlyNeedsNoMatchKey(): void
+    {
+        $mapping = new FieldMapping($this->connection, 'sku', '$.sku', MappingDirection::Outbound);
+
+        $result = $this->validate([$mapping], [$this->field('$.sku', RemoteFieldDataType::String)]);
+
+        self::assertTrue($result->isValid());
+    }
+
+    #[Test]
+    public function compositeRemoteFieldIsAWarning(): void
+    {
+        $matchKey = new FieldMapping($this->connection, 'sku', '$.sku', MappingDirection::Inbound);
+        $matchKey->setMatchKey(true);
+        $tags = new FieldMapping($this->connection, 'tags', '$.tags', MappingDirection::Inbound);
+
+        $result = $this->validate(
+            [$matchKey, $tags],
+            [$this->field('$.sku', RemoteFieldDataType::String), $this->field('$.tags', RemoteFieldDataType::Array)],
+        );
+
+        self::assertTrue($result->isValid());
+        self::assertCount(1, $result->warnings);
+        self::assertSame('tags', $result->warnings[0]->pimTarget);
+        self::assertStringContainsString('array', $result->warnings[0]->message);
+    }
+
+    #[Test]
+    public function unknownPathIsAWarning(): void
+    {
+        $matchKey = new FieldMapping($this->connection, 'sku', '$.sku', MappingDirection::Inbound);
+        $matchKey->setMatchKey(true);
+        $ghost = new FieldMapping($this->connection, 'mystery', '$.does.not.exist', MappingDirection::Inbound);
+
+        $result = $this->validate([$matchKey, $ghost], [$this->field('$.sku', RemoteFieldDataType::String)]);
+
+        self::assertCount(1, $result->warnings);
+        self::assertStringContainsString('not in the discovered schema', $result->warnings[0]->message);
+    }
+
+    /**
+     * @param list<FieldMapping> $mappings
+     * @param list<RemoteField>  $fields
+     */
+    private function validate(array $mappings, array $fields): \App\Integration\Generic\Application\Mapping\MappingValidationResult
+    {
+        $mappingRepo = $this->createStub(FieldMappingRepositoryInterface::class);
+        $mappingRepo->method('findByConnection')->willReturn($mappings);
+
+        $endpointRepo = $this->createStub(RemoteEndpointRepositoryInterface::class);
+        $endpointRepo->method('findByConnection')->willReturn([$this->endpoint]);
+
+        $fieldRepo = $this->createStub(RemoteFieldRepositoryInterface::class);
+        $fieldRepo->method('findByEndpoint')->willReturn($fields);
+
+        return new MappingValidator($mappingRepo, $endpointRepo, $fieldRepo)->validate($this->connection);
+    }
+
+    private function field(string $path, RemoteFieldDataType $type): RemoteField
+    {
+        return new RemoteField($this->endpoint, $path, $type);
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -5192,6 +5192,497 @@
                 }
             }
         },
+        "/api/field_mappings": {
+            "get": {
+                "operationId": "api_field_mappings_get_collection",
+                "tags": [
+                    "FieldMapping"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "FieldMapping collection",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "description": "FieldMapping.jsonld-admin.read collection.",
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/HydraCollectionBaseSchema"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "member"
+                                            ],
+                                            "properties": {
+                                                "member": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/FieldMapping.jsonld-admin.read"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/FieldMapping-admin.read"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Retrieves the collection of FieldMapping resources.",
+                "description": "Retrieves the collection of FieldMapping resources.",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "The collection page number",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        },
+                        "style": "form",
+                        "explode": true
+                    },
+                    {
+                        "name": "connection",
+                        "in": "query",
+                        "description": "Exact match on the parent Connection UUID (tenant-scoped).",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    }
+                ]
+            },
+            "post": {
+                "operationId": "api_field_mappings_post",
+                "tags": [
+                    "FieldMapping"
+                ],
+                "responses": {
+                    "201": {
+                        "description": "FieldMapping resource created",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FieldMapping.jsonld-admin.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FieldMapping-admin.read"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "422": {
+                        "description": "An error occurred",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Creates a FieldMapping resource.",
+                "description": "Creates a FieldMapping resource.",
+                "parameters": [],
+                "requestBody": {
+                    "description": "The new FieldMapping resource",
+                    "content": {
+                        "application/ld+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FieldMapping.FieldMappingInput-field_mapping.create"
+                            }
+                        },
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FieldMapping.FieldMappingInput-field_mapping.create"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            }
+        },
+        "/api/field_mappings/{id}": {
+            "get": {
+                "operationId": "api_field_mappings_id_get",
+                "tags": [
+                    "FieldMapping"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "FieldMapping resource",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FieldMapping.jsonld-admin.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FieldMapping-admin.read"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Retrieves a FieldMapping resource.",
+                "description": "Retrieves a FieldMapping resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "FieldMapping identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ]
+            },
+            "delete": {
+                "operationId": "api_field_mappings_id_delete",
+                "tags": [
+                    "FieldMapping"
+                ],
+                "responses": {
+                    "204": {
+                        "description": "FieldMapping resource deleted"
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Removes the FieldMapping resource.",
+                "description": "Removes the FieldMapping resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "FieldMapping identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ]
+            },
+            "patch": {
+                "operationId": "api_field_mappings_id_patch",
+                "tags": [
+                    "FieldMapping"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "FieldMapping resource updated",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FieldMapping.jsonld-admin.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FieldMapping-admin.read"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "422": {
+                        "description": "An error occurred",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Updates the FieldMapping resource.",
+                "description": "Updates the FieldMapping resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "FieldMapping identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "requestBody": {
+                    "description": "The updated FieldMapping resource",
+                    "content": {
+                        "application/merge-patch+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FieldMapping.FieldMappingPatchInput-field_mapping.patch.jsonMergePatch"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            }
+        },
         "/api/import-profiles": {
             "get": {
                 "operationId": "api_import-profiles_get_collection",
@@ -10846,6 +11337,45 @@
                     }
                 },
                 "summary": "Api connections id discover",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "settings.integrations.manage"
+            }
+        },
+        "/api/connections/{id}/mappings/validate": {
+            "post": {
+                "operationId": "api_connections_id_mappings_validate_post",
+                "tags": [
+                    "connections"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api connections id mappings validate",
                 "description": "Custom controller route.",
                 "parameters": [
                     {
@@ -19089,6 +19619,230 @@
                 ],
                 "description": "A representation of common errors."
             },
+            "FieldMapping-admin.read": {
+                "type": "object",
+                "description": "A 1:1 mapping between a PIM target and a remote field path (ADR-0022, epic\nAPIC, ticket APIC-P2-07).\n\n`pimTarget` names the PIM side \u2014 an attribute code or a system field\n(sku/name/status/category\u2026); `remoteFieldPath` is the external JSONPath. The\nmapping belongs to a {@see Connection} and is versioned so it can be reused\nacross sync bindings (the optional `bindingId` links it to a SyncBinding once\nthat lands in APIC-P3-01 \u2014 kept loose here, no FK). `direction` and\n`isMatchKey` drive the sync engines: the match key identifies the row to\nupsert, the direction gates inbound/outbound application.\n\n`TenantScoped` + Postgres RLS isolate every mapping to its tenant. Type\ncompatibility between the PIM target and the remote field is validated at the\nAPI edge (APIC-P2-08), not in this domain entity.",
+                "properties": {
+                    "id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uuid"
+                    },
+                    "bindingId": {
+                        "readOnly": true,
+                        "description": "Loose link to a future SyncBinding (APIC-P3-01); no FK until it exists.",
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uuid"
+                    },
+                    "pimTarget": {
+                        "maxLength": 255,
+                        "type": "string"
+                    },
+                    "remoteFieldPath": {
+                        "maxLength": 512,
+                        "type": "string"
+                    },
+                    "direction": {
+                        "default": "inbound",
+                        "type": "string",
+                        "enum": [
+                            "inbound",
+                            "outbound",
+                            "both"
+                        ]
+                    },
+                    "isMatchKey": {
+                        "readOnly": true,
+                        "description": "Serializer-facing alias so the read projection exposes the flag as\n`isMatchKey` (mirrors the input DTO), per the ObjectType convention.",
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "version": {
+                        "minimum": 0,
+                        "exclusiveMinimum": 0,
+                        "readOnly": true,
+                        "default": 1,
+                        "type": "integer"
+                    },
+                    "createdAt": {
+                        "readOnly": true,
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updatedAt": {
+                        "readOnly": true,
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "connectionId": {
+                        "readOnly": true,
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                },
+                "required": [
+                    "pimTarget",
+                    "remoteFieldPath"
+                ]
+            },
+            "FieldMapping.FieldMappingInput-field_mapping.create": {
+                "type": "object",
+                "description": "A 1:1 mapping between a PIM target and a remote field path (ADR-0022, epic\nAPIC, ticket APIC-P2-07).\n\n`pimTarget` names the PIM side \u2014 an attribute code or a system field\n(sku/name/status/category\u2026); `remoteFieldPath` is the external JSONPath. The\nmapping belongs to a {@see Connection} and is versioned so it can be reused\nacross sync bindings (the optional `bindingId` links it to a SyncBinding once\nthat lands in APIC-P3-01 \u2014 kept loose here, no FK). `direction` and\n`isMatchKey` drive the sync engines: the match key identifies the row to\nupsert, the direction gates inbound/outbound application.\n\n`TenantScoped` + Postgres RLS isolate every mapping to its tenant. Type\ncompatibility between the PIM target and the remote field is validated at the\nAPI edge (APIC-P2-08), not in this domain entity.",
+                "required": [
+                    "connection",
+                    "pimTarget",
+                    "remoteFieldPath"
+                ],
+                "properties": {
+                    "connection": {
+                        "default": "",
+                        "type": "string"
+                    },
+                    "pimTarget": {
+                        "maxLength": 255,
+                        "default": "",
+                        "type": "string"
+                    },
+                    "remoteFieldPath": {
+                        "maxLength": 512,
+                        "default": "",
+                        "type": "string"
+                    },
+                    "direction": {
+                        "enum": [
+                            "inbound",
+                            "outbound",
+                            "both"
+                        ],
+                        "default": "inbound",
+                        "type": "string"
+                    },
+                    "isMatchKey": {
+                        "default": false,
+                        "type": "boolean"
+                    }
+                }
+            },
+            "FieldMapping.FieldMappingPatchInput-field_mapping.patch.jsonMergePatch": {
+                "type": "object",
+                "description": "A 1:1 mapping between a PIM target and a remote field path (ADR-0022, epic\nAPIC, ticket APIC-P2-07).\n\n`pimTarget` names the PIM side \u2014 an attribute code or a system field\n(sku/name/status/category\u2026); `remoteFieldPath` is the external JSONPath. The\nmapping belongs to a {@see Connection} and is versioned so it can be reused\nacross sync bindings (the optional `bindingId` links it to a SyncBinding once\nthat lands in APIC-P3-01 \u2014 kept loose here, no FK). `direction` and\n`isMatchKey` drive the sync engines: the match key identifies the row to\nupsert, the direction gates inbound/outbound application.\n\n`TenantScoped` + Postgres RLS isolate every mapping to its tenant. Type\ncompatibility between the PIM target and the remote field is validated at the\nAPI edge (APIC-P2-08), not in this domain entity.",
+                "properties": {
+                    "pimTarget": {
+                        "maxLength": 255,
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "remoteFieldPath": {
+                        "maxLength": 512,
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "direction": {
+                        "enum": [
+                            "inbound",
+                            "outbound",
+                            "both"
+                        ],
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "isMatchKey": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ]
+                    }
+                }
+            },
+            "FieldMapping.jsonld-admin.read": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/HydraItemBaseSchema"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "uuid"
+                            },
+                            "bindingId": {
+                                "readOnly": true,
+                                "description": "Loose link to a future SyncBinding (APIC-P3-01); no FK until it exists.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "uuid"
+                            },
+                            "pimTarget": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "remoteFieldPath": {
+                                "maxLength": 512,
+                                "type": "string"
+                            },
+                            "direction": {
+                                "default": "inbound",
+                                "type": "string",
+                                "enum": [
+                                    "inbound",
+                                    "outbound",
+                                    "both"
+                                ]
+                            },
+                            "isMatchKey": {
+                                "readOnly": true,
+                                "description": "Serializer-facing alias so the read projection exposes the flag as\n`isMatchKey` (mirrors the input DTO), per the ObjectType convention.",
+                                "default": false,
+                                "type": "boolean"
+                            },
+                            "version": {
+                                "minimum": 0,
+                                "exclusiveMinimum": 0,
+                                "readOnly": true,
+                                "default": 1,
+                                "type": "integer"
+                            },
+                            "createdAt": {
+                                "readOnly": true,
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "updatedAt": {
+                                "readOnly": true,
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "connectionId": {
+                                "readOnly": true,
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        },
+                        "required": [
+                            "pimTarget",
+                            "remoteFieldPath"
+                        ]
+                    }
+                ],
+                "description": "A 1:1 mapping between a PIM target and a remote field path (ADR-0022, epic\nAPIC, ticket APIC-P2-07).\n\n`pimTarget` names the PIM side \u2014 an attribute code or a system field\n(sku/name/status/category\u2026); `remoteFieldPath` is the external JSONPath. The\nmapping belongs to a {@see Connection} and is versioned so it can be reused\nacross sync bindings (the optional `bindingId` links it to a SyncBinding once\nthat lands in APIC-P3-01 \u2014 kept loose here, no FK). `direction` and\n`isMatchKey` drive the sync engines: the match key identifies the row to\nupsert, the direction gates inbound/outbound application.\n\n`TenantScoped` + Postgres RLS isolate every mapping to its tenant. Type\ncompatibility between the PIM target and the remote field is validated at the\nAPI edge (APIC-P2-08), not in this domain entity."
+            },
             "HydraCollectionBaseSchema": {
                 "allOf": [
                     {
@@ -21543,6 +22297,10 @@
         {
             "name": "Connection",
             "description": "A consumer-side connection to one external REST/JSON API (ADR-0022, epic APIC).\n\nHolds the transport definition \u2014 base URL, auth type, default headers, an\noptional rate hint \u2014 plus the reversibly-encrypted credentials needed to\ncall the remote. The actual encryption-at-write + response masking lands in\nAPIC-P1-02; this entity stores the already-produced ciphertext + master-key\nversion in two columns, mirroring `TenantAgentConfig` / ADR-0017.\n\n`TenantScoped` + Postgres RLS isolate every connection to its tenant. Scheme\n(http/https) and SSRF-safe descriptor validation are enforced separately\n(APIC-P1-03/P1-04), not at this domain layer."
+        },
+        {
+            "name": "FieldMapping",
+            "description": "A 1:1 mapping between a PIM target and a remote field path (ADR-0022, epic\nAPIC, ticket APIC-P2-07).\n\n`pimTarget` names the PIM side \u2014 an attribute code or a system field\n(sku/name/status/category\u2026); `remoteFieldPath` is the external JSONPath. The\nmapping belongs to a {@see Connection} and is versioned so it can be reused\nacross sync bindings (the optional `bindingId` links it to a SyncBinding once\nthat lands in APIC-P3-01 \u2014 kept loose here, no FK). `direction` and\n`isMatchKey` drive the sync engines: the match key identifies the row to\nupsert, the direction gates inbound/outbound application.\n\n`TenantScoped` + Postgres RLS isolate every mapping to its tenant. Type\ncompatibility between the PIM target and the remote field is validated at the\nAPI edge (APIC-P2-08), not in this domain entity."
         },
         {
             "name": "RemoteEndpoint",


### PR DESCRIPTION
## Cel

APIC-P2-08 — persist mapowań + ostrzeżenie przy niezgodności typów + wymóg ≥1 matchKey dla inbound.

## Zakres

- **API Platform `FieldMapping`** — CRUD (GetCollection/Get/Post/Patch/Delete), `?connection=` filtr, serializer read-projection (`isMatchKey` via `getIsMatchKey()` per konwencja ObjectType), voter (`integration`), processor tenant-scoped (404) + **bump version** na każdą zmianę PATCH (AC-2 wersjonowanie/reuse).
- **`POST /api/connections/{id}/mappings/validate`** → `MappingValidator`:
  - **error** gdy istnieje mapowanie inbound/both, ale żadne `isMatchKey` (AC-3 → `valid:false`),
  - **warning** (nie błąd, ADR-0016 decyzja 5) gdy remote field jest composite (object/array → 1:1 do skalara gubi dane) lub gdy ścieżka nie ma odpowiednika w wykrytym schemacie. Typ PIM targetu nie jest rozwiązywany (cross-context Catalog) — sygnałem jest kształt remote field.
- **OpenAPI snapshot** zregenerowany — czysto addytywnie (+3 paths, +schemas; istniejące identyczne).

## Testy / bramki (kontener api)

- **PHPStan max** ✅ · **Deptrac** 0 ✅ · **PHP-CS-Fixer** 0 ✅ · routing/DI zweryfikowane.
- **PHPUnit** `MappingValidatorTest` ✅ 5/5 (inbound bez matchKey = error, z matchKey = valid, outbound-only OK, composite = warning, unknown path = warning) — `createStub` (failOnNotice). Pełny Generic unit regresja: **94/94**.
- **`FieldMappingApiTest`** (Layer 3, **CI-only** — lokalny JWT `bad decrypt`): CRUD, patch→version 2, filtr `?connection`, validate (inbound-no-matchKey → valid:false / matchKey → valid:true / 404), 401/403.

Refs #1777