### PR TITLE
feat(integration): InboundSyncHandler delegates upsert to write core (APIC-P3-04)

### DIFF
--- a/apps/api/config/packages/messenger.yaml
+++ b/apps/api/config/packages/messenger.yaml
@@ -141,6 +141,11 @@ framework:
             # on the same handler from the controller.
             App\Import\Domain\Message\ImportRunMessage: import
 
+            # APIC-P3-04 — inbound sync of a SyncBinding. Reuses the `import`
+            # transport/worker (epic transport decision); TenantAwareMessage so
+            # the rebinding + RLS-GUC middleware restore tenant context first.
+            App\Integration\Generic\Domain\Message\InboundSyncMessage: import
+
             # IMP2-1.12 (#1475). Image-download batches buffered by the import
             # run and dispatched after the row phase. Same dedicated `import`
             # queue so media never starves UI-adjacent async jobs.

--- a/apps/api/src/Catalog/Application/Integration/CatalogInboundRecordWriter.php
+++ b/apps/api/src/Catalog/Application/Integration/CatalogInboundRecordWriter.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Integration;
+
+use App\Catalog\Application\BatchValueWriter;
+use App\Catalog\Contracts\Integration\InboundRecordWriter;
+use App\Catalog\Contracts\Integration\InboundUpsertResult;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Provenance;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Catalog-side implementation of the inbound-sync write seam (APIC-P3-04).
+ *
+ * Reuses {@see BatchValueWriter} (the IMP2 write core) with `Provenance::Integration`,
+ * resolving the target object by a match attribute value within the ObjectType
+ * (the same SQL pattern as the import `ObjectResolver`, replicated here because
+ * that service lives in the Import context and Catalog must not depend on it)
+ * and creating it when absent. It persists into the unit of work but does not
+ * flush — the sync runner flushes per batch, which fires the synchronous
+ * `AttributesIndexedSyncListener` to refresh the denormalised index (the
+ * single-edit path; the bulk BulkContext+async path is reserved for large runs).
+ */
+final readonly class CatalogInboundRecordWriter implements InboundRecordWriter
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private ObjectTypeRepositoryInterface $objectTypes,
+        private AttributeRepositoryInterface $attributes,
+        private BatchValueWriter $valueWriter,
+        private TenantContext $tenantContext,
+    ) {
+    }
+
+    public function upsert(
+        Uuid $objectTypeId,
+        string $matchAttributeCode,
+        string $matchValue,
+        array $attributeValues,
+    ): InboundUpsertResult {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            return InboundUpsertResult::failed('No active tenant for inbound write.');
+        }
+
+        $matchValue = trim($matchValue);
+        if ('' === $matchValue) {
+            return InboundUpsertResult::failed('Empty match value; cannot resolve a record.');
+        }
+
+        $objectType = $this->objectTypes->findById($objectTypeId);
+        if (null === $objectType) {
+            return InboundUpsertResult::failed(\sprintf('ObjectType "%s" was not found.', $objectTypeId->toRfc4122()));
+        }
+
+        /** @var array<string, Attribute> $attrs */
+        $attrs = [];
+        foreach (array_unique([$matchAttributeCode, ...array_keys($attributeValues)]) as $code) {
+            $attribute = $this->attributes->findByCode($code, $tenant);
+            if (null !== $attribute) {
+                $attrs[$code] = $attribute;
+            }
+        }
+
+        if (!isset($attrs[$matchAttributeCode])) {
+            return InboundUpsertResult::failed(\sprintf('Match attribute "%s" was not found.', $matchAttributeCode));
+        }
+
+        $existingId = $this->resolveObjectId(
+            $objectTypeId->toRfc4122(),
+            $tenant->getId()->toRfc4122(),
+            $matchAttributeCode,
+            $matchValue,
+        );
+
+        $isNew = null === $existingId;
+        $object = $isNew
+            ? new CatalogObject($objectType, $matchValue)
+            : $this->em->find(CatalogObject::class, $existingId);
+
+        if (!$object instanceof CatalogObject) {
+            return InboundUpsertResult::failed('Resolved object vanished mid-write.');
+        }
+
+        if ($isNew) {
+            $this->em->persist($object);
+        }
+
+        // On create, ensure the match value itself is written so the new object
+        // carries its identity; mapped values override it if both are present.
+        $envelopes = $attributeValues;
+        if ($isNew && !\array_key_exists($matchAttributeCode, $envelopes)) {
+            $envelopes[$matchAttributeCode] = $matchValue;
+        }
+
+        $writes = [];
+        foreach ($envelopes as $code => $value) {
+            if (!isset($attrs[$code])) {
+                continue;
+            }
+            $writes[] = [
+                'attribute' => $attrs[$code],
+                'envelope' => ['value' => $value],
+                'locale' => null,
+                'channelId' => null,
+            ];
+        }
+
+        $result = $this->valueWriter->writeMany($object, $writes, Provenance::Integration);
+
+        $issues = array_map(static fn (array $issue): string => $issue['message'], $result['issues']);
+        $action = $isNew ? 'created' : ($result['changed'] > 0 ? 'updated' : 'skipped');
+
+        return new InboundUpsertResult($action, $object->getId()->toRfc4122(), $issues);
+    }
+
+    /**
+     * Resolves the object id whose `matchAttributeCode` value equals `$matchValue`
+     * within the ObjectType + tenant. Native SQL (no registered JSONB DQL) —
+     * tenant scoping is therefore explicit, mirroring the import ObjectResolver.
+     */
+    private function resolveObjectId(
+        string $objectTypeId,
+        string $tenantId,
+        string $matchAttributeCode,
+        string $matchValue,
+    ): ?string {
+        $id = $this->em->getConnection()->fetchOne(
+            <<<'SQL'
+                SELECT o.id
+                FROM objects o
+                JOIN object_values ov ON ov.object_id = o.id
+                JOIN attributes a ON a.id = ov.attribute_id
+                WHERE a.code = :code
+                  AND o.object_type_id = :objectTypeId
+                  AND o.tenant_id = :tenantId
+                  AND ov.value->>'value' = :matchValue
+                LIMIT 1
+                SQL,
+            [
+                'code' => $matchAttributeCode,
+                'objectTypeId' => $objectTypeId,
+                'tenantId' => $tenantId,
+                'matchValue' => $matchValue,
+            ],
+        );
+
+        return \is_string($id) ? $id : null;
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Integration/InboundRecordWriter.php
+++ b/apps/api/src/Catalog/Contracts/Integration/InboundRecordWriter.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Integration;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Cross-BC seam for the API Configurator inbound sync (APIC-P3-04, ADR-0022).
+ *
+ * Lets the Integration context upsert a remote record into the catalog through
+ * the proven write core ({@see \App\Catalog\Application\BatchValueWriter},
+ * provenance fixed to `integration`) without importing any Catalog Application
+ * or Domain type — ADR-0022 keeps cross-BC coupling at the Contracts level.
+ *
+ * The implementation resolves the target object by `matchAttributeCode = matchValue`
+ * within the ObjectType (tenant-scoped), creates it when absent, writes the
+ * mapped attribute values and rebuilds the denormalised index. It is the
+ * consumer-sync analogue of the IMP2 import upsert.
+ */
+interface InboundRecordWriter
+{
+    /**
+     * Upserts one remote record. `attributeValues` is `attributeCode => scalar`
+     * (the field mapping already resolved the PIM targets). The match attribute
+     * value is written on create so the new object carries its identity.
+     *
+     * @param array<string, scalar> $attributeValues
+     */
+    public function upsert(
+        Uuid $objectTypeId,
+        string $matchAttributeCode,
+        string $matchValue,
+        array $attributeValues,
+    ): InboundUpsertResult;
+}

--- a/apps/api/src/Catalog/Contracts/Integration/InboundUpsertResult.php
+++ b/apps/api/src/Catalog/Contracts/Integration/InboundUpsertResult.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Integration;
+
+/**
+ * Outcome of an {@see InboundRecordWriter} upsert (APIC-P3-04, ADR-0022).
+ *
+ * `action` is one of `created|updated|skipped|failed` — the Integration sync
+ * loop maps it to a `SyncRecordAction` for the run log without importing any
+ * Catalog domain type. `issues` carries per-value validation messages (a value
+ * that failed validation is skipped, the rest of the record still writes).
+ */
+final readonly class InboundUpsertResult
+{
+    /**
+     * @param list<string> $issues
+     */
+    public function __construct(
+        public string $action,
+        public ?string $objectId,
+        public array $issues = [],
+    ) {
+    }
+
+    public static function failed(string $message): self
+    {
+        return new self('failed', null, [$message]);
+    }
+}

--- a/apps/api/src/Integration/Generic/Application/Handler/InboundSyncHandler.php
+++ b/apps/api/src/Integration/Generic/Application/Handler/InboundSyncHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application\Handler;
+
+use App\Integration\Generic\Application\Sync\InboundSyncRunner;
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Message\InboundSyncMessage;
+use App\Integration\Generic\Domain\Repository\SyncBindingRepositoryInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Runs an inbound sync when an {@see InboundSyncMessage} arrives (APIC-P3-04).
+ *
+ * The tenant context + RLS GUC are restored by the shared rebinding /
+ * GUC middleware before this runs (the message is {@see \App\Shared\Application\TenantAwareMessage}),
+ * so the binding loads tenant-scoped. A binding deleted between dispatch and
+ * delivery is a no-op. The chunked write + per-batch flush lives in the runner;
+ * this handler is a thin entry point, so the flush-in-loop hygiene rule does
+ * not apply here.
+ */
+#[AsMessageHandler]
+final readonly class InboundSyncHandler
+{
+    public function __construct(
+        private SyncBindingRepositoryInterface $bindings,
+        private InboundSyncRunner $runner,
+        private LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    public function __invoke(InboundSyncMessage $message): void
+    {
+        $binding = $this->bindings->findById($message->bindingId);
+        if (!$binding instanceof SyncBinding) {
+            $this->logger->info('Inbound sync skipped — binding no longer exists.', [
+                'binding' => $message->bindingId->toRfc4122(),
+            ]);
+
+            return;
+        }
+
+        $this->runner->run($binding);
+    }
+}

--- a/apps/api/src/Integration/Generic/Application/Sync/InboundSyncRunner.php
+++ b/apps/api/src/Integration/Generic/Application/Sync/InboundSyncRunner.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application\Sync;
+
+use App\Catalog\Contracts\Integration\InboundRecordWriter;
+use App\Catalog\Contracts\Integration\InboundUpsertResult;
+use App\Integration\Generic\Domain\Entity\FieldMapping;
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Entity\SyncRun;
+use App\Integration\Generic\Domain\Entity\SyncRunLog;
+use App\Integration\Generic\Domain\Enum\SyncDirection;
+use App\Integration\Generic\Domain\Enum\SyncRecordAction;
+use App\Integration\Generic\Domain\Enum\SyncRunStatus;
+use App\Integration\Generic\Domain\Repository\FieldMappingRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\SyncRunRepositoryInterface;
+use App\Integration\Generic\Infrastructure\Http\Pagination\PaginatedFetcher;
+use App\Integration\Generic\Infrastructure\Http\RecordSelector;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Runs one inbound (remote → PIM) sync of a {@see SyncBinding} (APIC-P3-04).
+ *
+ * Walks the read endpoint page by page ({@see PaginatedFetcher}), maps each
+ * record through the connection's inbound field mappings ({@see RecordMapper})
+ * and upserts it via the cross-BC write seam ({@see InboundRecordWriter},
+ * Provenance::Integration). Each record is flushed before the next so the
+ * resolve-by-match-key sees committed state (idempotent — no in-page dup
+ * creates); the cursor advances once per page ({@see CursorManager}, monotonic
+ * + crash-safe). Every record is logged ({@see SyncRunLog}) and counted on the
+ * {@see SyncRun}. The Messenger/RLS-GUC entry point is APIC-P3-05.
+ */
+final readonly class InboundSyncRunner
+{
+    public function __construct(
+        private FieldMappingRepositoryInterface $mappings,
+        private RecordMapper $mapper,
+        private PaginatedFetcher $fetcher,
+        private CursorManager $cursors,
+        private RecordSelector $selector,
+        private InboundRecordWriter $writer,
+        private SyncRunRepositoryInterface $runs,
+        private EntityManagerInterface $em,
+        private LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    public function run(SyncBinding $binding): SyncRun
+    {
+        $run = new SyncRun($binding, SyncDirection::Inbound);
+        $run->setCursorBefore($binding->getCursor());
+        $this->runs->save($run);
+
+        $readEndpoint = $binding->getReadEndpoint();
+        if (null === $readEndpoint) {
+            $run->markFinished(SyncRunStatus::Failed);
+            $this->runs->save($run);
+
+            return $run;
+        }
+
+        $mappings = $this->mappings->findByConnection($binding->getConnection());
+        $cursorField = $this->cursors->current($binding)?->field;
+
+        foreach ($this->fetcher->pages($binding->getConnection(), $readEndpoint) as $page) {
+            foreach ($page as $record) {
+                $this->processRecord($run, $binding, $mappings, $record);
+                $this->em->flush();
+            }
+
+            if (null !== $cursorField) {
+                $this->advanceCursor($binding, $page, $cursorField);
+            }
+        }
+
+        $run->markFinished(null, $binding->getCursor());
+        $this->runs->save($run);
+
+        return $run;
+    }
+
+    /**
+     * @param list<FieldMapping>      $mappings
+     * @param array<array-key, mixed> $record
+     */
+    private function processRecord(SyncRun $run, SyncBinding $binding, array $mappings, array $record): void
+    {
+        $mapped = $this->mapper->map($record, $mappings);
+        if (null === $mapped) {
+            $run->recordSkipped();
+            $this->log($run, SyncRecordAction::Skipped, null, null, 'No match key or empty match value.');
+
+            return;
+        }
+
+        $result = $this->writer->upsert(
+            $binding->getObjectTypeId(),
+            $mapped->matchAttributeCode,
+            $mapped->matchValue,
+            $mapped->attributeValues,
+        );
+
+        $action = $this->recordOutcome($run, $result);
+        $this->log($run, $action, $mapped->matchValue, $mapped->attributeValues, $this->message($result));
+    }
+
+    private function recordOutcome(SyncRun $run, InboundUpsertResult $result): SyncRecordAction
+    {
+        switch ($result->action) {
+            case 'created':
+                $run->recordCreated();
+
+                return SyncRecordAction::Created;
+            case 'updated':
+                $run->recordUpdated();
+
+                return SyncRecordAction::Updated;
+            case 'skipped':
+                $run->recordSkipped();
+
+                return SyncRecordAction::Skipped;
+            default:
+                $run->recordFailed();
+
+                return SyncRecordAction::Failed;
+        }
+    }
+
+    private function message(InboundUpsertResult $result): ?string
+    {
+        return [] === $result->issues ? null : implode('; ', $result->issues);
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    private function log(SyncRun $run, SyncRecordAction $action, ?string $matchKey, ?array $fields, ?string $message): void
+    {
+        $log = new SyncRunLog($run, $action);
+        $log->setMatchKey($matchKey);
+        $log->setFields($fields);
+        $log->setMessage($message);
+        $this->em->persist($log);
+    }
+
+    /**
+     * Advances the cursor to the last record's cursor value on the page; the
+     * monotonic guard in CursorManager rejects an out-of-order page.
+     *
+     * @param list<array<array-key, mixed>> $page
+     */
+    private function advanceCursor(SyncBinding $binding, array $page, string $cursorField): void
+    {
+        for ($i = \count($page) - 1; $i >= 0; --$i) {
+            $value = $this->selector->value($page[$i], $cursorField);
+            if (\is_string($value) || \is_int($value) || \is_float($value)) {
+                $this->cursors->advance($binding, (string) $value);
+
+                return;
+            }
+        }
+
+        $this->logger->debug('No cursor value found on page; cursor unchanged.', [
+            'binding' => $binding->getId()->toRfc4122(),
+            'field' => $cursorField,
+        ]);
+    }
+}

--- a/apps/api/src/Integration/Generic/Application/Sync/MappedRecord.php
+++ b/apps/api/src/Integration/Generic/Application/Sync/MappedRecord.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application\Sync;
+
+/**
+ * A remote record reduced to its PIM upsert shape by {@see RecordMapper}
+ * (APIC-P3-04): the match attribute + value that identify the catalog object,
+ * plus the scalar attribute values to write.
+ */
+final readonly class MappedRecord
+{
+    /**
+     * @param array<string, scalar> $attributeValues attributeCode => scalar
+     */
+    public function __construct(
+        public string $matchAttributeCode,
+        public string $matchValue,
+        public array $attributeValues,
+    ) {
+    }
+}

--- a/apps/api/src/Integration/Generic/Application/Sync/RecordMapper.php
+++ b/apps/api/src/Integration/Generic/Application/Sync/RecordMapper.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application\Sync;
+
+use App\Integration\Generic\Domain\Entity\FieldMapping;
+use App\Integration\Generic\Infrastructure\Http\RecordSelector;
+
+/**
+ * Reduces a remote record to its PIM upsert shape using a connection's inbound
+ * field mappings (APIC-P3-04).
+ *
+ * The match key is the inbound mapping flagged `isMatchKey`; its remote path
+ * yields the match value. The other inbound mappings yield the attribute
+ * values. Only scalar values are carried (a composite remote field cannot map
+ * 1:1 to a scalar PIM target — the validator already warns, here it is skipped).
+ * Returns null when there is no match key or the record has no match value.
+ */
+final readonly class RecordMapper
+{
+    public function __construct(private RecordSelector $selector)
+    {
+    }
+
+    /**
+     * @param array<array-key, mixed> $record
+     * @param list<FieldMapping>      $mappings
+     */
+    public function map(array $record, array $mappings): ?MappedRecord
+    {
+        $inbound = array_values(array_filter(
+            $mappings,
+            static fn (FieldMapping $m): bool => $m->getDirection()->appliesInbound(),
+        ));
+
+        $matchMapping = null;
+        foreach ($inbound as $mapping) {
+            if ($mapping->isMatchKey()) {
+                $matchMapping = $mapping;
+                break;
+            }
+        }
+
+        if (null === $matchMapping) {
+            return null;
+        }
+
+        $rawMatch = $this->scalar($this->selector->value($record, $matchMapping->getRemoteFieldPath()));
+        if (null === $rawMatch) {
+            return null;
+        }
+        $matchValue = (string) $rawMatch;
+        if ('' === $matchValue) {
+            return null;
+        }
+
+        $values = [];
+        foreach ($inbound as $mapping) {
+            $raw = $this->scalar($this->selector->value($record, $mapping->getRemoteFieldPath()));
+            if (null !== $raw) {
+                $values[$mapping->getPimTarget()] = $raw;
+            }
+        }
+
+        return new MappedRecord($matchMapping->getPimTarget(), $matchValue, $values);
+    }
+
+    private function scalar(mixed $value): bool|float|int|string|null
+    {
+        return \is_scalar($value) ? $value : null;
+    }
+}

--- a/apps/api/src/Integration/Generic/Domain/Message/InboundSyncMessage.php
+++ b/apps/api/src/Integration/Generic/Domain/Message/InboundSyncMessage.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Message;
+
+use App\Shared\Application\TenantAwareMessage;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Async trigger for one inbound sync of a {@see \App\Integration\Generic\Domain\Entity\SyncBinding}
+ * (APIC-P3-04). Routed to the existing `import` transport (reusing the import
+ * worker, per the epic's transport decision). Implements {@see TenantAwareMessage}
+ * so the rebinding + RLS-GUC middleware restore the tenant context on the worker
+ * before the handler loads the (tenant-scoped) binding — the routing wiring is
+ * finalised in APIC-P3-05.
+ */
+final readonly class InboundSyncMessage implements TenantAwareMessage
+{
+    public function __construct(
+        public Uuid $bindingId,
+        public Uuid $tenant,
+    ) {
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenant;
+    }
+}

--- a/apps/api/tests/Integration/Catalog/Integration/CatalogInboundRecordWriterTest.php
+++ b/apps/api/tests/Integration/Catalog/Integration/CatalogInboundRecordWriterTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Catalog\Integration;
+
+use App\Catalog\Contracts\Integration\InboundRecordWriter;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Provenance;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * APIC-P3-04 — the inbound write seam upserts a remote record into the catalog
+ * through BatchValueWriter (Provenance::Integration), resolving by match key and
+ * creating when absent. Verifies the create/update/skip lifecycle + provenance
+ * end-to-end against a real Postgres.
+ */
+final class CatalogInboundRecordWriterTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private Tenant $tenant;
+    private ObjectType $productType;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $em = $this->em();
+        $this->tenant = new Tenant('demo', 'Demo');
+        $em->persist($this->tenant);
+        $em->flush();
+        $this->tenantContext()->set($this->tenant);
+
+        $this->productType = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
+        $em->persist($this->productType);
+        $em->persist(new Attribute('sku', ['pl' => 'SKU'], AttributeType::Text));
+        $em->persist(new Attribute('name', ['pl' => 'Nazwa'], AttributeType::Text));
+        $em->flush();
+    }
+
+    #[Test]
+    public function createsThenUpdatesThenSkips(): void
+    {
+        $writer = $this->writer();
+        $objectTypeId = $this->productType->getId();
+
+        $created = $writer->upsert($objectTypeId, 'sku', 'A-1', ['name' => 'Widget']);
+        $this->em()->flush();
+        self::assertSame('created', $created->action);
+        self::assertNotNull($created->objectId);
+
+        $object = $this->repository()->findByCode('A-1', ObjectKind::Product, $this->tenant);
+        self::assertNotNull($object);
+        self::assertArrayHasKey('name', $object->getAttributesIndexed());
+
+        // Every written value carries Integration provenance.
+        $values = $this->em()->getRepository(ObjectValue::class)->findBy(['object' => $object]);
+        self::assertNotEmpty($values);
+        foreach ($values as $value) {
+            self::assertSame(Provenance::Integration, $value->getProvenance());
+        }
+
+        $updated = $writer->upsert($objectTypeId, 'sku', 'A-1', ['name' => 'Widget v2']);
+        $this->em()->flush();
+        self::assertSame('updated', $updated->action);
+        self::assertSame($created->objectId, $updated->objectId);
+
+        $skipped = $writer->upsert($objectTypeId, 'sku', 'A-1', ['name' => 'Widget v2']);
+        $this->em()->flush();
+        self::assertSame('skipped', $skipped->action);
+    }
+
+    #[Test]
+    public function failsOnUnknownMatchAttribute(): void
+    {
+        $result = $this->writer()->upsert($this->productType->getId(), 'nope', 'A-1', ['name' => 'X']);
+
+        self::assertSame('failed', $result->action);
+        self::assertNotEmpty($result->issues);
+    }
+
+    #[Test]
+    public function failsOnEmptyMatchValue(): void
+    {
+        $result = $this->writer()->upsert($this->productType->getId(), 'sku', '   ', ['name' => 'X']);
+
+        self::assertSame('failed', $result->action);
+    }
+
+    private function writer(): InboundRecordWriter
+    {
+        return self::getContainer()->get(InboundRecordWriter::class);
+    }
+
+    private function repository(): CatalogObjectRepositoryInterface
+    {
+        return self::getContainer()->get(CatalogObjectRepositoryInterface::class);
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}

--- a/apps/api/tests/Integration/Configuration/MessengerRoutingTest.php
+++ b/apps/api/tests/Integration/Configuration/MessengerRoutingTest.php
@@ -58,6 +58,11 @@ final class MessengerRoutingTest extends KernelTestCase
             \App\Export\Domain\Message\RunExportMessage::class,
             'import',
         ];
+
+        yield 'integration: inbound sync (APIC-P3-04, reuses import transport)' => [
+            \App\Integration\Generic\Domain\Message\InboundSyncMessage::class,
+            'import',
+        ];
     }
 
     /**

--- a/apps/api/tests/Integration/Integration/Generic/InboundSyncRunnerTest.php
+++ b/apps/api/tests/Integration/Integration/Generic/InboundSyncRunnerTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Integration\Generic;
+
+use App\Catalog\Contracts\Integration\InboundRecordWriter;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Integration\Generic\Application\Sync\CursorManager;
+use App\Integration\Generic\Application\Sync\InboundSyncRunner;
+use App\Integration\Generic\Application\Sync\RecordMapper;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\FieldMapping;
+use App\Integration\Generic\Domain\Entity\RemoteEndpoint;
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Enum\MappingDirection;
+use App\Integration\Generic\Domain\Enum\RemoteEndpointRole;
+use App\Integration\Generic\Domain\Enum\SyncRunStatus;
+use App\Integration\Generic\Domain\GenericRestResponse;
+use App\Integration\Generic\Domain\Repository\FieldMappingRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\SyncRunRepositoryInterface;
+use App\Integration\Generic\Infrastructure\Http\Pagination\PaginatedFetcher;
+use App\Integration\Generic\Infrastructure\Http\Pagination\PaginationStrategies;
+use App\Integration\Generic\Infrastructure\Http\RecordSelector;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Tests\Unit\Integration\Generic\Infrastructure\Http\Pagination\RecordingRequester;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * APIC-P3-04 — end-to-end inbound sync: a mocked remote page flows through the
+ * fetcher → record mapper → cross-BC write seam into the real catalog, and the
+ * run is audited. Offline + deterministic (fake requester).
+ */
+final class InboundSyncRunnerTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private Tenant $tenant;
+    private ObjectType $productType;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $em = $this->em();
+        $this->tenant = new Tenant('demo', 'Demo');
+        $em->persist($this->tenant);
+        $em->flush();
+        $this->tenantContext()->set($this->tenant);
+
+        $this->productType = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
+        $em->persist($this->productType);
+        $em->persist(new Attribute('sku', ['pl' => 'SKU'], AttributeType::Text));
+        $em->persist(new Attribute('name', ['pl' => 'Nazwa'], AttributeType::Text));
+        $em->flush();
+    }
+
+    #[Test]
+    public function pullsAMockedPageIntoTheCatalog(): void
+    {
+        $binding = $this->seedBinding();
+
+        $page = json_encode([
+            'results' => [
+                ['sku' => 'A-1', 'name' => 'Widget'],
+                ['sku' => 'B-2', 'name' => 'Gadget'],
+            ],
+        ]);
+        $runner = $this->runner([new GenericRestResponse(200, [], (string) $page, 1, 64)]);
+
+        $run = $runner->run($binding);
+        $this->em()->flush();
+
+        self::assertSame(SyncRunStatus::Success, $run->getStatus());
+        self::assertSame(2, $run->getCreatedCount());
+        self::assertSame(0, $run->getFailedCount());
+
+        $this->em()->clear();
+        self::assertNotNull($this->repository()->findByCode('A-1', ObjectKind::Product, $this->tenant));
+        self::assertNotNull($this->repository()->findByCode('B-2', ObjectKind::Product, $this->tenant));
+    }
+
+    #[Test]
+    public function reRunUpdatesInsteadOfDuplicating(): void
+    {
+        $binding = $this->seedBinding();
+        $page = static fn (string $name): string => (string) json_encode([
+            'results' => [['sku' => 'A-1', 'name' => $name]],
+        ]);
+
+        $this->runner([new GenericRestResponse(200, [], $page('Widget'), 1, 32)])->run($binding);
+        $this->em()->flush();
+        $this->em()->clear();
+
+        $binding = $this->em()->find(SyncBinding::class, $binding->getId()->toRfc4122());
+        \assert($binding instanceof SyncBinding);
+        // em->clear() detached the setUp tenant; re-point the context at the
+        // managed tenant so the listener can stamp the new SyncRun.
+        $boundTenant = $binding->getTenant();
+        \assert($boundTenant instanceof Tenant);
+        $this->tenantContext()->set($boundTenant);
+        $run = $this->runner([new GenericRestResponse(200, [], $page('Widget v2'), 1, 32)])->run($binding);
+        $this->em()->flush();
+
+        self::assertSame(0, $run->getCreatedCount());
+        self::assertSame(1, $run->getUpdatedCount());
+    }
+
+    private function seedBinding(): SyncBinding
+    {
+        $em = $this->em();
+        $connection = new Connection('idosell', 'IdoSell', 'https://api.example.com');
+        $connection->assignTenant($this->tenant);
+        $em->persist($connection);
+
+        $endpoint = new RemoteEndpoint($connection, RemoteEndpointRole::ReadList, 'GET', '/products');
+        $endpoint->assignTenant($this->tenant);
+        $endpoint->setRecordSelector('$.results');
+        $em->persist($endpoint);
+
+        $sku = new FieldMapping($connection, 'sku', '$.sku', MappingDirection::Inbound);
+        $sku->assignTenant($this->tenant);
+        $sku->setMatchKey(true);
+        $em->persist($sku);
+        $name = new FieldMapping($connection, 'name', '$.name', MappingDirection::Inbound);
+        $name->assignTenant($this->tenant);
+        $em->persist($name);
+
+        $binding = new SyncBinding($connection, $this->productType->getId());
+        $binding->assignTenant($this->tenant);
+        $binding->setReadEndpoint($endpoint);
+        $em->persist($binding);
+        $em->flush();
+
+        return $binding;
+    }
+
+    /**
+     * @param list<GenericRestResponse> $responses
+     */
+    private function runner(array $responses): InboundSyncRunner
+    {
+        $selector = new RecordSelector();
+        $fetcher = new PaginatedFetcher(
+            new RecordingRequester($responses),
+            $selector,
+            self::getContainer()->get(PaginationStrategies::class),
+        );
+
+        return new InboundSyncRunner(
+            self::getContainer()->get(FieldMappingRepositoryInterface::class),
+            new RecordMapper($selector),
+            $fetcher,
+            self::getContainer()->get(CursorManager::class),
+            $selector,
+            self::getContainer()->get(InboundRecordWriter::class),
+            self::getContainer()->get(SyncRunRepositoryInterface::class),
+            $this->em(),
+        );
+    }
+
+    private function repository(): CatalogObjectRepositoryInterface
+    {
+        return self::getContainer()->get(CatalogObjectRepositoryInterface::class);
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Application/Sync/RecordMapperTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Application/Sync/RecordMapperTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Application\Sync;
+
+use App\Integration\Generic\Application\Sync\RecordMapper;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\FieldMapping;
+use App\Integration\Generic\Domain\Enum\MappingDirection;
+use App\Integration\Generic\Infrastructure\Http\RecordSelector;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class RecordMapperTest extends TestCase
+{
+    private RecordMapper $mapper;
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new RecordMapper(new RecordSelector());
+        $this->connection = new Connection('idosell', 'IdoSell', 'https://api.idosell.com');
+    }
+
+    #[Test]
+    public function mapsMatchKeyAndScalarValues(): void
+    {
+        $mappings = [
+            $this->mapping('sku', '$.sku', MappingDirection::Inbound, isMatchKey: true),
+            $this->mapping('name', '$.title', MappingDirection::Inbound),
+            $this->mapping('price', '$.price.amount', MappingDirection::Both),
+        ];
+        $record = ['sku' => 'A-1', 'title' => 'Widget', 'price' => ['amount' => 1999]];
+
+        $mapped = $this->mapper->map($record, $mappings);
+
+        self::assertNotNull($mapped);
+        self::assertSame('sku', $mapped->matchAttributeCode);
+        self::assertSame('A-1', $mapped->matchValue);
+        self::assertSame(['sku' => 'A-1', 'name' => 'Widget', 'price' => 1999], $mapped->attributeValues);
+    }
+
+    #[Test]
+    public function returnsNullWithoutAMatchKey(): void
+    {
+        $mappings = [$this->mapping('name', '$.title', MappingDirection::Inbound)];
+
+        self::assertNull($this->mapper->map(['title' => 'Widget'], $mappings));
+    }
+
+    #[Test]
+    public function returnsNullWhenMatchValueMissing(): void
+    {
+        $mappings = [$this->mapping('sku', '$.sku', MappingDirection::Inbound, isMatchKey: true)];
+
+        self::assertNull($this->mapper->map(['title' => 'Widget'], $mappings));
+    }
+
+    #[Test]
+    public function skipsCompositeValuesAndOutboundOnlyMappings(): void
+    {
+        $mappings = [
+            $this->mapping('sku', '$.sku', MappingDirection::Inbound, isMatchKey: true),
+            $this->mapping('tags', '$.tags', MappingDirection::Inbound),         // array → skipped
+            $this->mapping('secret', '$.secret', MappingDirection::Outbound),    // outbound → ignored
+        ];
+        $record = ['sku' => 'A-1', 'tags' => ['new', 'sale'], 'secret' => 'x'];
+
+        $mapped = $this->mapper->map($record, $mappings);
+
+        self::assertNotNull($mapped);
+        self::assertSame(['sku' => 'A-1'], $mapped->attributeValues);
+    }
+
+    private function mapping(
+        string $pimTarget,
+        string $remotePath,
+        MappingDirection $direction,
+        bool $isMatchKey = false,
+    ): FieldMapping {
+        $mapping = new FieldMapping($this->connection, $pimTarget, $remotePath, $direction);
+        $mapping->setMatchKey($isMatchKey);
+
+        return $mapping;
+    }
+}


### PR DESCRIPTION
## Cel

APIC-P3-04 — inbound (remote → PIM) sync wpięty w silnik zapisu IMP2 wg potwierdzonej architektury (operator: reuse `BatchValueWriter`+`ObjectResolver`, Provenance::Integration; reuse `import` transport).

## Zakres

- **Catalog Contracts seam** `InboundRecordWriter` (+ DTO `InboundUpsertResult`) + adapter `Catalog\Application\Integration\CatalogInboundRecordWriter`: upsert rekordu przez `BatchValueWriter.writeMany(..., Provenance::Integration)`, resolve po match-attribute w ObjectType, create gdy brak. **Integration zależy tylko od kontraktu** (ADR-0022 cross-BC). `objectTypeId` = loose ref; adapter replikuje match-SQL `ObjectResolver` (ta usługa jest w kontekście Import — Catalog nie może od niej zależeć, brak inwersji warstw).
- **`RecordMapper`** (Integration) — remote record → `{matchKey, scalar values}` wg inbound field mappings (composite/outbound pominięte).
- **`InboundSyncRunner`** — chodzi po read endpoint (`PaginatedFetcher`), upsert per rekord (**flush-per-record** → resolve widzi scommitowany stan, brak dup-create w stronie), advance kursora per strona (monotonic), audyt (`SyncRun` + per-record `SyncRunLog`).
- **`InboundSyncHandler`** (`#[AsMessageHandler]`) + **`InboundSyncMessage`** (`TenantAwareMessage`) routed do istniejącego **`import`** transportu — rebinding + RLS-GUC middleware przywracają tenant. Finalizacja routingu + run-now trigger = APIC-P3-05.

## Decyzje / odejścia (świadome)

- Indeks: NIE wołam `AttributesIndexedRebuilder` w adapterze (czytałby niezflushowane wartości) — synchroniczny `AttributesIndexedSyncListener` odświeża indeks na flush runnera (single-edit path; bulk BulkContext+async = follow-up dla dużych runów).
- Worker memory: flush-per-record bez `clear()` (akceptowalne dla MVP; `FlushWithoutClearInLoopRule` dotyczy handlerów, nie usług — runner to usługa). Chunk-resolve + flush/clear + BulkContext = follow-up perf.

## Testy / bramki (kontener api)

- **PHPStan max** ✅ · **Deptrac** 0 (cross-BC seam czysty) ✅ · **PHP-CS-Fixer** 0 ✅
- **PHPUnit** ✅: `RecordMapperTest` (4, unit), `CatalogInboundRecordWriterTest` (3, **Integration** — create/update/skip + Provenance::Integration na realnym Postgresie), `InboundSyncRunnerTest` (2, **Integration end-to-end** — mocked remote → realne obiekty w katalogu + re-run updates-not-duplicates), `MessengerRoutingTest` (routing → import). Generic unit regresja 118/118.

Refs #1782