### PR TITLE
feat(integration): cursor manager with monotonic crash-safe persistence (APIC-P3-03)

### DIFF
--- a/apps/api/src/Integration/Generic/Application/Sync/CursorManager.php
+++ b/apps/api/src/Integration/Generic/Application/Sync/CursorManager.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application\Sync;
+
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Enum\CursorType;
+use App\Integration\Generic\Domain\Repository\SyncBindingRepositoryInterface;
+use DateTimeImmutable;
+use Exception;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Moves a SyncBinding's delta-sync cursor forward, atomically and monotonically
+ * (ADR-0022, epic APIC, ticket APIC-P3-03).
+ *
+ * The inbound handler advances the cursor once per processed batch, so the
+ * persisted value always trails fully-committed work: a crash mid-batch leaves
+ * the cursor at the last batch and the re-run re-pulls only that window (the
+ * upsert is idempotent — no duplicates). `advance()` rejects a value that would
+ * move the cursor backward (a paging glitch or out-of-order page), guarding
+ * against skipped or re-processed records; an `opaque` token is accepted as-is
+ * since the remote owns its ordering.
+ */
+final readonly class CursorManager
+{
+    public function __construct(
+        private SyncBindingRepositoryInterface $bindings,
+        private LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    public function current(SyncBinding $binding): ?CursorState
+    {
+        return CursorState::fromArray($binding->getCursor());
+    }
+
+    /**
+     * Advances the binding's cursor to `$newValue` and persists it atomically.
+     * Returns false (and persists nothing) when the binding has no cursor
+     * configured or the new value is not strictly forward.
+     */
+    public function advance(SyncBinding $binding, string $newValue): bool
+    {
+        $state = $this->current($binding);
+        if (null === $state) {
+            return false;
+        }
+
+        if (!self::isForward($state->type, $state->value, $newValue)) {
+            $this->logger->warning('Rejected non-monotonic cursor advance.', [
+                'binding' => $binding->getId()->toRfc4122(),
+                'type' => $state->type->value,
+                'from' => $state->value,
+                'to' => $newValue,
+            ]);
+
+            return false;
+        }
+
+        $binding->setCursor($state->withValue($newValue)->toArray());
+        $this->bindings->save($binding);
+
+        return true;
+    }
+
+    /**
+     * Whether `$new` moves the cursor forward (or is the first value). Opaque
+     * tokens are always accepted; comparable types require `new >= current`.
+     */
+    private static function isForward(CursorType $type, ?string $current, string $new): bool
+    {
+        if (null === $current || '' === $current || !$type->isComparable()) {
+            return true;
+        }
+
+        return match ($type) {
+            CursorType::IncrementalId => (int) $new >= (int) $current,
+            CursorType::UpdatedAt => self::timestampForward($current, $new),
+            CursorType::Opaque => true,
+        };
+    }
+
+    /**
+     * An unparseable new timestamp is rejected (cannot validate forward
+     * progress); an unparseable stored value is treated as a reset (accept).
+     */
+    private static function timestampForward(string $current, string $new): bool
+    {
+        $newTs = self::tryTimestamp($new);
+        if (null === $newTs) {
+            return false;
+        }
+
+        $currentTs = self::tryTimestamp($current);
+
+        return null === $currentTs || $newTs >= $currentTs;
+    }
+
+    private static function tryTimestamp(string $value): ?int
+    {
+        try {
+            return new DateTimeImmutable($value)->getTimestamp();
+        } catch (Exception) {
+            return null;
+        }
+    }
+}

--- a/apps/api/src/Integration/Generic/Application/Sync/CursorState.php
+++ b/apps/api/src/Integration/Generic/Application/Sync/CursorState.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application\Sync;
+
+use App\Integration\Generic\Domain\Enum\CursorType;
+
+/**
+ * The parsed delta-sync cursor of a SyncBinding (ADR-0022, epic APIC, ticket
+ * APIC-P3-03): the source `field`, its {@see CursorType} and the last persisted
+ * `value` (null until the first run advances it). Serialises back to the
+ * binding's `{field, type, state}` JSONB envelope.
+ */
+final readonly class CursorState
+{
+    public function __construct(
+        public CursorType $type,
+        public string $field,
+        public ?string $value = null,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed>|null $cursor the binding's cursor JSONB
+     */
+    public static function fromArray(?array $cursor): ?self
+    {
+        if (null === $cursor) {
+            return null;
+        }
+
+        $type = \is_string($cursor['type'] ?? null) ? CursorType::tryFrom($cursor['type']) : null;
+        $field = $cursor['field'] ?? null;
+        if (null === $type || !\is_string($field) || '' === $field) {
+            return null;
+        }
+
+        $value = $cursor['state'] ?? null;
+
+        return new self($type, $field, \is_string($value) ? $value : null);
+    }
+
+    public function withValue(string $value): self
+    {
+        return new self($this->type, $this->field, $value);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'field' => $this->field,
+            'type' => $this->type->value,
+            'state' => $this->value,
+        ];
+    }
+}

--- a/apps/api/src/Integration/Generic/Domain/Enum/CursorType.php
+++ b/apps/api/src/Integration/Generic/Domain/Enum/CursorType.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Enum;
+
+/**
+ * The kind of delta-sync cursor a {@see \App\Integration\Generic\Domain\Entity\SyncBinding}
+ * tracks (ADR-0022, epic APIC, ticket APIC-P3-03).
+ *
+ * `updated_at` is a timestamp watermark, `incremental_id` a monotonic integer,
+ * `opaque` a server-supplied token whose ordering the remote owns (so the
+ * cursor manager accepts any new opaque value).
+ */
+enum CursorType: string
+{
+    case UpdatedAt = 'updated_at';
+    case IncrementalId = 'incremental_id';
+    case Opaque = 'opaque';
+
+    /** Whether the manager can compare two values of this type for forward progress. */
+    public function isComparable(): bool
+    {
+        return self::Opaque !== $this;
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Application/Sync/CursorManagerTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Application/Sync/CursorManagerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Application\Sync;
+
+use App\Integration\Generic\Application\Sync\CursorManager;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Repository\SyncBindingRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class CursorManagerTest extends TestCase
+{
+    #[Test]
+    public function advancesAndPersistsAtomicallyAfterABatch(): void
+    {
+        $binding = $this->binding(['field' => 'id', 'type' => 'incremental_id', 'state' => '100']);
+        $repo = $this->createMock(SyncBindingRepositoryInterface::class);
+        $repo->expects(self::once())->method('save')->with($binding);
+
+        $advanced = new CursorManager($repo)->advance($binding, '250');
+
+        self::assertTrue($advanced);
+        self::assertSame('250', $binding->getCursor()['state'] ?? null);
+    }
+
+    #[Test]
+    public function rejectsBackwardIncrementalId(): void
+    {
+        $binding = $this->binding(['field' => 'id', 'type' => 'incremental_id', 'state' => '500']);
+        $repo = $this->createMock(SyncBindingRepositoryInterface::class);
+        $repo->expects(self::never())->method('save');
+
+        $advanced = new CursorManager($repo)->advance($binding, '499');
+
+        self::assertFalse($advanced);
+        // A crash-resume that replays an older page must not move the cursor back.
+        self::assertSame('500', $binding->getCursor()['state'] ?? null);
+    }
+
+    #[Test]
+    public function acceptsEqualValueForIdempotentReprocessing(): void
+    {
+        $binding = $this->binding(['field' => 'id', 'type' => 'incremental_id', 'state' => '500']);
+        $repo = $this->createStub(SyncBindingRepositoryInterface::class);
+
+        self::assertTrue(new CursorManager($repo)->advance($binding, '500'));
+    }
+
+    #[Test]
+    public function comparesUpdatedAtTimestamps(): void
+    {
+        $binding = $this->binding(['field' => 'updated_at', 'type' => 'updated_at', 'state' => '2026-06-01T00:00:00+00:00']);
+        $repo = $this->createStub(SyncBindingRepositoryInterface::class);
+        $manager = new CursorManager($repo);
+
+        self::assertTrue($manager->advance($binding, '2026-06-02T00:00:00+00:00'));
+        self::assertFalse($manager->advance($binding, '2026-05-31T00:00:00+00:00'));
+    }
+
+    #[Test]
+    public function rejectsUnparseableNewTimestamp(): void
+    {
+        $binding = $this->binding(['field' => 'updated_at', 'type' => 'updated_at', 'state' => '2026-06-01T00:00:00+00:00']);
+        $repo = $this->createStub(SyncBindingRepositoryInterface::class);
+
+        self::assertFalse(new CursorManager($repo)->advance($binding, 'not-a-date'));
+    }
+
+    #[Test]
+    public function opaqueCursorAlwaysAdvances(): void
+    {
+        $binding = $this->binding(['field' => 'next', 'type' => 'opaque', 'state' => 'TOKEN-A']);
+        $repo = $this->createStub(SyncBindingRepositoryInterface::class);
+
+        self::assertTrue(new CursorManager($repo)->advance($binding, 'TOKEN-B'));
+        self::assertSame('TOKEN-B', $binding->getCursor()['state'] ?? null);
+    }
+
+    #[Test]
+    public function firstAdvanceAcceptsAnyValue(): void
+    {
+        $binding = $this->binding(['field' => 'id', 'type' => 'incremental_id']);
+        $repo = $this->createStub(SyncBindingRepositoryInterface::class);
+
+        self::assertTrue(new CursorManager($repo)->advance($binding, '42'));
+    }
+
+    #[Test]
+    public function returnsFalseWhenNoCursorConfigured(): void
+    {
+        $binding = $this->binding(null);
+        $repo = $this->createMock(SyncBindingRepositoryInterface::class);
+        $repo->expects(self::never())->method('save');
+
+        self::assertFalse(new CursorManager($repo)->advance($binding, '1'));
+    }
+
+    /**
+     * @param array<string, mixed>|null $cursor
+     */
+    private function binding(?array $cursor): SyncBinding
+    {
+        $connection = new Connection('idosell', 'IdoSell PL', 'https://api.idosell.com');
+        $binding = new SyncBinding($connection, Uuid::v7());
+        $binding->setCursor($cursor);
+
+        return $binding;
+    }
+}


### PR DESCRIPTION
## Cel

APIC-P3-03 — atomowe, monotoniczne przesuwanie kursora delta-sync (crash-safe, brak re-procesowania/duplikatów).

## Zakres (`src/Integration/Generic/Application/Sync/`)

- **`CursorManager`** — `current(binding)` + `advance(binding, newValue)`: waliduje monotoniczność przed persist, atomowy zapis (jeden `save` per batch). Inbound handler woła `advance()` po każdym scommitowanym batchu → crash zostawia kursor na ostatnim batchu, re-run pobiera tylko to okno (idempotentny upsert). Cofnięcie (out-of-order page) **odrzucone**; `opaque` token akceptowany as-is (remote zarządza kolejnością); nieparsowalny nowy timestamp → odrzucony; skorumpowany zapisany → reset.
- **`CursorType`** enum (`updated_at|incremental_id|opaque`) + **`CursorState`** VO (parsowanie `{field,type,state}` JSONB envelope SyncBindingu).

## Testy / bramki (kontener api)

- **PHPStan max** ✅ · **Deptrac** 0 ✅ · **PHP-CS-Fixer** 0 ✅
- **PHPUnit** ✅ 8/8: atomic persist after batch (AC-2), reject backward incremental id (AC-1), accept equal (idempotent re-process AC-3), updated_at compare, reject unparseable new timestamp, opaque always advances, first-advance accepts any, no-cursor → false.

Refs #1781