### PR TITLE
feat(ui): build 1:1 field mapping screen (APIC-P2-09)

### DIFF
--- a/apps/admin/e2e/1778-api-mapping-screen.spec.ts
+++ b/apps/admin/e2e/1778-api-mapping-screen.spec.ts
@@ -1,0 +1,122 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, type Route, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * APIC-P2-09 (#1778) — the 1:1 field mapping screen. The mapping + descriptor +
+ * validate APIs are mocked (stateful), so the test is deterministic and offline:
+ * add a mapping, toggle its match key, and check the discovered-field pools.
+ */
+test('APIC-P2-09 — field mapper: add mapping + toggle match key', async ({ page }) => {
+  await loginAsAdmin(page);
+
+  const mappings: Array<Record<string, unknown>> = [];
+
+  await page.route('**/api/field_mappings**', (route: Route) => {
+    const url = route.request().url();
+    const method = route.request().method();
+    const match = url.match(/\/field_mappings\/([^/?]+)/);
+
+    if (method === 'POST' && match === null) {
+      const body = route.request().postDataJSON() as Record<string, unknown>;
+      const created = {
+        id: `map-${mappings.length + 1}`,
+        connectionId: 'conn-1',
+        pimTarget: body.pimTarget ?? 'sku',
+        remoteFieldPath: body.remoteFieldPath ?? '$.sku',
+        direction: body.direction ?? 'inbound',
+        isMatchKey: body.isMatchKey ?? false,
+        version: 1,
+      };
+      mappings.push(created);
+      return route.fulfill({
+        status: 201,
+        contentType: 'application/ld+json',
+        body: JSON.stringify(created),
+      });
+    }
+
+    if (method === 'PATCH' && match !== null) {
+      const id = match[1];
+      const body = route.request().postDataJSON() as Record<string, unknown>;
+      const row = mappings.find((m) => m.id === id);
+      if (row !== undefined) {
+        Object.assign(row, body, { version: (row.version as number) + 1 });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/ld+json',
+        body: JSON.stringify(row ?? {}),
+      });
+    }
+
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify({ member: mappings, totalItems: mappings.length }),
+    });
+  });
+
+  await page.route('**/api/remote_endpoints**', (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify({
+        member: [
+          {
+            id: 'ep-1',
+            connectionId: 'conn-1',
+            role: 'read_list',
+            httpMethod: 'GET',
+            pathTemplate: '/products',
+            pagination: { strategy: 'none' },
+            recordSelector: '$.results',
+          },
+        ],
+        totalItems: 1,
+      }),
+    }),
+  );
+
+  await page.route('**/api/remote_fields**', (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify({
+        member: [
+          { id: 'rf-1', path: '$.sku', dataType: 'string' },
+          { id: 'rf-2', path: '$.name', dataType: 'string' },
+        ],
+        totalItems: 2,
+      }),
+    }),
+  );
+
+  await page.route('**/api/connections/*/mappings/validate', (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ valid: true, errors: [], warnings: [] }),
+    }),
+  );
+
+  await page.goto('/integrations/api-configurator/connections/conn-1/mapping');
+
+  await expect(page.getByRole('heading', { name: /mapowanie pól|field mapping/i })).toBeVisible();
+
+  // Add a mapping.
+  await page.getByLabel(/atrybut pim|pim attribute/i).fill('sku');
+  await page.getByLabel(/pole zewnętrzne|external field/i).fill('$.sku');
+  await page.getByRole('button', { name: /dodaj mapowanie 1:1|add 1:1 mapping/i }).click();
+
+  await expect(page.getByText('sku', { exact: true })).toBeVisible();
+  await expect(page.getByText('$.sku', { exact: true })).toBeVisible();
+
+  // Toggle the match key → the badge appears after the optimistic refetch.
+  await page.getByRole('button', { name: /^key$/i }).click();
+  await expect(page.getByText(/match key/i)).toBeVisible();
+
+  const a11y = await new AxeBuilder({ page }).analyze();
+  expect(a11y.violations).toEqual([]);
+});

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -60,6 +60,10 @@ const ConnectionWizardPage = lazyPage(
   () => import('@/features/api-configurator/consumer/wizard/ConnectionWizardPage'),
   'ConnectionWizardPage',
 );
+const MappingScreen = lazyPage(
+  () => import('@/features/api-configurator/consumer/mapping/MappingScreen'),
+  'MappingScreen',
+);
 const ApiMonitorPlaceholder = lazyPage(
   () => import('@/features/api-configurator/monitor/ApiMonitorPlaceholder'),
   'ApiMonitorPlaceholder',
@@ -635,6 +639,10 @@ function App() {
                     <Route
                       path="/integrations/api-configurator/connections/new"
                       element={<ConnectionWizardPage />}
+                    />
+                    <Route
+                      path="/integrations/api-configurator/connections/:id/mapping"
+                      element={<MappingScreen />}
                     />
                     <Route
                       path="/integrations/api-configurator/monitor"

--- a/apps/admin/src/features/api-configurator/consumer/mapping/MappingScreen.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/mapping/MappingScreen.tsx
@@ -1,0 +1,391 @@
+import {
+  useApiUrl,
+  useCreate,
+  useCustomMutation,
+  useDelete,
+  useList,
+  useUpdate,
+} from '@refinedev/core';
+import { ArrowLeft, Plus, Trash2, TriangleAlert } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useParams } from 'react-router';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+import {
+  CoverageBar,
+  DirToggle,
+  type SyncDirection,
+  TypeCompat,
+} from '../../components/primitives';
+import type { RemoteEndpointRow } from '../wizard/steps/StepEndpoints';
+
+type ApiDirection = 'inbound' | 'outbound' | 'both';
+
+interface FieldMappingRow {
+  id: string;
+  connectionId: string;
+  pimTarget: string;
+  remoteFieldPath: string;
+  direction: ApiDirection;
+  isMatchKey: boolean;
+  version: number;
+}
+
+interface RemoteFieldRow {
+  id: string;
+  path: string;
+  dataType: string;
+}
+
+interface ValidateWarning {
+  pimTarget: string;
+  remoteFieldPath: string;
+  message: string;
+}
+
+interface ValidateResult {
+  valid: boolean;
+  errors: string[];
+  warnings: ValidateWarning[];
+}
+
+/** Common PIM targets offered in the mapper (system fields); custom attribute codes can be typed. */
+const PIM_TARGETS = ['sku', 'name', 'status', 'description', 'category', 'price'];
+
+const HUB = '/integrations/api-configurator/connections';
+
+const toToggle = (d: ApiDirection): SyncDirection => (d === 'both' ? 'bidirectional' : d);
+const toApi = (d: SyncDirection): ApiDirection => (d === 'bidirectional' ? 'both' : d);
+
+/**
+ * APIC-P2-09 — the two-column field mapper (PIM ↔ remote). Lists a connection's
+ * FieldMappings against the P2-08 CRUD API with direction + match-key toggles,
+ * a coverage bar, and per-row type warnings from the validate endpoint. The
+ * value-transform engine is a deferred §7 hook (disabled placeholder).
+ *
+ * The remote-field pool is sourced from the connection's first read endpoint
+ * (the common single-stream case); multi-endpoint pooling lands with the
+ * connection detail view (P3-12).
+ */
+export function MappingScreen() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const apiUrl = useApiUrl();
+  const { id: connectionId = null } = useParams();
+
+  const mappingsQuery = useList<FieldMappingRow>({
+    resource: 'field_mappings',
+    filters:
+      connectionId === null ? [] : [{ field: 'connection', operator: 'eq', value: connectionId }],
+    queryOptions: { enabled: connectionId !== null },
+    pagination: { mode: 'off' },
+  });
+  const endpointsQuery = useList<RemoteEndpointRow>({
+    resource: 'remote_endpoints',
+    filters:
+      connectionId === null ? [] : [{ field: 'connection', operator: 'eq', value: connectionId }],
+    queryOptions: { enabled: connectionId !== null },
+    pagination: { mode: 'off' },
+  });
+
+  const readEndpointId = useMemo(
+    () => endpointsQuery.result.data.find((e) => e.role.startsWith('read'))?.id ?? null,
+    [endpointsQuery.result.data],
+  );
+
+  const fieldsQuery = useList<RemoteFieldRow>({
+    resource: 'remote_fields',
+    filters:
+      readEndpointId === null ? [] : [{ field: 'endpoint', operator: 'eq', value: readEndpointId }],
+    queryOptions: { enabled: readEndpointId !== null },
+    pagination: { mode: 'off' },
+  });
+
+  const { mutate: create } = useCreate();
+  const { mutate: update } = useUpdate();
+  const { mutate: remove } = useDelete();
+  const { mutate: runValidate } = useCustomMutation<ValidateResult>();
+  const [validation, setValidation] = useState<ValidateResult | null>(null);
+
+  const mappings = mappingsQuery.result.data;
+  const remoteFields = fieldsQuery.result.data;
+
+  const validate = useCallback(() => {
+    if (connectionId === null) {
+      return;
+    }
+    runValidate(
+      {
+        url: `${apiUrl}/connections/${connectionId}/mappings/validate`,
+        method: 'post',
+        values: {},
+      },
+      { onSuccess: ({ data }) => setValidation(data as unknown as ValidateResult) },
+    );
+  }, [apiUrl, connectionId, runValidate]);
+
+  // Re-validate whenever the mapping set changes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-run on mapping count/version, not the callback identity
+  useEffect(() => {
+    if (mappings.length > 0) {
+      validate();
+    } else {
+      setValidation(null);
+    }
+  }, [mappings.length, mappings.map((m) => `${m.id}:${m.version}`).join(','), validate]);
+
+  const warningFor = useCallback(
+    (m: FieldMappingRow): string | null =>
+      validation?.warnings.find(
+        (w) => w.pimTarget === m.pimTarget && w.remoteFieldPath === m.remoteFieldPath,
+      )?.message ?? null,
+    [validation],
+  );
+
+  const mappedTargets = useMemo(() => new Set(mappings.map((m) => m.pimTarget)), [mappings]);
+  const mappedPaths = useMemo(() => new Set(mappings.map((m) => m.remoteFieldPath)), [mappings]);
+  const unmappedTargets = PIM_TARGETS.filter((target) => !mappedTargets.has(target));
+  const unmappedFields = remoteFields.filter((f) => !mappedPaths.has(f.path));
+  const warningCount = validation?.warnings.length ?? 0;
+
+  const [newTarget, setNewTarget] = useState('');
+  const [newPath, setNewPath] = useState('');
+
+  function refresh(): void {
+    void mappingsQuery.query.refetch();
+  }
+
+  function addMapping(): void {
+    if (connectionId === null || newTarget.trim() === '' || newPath.trim() === '') {
+      return;
+    }
+    create(
+      {
+        resource: 'field_mappings',
+        values: {
+          connection: connectionId,
+          pimTarget: newTarget.trim(),
+          remoteFieldPath: newPath.trim(),
+          direction: 'inbound',
+          isMatchKey: false,
+        },
+        successNotification: false,
+      },
+      {
+        onSuccess: () => {
+          setNewTarget('');
+          setNewPath('');
+          refresh();
+        },
+      },
+    );
+  }
+
+  function patch(id: string, values: Record<string, unknown>): void {
+    update(
+      { resource: 'field_mappings', id, values, successNotification: false },
+      { onSuccess: refresh },
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center gap-3">
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={() => navigate(HUB)}
+          aria-label={t('api_configurator.mapping.back')}
+        >
+          <ArrowLeft className="size-4" aria-hidden="true" />
+        </Button>
+        <div className="min-w-0 flex-1">
+          <h1 className="font-display text-[22px] font-semibold tracking-tight">
+            {t('api_configurator.mapping.title')}
+          </h1>
+          <p className="text-[12.5px] text-zinc-500">{t('api_configurator.mapping.subtitle')}</p>
+        </div>
+        <div className="flex items-center gap-4">
+          {warningCount > 0 ? (
+            <span className="inline-flex items-center gap-1.5 text-[11.5px] font-medium text-amber-800">
+              <TriangleAlert className="size-4 text-amber-600" aria-hidden="true" />
+              {t('api_configurator.mapping.warnings', { count: warningCount })}
+            </span>
+          ) : null}
+          <CoverageBar
+            mapped={mappings.length}
+            total={PIM_TARGETS.length}
+            width={160}
+            ariaLabel={t('api_configurator.mapping.coverage')}
+          />
+        </div>
+      </div>
+
+      {validation !== null && !validation.valid ? (
+        <div className="rounded-xl border border-rose-200 bg-rose-50/60 p-3 text-[12.5px] text-rose-800">
+          {validation.errors.map((error) => (
+            <div key={error}>{error}</div>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="space-y-2">
+        {mappings.map((m) => {
+          const warning = warningFor(m);
+          return (
+            <div
+              key={m.id}
+              className={`rounded-2xl border bg-white p-3 ${warning === null ? 'border-zinc-200' : 'border-amber-200'}`}
+            >
+              <div className="grid grid-cols-1 items-center gap-3 lg:grid-cols-[1fr_140px_1fr]">
+                <div className="rounded-xl border border-zinc-100 bg-zinc-50/70 px-3 py-2.5">
+                  <span className="text-[13px] font-semibold text-zinc-900">{m.pimTarget}</span>
+                  {m.isMatchKey ? (
+                    <span className="ml-2 rounded bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium text-amber-800">
+                      {t('api_configurator.mapping.match_key')}
+                    </span>
+                  ) : null}
+                </div>
+                <div className="flex flex-col items-center gap-1.5">
+                  <DirToggle
+                    value={toToggle(m.direction)}
+                    onChange={(next) => patch(m.id, { direction: toApi(next) })}
+                    title={t('api_configurator.mapping.direction')}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => patch(m.id, { isMatchKey: !m.isMatchKey })}
+                    aria-pressed={m.isMatchKey}
+                    className={`h-6 rounded-md border px-2 text-[10px] font-medium transition ${m.isMatchKey ? 'border-amber-200 bg-amber-50 text-amber-800' : 'border-zinc-200 bg-white text-zinc-500 hover:text-zinc-800'}`}
+                  >
+                    {t('api_configurator.mapping.key')}
+                  </button>
+                </div>
+                <div className="rounded-xl border border-sky-100 bg-sky-50/40 px-3 py-2.5">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate font-mono text-[12.5px] font-medium text-zinc-900">
+                      {m.remoteFieldPath}
+                    </span>
+                    <TypeCompat
+                      ok={warning === null}
+                      title={warning ?? t('api_configurator.mapping.type_ok')}
+                    />
+                  </div>
+                </div>
+              </div>
+
+              {warning !== null ? (
+                <div className="mt-2 flex items-center gap-2.5 rounded-xl bg-amber-50/70 px-3 py-2 text-[11.5px] text-amber-900">
+                  <TriangleAlert className="size-4 shrink-0 text-amber-600" aria-hidden="true" />
+                  <span className="flex-1">{warning}</span>
+                  <button
+                    type="button"
+                    disabled
+                    title={t('api_configurator.mapping.transform_hint')}
+                    className="shrink-0 cursor-not-allowed rounded-md border border-dashed border-zinc-300 px-2 py-0.5 text-[10.5px] font-medium text-zinc-500"
+                  >
+                    {t('api_configurator.mapping.transform')}
+                  </button>
+                </div>
+              ) : null}
+
+              <div className="mt-2 flex justify-end">
+                <button
+                  type="button"
+                  onClick={() =>
+                    remove({ resource: 'field_mappings', id: m.id }, { onSuccess: refresh })
+                  }
+                  className="flex items-center gap-1 text-[11px] font-medium text-zinc-500 hover:text-rose-600"
+                >
+                  <Trash2 className="size-3.5" aria-hidden="true" />
+                  {t('api_configurator.mapping.remove')}
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="grid grid-cols-1 items-end gap-3 rounded-xl border border-dashed border-zinc-300 p-4 lg:grid-cols-[1fr_1fr_auto]">
+        <Input
+          value={newTarget}
+          onChange={(e) => setNewTarget(e.target.value)}
+          placeholder={t('api_configurator.mapping.pim_placeholder')}
+          aria-label={t('api_configurator.mapping.pim_target')}
+          list="pim-target-suggestions"
+          className="h-9"
+        />
+        <datalist id="pim-target-suggestions">
+          {unmappedTargets.map((target) => (
+            <option key={target} value={target} />
+          ))}
+        </datalist>
+        <Input
+          value={newPath}
+          onChange={(e) => setNewPath(e.target.value)}
+          placeholder="$.sku"
+          aria-label={t('api_configurator.mapping.remote_path')}
+          list="remote-path-suggestions"
+          className="h-9 font-mono"
+        />
+        <datalist id="remote-path-suggestions">
+          {unmappedFields.map((field) => (
+            <option key={field.path} value={field.path} />
+          ))}
+        </datalist>
+        <Button type="button" onClick={addMapping}>
+          <Plus className="mr-1 size-4" aria-hidden="true" />
+          {t('api_configurator.mapping.add')}
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <div className="soft-shadow rounded-2xl border border-zinc-200 bg-white p-4">
+          <div className="mb-3 text-[11px] font-medium uppercase tracking-wider text-zinc-500">
+            {t('api_configurator.mapping.unmapped_pim', { count: unmappedTargets.length })}
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {unmappedTargets.length === 0 ? (
+              <span className="text-[12px] text-emerald-700">
+                {t('api_configurator.mapping.all_pim_mapped')}
+              </span>
+            ) : (
+              unmappedTargets.map((target) => (
+                <span
+                  key={target}
+                  className="rounded-lg border border-zinc-200 px-2 py-1 text-[11.5px] text-zinc-700"
+                >
+                  {target}
+                </span>
+              ))
+            )}
+          </div>
+        </div>
+        <div className="soft-shadow rounded-2xl border border-zinc-200 bg-white p-4">
+          <div className="mb-3 text-[11px] font-medium uppercase tracking-wider text-zinc-500">
+            {t('api_configurator.mapping.unmapped_remote', { count: unmappedFields.length })}
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {unmappedFields.length === 0 ? (
+              <span className="text-[12px] text-zinc-500">
+                {t('api_configurator.mapping.all_remote_mapped')}
+              </span>
+            ) : (
+              unmappedFields.map((field) => (
+                <span
+                  key={field.path}
+                  className="rounded-lg border border-zinc-200 px-2 py-1 font-mono text-[11.5px] text-zinc-700"
+                >
+                  {field.path}
+                </span>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1844,6 +1844,28 @@
         "saving": "Saving…",
         "saved": "Fields saved"
       }
+    },
+    "mapping": {
+      "title": "Field mapping",
+      "subtitle": "Connect PIM attributes to external API fields (1:1 mapping).",
+      "back": "Back",
+      "warnings": "{{count}} type warnings",
+      "coverage": "Mapping coverage",
+      "match_key": "match key",
+      "direction": "Sync direction",
+      "key": "key",
+      "type_ok": "Types compatible",
+      "transform_hint": "Transform engine — planned (MVP = 1:1 mapping)",
+      "transform": "transform",
+      "remove": "remove",
+      "pim_placeholder": "sku, name, status, attribute code…",
+      "pim_target": "PIM attribute",
+      "remote_path": "External field (JSONPath)",
+      "add": "Add 1:1 mapping",
+      "unmapped_pim": "Unmapped PIM attributes · {{count}}",
+      "all_pim_mapped": "All attributes mapped ✓",
+      "unmapped_remote": "Unmapped external fields · {{count}}",
+      "all_remote_mapped": "None — all fields used"
     }
   },
   "api_profiles": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1892,6 +1892,28 @@
         "saving": "Zapisywanie…",
         "saved": "Pola zapisane"
       }
+    },
+    "mapping": {
+      "title": "Mapowanie pól",
+      "subtitle": "Połącz atrybuty PIM z polami zewnętrznego API (mapowanie 1:1).",
+      "back": "Wstecz",
+      "warnings": "{{count}} ostrzeżeń typów",
+      "coverage": "Pokrycie mapowania",
+      "match_key": "match key",
+      "direction": "Kierunek synchronizacji",
+      "key": "key",
+      "type_ok": "Typy zgodne",
+      "transform_hint": "Silnik transformacji — w planie (MVP = mapowanie 1:1)",
+      "transform": "transformacja",
+      "remove": "usuń",
+      "pim_placeholder": "sku, name, status, kod atrybutu…",
+      "pim_target": "Atrybut PIM",
+      "remote_path": "Pole zewnętrzne (JSONPath)",
+      "add": "Dodaj mapowanie 1:1",
+      "unmapped_pim": "Niezmapowane atrybuty PIM · {{count}}",
+      "all_pim_mapped": "Wszystkie atrybuty zmapowane ✓",
+      "unmapped_remote": "Niezmapowane pola zewnętrzne · {{count}}",
+      "all_remote_mapped": "Brak — wszystkie pola wykorzystane"
     }
   },
   "api_profiles": {


### PR DESCRIPTION
## Cel

APIC-P2-09 — mapper dwukolumnowy PIM ↔ remote wg `api-mapping.jsx`. Ostatni ticket M2.

## Zakres (`features/api-configurator/consumer/mapping/`)

- **`MappingScreen`** (`/connections/{id}/mapping`): wiersze mapowań z FieldMapping CRUD (P2-08) — lewy panel PIM, środek `DirToggle` (inbound/both/outbound) + match-key toggle, prawy panel remote z `TypeCompat`; `CoverageBar` w nagłówku; per-wiersz **type warnings** z `POST /connections/{id}/mappings/validate` + baner błędów (brak matchKey dla inbound); inline „Dodaj mapowanie 1:1" (inputy pimTarget + JSONPath z `datalist` podpowiedziami); pule niezmapowanych (PIM + remote); **disabled „transformacja"** placeholder (deferred §7 hook).
- Konwersja `bidirectional` (UI DirToggle) ↔ `both` (API). i18n `api_configurator.mapping.*` (pl + en). Trasa pod `KonfiguratorApiLayout`.

## Decyzje / ograniczenia MVP

- Pula remote-fields z **pierwszego read endpointu** połączenia (typowy single-stream); multi-endpoint pooling dochodzi z detalem połączenia (P3-12).
- Cele PIM: kuratorowana lista pól systemowych (sku/name/status/…) + dowolny kod atrybutu wpisywany ręcznie (bez cross-BC lookupu Catalog w MVP).
- **Nie pixel-perfect** względem prototypu (free-text inputy zamiast pełnego selecta atrybutów PIM); funkcjonalnie kompletny mapper.

## Testy / bramki

- `tsc` ✅ · `biome check src e2e` (0 errors) ✅ · `vitest run` (17) ✅ · `vite build` ✅
- **Playwright** `1778-...spec.ts`: nawigacja → dodanie mapowania (mock CRUD, wiersz pojawia się) → toggle match key (badge) → **AxeBuilder** 0 violations. API mockowane (`page.route`, stateful).

## Smoke test

`ships functional mapper, end-to-end nieprzetestowane na żywym tenantcie` — CRUD/validate mockowane w E2E; backend ścieżki CI-zweryfikowane przez P2-08 ApiTestCase.

Refs #1778