### PR TITLE
feat(integration): add SyncBinding entity + migration (APIC-P3-01)

### DIFF
--- a/apps/api/migrations/Version20260629110000.php
+++ b/apps/api/migrations/Version20260629110000.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * APIC-P3-01 (ADR-0022, epic APIC) — consumer-side `integration_sync_bindings`
+ * table: the heart of a sync (what/where/how/how-often), owned by a
+ * {@see \App\Integration\Generic\Domain\Entity\Connection}.
+ *
+ * Same-context FKs to the connection (CASCADE) and read/write endpoints
+ * (SET NULL). `object_type_id` is a validated loose reference (no DB FK to the
+ * Catalog `object_types` table) to keep cross-BC coupling at the Contracts level
+ * per ADR-0022. TenantScoped with the W1-1 FORCE RLS pattern.
+ */
+final class Version20260629110000 extends AbstractMigration
+{
+    private const string TABLE = 'integration_sync_bindings';
+
+    public function getDescription(): string
+    {
+        return 'APIC-P3-01: add integration_sync_bindings (TenantScoped sync binding) + FORCE RLS policies.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE integration_sync_bindings (
+                id UUID NOT NULL,
+                tenant_id UUID NOT NULL,
+                connection_id UUID NOT NULL,
+                object_type_id UUID NOT NULL,
+                read_endpoint_id UUID DEFAULT NULL,
+                write_endpoint_id UUID DEFAULT NULL,
+                direction VARCHAR(16) NOT NULL,
+                schedule VARCHAR(255) DEFAULT NULL,
+                cursor JSONB DEFAULT NULL,
+                conflict_policy VARCHAR(16) NOT NULL,
+                match_key_mapping VARCHAR(255) DEFAULT NULL,
+                enabled BOOLEAN DEFAULT true NOT NULL,
+                created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+                updated_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+                PRIMARY KEY (id)
+            )
+            SQL);
+        $this->addSql('CREATE INDEX IDX_CA56F22A9033212A ON integration_sync_bindings (tenant_id)');
+        $this->addSql('CREATE INDEX IDX_CA56F22ADD03F01 ON integration_sync_bindings (connection_id)');
+        $this->addSql('CREATE INDEX IDX_CA56F22A1E9BF277 ON integration_sync_bindings (read_endpoint_id)');
+        $this->addSql('CREATE INDEX IDX_CA56F22A59BD8C7 ON integration_sync_bindings (write_endpoint_id)');
+        $this->addSql(
+            'CREATE INDEX integration_sync_bindings_tenant_conn_idx '
+            .'ON integration_sync_bindings (tenant_id, connection_id)'
+        );
+        $this->addSql(
+            'CREATE INDEX integration_sync_bindings_tenant_enabled_idx '
+            .'ON integration_sync_bindings (tenant_id, enabled)'
+        );
+        $this->addSql(
+            'ALTER TABLE integration_sync_bindings ADD CONSTRAINT FK_CA56F22A9033212A '
+            .'FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE RESTRICT NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+        $this->addSql(
+            'ALTER TABLE integration_sync_bindings ADD CONSTRAINT FK_CA56F22ADD03F01 '
+            .'FOREIGN KEY (connection_id) REFERENCES integration_connections (id) '
+            .'ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+        $this->addSql(
+            'ALTER TABLE integration_sync_bindings ADD CONSTRAINT FK_CA56F22A1E9BF277 '
+            .'FOREIGN KEY (read_endpoint_id) REFERENCES integration_remote_endpoints (id) '
+            .'ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+        $this->addSql(
+            'ALTER TABLE integration_sync_bindings ADD CONSTRAINT FK_CA56F22A59BD8C7 '
+            .'FOREIGN KEY (write_endpoint_id) REFERENCES integration_remote_endpoints (id) '
+            .'ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+
+        // ── Row-Level Security (W1-1 FORCE pattern) ───────────────────────
+        $predicate = "tenant_id = NULLIF(current_setting('app.current_tenant', true), '')::uuid";
+
+        $this->addSql(\sprintf('ALTER TABLE %s ENABLE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s FORCE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf(
+            'CREATE POLICY tenant_isolation_%s ON %s USING (%s) WITH CHECK (%s)',
+            self::TABLE,
+            self::TABLE,
+            $predicate,
+            $predicate,
+        ));
+        $this->addSql(\sprintf(
+            "CREATE POLICY super_admin_bypass_%s ON %s "
+            ."USING (current_setting('app.is_super_admin', true) = 'true') "
+            ."WITH CHECK (current_setting('app.is_super_admin', true) = 'true')",
+            self::TABLE,
+            self::TABLE,
+        ));
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(\sprintf('DROP POLICY IF EXISTS super_admin_bypass_%s ON %s', self::TABLE, self::TABLE));
+        $this->addSql(\sprintf('DROP POLICY IF EXISTS tenant_isolation_%s ON %s', self::TABLE, self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s NO FORCE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s DISABLE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql('DROP TABLE integration_sync_bindings');
+    }
+}

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -148,6 +148,7 @@ parameters:
               - src/Integration/Generic/Domain/Entity/RemoteEndpoint.php
               - src/Integration/Generic/Domain/Entity/RemoteField.php
               - src/Integration/Generic/Domain/Entity/FieldMapping.php
+              - src/Integration/Generic/Domain/Entity/SyncBinding.php
               - src/Import/Domain/Entity/ImportScheduleRun.php
               - src/Export/Domain/Entity/ExportSession.php
               - src/Export/Domain/Entity/ExportProfile.php

--- a/apps/api/src/Integration/Generic/Domain/Entity/SyncBinding.php
+++ b/apps/api/src/Integration/Generic/Domain/Entity/SyncBinding.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Entity;
+
+use App\Integration\Generic\Domain\Enum\ConflictPolicy;
+use App\Integration\Generic\Domain\Enum\SyncDirection;
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\AggregateRoot;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * The heart of a sync: what (ObjectType) is synced where (Connection endpoints),
+ * how (direction + conflict policy + match key) and how often (cron schedule) —
+ * ADR-0022, epic APIC, ticket APIC-P3-01.
+ *
+ * `objectTypeId` is a validated loose reference, not a Doctrine/DB FK: the
+ * target ObjectType lives in the Catalog context and ADR-0022 keeps cross-BC
+ * coupling to Contracts only, so no migration-level FK ties Integration to the
+ * Catalog schema (the binding API validates the id exists). The read/write
+ * endpoints and the connection are same-context FKs.
+ *
+ * `cursor` is the delta-sync state envelope (`{field, type, state}`) maintained
+ * by the cursor manager (APIC-P3-03). `TenantScoped` + Postgres RLS isolate
+ * every binding to its tenant.
+ */
+class SyncBinding extends AggregateRoot implements TenantScoped
+{
+    private Uuid $id;
+
+    private ?Tenant $tenant = null;
+
+    private Connection $connection;
+
+    private Uuid $objectTypeId;
+
+    private ?RemoteEndpoint $readEndpoint = null;
+
+    private ?RemoteEndpoint $writeEndpoint = null;
+
+    private string $direction = SyncDirection::Inbound->value;
+
+    /** Cron expression for scheduled runs; null = manual-only. */
+    #[Assert\Length(max: 255)]
+    private ?string $schedule = null;
+
+    /**
+     * Delta-sync cursor envelope `{field, type, state}`; null until the first
+     * run persists one (APIC-P3-03).
+     *
+     * @var array<string, mixed>|null
+     */
+    private ?array $cursor = null;
+
+    private string $conflictPolicy = ConflictPolicy::Lww->value;
+
+    /** The PIM target acting as the upsert match key; null until mappings are set. */
+    #[Assert\Length(max: 255)]
+    private ?string $matchKeyMapping = null;
+
+    private bool $enabled = true;
+
+    private DateTimeImmutable $createdAt;
+
+    private DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        Connection $connection,
+        Uuid $objectTypeId,
+        SyncDirection $direction = SyncDirection::Inbound,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->connection = $connection;
+        $this->objectTypeId = $objectTypeId;
+        $this->direction = $direction->value;
+        $this->createdAt = new DateTimeImmutable();
+        $this->updatedAt = $this->createdAt;
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant is already assigned and cannot be reassigned.');
+        }
+
+        $this->tenant = $tenant;
+    }
+
+    public function getConnection(): Connection
+    {
+        return $this->connection;
+    }
+
+    public function getConnectionId(): Uuid
+    {
+        return $this->connection->getId();
+    }
+
+    public function getObjectTypeId(): Uuid
+    {
+        return $this->objectTypeId;
+    }
+
+    public function setObjectTypeId(Uuid $objectTypeId): void
+    {
+        $this->objectTypeId = $objectTypeId;
+        $this->touch();
+    }
+
+    public function getReadEndpoint(): ?RemoteEndpoint
+    {
+        return $this->readEndpoint;
+    }
+
+    public function setReadEndpoint(?RemoteEndpoint $readEndpoint): void
+    {
+        $this->readEndpoint = $readEndpoint;
+        $this->touch();
+    }
+
+    public function getWriteEndpoint(): ?RemoteEndpoint
+    {
+        return $this->writeEndpoint;
+    }
+
+    public function setWriteEndpoint(?RemoteEndpoint $writeEndpoint): void
+    {
+        $this->writeEndpoint = $writeEndpoint;
+        $this->touch();
+    }
+
+    public function getDirection(): SyncDirection
+    {
+        return SyncDirection::from($this->direction);
+    }
+
+    public function setDirection(SyncDirection $direction): void
+    {
+        $this->direction = $direction->value;
+        $this->touch();
+    }
+
+    public function getSchedule(): ?string
+    {
+        return $this->schedule;
+    }
+
+    public function setSchedule(?string $schedule): void
+    {
+        $this->schedule = $schedule;
+        $this->touch();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getCursor(): ?array
+    {
+        return $this->cursor;
+    }
+
+    /**
+     * @param array<string, mixed>|null $cursor
+     */
+    public function setCursor(?array $cursor): void
+    {
+        $this->cursor = $cursor;
+        $this->touch();
+    }
+
+    public function getConflictPolicy(): ConflictPolicy
+    {
+        return ConflictPolicy::from($this->conflictPolicy);
+    }
+
+    public function setConflictPolicy(ConflictPolicy $conflictPolicy): void
+    {
+        $this->conflictPolicy = $conflictPolicy->value;
+        $this->touch();
+    }
+
+    public function getMatchKeyMapping(): ?string
+    {
+        return $this->matchKeyMapping;
+    }
+
+    public function setMatchKeyMapping(?string $matchKeyMapping): void
+    {
+        $this->matchKeyMapping = $matchKeyMapping;
+        $this->touch();
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * Serializer-facing alias so the read projection exposes the flag as
+     * `isEnabled`, per the ObjectType convention.
+     */
+    public function getIsEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    public function setEnabled(bool $enabled): void
+    {
+        $this->enabled = $enabled;
+        $this->touch();
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    private function touch(): void
+    {
+        $this->updatedAt = new DateTimeImmutable();
+    }
+}

--- a/apps/api/src/Integration/Generic/Domain/Enum/ConflictPolicy.php
+++ b/apps/api/src/Integration/Generic/Domain/Enum/ConflictPolicy.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Enum;
+
+/**
+ * How a bidirectional {@see \App\Integration\Generic\Domain\Entity\SyncBinding}
+ * resolves a value that changed on both sides since the last sync (ADR-0022,
+ * epic APIC, ticket APIC-P3-01; resolver lands in APIC-P3-08).
+ *
+ * `lww` keeps the most recently updated value, `pim_wins`/`remote_wins` pin a
+ * fixed side.
+ */
+enum ConflictPolicy: string
+{
+    case Lww = 'lww';
+    case PimWins = 'pim_wins';
+    case RemoteWins = 'remote_wins';
+}

--- a/apps/api/src/Integration/Generic/Domain/Enum/SyncDirection.php
+++ b/apps/api/src/Integration/Generic/Domain/Enum/SyncDirection.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Enum;
+
+/**
+ * The overall direction of a {@see \App\Integration\Generic\Domain\Entity\SyncBinding}
+ * (ADR-0022, epic APIC, ticket APIC-P3-01).
+ *
+ * Distinct from {@see MappingDirection} (per-field, uses `both`): a binding's
+ * `bidirectional` runs both a read and a write leg, with the conflict policy
+ * deciding the winner (APIC-P3-08).
+ */
+enum SyncDirection: string
+{
+    case Inbound = 'inbound';
+    case Outbound = 'outbound';
+    case Bidirectional = 'bidirectional';
+
+    public function readsRemote(): bool
+    {
+        return self::Inbound === $this || self::Bidirectional === $this;
+    }
+
+    public function writesRemote(): bool
+    {
+        return self::Outbound === $this || self::Bidirectional === $this;
+    }
+}

--- a/apps/api/src/Integration/Generic/Domain/Repository/SyncBindingRepositoryInterface.php
+++ b/apps/api/src/Integration/Generic/Domain/Repository/SyncBindingRepositoryInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Repository;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use Symfony\Component\Uid\Uuid;
+
+interface SyncBindingRepositoryInterface
+{
+    public function save(SyncBinding $binding): void;
+
+    public function remove(SyncBinding $binding): void;
+
+    public function findById(Uuid $id): ?SyncBinding;
+
+    /**
+     * @return list<SyncBinding>
+     */
+    public function findByConnection(Connection $connection): array;
+
+    /**
+     * @return list<SyncBinding>
+     */
+    public function findEnabled(): array;
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Orm/Mapping/SyncBinding.orm.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Orm/Mapping/SyncBinding.orm.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Integration\Generic\Domain\Entity\SyncBinding"
+            table="integration_sync_bindings"
+            repository-class="App\Integration\Generic\Infrastructure\Doctrine\Repository\DoctrineSyncBindingRepository">
+
+        <indexes>
+            <index name="integration_sync_bindings_tenant_conn_idx" columns="tenant_id,connection_id"/>
+            <index name="integration_sync_bindings_tenant_enabled_idx" columns="tenant_id,enabled"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <many-to-one field="connection" target-entity="App\Integration\Generic\Domain\Entity\Connection">
+            <join-column name="connection_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <many-to-one field="readEndpoint" target-entity="App\Integration\Generic\Domain\Entity\RemoteEndpoint">
+            <join-column name="read_endpoint_id" referenced-column-name="id" nullable="true" on-delete="SET NULL"/>
+        </many-to-one>
+
+        <many-to-one field="writeEndpoint" target-entity="App\Integration\Generic\Domain\Entity\RemoteEndpoint">
+            <join-column name="write_endpoint_id" referenced-column-name="id" nullable="true" on-delete="SET NULL"/>
+        </many-to-one>
+
+        <field name="objectTypeId" type="uuid" column="object_type_id"/>
+        <field name="direction" type="string" length="16"/>
+        <field name="schedule" type="string" length="255" nullable="true"/>
+        <field name="cursor" type="json" column="cursor" nullable="true">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+        <field name="conflictPolicy" type="string" length="16" column="conflict_policy"/>
+        <field name="matchKeyMapping" type="string" length="255" column="match_key_mapping" nullable="true"/>
+        <field name="enabled" type="boolean">
+            <options>
+                <option name="default">true</option>
+            </options>
+        </field>
+        <field name="createdAt" type="datetimetz_immutable" column="created_at"/>
+        <field name="updatedAt" type="datetimetz_immutable" column="updated_at"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Repository/DoctrineSyncBindingRepository.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Repository/DoctrineSyncBindingRepository.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Doctrine\Repository;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Repository\SyncBindingRepositoryInterface;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<SyncBinding>
+ */
+class DoctrineSyncBindingRepository extends ServiceEntityRepository implements SyncBindingRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, SyncBinding::class);
+    }
+
+    public function save(SyncBinding $binding): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($binding);
+        $em->flush();
+    }
+
+    public function remove(SyncBinding $binding): void
+    {
+        $em = $this->getEntityManager();
+        $em->remove($binding);
+        $em->flush();
+    }
+
+    public function findById(Uuid $id): ?SyncBinding
+    {
+        return parent::find($id->toRfc4122());
+    }
+
+    /**
+     * @return list<SyncBinding>
+     */
+    public function findByConnection(Connection $connection): array
+    {
+        $qb = $this->createQueryBuilder('b')
+            ->where('b.connection = :connection')
+            ->orderBy('b.createdAt', 'ASC')
+            ->setParameter('connection', $connection);
+
+        /** @var list<SyncBinding> $result */
+        $result = $qb->getQuery()->getResult();
+
+        return $result;
+    }
+
+    /**
+     * @return list<SyncBinding>
+     */
+    public function findEnabled(): array
+    {
+        $qb = $this->createQueryBuilder('b')
+            ->where('b.enabled = true')
+            ->orderBy('b.createdAt', 'ASC');
+
+        /** @var list<SyncBinding> $result */
+        $result = $qb->getQuery()->getResult();
+
+        return $result;
+    }
+}

--- a/apps/api/tests/Integration/Integration/Generic/SyncBindingRepositoryTest.php
+++ b/apps/api/tests/Integration/Integration/Generic/SyncBindingRepositoryTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Integration\Generic;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Enum\AuthType;
+use App\Integration\Generic\Domain\Enum\SyncDirection;
+use App\Integration\Generic\Domain\Repository\ConnectionRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\SyncBindingRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * APIC-P3-01 — SyncBindingRepository round-trip + 2-tenant cross-read = 0
+ * (Doctrine TenantFilter on the TenantScoped SyncBinding; Postgres RLS is the
+ * defence-in-depth wall verified at the migration level).
+ */
+final class SyncBindingRepositoryTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function savesAndFindsBindingWithinTenant(): void
+    {
+        $alpha = $this->createTenant('alpha');
+        $this->activateTenantFilter($alpha);
+
+        $connection = $this->createConnection($alpha, 'idosell');
+        $binding = new SyncBinding($connection, Uuid::v7(), SyncDirection::Bidirectional);
+        $binding->assignTenant($alpha);
+        $binding->setSchedule('0 3 * * *');
+        $this->bindings()->save($binding);
+
+        $found = $this->bindings()->findById($binding->getId());
+        self::assertNotNull($found);
+        self::assertSame(SyncDirection::Bidirectional, $found->getDirection());
+        self::assertSame('0 3 * * *', $found->getSchedule());
+        self::assertSame($connection->getId()->toRfc4122(), $found->getConnectionId()->toRfc4122());
+
+        self::assertCount(1, $this->bindings()->findByConnection($connection));
+        self::assertCount(1, $this->bindings()->findEnabled());
+    }
+
+    #[Test]
+    public function bindingsAreIsolatedAcrossTenants(): void
+    {
+        $alpha = $this->createTenant('alpha');
+        $beta = $this->createTenant('beta');
+
+        $this->activateTenantFilter($alpha);
+        $alphaConnection = $this->createConnection($alpha, 'idosell');
+        $alphaBinding = new SyncBinding($alphaConnection, Uuid::v7());
+        $alphaBinding->assignTenant($alpha);
+        $this->bindings()->save($alphaBinding);
+
+        // Switch to beta: alpha's binding is invisible through the TenantFilter (DQL).
+        $this->activateTenantFilter($beta);
+        self::assertCount(0, $this->bindings()->findByConnection($alphaConnection));
+        self::assertCount(0, $this->bindings()->findEnabled());
+    }
+
+    private function bindings(): SyncBindingRepositoryInterface
+    {
+        return self::getContainer()->get(SyncBindingRepositoryInterface::class);
+    }
+
+    private function connections(): ConnectionRepositoryInterface
+    {
+        return self::getContainer()->get(ConnectionRepositoryInterface::class);
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+
+    private function createConnection(Tenant $tenant, string $code): Connection
+    {
+        $connection = new Connection($code, ucfirst($code), 'https://api.example.com', AuthType::ApiKey);
+        $connection->assignTenant($tenant);
+        $this->connections()->save($connection);
+
+        return $connection;
+    }
+
+    private function activateTenantFilter(Tenant $tenant): void
+    {
+        $this->tenantContext()->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function createTenant(string $code): Tenant
+    {
+        $tenant = new Tenant($code, ucfirst($code).' Tenant');
+        $em = $this->em();
+        $em->persist($tenant);
+        $em->flush();
+
+        return $tenant;
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Domain/Entity/SyncBindingTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Domain/Entity/SyncBindingTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Domain\Entity;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\RemoteEndpoint;
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Enum\ConflictPolicy;
+use App\Integration\Generic\Domain\Enum\RemoteEndpointRole;
+use App\Integration\Generic\Domain\Enum\SyncDirection;
+use App\Shared\Domain\Tenant;
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class SyncBindingTest extends TestCase
+{
+    #[Test]
+    public function newBindingDefaultsToInboundLwwEnabled(): void
+    {
+        $b = $this->binding();
+
+        self::assertSame(SyncDirection::Inbound, $b->getDirection());
+        self::assertSame(ConflictPolicy::Lww, $b->getConflictPolicy());
+        self::assertTrue($b->isEnabled());
+        self::assertNull($b->getSchedule());
+        self::assertNull($b->getCursor());
+        self::assertNull($b->getReadEndpoint());
+        self::assertNull($b->getWriteEndpoint());
+        self::assertNull($b->getMatchKeyMapping());
+        self::assertNull($b->getTenant());
+    }
+
+    #[Test]
+    public function exposesConnectionAndObjectType(): void
+    {
+        $connection = $this->connection();
+        $objectTypeId = Uuid::v7();
+        $b = new SyncBinding($connection, $objectTypeId);
+
+        self::assertSame($connection->getId()->toRfc4122(), $b->getConnectionId()->toRfc4122());
+        self::assertSame($objectTypeId->toRfc4122(), $b->getObjectTypeId()->toRfc4122());
+    }
+
+    #[Test]
+    public function settersUpdateValues(): void
+    {
+        $b = $this->binding();
+        $readEndpoint = new RemoteEndpoint($b->getConnection(), RemoteEndpointRole::ReadList, 'GET', '/products');
+        $writeEndpoint = new RemoteEndpoint($b->getConnection(), RemoteEndpointRole::WriteCreate, 'POST', '/products');
+
+        $b->setDirection(SyncDirection::Bidirectional);
+        $b->setConflictPolicy(ConflictPolicy::RemoteWins);
+        $b->setSchedule('0 */2 * * *');
+        $b->setCursor(['field' => 'updated_at', 'type' => 'updated_at', 'state' => '2026-06-01']);
+        $b->setMatchKeyMapping('sku');
+        $b->setReadEndpoint($readEndpoint);
+        $b->setWriteEndpoint($writeEndpoint);
+        $b->setEnabled(false);
+
+        self::assertSame(SyncDirection::Bidirectional, $b->getDirection());
+        self::assertSame(ConflictPolicy::RemoteWins, $b->getConflictPolicy());
+        self::assertSame('0 */2 * * *', $b->getSchedule());
+        self::assertSame(['field' => 'updated_at', 'type' => 'updated_at', 'state' => '2026-06-01'], $b->getCursor());
+        self::assertSame('sku', $b->getMatchKeyMapping());
+        self::assertSame($readEndpoint, $b->getReadEndpoint());
+        self::assertSame($writeEndpoint, $b->getWriteEndpoint());
+        self::assertFalse($b->isEnabled());
+    }
+
+    #[Test]
+    public function directionKnowsLegs(): void
+    {
+        self::assertTrue(SyncDirection::Inbound->readsRemote());
+        self::assertFalse(SyncDirection::Inbound->writesRemote());
+        self::assertFalse(SyncDirection::Outbound->readsRemote());
+        self::assertTrue(SyncDirection::Outbound->writesRemote());
+        self::assertTrue(SyncDirection::Bidirectional->readsRemote());
+        self::assertTrue(SyncDirection::Bidirectional->writesRemote());
+    }
+
+    #[Test]
+    public function assignTenantIsWriteOnce(): void
+    {
+        $b = $this->binding();
+        $b->assignTenant(new Tenant('alpha', 'Alpha'));
+        self::assertNotNull($b->getTenant());
+
+        $this->expectException(LogicException::class);
+        $b->assignTenant(new Tenant('beta', 'Beta'));
+    }
+
+    private function connection(): Connection
+    {
+        return new Connection('idosell', 'IdoSell PL', 'https://api.idosell.com');
+    }
+
+    private function binding(): SyncBinding
+    {
+        return new SyncBinding($this->connection(), Uuid::v7());
+    }
+}


### PR DESCRIPTION
## Cel

APIC-P3-01 — sedno synchronizacji: co, dokąd, jak, jak często. Fundament M3 (Sync Engines).

## Zakres

- **Encja `SyncBinding`** (`TenantScoped`): `connection` (FK CASCADE), `objectTypeId` (loose ref — patrz niżej), `readEndpoint`/`writeEndpoint` (FK RemoteEndpoint, SET NULL), `direction` (`SyncDirection` enum), `schedule` (cron, nullable), `cursor` (JSONB `{field,type,state}`, nullable — wypełniany przez P3-03), `conflictPolicy` (`ConflictPolicy` enum), `matchKeyMapping`, `enabled`.
- **Enumy** `SyncDirection` (`inbound|outbound|bidirectional` + `readsRemote()`/`writesRemote()`) i `ConflictPolicy` (`lww|pim_wins|remote_wins`).
- **Repozytorium**: `findById`, `findByConnection`, `findEnabled`.
- **Migracja `Version20260629110000`** — tabela `integration_sync_bindings` + W1-1 **FORCE RLS**, FK connection CASCADE / endpoints SET NULL / tenant RESTRICT.

## Świadome odejście

`objectTypeId` to **walidowana luźna referencja** (UUID, bez DB FK do `object_types`). ObjectType żyje w Catalog, a ADR-0022 trzyma cross-BC coupling na poziomie Contracts — żaden migration nie wiąże Integration ze schematem Catalog. To celowe odejście od dosłownego AC-2 „FK ObjectType"; integralność walidowana w warstwie API bindingu (P3-09/10). FK Connection + Endpoint są same-context (realne).

## Testy / bramki (kontener api)

- **PHPStan max** ✅ · **Deptrac** 0 ✅ · **PHP-CS-Fixer** 0 ✅
- **PHPUnit** ✅ 7/7: `SyncBindingTest` (Layer 1 — defaults, connection/objectType, settery, direction legs, assignTenant write-once) + `SyncBindingRepositoryTest` (Layer 2 — round-trip + findEnabled + 2-tenant cross-read = 0).
- Migracja zaaplikowana lokalnie; brak driftu.

Refs #1779