### PR TITLE
feat(integration): add SyncRun + SyncRunLog entities + migration (APIC-P3-02)

### DIFF
--- a/apps/api/migrations/Version20260629120000.php
+++ b/apps/api/migrations/Version20260629120000.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * APIC-P3-02 (ADR-0022, epic APIC) — sync audit tables: `integration_sync_runs`
+ * (one execution of a {@see \App\Integration\Generic\Domain\Entity\SyncBinding},
+ * with counters + cursor before/after) and `integration_sync_run_logs`
+ * (per-record detail). Both TenantScoped with the W1-1 FORCE RLS pattern; the
+ * run FK to the binding and the log FK to the run cascade on delete.
+ */
+final class Version20260629120000 extends AbstractMigration
+{
+    private const string RUNS = 'integration_sync_runs';
+    private const string LOGS = 'integration_sync_run_logs';
+
+    public function getDescription(): string
+    {
+        return 'APIC-P3-02: add integration_sync_runs + integration_sync_run_logs (TenantScoped audit) + FORCE RLS.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE integration_sync_runs (
+                id UUID NOT NULL,
+                tenant_id UUID NOT NULL,
+                binding_id UUID NOT NULL,
+                direction VARCHAR(16) NOT NULL,
+                started_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+                finished_at TIMESTAMP(0) WITH TIME ZONE DEFAULT NULL,
+                status VARCHAR(16) NOT NULL,
+                created_count INT DEFAULT 0 NOT NULL,
+                updated_count INT DEFAULT 0 NOT NULL,
+                skipped_count INT DEFAULT 0 NOT NULL,
+                failed_count INT DEFAULT 0 NOT NULL,
+                cursor_before JSONB DEFAULT NULL,
+                cursor_after JSONB DEFAULT NULL,
+                PRIMARY KEY (id)
+            )
+            SQL);
+        $this->addSql('CREATE INDEX IDX_922106F39033212A ON integration_sync_runs (tenant_id)');
+        $this->addSql('CREATE INDEX IDX_922106F34AC8159D ON integration_sync_runs (binding_id)');
+        $this->addSql('CREATE INDEX integration_sync_runs_tenant_binding_idx ON integration_sync_runs (tenant_id, binding_id)');
+        $this->addSql('CREATE INDEX integration_sync_runs_tenant_started_idx ON integration_sync_runs (tenant_id, started_at)');
+        $this->addSql(
+            'ALTER TABLE integration_sync_runs ADD CONSTRAINT FK_922106F39033212A '
+            .'FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE RESTRICT NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+        $this->addSql(
+            'ALTER TABLE integration_sync_runs ADD CONSTRAINT FK_922106F34AC8159D '
+            .'FOREIGN KEY (binding_id) REFERENCES integration_sync_bindings (id) '
+            .'ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE integration_sync_run_logs (
+                id UUID NOT NULL,
+                tenant_id UUID NOT NULL,
+                run_id UUID NOT NULL,
+                match_key VARCHAR(255) DEFAULT NULL,
+                action VARCHAR(16) NOT NULL,
+                fields JSONB DEFAULT NULL,
+                message TEXT DEFAULT NULL,
+                created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+                PRIMARY KEY (id)
+            )
+            SQL);
+        $this->addSql('CREATE INDEX IDX_F67E26299033212A ON integration_sync_run_logs (tenant_id)');
+        $this->addSql('CREATE INDEX IDX_F67E262984E3FEC4 ON integration_sync_run_logs (run_id)');
+        $this->addSql('CREATE INDEX integration_sync_run_logs_tenant_run_idx ON integration_sync_run_logs (tenant_id, run_id)');
+        $this->addSql(
+            'ALTER TABLE integration_sync_run_logs ADD CONSTRAINT FK_F67E26299033212A '
+            .'FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE RESTRICT NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+        $this->addSql(
+            'ALTER TABLE integration_sync_run_logs ADD CONSTRAINT FK_F67E262984E3FEC4 '
+            .'FOREIGN KEY (run_id) REFERENCES integration_sync_runs (id) '
+            .'ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+
+        foreach ([self::RUNS, self::LOGS] as $table) {
+            $this->enableRls($table);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach ([self::LOGS, self::RUNS] as $table) {
+            $this->addSql(\sprintf('DROP POLICY IF EXISTS super_admin_bypass_%s ON %s', $table, $table));
+            $this->addSql(\sprintf('DROP POLICY IF EXISTS tenant_isolation_%s ON %s', $table, $table));
+            $this->addSql(\sprintf('ALTER TABLE %s NO FORCE ROW LEVEL SECURITY', $table));
+            $this->addSql(\sprintf('ALTER TABLE %s DISABLE ROW LEVEL SECURITY', $table));
+        }
+        $this->addSql('DROP TABLE integration_sync_run_logs');
+        $this->addSql('DROP TABLE integration_sync_runs');
+    }
+
+    private function enableRls(string $table): void
+    {
+        $predicate = "tenant_id = NULLIF(current_setting('app.current_tenant', true), '')::uuid";
+
+        $this->addSql(\sprintf('ALTER TABLE %s ENABLE ROW LEVEL SECURITY', $table));
+        $this->addSql(\sprintf('ALTER TABLE %s FORCE ROW LEVEL SECURITY', $table));
+        $this->addSql(\sprintf(
+            'CREATE POLICY tenant_isolation_%s ON %s USING (%s) WITH CHECK (%s)',
+            $table,
+            $table,
+            $predicate,
+            $predicate,
+        ));
+        $this->addSql(\sprintf(
+            "CREATE POLICY super_admin_bypass_%s ON %s "
+            ."USING (current_setting('app.is_super_admin', true) = 'true') "
+            ."WITH CHECK (current_setting('app.is_super_admin', true) = 'true')",
+            $table,
+            $table,
+        ));
+    }
+}

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -149,6 +149,8 @@ parameters:
               - src/Integration/Generic/Domain/Entity/RemoteField.php
               - src/Integration/Generic/Domain/Entity/FieldMapping.php
               - src/Integration/Generic/Domain/Entity/SyncBinding.php
+              - src/Integration/Generic/Domain/Entity/SyncRun.php
+              - src/Integration/Generic/Domain/Entity/SyncRunLog.php
               - src/Import/Domain/Entity/ImportScheduleRun.php
               - src/Export/Domain/Entity/ExportSession.php
               - src/Export/Domain/Entity/ExportProfile.php

--- a/apps/api/src/Integration/Generic/Domain/Entity/SyncRun.php
+++ b/apps/api/src/Integration/Generic/Domain/Entity/SyncRun.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Entity;
+
+use App\Integration\Generic\Domain\Enum\SyncDirection;
+use App\Integration\Generic\Domain\Enum\SyncRunStatus;
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\AggregateRoot;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * The audit record of one sync execution of a {@see SyncBinding} (ADR-0022,
+ * epic APIC, ticket APIC-P3-02; mirrors `ImportScheduleRun` + `sync_job_logs`).
+ *
+ * Captures the direction, lifecycle status, per-outcome counters and the cursor
+ * before/after the run (so a delta sync is auditable and resumable). Per-record
+ * detail lives in {@see SyncRunLog}. `TenantScoped` + Postgres RLS isolate every
+ * run to its tenant.
+ */
+class SyncRun extends AggregateRoot implements TenantScoped
+{
+    private Uuid $id;
+
+    private ?Tenant $tenant = null;
+
+    private SyncBinding $binding;
+
+    private string $direction;
+
+    private DateTimeImmutable $startedAt;
+
+    private ?DateTimeImmutable $finishedAt = null;
+
+    private string $status = SyncRunStatus::Running->value;
+
+    private int $createdCount = 0;
+
+    private int $updatedCount = 0;
+
+    private int $skippedCount = 0;
+
+    private int $failedCount = 0;
+
+    /** @var array<string, mixed>|null */
+    private ?array $cursorBefore = null;
+
+    /** @var array<string, mixed>|null */
+    private ?array $cursorAfter = null;
+
+    public function __construct(
+        SyncBinding $binding,
+        SyncDirection $direction,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->binding = $binding;
+        $this->direction = $direction->value;
+        $this->startedAt = new DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant is already assigned and cannot be reassigned.');
+        }
+
+        $this->tenant = $tenant;
+    }
+
+    public function getBinding(): SyncBinding
+    {
+        return $this->binding;
+    }
+
+    public function getBindingId(): Uuid
+    {
+        return $this->binding->getId();
+    }
+
+    public function getDirection(): SyncDirection
+    {
+        return SyncDirection::from($this->direction);
+    }
+
+    public function getStartedAt(): DateTimeImmutable
+    {
+        return $this->startedAt;
+    }
+
+    public function getFinishedAt(): ?DateTimeImmutable
+    {
+        return $this->finishedAt;
+    }
+
+    public function getStatus(): SyncRunStatus
+    {
+        return SyncRunStatus::from($this->status);
+    }
+
+    public function getCreatedCount(): int
+    {
+        return $this->createdCount;
+    }
+
+    public function getUpdatedCount(): int
+    {
+        return $this->updatedCount;
+    }
+
+    public function getSkippedCount(): int
+    {
+        return $this->skippedCount;
+    }
+
+    public function getFailedCount(): int
+    {
+        return $this->failedCount;
+    }
+
+    public function recordCreated(): void
+    {
+        ++$this->createdCount;
+    }
+
+    public function recordUpdated(): void
+    {
+        ++$this->updatedCount;
+    }
+
+    public function recordSkipped(): void
+    {
+        ++$this->skippedCount;
+    }
+
+    public function recordFailed(): void
+    {
+        ++$this->failedCount;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getCursorBefore(): ?array
+    {
+        return $this->cursorBefore;
+    }
+
+    /**
+     * @param array<string, mixed>|null $cursorBefore
+     */
+    public function setCursorBefore(?array $cursorBefore): void
+    {
+        $this->cursorBefore = $cursorBefore;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getCursorAfter(): ?array
+    {
+        return $this->cursorAfter;
+    }
+
+    /**
+     * Stamps the terminal status, finish time and final cursor. The status is
+     * derived from the failed counter unless overridden.
+     *
+     * @param array<string, mixed>|null $cursorAfter
+     */
+    public function markFinished(?SyncRunStatus $status = null, ?array $cursorAfter = null): void
+    {
+        $this->finishedAt = new DateTimeImmutable();
+        $this->cursorAfter = $cursorAfter;
+        $this->status = ($status ?? $this->deriveStatus())->value;
+    }
+
+    private function deriveStatus(): SyncRunStatus
+    {
+        if (0 === $this->failedCount) {
+            return SyncRunStatus::Success;
+        }
+
+        return ($this->createdCount + $this->updatedCount) > 0
+            ? SyncRunStatus::Partial
+            : SyncRunStatus::Failed;
+    }
+}

--- a/apps/api/src/Integration/Generic/Domain/Entity/SyncRunLog.php
+++ b/apps/api/src/Integration/Generic/Domain/Entity/SyncRunLog.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Entity;
+
+use App\Integration\Generic\Domain\Enum\SyncRecordAction;
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\AggregateRoot;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Per-record detail of a {@see SyncRun} (ADR-0022, epic APIC, ticket APIC-P3-02):
+ * the match key that identified the row, the action taken, the fields touched
+ * and an optional message (the error text for a failed record).
+ *
+ * `TenantScoped` + Postgres RLS isolate every log line to its tenant; the FK to
+ * SyncRun cascades on delete.
+ */
+class SyncRunLog extends AggregateRoot implements TenantScoped
+{
+    private Uuid $id;
+
+    private ?Tenant $tenant = null;
+
+    private SyncRun $run;
+
+    #[Assert\Length(max: 255)]
+    private ?string $matchKey = null;
+
+    private string $action;
+
+    /**
+     * The fields written/compared for this record; null for skips/failures.
+     *
+     * @var array<string, mixed>|null
+     */
+    private ?array $fields = null;
+
+    private ?string $message = null;
+
+    private DateTimeImmutable $createdAt;
+
+    public function __construct(
+        SyncRun $run,
+        SyncRecordAction $action,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->run = $run;
+        $this->action = $action->value;
+        $this->createdAt = new DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant is already assigned and cannot be reassigned.');
+        }
+
+        $this->tenant = $tenant;
+    }
+
+    public function getRun(): SyncRun
+    {
+        return $this->run;
+    }
+
+    public function getRunId(): Uuid
+    {
+        return $this->run->getId();
+    }
+
+    public function getMatchKey(): ?string
+    {
+        return $this->matchKey;
+    }
+
+    public function setMatchKey(?string $matchKey): void
+    {
+        $this->matchKey = $matchKey;
+    }
+
+    public function getAction(): SyncRecordAction
+    {
+        return SyncRecordAction::from($this->action);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getFields(): ?array
+    {
+        return $this->fields;
+    }
+
+    /**
+     * @param array<string, mixed>|null $fields
+     */
+    public function setFields(?array $fields): void
+    {
+        $this->fields = $fields;
+    }
+
+    public function getMessage(): ?string
+    {
+        return $this->message;
+    }
+
+    public function setMessage(?string $message): void
+    {
+        $this->message = $message;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/apps/api/src/Integration/Generic/Domain/Enum/SyncRecordAction.php
+++ b/apps/api/src/Integration/Generic/Domain/Enum/SyncRecordAction.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Enum;
+
+/**
+ * The outcome recorded for a single record in a {@see \App\Integration\Generic\Domain\Entity\SyncRunLog}
+ * (ADR-0022, epic APIC, ticket APIC-P3-02). `failed` is the per-record error
+ * state; the others are successful upsert/skip outcomes.
+ */
+enum SyncRecordAction: string
+{
+    case Created = 'created';
+    case Updated = 'updated';
+    case Skipped = 'skipped';
+    case Failed = 'failed';
+}

--- a/apps/api/src/Integration/Generic/Domain/Enum/SyncRunStatus.php
+++ b/apps/api/src/Integration/Generic/Domain/Enum/SyncRunStatus.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Enum;
+
+/**
+ * Lifecycle status of a {@see \App\Integration\Generic\Domain\Entity\SyncRun}
+ * (ADR-0022, epic APIC, ticket APIC-P3-02; mirrors the `ScheduleRunStatus`
+ * pattern).
+ */
+enum SyncRunStatus: string
+{
+    case Running = 'running';
+    case Success = 'success';
+    case Partial = 'partial';
+    case Failed = 'failed';
+
+    public function isTerminal(): bool
+    {
+        return self::Running !== $this;
+    }
+}

--- a/apps/api/src/Integration/Generic/Domain/Repository/SyncRunLogRepositoryInterface.php
+++ b/apps/api/src/Integration/Generic/Domain/Repository/SyncRunLogRepositoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Repository;
+
+use App\Integration\Generic\Domain\Entity\SyncRun;
+use App\Integration\Generic\Domain\Entity\SyncRunLog;
+use Symfony\Component\Uid\Uuid;
+
+interface SyncRunLogRepositoryInterface
+{
+    public function save(SyncRunLog $log): void;
+
+    public function findById(Uuid $id): ?SyncRunLog;
+
+    /**
+     * @return list<SyncRunLog>
+     */
+    public function findByRun(SyncRun $run): array;
+}

--- a/apps/api/src/Integration/Generic/Domain/Repository/SyncRunRepositoryInterface.php
+++ b/apps/api/src/Integration/Generic/Domain/Repository/SyncRunRepositoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Repository;
+
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Entity\SyncRun;
+use Symfony\Component\Uid\Uuid;
+
+interface SyncRunRepositoryInterface
+{
+    public function save(SyncRun $run): void;
+
+    public function findById(Uuid $id): ?SyncRun;
+
+    /**
+     * @return list<SyncRun>
+     */
+    public function findByBinding(SyncBinding $binding): array;
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Orm/Mapping/SyncRun.orm.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Orm/Mapping/SyncRun.orm.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Integration\Generic\Domain\Entity\SyncRun"
+            table="integration_sync_runs"
+            repository-class="App\Integration\Generic\Infrastructure\Doctrine\Repository\DoctrineSyncRunRepository">
+
+        <indexes>
+            <index name="integration_sync_runs_tenant_binding_idx" columns="tenant_id,binding_id"/>
+            <index name="integration_sync_runs_tenant_started_idx" columns="tenant_id,started_at"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <many-to-one field="binding" target-entity="App\Integration\Generic\Domain\Entity\SyncBinding">
+            <join-column name="binding_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="direction" type="string" length="16"/>
+        <field name="startedAt" type="datetimetz_immutable" column="started_at"/>
+        <field name="finishedAt" type="datetimetz_immutable" column="finished_at" nullable="true"/>
+        <field name="status" type="string" length="16"/>
+        <field name="createdCount" type="integer" column="created_count">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+        <field name="updatedCount" type="integer" column="updated_count">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+        <field name="skippedCount" type="integer" column="skipped_count">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+        <field name="failedCount" type="integer" column="failed_count">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+        <field name="cursorBefore" type="json" column="cursor_before" nullable="true">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+        <field name="cursorAfter" type="json" column="cursor_after" nullable="true">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Orm/Mapping/SyncRunLog.orm.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Orm/Mapping/SyncRunLog.orm.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Integration\Generic\Domain\Entity\SyncRunLog"
+            table="integration_sync_run_logs"
+            repository-class="App\Integration\Generic\Infrastructure\Doctrine\Repository\DoctrineSyncRunLogRepository">
+
+        <indexes>
+            <index name="integration_sync_run_logs_tenant_run_idx" columns="tenant_id,run_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <many-to-one field="run" target-entity="App\Integration\Generic\Domain\Entity\SyncRun">
+            <join-column name="run_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="matchKey" type="string" length="255" column="match_key" nullable="true"/>
+        <field name="action" type="string" length="16"/>
+        <field name="fields" type="json" column="fields" nullable="true">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+        <field name="message" type="text" nullable="true"/>
+        <field name="createdAt" type="datetimetz_immutable" column="created_at"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Repository/DoctrineSyncRunLogRepository.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Repository/DoctrineSyncRunLogRepository.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Doctrine\Repository;
+
+use App\Integration\Generic\Domain\Entity\SyncRun;
+use App\Integration\Generic\Domain\Entity\SyncRunLog;
+use App\Integration\Generic\Domain\Repository\SyncRunLogRepositoryInterface;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<SyncRunLog>
+ */
+class DoctrineSyncRunLogRepository extends ServiceEntityRepository implements SyncRunLogRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, SyncRunLog::class);
+    }
+
+    public function save(SyncRunLog $log): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($log);
+        $em->flush();
+    }
+
+    public function findById(Uuid $id): ?SyncRunLog
+    {
+        return parent::find($id->toRfc4122());
+    }
+
+    /**
+     * @return list<SyncRunLog>
+     */
+    public function findByRun(SyncRun $run): array
+    {
+        $qb = $this->createQueryBuilder('l')
+            ->where('l.run = :run')
+            ->orderBy('l.createdAt', 'ASC')
+            ->setParameter('run', $run);
+
+        /** @var list<SyncRunLog> $result */
+        $result = $qb->getQuery()->getResult();
+
+        return $result;
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Repository/DoctrineSyncRunRepository.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Repository/DoctrineSyncRunRepository.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Doctrine\Repository;
+
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Entity\SyncRun;
+use App\Integration\Generic\Domain\Repository\SyncRunRepositoryInterface;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<SyncRun>
+ */
+class DoctrineSyncRunRepository extends ServiceEntityRepository implements SyncRunRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, SyncRun::class);
+    }
+
+    public function save(SyncRun $run): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($run);
+        $em->flush();
+    }
+
+    public function findById(Uuid $id): ?SyncRun
+    {
+        return parent::find($id->toRfc4122());
+    }
+
+    /**
+     * @return list<SyncRun>
+     */
+    public function findByBinding(SyncBinding $binding): array
+    {
+        $qb = $this->createQueryBuilder('r')
+            ->where('r.binding = :binding')
+            ->orderBy('r.startedAt', 'DESC')
+            ->setParameter('binding', $binding);
+
+        /** @var list<SyncRun> $result */
+        $result = $qb->getQuery()->getResult();
+
+        return $result;
+    }
+}

--- a/apps/api/tests/Integration/Integration/Generic/SyncRunRepositoryTest.php
+++ b/apps/api/tests/Integration/Integration/Generic/SyncRunRepositoryTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Integration\Generic;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Entity\SyncRun;
+use App\Integration\Generic\Domain\Entity\SyncRunLog;
+use App\Integration\Generic\Domain\Enum\AuthType;
+use App\Integration\Generic\Domain\Enum\SyncDirection;
+use App\Integration\Generic\Domain\Enum\SyncRecordAction;
+use App\Integration\Generic\Domain\Repository\ConnectionRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\SyncBindingRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\SyncRunLogRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\SyncRunRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * APIC-P3-02 — SyncRun + SyncRunLog round-trip (counters, cursor, per-record
+ * log) + 2-tenant cross-read = 0 (Doctrine TenantFilter; Postgres RLS verified
+ * at the migration level).
+ */
+final class SyncRunRepositoryTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function persistsRunWithCountersAndPerRecordLog(): void
+    {
+        $alpha = $this->createTenant('alpha');
+        $this->activateTenantFilter($alpha);
+        $binding = $this->createBinding($alpha);
+
+        $run = new SyncRun($binding, SyncDirection::Inbound);
+        $run->assignTenant($alpha);
+        $run->setCursorBefore(['state' => '2026-06-01']);
+        $run->recordCreated();
+        $run->recordFailed();
+        $run->markFinished(null, ['state' => '2026-06-02']);
+        $this->runs()->save($run);
+
+        $log = new SyncRunLog($run, SyncRecordAction::Created);
+        $log->assignTenant($alpha);
+        $log->setMatchKey('A-1');
+        $log->setFields(['sku' => 'A-1', 'name' => 'Widget']);
+        $this->logs()->save($log);
+
+        $foundRun = $this->runs()->findById($run->getId());
+        self::assertNotNull($foundRun);
+        self::assertSame(1, $foundRun->getCreatedCount());
+        self::assertSame(1, $foundRun->getFailedCount());
+        self::assertSame(['state' => '2026-06-01'], $foundRun->getCursorBefore());
+        self::assertSame(['state' => '2026-06-02'], $foundRun->getCursorAfter());
+        self::assertCount(1, $this->runs()->findByBinding($binding));
+
+        $logs = $this->logs()->findByRun($run);
+        self::assertCount(1, $logs);
+        self::assertSame('A-1', $logs[0]->getMatchKey());
+        self::assertSame(SyncRecordAction::Created, $logs[0]->getAction());
+        self::assertSame(['sku' => 'A-1', 'name' => 'Widget'], $logs[0]->getFields());
+    }
+
+    #[Test]
+    public function runsAreIsolatedAcrossTenants(): void
+    {
+        $alpha = $this->createTenant('alpha');
+        $beta = $this->createTenant('beta');
+
+        $this->activateTenantFilter($alpha);
+        $binding = $this->createBinding($alpha);
+        $run = new SyncRun($binding, SyncDirection::Inbound);
+        $run->assignTenant($alpha);
+        $this->runs()->save($run);
+
+        $this->activateTenantFilter($beta);
+        self::assertCount(0, $this->runs()->findByBinding($binding));
+    }
+
+    private function runs(): SyncRunRepositoryInterface
+    {
+        return self::getContainer()->get(SyncRunRepositoryInterface::class);
+    }
+
+    private function logs(): SyncRunLogRepositoryInterface
+    {
+        return self::getContainer()->get(SyncRunLogRepositoryInterface::class);
+    }
+
+    private function bindings(): SyncBindingRepositoryInterface
+    {
+        return self::getContainer()->get(SyncBindingRepositoryInterface::class);
+    }
+
+    private function connections(): ConnectionRepositoryInterface
+    {
+        return self::getContainer()->get(ConnectionRepositoryInterface::class);
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+
+    private function createBinding(Tenant $tenant): SyncBinding
+    {
+        $connection = new Connection('idosell', 'IdoSell', 'https://api.example.com', AuthType::ApiKey);
+        $connection->assignTenant($tenant);
+        $this->connections()->save($connection);
+
+        $binding = new SyncBinding($connection, Uuid::v7());
+        $binding->assignTenant($tenant);
+        $this->bindings()->save($binding);
+
+        return $binding;
+    }
+
+    private function activateTenantFilter(Tenant $tenant): void
+    {
+        $this->tenantContext()->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function createTenant(string $code): Tenant
+    {
+        $tenant = new Tenant($code, ucfirst($code).' Tenant');
+        $em = $this->em();
+        $em->persist($tenant);
+        $em->flush();
+
+        return $tenant;
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Domain/Entity/SyncRunTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Domain/Entity/SyncRunTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Domain\Entity;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Entity\SyncRun;
+use App\Integration\Generic\Domain\Enum\SyncDirection;
+use App\Integration\Generic\Domain\Enum\SyncRunStatus;
+use App\Shared\Domain\Tenant;
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class SyncRunTest extends TestCase
+{
+    #[Test]
+    public function newRunStartsRunningWithZeroCounts(): void
+    {
+        $run = $this->makeRun();
+
+        self::assertSame(SyncRunStatus::Running, $run->getStatus());
+        self::assertSame(SyncDirection::Inbound, $run->getDirection());
+        self::assertNull($run->getFinishedAt());
+        self::assertSame(0, $run->getCreatedCount());
+        self::assertSame(0, $run->getUpdatedCount());
+        self::assertSame(0, $run->getSkippedCount());
+        self::assertSame(0, $run->getFailedCount());
+    }
+
+    #[Test]
+    public function countersIncrement(): void
+    {
+        $run = $this->makeRun();
+        $run->recordCreated();
+        $run->recordCreated();
+        $run->recordUpdated();
+        $run->recordSkipped();
+        $run->recordFailed();
+
+        self::assertSame(2, $run->getCreatedCount());
+        self::assertSame(1, $run->getUpdatedCount());
+        self::assertSame(1, $run->getSkippedCount());
+        self::assertSame(1, $run->getFailedCount());
+    }
+
+    #[Test]
+    public function finishDerivesSuccessWhenNoFailures(): void
+    {
+        $run = $this->makeRun();
+        $run->recordCreated();
+        $run->markFinished(null, ['state' => '2026-06-02']);
+
+        self::assertSame(SyncRunStatus::Success, $run->getStatus());
+        self::assertNotNull($run->getFinishedAt());
+        self::assertSame(['state' => '2026-06-02'], $run->getCursorAfter());
+    }
+
+    #[Test]
+    public function finishDerivesPartialWhenSomeFailed(): void
+    {
+        $run = $this->makeRun();
+        $run->recordCreated();
+        $run->recordFailed();
+        $run->markFinished();
+
+        self::assertSame(SyncRunStatus::Partial, $run->getStatus());
+    }
+
+    #[Test]
+    public function finishDerivesFailedWhenNothingSucceeded(): void
+    {
+        $run = $this->makeRun();
+        $run->recordFailed();
+        $run->markFinished();
+
+        self::assertSame(SyncRunStatus::Failed, $run->getStatus());
+    }
+
+    #[Test]
+    public function cursorBeforeIsStored(): void
+    {
+        $run = $this->makeRun();
+        $run->setCursorBefore(['state' => '2026-06-01']);
+
+        self::assertSame(['state' => '2026-06-01'], $run->getCursorBefore());
+    }
+
+    #[Test]
+    public function assignTenantIsWriteOnce(): void
+    {
+        $run = $this->makeRun();
+        $run->assignTenant(new Tenant('alpha', 'Alpha'));
+        self::assertNotNull($run->getTenant());
+
+        $this->expectException(LogicException::class);
+        $run->assignTenant(new Tenant('beta', 'Beta'));
+    }
+
+    private function makeRun(): SyncRun
+    {
+        $connection = new Connection('idosell', 'IdoSell PL', 'https://api.idosell.com');
+        $binding = new SyncBinding($connection, Uuid::v7());
+
+        return new SyncRun($binding, SyncDirection::Inbound);
+    }
+}


### PR DESCRIPTION
## Cel

APIC-P3-02 — audyt runów synchronizacji (wzorzec `ImportScheduleRun` + `sync_job_logs`). Zasila monitor (P4-01/02) i scheduler (P3-09).

## Zakres

- **Encja `SyncRun`** (`TenantScoped`): `binding` (FK CASCADE), `direction`, `startedAt`/`finishedAt`, `status` (`SyncRunStatus`), liczniki created/updated/skipped/failed, `cursorBefore`/`cursorAfter` (JSONB). `markFinished()` derywuje success/partial/failed z licznika błędów.
- **Encja `SyncRunLog`** (`TenantScoped`): `run` (FK CASCADE), `matchKey`, `action` (`SyncRecordAction` — created/updated/skipped/failed), `fields` (JSONB), `message`.
- **Enumy** `SyncRunStatus` (running/success/partial/failed) + `SyncRecordAction`.
- **Repozytoria**: `SyncRun` (findById, findByBinding), `SyncRunLog` (findById, findByRun).
- **Migracja `Version20260629120000`** — obie tabele + W1-1 **FORCE RLS** (pętla po tabelach), FK binding/run CASCADE, tenant RESTRICT.

## Testy / bramki (kontener api)

- **PHPStan max** ✅ · **Deptrac** 0 ✅ · **PHP-CS-Fixer** 0 ✅
- **PHPUnit** ✅ 9/9: `SyncRunTest` (Layer 1 — counters, markFinished success/partial/failed derivation, cursor before/after, assignTenant) + `SyncRunRepositoryTest` (Layer 2 — run+log round-trip z licznikami/kursorem/per-record log + 2-tenant cross-read = 0).
- Migracja zaaplikowana lokalnie; brak driftu.

Refs #1780