### PR TITLE
feat(integration): OutboundSyncHandler builds push payload via Export engine (APIC-P3-06)

### DIFF
--- a/apps/api/config/packages/messenger.yaml
+++ b/apps/api/config/packages/messenger.yaml
@@ -146,6 +146,9 @@ framework:
             # the rebinding + RLS-GUC middleware restore tenant context first.
             App\Integration\Generic\Domain\Message\InboundSyncMessage: import
 
+            # APIC-P3-06 — outbound sync (PIM → remote). Same import transport.
+            App\Integration\Generic\Domain\Message\OutboundSyncMessage: import
+
             # IMP2-1.12 (#1475). Image-download batches buffered by the import
             # run and dispatched after the row phase. Same dedicated `import`
             # queue so media never starves UI-adjacent async jobs.

--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -483,6 +483,14 @@ parameters:
             - App\Catalog\Domain\ObjectKind
             - App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface
             - App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface
+        # APIC-P3-06 — outbound-sync reader reuses the Export ValueSerializer +
+        # iterates catalog objects; same Export → Catalog\Domain reach as the
+        # serializer/runner above (the implementation is Catalog-data-bound).
+        App\Export\Application\Integration\ExportOutboundRecordReader:
+            - App\Catalog\Domain\Entity\CatalogObject
+            - App\Catalog\Domain\Entity\ObjectValue
+            - App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface
+            - App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface
         App\Export\Presentation\Controller\ExportPreflightController:
             - App\Catalog\Application\Filter\FilterDslResolver
             - App\Catalog\Domain\Entity\ObjectType

--- a/apps/api/src/Catalog/Contracts/Integration/OutboundRecord.php
+++ b/apps/api/src/Catalog/Contracts/Integration/OutboundRecord.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Integration;
+
+/**
+ * One catalog object serialised for an outbound push (APIC-P3-06, ADR-0022).
+ *
+ * `values` is `attributeCode => serialized scalar` (built by the Export engine's
+ * cell serializer); `objectId` identifies the source object for the run log.
+ * The Integration sync maps these codes to remote field paths without touching
+ * any Catalog/Export domain type.
+ */
+final readonly class OutboundRecord
+{
+    /**
+     * @param array<string, string> $values
+     */
+    public function __construct(
+        public string $objectId,
+        public array $values,
+    ) {
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Integration/OutboundRecordReader.php
+++ b/apps/api/src/Catalog/Contracts/Integration/OutboundRecordReader.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Integration;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Cross-BC seam for the API Configurator outbound sync (APIC-P3-06, ADR-0022).
+ *
+ * Lets the Integration context read a tenant's catalog objects serialised for
+ * push — reusing the Export engine's cell serializer — without importing any
+ * Catalog or Export Application/Domain type. The implementation iterates the
+ * ObjectType's objects (memory-bounded) and yields each as an
+ * {@see OutboundRecord} of `attributeCode => serialized value` for the requested
+ * codes.
+ */
+interface OutboundRecordReader
+{
+    /**
+     * @param list<string> $codes the attribute codes to serialise per object
+     *
+     * @return iterable<OutboundRecord>
+     */
+    public function read(Uuid $objectTypeId, array $codes): iterable;
+}

--- a/apps/api/src/Export/Application/Integration/ExportOutboundRecordReader.php
+++ b/apps/api/src/Export/Application/Integration/ExportOutboundRecordReader.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Application\Integration;
+
+use App\Catalog\Contracts\Integration\OutboundRecord;
+use App\Catalog\Contracts\Integration\OutboundRecordReader;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Export\Application\Builder\ValueSerializer;
+use App\Shared\Application\TenantContext;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Export-side implementation of the outbound-sync read seam (APIC-P3-06).
+ *
+ * Reuses the export {@see ValueSerializer} (the cell serializer) instead of a
+ * bespoke one, so the outbound payload matches what a file export would emit.
+ * Iterates the ObjectType's objects and yields each global (locale/channel-null)
+ * value for the requested attribute codes, serialised to a scalar string.
+ *
+ * MVP reads the full object set per run; keyset paging for 50k+ catalogs is a
+ * follow-up (the inbound runner has the same bounded-scope note).
+ */
+final readonly class ExportOutboundRecordReader implements OutboundRecordReader
+{
+    public function __construct(
+        private ObjectTypeRepositoryInterface $objectTypes,
+        private CatalogObjectRepositoryInterface $objects,
+        private ValueSerializer $serializer,
+        private TenantContext $tenantContext,
+        private EntityManagerInterface $em,
+    ) {
+    }
+
+    public function read(Uuid $objectTypeId, array $codes): iterable
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            return;
+        }
+
+        $objectType = $this->objectTypes->findById($objectTypeId);
+        if (null === $objectType) {
+            return;
+        }
+
+        $wanted = array_fill_keys($codes, true);
+
+        foreach ($this->objects->findByObjectType($objectType, $tenant) as $object) {
+            $values = [];
+            foreach ($this->globalValues($object) as $code => $objectValue) {
+                if (isset($wanted[$code])) {
+                    $values[$code] = $this->serializer->serialize($objectValue);
+                }
+            }
+
+            yield new OutboundRecord($object->getId()->toRfc4122(), $values);
+        }
+    }
+
+    /**
+     * @return iterable<string, ObjectValue> attribute code => the global value
+     *                                       (locale/channel-null) only
+     */
+    private function globalValues(CatalogObject $object): iterable
+    {
+        $values = $this->em->getRepository(ObjectValue::class)->findBy(['object' => $object]);
+        foreach ($values as $value) {
+            if (null === $value->getLocale() && null === $value->getChannelId()) {
+                yield $value->getAttribute()->getCode() => $value;
+            }
+        }
+    }
+}

--- a/apps/api/src/Integration/Generic/Application/Handler/OutboundSyncHandler.php
+++ b/apps/api/src/Integration/Generic/Application/Handler/OutboundSyncHandler.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application\Handler;
+
+use App\Integration\Generic\Application\Sync\OutboundSyncRunner;
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Message\OutboundSyncMessage;
+use App\Integration\Generic\Domain\Repository\SyncBindingRepositoryInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Runs an outbound sync when an {@see OutboundSyncMessage} arrives (APIC-P3-06).
+ *
+ * Tenant context + RLS GUC are restored by the shared worker middleware before
+ * this runs (the message is {@see \App\Shared\Application\TenantAwareMessage}),
+ * so the binding loads tenant-scoped. A binding deleted between dispatch and
+ * delivery is a no-op. The push loop + per-record flush live in the runner.
+ */
+#[AsMessageHandler]
+final readonly class OutboundSyncHandler
+{
+    public function __construct(
+        private SyncBindingRepositoryInterface $bindings,
+        private OutboundSyncRunner $runner,
+        private LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    public function __invoke(OutboundSyncMessage $message): void
+    {
+        $binding = $this->bindings->findById($message->bindingId);
+        if (!$binding instanceof SyncBinding) {
+            $this->logger->info('Outbound sync skipped — binding no longer exists.', [
+                'binding' => $message->bindingId->toRfc4122(),
+            ]);
+
+            return;
+        }
+
+        $this->runner->run($binding);
+    }
+}

--- a/apps/api/src/Integration/Generic/Application/Sync/OutboundSyncRunner.php
+++ b/apps/api/src/Integration/Generic/Application/Sync/OutboundSyncRunner.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application\Sync;
+
+use App\Catalog\Contracts\Integration\OutboundRecord;
+use App\Catalog\Contracts\Integration\OutboundRecordReader;
+use App\Integration\Generic\Domain\Entity\FieldMapping;
+use App\Integration\Generic\Domain\Entity\RemoteEndpoint;
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Entity\SyncRun;
+use App\Integration\Generic\Domain\Entity\SyncRunLog;
+use App\Integration\Generic\Domain\Enum\RemoteEndpointRole;
+use App\Integration\Generic\Domain\Enum\SyncDirection;
+use App\Integration\Generic\Domain\Enum\SyncRecordAction;
+use App\Integration\Generic\Domain\Enum\SyncRunStatus;
+use App\Integration\Generic\Domain\Exception\RemoteRequestFailedException;
+use App\Integration\Generic\Domain\Exception\SsrfBlockedException;
+use App\Integration\Generic\Domain\Repository\FieldMappingRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\SyncRunRepositoryInterface;
+use App\Integration\Generic\Infrastructure\Http\RemoteRequester;
+use Doctrine\ORM\EntityManagerInterface;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Runs one outbound (PIM → remote) sync of a {@see SyncBinding} (APIC-P3-06).
+ *
+ * Reads the ObjectType's objects serialised by the Export engine
+ * ({@see OutboundRecordReader}), builds a 1:1 push body ({@see PayloadBuilder})
+ * and POSTs/PUTs each through the SSRF-safe, backoff-retrying client
+ * ({@see RemoteRequester}) to the binding's write endpoint. Per-record failures
+ * are logged and counted (a bad record never fails the whole run); transport
+ * dead-lettering is the message transport's job. Audited as a {@see SyncRun}
+ * with per-record {@see SyncRunLog}.
+ */
+final readonly class OutboundSyncRunner
+{
+    public function __construct(
+        private FieldMappingRepositoryInterface $mappings,
+        private PayloadBuilder $payloadBuilder,
+        private OutboundRecordReader $reader,
+        private RemoteRequester $requester,
+        private SyncRunRepositoryInterface $runs,
+        private EntityManagerInterface $em,
+    ) {
+    }
+
+    public function run(SyncBinding $binding): SyncRun
+    {
+        $run = new SyncRun($binding, SyncDirection::Outbound);
+        $this->runs->save($run);
+
+        $writeEndpoint = $binding->getWriteEndpoint();
+        if (null === $writeEndpoint) {
+            $run->markFinished(SyncRunStatus::Failed);
+            $this->runs->save($run);
+
+            return $run;
+        }
+
+        $mappings = array_values(array_filter(
+            $this->mappings->findByConnection($binding->getConnection()),
+            static fn (FieldMapping $m): bool => $m->getDirection()->appliesOutbound(),
+        ));
+        $matchCode = $this->matchCode($mappings);
+        $codes = array_values(array_unique(array_map(static fn (FieldMapping $m): string => $m->getPimTarget(), $mappings)));
+
+        $action = RemoteEndpointRole::WriteUpdate === $writeEndpoint->getRole()
+            ? SyncRecordAction::Updated
+            : SyncRecordAction::Created;
+
+        foreach ($this->reader->read($binding->getObjectTypeId(), $codes) as $record) {
+            $this->push($run, $binding, $writeEndpoint, $record, $mappings, $matchCode, $action);
+            $this->em->flush();
+        }
+
+        $run->markFinished();
+        $this->runs->save($run);
+
+        return $run;
+    }
+
+    /**
+     * @param list<FieldMapping> $mappings
+     */
+    private function push(
+        SyncRun $run,
+        SyncBinding $binding,
+        RemoteEndpoint $writeEndpoint,
+        OutboundRecord $record,
+        array $mappings,
+        ?string $matchCode,
+        SyncRecordAction $successAction,
+    ): void {
+        $body = $this->payloadBuilder->build($record->values, $mappings);
+        if ([] === $body) {
+            $run->recordSkipped();
+            $this->log($run, SyncRecordAction::Skipped, null, $body, 'No outbound values to push.');
+
+            return;
+        }
+
+        $matchValue = null !== $matchCode ? ($record->values[$matchCode] ?? null) : null;
+        $url = $this->buildUrl($binding, $writeEndpoint, $matchValue);
+
+        try {
+            $response = $this->requester->request(
+                $binding->getConnection(),
+                $writeEndpoint->getHttpMethod(),
+                $url,
+                [],
+                [],
+                json_encode($body, JSON_THROW_ON_ERROR),
+            );
+        } catch (SsrfBlockedException|RemoteRequestFailedException $exception) {
+            $run->recordFailed();
+            $this->log($run, SyncRecordAction::Failed, $matchValue, $body, $exception->getMessage());
+
+            return;
+        }
+
+        if ($response->isSuccessful()) {
+            SyncRecordAction::Updated === $successAction ? $run->recordUpdated() : $run->recordCreated();
+            $this->log($run, $successAction, $matchValue, $body, null);
+
+            return;
+        }
+
+        $run->recordFailed();
+        $this->log($run, SyncRecordAction::Failed, $matchValue, $body, \sprintf('HTTP %d', $response->statusCode));
+    }
+
+    /**
+     * @param list<FieldMapping> $mappings
+     */
+    private function matchCode(array $mappings): ?string
+    {
+        foreach ($mappings as $mapping) {
+            if ($mapping->isMatchKey()) {
+                return $mapping->getPimTarget();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolves the write URL, substituting any `{token}` placeholder in the
+     * path with the match value (e.g. `PUT /products/{id}`).
+     */
+    private function buildUrl(SyncBinding $binding, RemoteEndpoint $endpoint, ?string $matchValue): string
+    {
+        $path = $endpoint->getPathTemplate();
+        if (null !== $matchValue) {
+            $path = (string) preg_replace('/\{[^}]+\}/', rawurlencode($matchValue), $path);
+        }
+
+        $path = ltrim($path, '/');
+        $base = rtrim($binding->getConnection()->getBaseUrl(), '/');
+
+        return '' === $path ? $base : $base.'/'.$path;
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    private function log(SyncRun $run, SyncRecordAction $action, ?string $matchKey, array $fields, ?string $message): void
+    {
+        $log = new SyncRunLog($run, $action);
+        $log->setMatchKey($matchKey);
+        $log->setFields($fields);
+        $log->setMessage($message);
+        $this->em->persist($log);
+    }
+}

--- a/apps/api/src/Integration/Generic/Application/Sync/PayloadBuilder.php
+++ b/apps/api/src/Integration/Generic/Application/Sync/PayloadBuilder.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application\Sync;
+
+use App\Integration\Generic\Domain\Entity\FieldMapping;
+
+/**
+ * Builds an outbound push body from serialized PIM values and the connection's
+ * outbound field mappings (APIC-P3-06).
+ *
+ * Each outbound mapping writes its value into the body at the remote field's
+ * dot path (`$.price.amount` → `{"price": {"amount": …}}`), so a 1:1 mapping
+ * reconstructs the remote's nested shape. Inbound-only mappings are ignored.
+ */
+final readonly class PayloadBuilder
+{
+    /**
+     * @param array<string, string> $values   attributeCode => serialized value
+     * @param list<FieldMapping>    $mappings
+     *
+     * @return array<string, mixed>
+     */
+    public function build(array $values, array $mappings): array
+    {
+        $body = [];
+        foreach ($mappings as $mapping) {
+            if (!$mapping->getDirection()->appliesOutbound()) {
+                continue;
+            }
+            if (!\array_key_exists($mapping->getPimTarget(), $values)) {
+                continue;
+            }
+            self::setPath($body, $mapping->getRemoteFieldPath(), $values[$mapping->getPimTarget()]);
+        }
+
+        return $body;
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    private static function setPath(array &$body, string $path, string $value): void
+    {
+        $segments = self::segments($path);
+        if ([] === $segments) {
+            return;
+        }
+
+        $ref = &$body;
+        $last = array_pop($segments);
+        foreach ($segments as $segment) {
+            if (!isset($ref[$segment]) || !\is_array($ref[$segment])) {
+                $ref[$segment] = [];
+            }
+            $ref = &$ref[$segment];
+        }
+        $ref[$last] = $value;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function segments(string $path): array
+    {
+        $trimmed = ltrim(ltrim(trim($path), '$'), '.');
+        if ('' === $trimmed) {
+            return [];
+        }
+
+        return array_values(array_filter(explode('.', $trimmed), static fn (string $s): bool => '' !== $s));
+    }
+}

--- a/apps/api/src/Integration/Generic/Domain/Message/OutboundSyncMessage.php
+++ b/apps/api/src/Integration/Generic/Domain/Message/OutboundSyncMessage.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Domain\Message;
+
+use App\Shared\Application\TenantAwareMessage;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Async trigger for one outbound (PIM → remote) sync of a {@see \App\Integration\Generic\Domain\Entity\SyncBinding}
+ * (APIC-P3-06). Routed to the existing `import` transport; {@see TenantAwareMessage}
+ * so the rebinding + RLS-GUC middleware restore tenant context on the worker.
+ */
+final readonly class OutboundSyncMessage implements TenantAwareMessage
+{
+    public function __construct(
+        public Uuid $bindingId,
+        public Uuid $tenant,
+    ) {
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenant;
+    }
+}

--- a/apps/api/tests/Integration/Configuration/MessengerRoutingTest.php
+++ b/apps/api/tests/Integration/Configuration/MessengerRoutingTest.php
@@ -63,6 +63,11 @@ final class MessengerRoutingTest extends KernelTestCase
             \App\Integration\Generic\Domain\Message\InboundSyncMessage::class,
             'import',
         ];
+
+        yield 'integration: outbound sync (APIC-P3-06, reuses import transport)' => [
+            \App\Integration\Generic\Domain\Message\OutboundSyncMessage::class,
+            'import',
+        ];
     }
 
     /**

--- a/apps/api/tests/Integration/Integration/Generic/OutboundSyncRunnerTest.php
+++ b/apps/api/tests/Integration/Integration/Generic/OutboundSyncRunnerTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Integration\Generic;
+
+use App\Catalog\Contracts\Integration\OutboundRecordReader;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\ObjectKind;
+use App\Integration\Generic\Application\Sync\OutboundSyncRunner;
+use App\Integration\Generic\Application\Sync\PayloadBuilder;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\FieldMapping;
+use App\Integration\Generic\Domain\Entity\RemoteEndpoint;
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Enum\MappingDirection;
+use App\Integration\Generic\Domain\Enum\RemoteEndpointRole;
+use App\Integration\Generic\Domain\Enum\SyncDirection;
+use App\Integration\Generic\Domain\Enum\SyncRunStatus;
+use App\Integration\Generic\Domain\GenericRestResponse;
+use App\Integration\Generic\Domain\Repository\SyncRunRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Tests\Unit\Integration\Generic\Infrastructure\Http\Pagination\RecordingRequester;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * APIC-P3-06 — end-to-end outbound sync: real catalog objects are serialised by
+ * the Export-engine reader, mapped to a 1:1 push body and POSTed to the write
+ * endpoint (push captured by a fake requester). Offline + deterministic.
+ */
+final class OutboundSyncRunnerTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private Tenant $tenant;
+    private ObjectType $productType;
+    private Attribute $sku;
+    private Attribute $name;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $em = $this->em();
+        $this->tenant = new Tenant('demo', 'Demo');
+        $em->persist($this->tenant);
+        $em->flush();
+        $this->tenantContext()->set($this->tenant);
+
+        $this->productType = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
+        $em->persist($this->productType);
+        $this->sku = new Attribute('sku', ['pl' => 'SKU'], AttributeType::Text);
+        $this->name = new Attribute('name', ['pl' => 'Nazwa'], AttributeType::Text);
+        $em->persist($this->sku);
+        $em->persist($this->name);
+        $em->flush();
+    }
+
+    #[Test]
+    public function pushesEachObjectAsAMappedBody(): void
+    {
+        $this->seedObject('A-1', 'Widget');
+        $this->seedObject('B-2', 'Gadget');
+        $binding = $this->seedBinding();
+
+        $requester = new RecordingRequester(default: new GenericRestResponse(201, [], '{}', 1, 2));
+        $run = $this->runner($requester)->run($binding);
+        $this->em()->flush();
+
+        self::assertSame(SyncRunStatus::Success, $run->getStatus());
+        self::assertSame(2, $run->getCreatedCount());
+        self::assertCount(2, $requester->calls);
+
+        // Each push is a POST to the write endpoint with a {sku,name} body.
+        $skus = [];
+        foreach ($requester->calls as $call) {
+            self::assertSame('POST', $call['method']);
+            self::assertSame('https://api.example.com/products', $call['url']);
+            $body = json_decode((string) $call['body'], true, 512, JSON_THROW_ON_ERROR);
+            self::assertIsArray($body);
+            self::assertArrayHasKey('sku', $body);
+            self::assertArrayHasKey('name', $body);
+            $skus[] = $body['sku'];
+        }
+        sort($skus);
+        self::assertSame(['A-1', 'B-2'], $skus);
+    }
+
+    private function seedObject(string $sku, string $name): void
+    {
+        $em = $this->em();
+        $object = new CatalogObject($this->productType, $sku);
+        $em->persist($object);
+        $em->persist(new ObjectValue($object, $this->sku, ['value' => $sku]));
+        $em->persist(new ObjectValue($object, $this->name, ['value' => $name]));
+        $em->flush();
+    }
+
+    private function seedBinding(): SyncBinding
+    {
+        $em = $this->em();
+        $connection = new Connection('idosell', 'IdoSell', 'https://api.example.com');
+        $connection->assignTenant($this->tenant);
+        $em->persist($connection);
+
+        $writeEndpoint = new RemoteEndpoint($connection, RemoteEndpointRole::WriteCreate, 'POST', '/products');
+        $writeEndpoint->assignTenant($this->tenant);
+        $em->persist($writeEndpoint);
+
+        $skuMapping = new FieldMapping($connection, 'sku', '$.sku', MappingDirection::Outbound);
+        $skuMapping->assignTenant($this->tenant);
+        $skuMapping->setMatchKey(true);
+        $em->persist($skuMapping);
+        $nameMapping = new FieldMapping($connection, 'name', '$.name', MappingDirection::Outbound);
+        $nameMapping->assignTenant($this->tenant);
+        $em->persist($nameMapping);
+
+        $binding = new SyncBinding($connection, $this->productType->getId(), SyncDirection::Outbound);
+        $binding->assignTenant($this->tenant);
+        $binding->setWriteEndpoint($writeEndpoint);
+        $em->persist($binding);
+        $em->flush();
+
+        return $binding;
+    }
+
+    private function runner(RecordingRequester $requester): OutboundSyncRunner
+    {
+        return new OutboundSyncRunner(
+            self::getContainer()->get(\App\Integration\Generic\Domain\Repository\FieldMappingRepositoryInterface::class),
+            new PayloadBuilder(),
+            self::getContainer()->get(OutboundRecordReader::class),
+            $requester,
+            self::getContainer()->get(SyncRunRepositoryInterface::class),
+            $this->em(),
+        );
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Application/Sync/PayloadBuilderTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Application/Sync/PayloadBuilderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Application\Sync;
+
+use App\Integration\Generic\Application\Sync\PayloadBuilder;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\FieldMapping;
+use App\Integration\Generic\Domain\Enum\MappingDirection;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PayloadBuilderTest extends TestCase
+{
+    private PayloadBuilder $builder;
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->builder = new PayloadBuilder();
+        $this->connection = new Connection('idosell', 'IdoSell', 'https://api.idosell.com');
+    }
+
+    #[Test]
+    public function buildsNestedBodyFromOutboundMappings(): void
+    {
+        $mappings = [
+            $this->mapping('sku', '$.sku', MappingDirection::Outbound),
+            $this->mapping('name', '$.title', MappingDirection::Both),
+            $this->mapping('price', '$.price.amount', MappingDirection::Outbound),
+        ];
+        $values = ['sku' => 'A-1', 'name' => 'Widget', 'price' => '1999'];
+
+        $body = $this->builder->build($values, $mappings);
+
+        self::assertSame([
+            'sku' => 'A-1',
+            'title' => 'Widget',
+            'price' => ['amount' => '1999'],
+        ], $body);
+    }
+
+    #[Test]
+    public function ignoresInboundOnlyMappingsAndMissingValues(): void
+    {
+        $mappings = [
+            $this->mapping('sku', '$.sku', MappingDirection::Outbound),
+            $this->mapping('secret', '$.secret', MappingDirection::Inbound), // inbound-only → ignored
+            $this->mapping('gone', '$.gone', MappingDirection::Outbound),     // no value → skipped
+        ];
+        $values = ['sku' => 'A-1', 'secret' => 'x'];
+
+        $body = $this->builder->build($values, $mappings);
+
+        self::assertSame(['sku' => 'A-1'], $body);
+    }
+
+    private function mapping(string $pimTarget, string $remotePath, MappingDirection $direction): FieldMapping
+    {
+        return new FieldMapping($this->connection, $pimTarget, $remotePath, $direction);
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Infrastructure/Http/Pagination/RecordingRequester.php
+++ b/apps/api/tests/Unit/Integration/Generic/Infrastructure/Http/Pagination/RecordingRequester.php
@@ -16,7 +16,7 @@ use App\Integration\Generic\Infrastructure\Http\RemoteRequester;
  */
 final class RecordingRequester implements RemoteRequester
 {
-    /** @var list<array{url: string, query: array<string, string|int>}> */
+    /** @var list<array{url: string, method: string, query: array<string, string|int>, body: ?string}> */
     public array $calls = [];
 
     /**
@@ -36,7 +36,7 @@ final class RecordingRequester implements RemoteRequester
         array $headers = [],
         ?string $body = null,
     ): GenericRestResponse {
-        $this->calls[] = ['url' => $url, 'query' => $query];
+        $this->calls[] = ['url' => $url, 'method' => $method, 'query' => $query, 'body' => $body];
 
         return array_shift($this->queue)
             ?? $this->default


### PR DESCRIPTION
## Cel

APIC-P3-06 — outbound push (PIM → remote), payload budowany **Export engine** (nie własny serializer).

## Zakres

- **Catalog Contracts seam** `OutboundRecordReader` (+ `OutboundRecord`) — czyta obiekty `ObjectType` zserializowane przez **`ValueSerializer`** Export engine (adapter `Export\Application\Integration\ExportOutboundRecordReader`), więc payload = to co eksport pliku. Integration zależy tylko od kontraktu (Catalog_Contracts).
- **`PayloadBuilder`** (Integration) — `{code => serialized}` + outbound field mappings → **zagnieżdżone body** (`$.price.amount` → `{"price":{"amount":…}}`), 1:1.
- **`OutboundSyncRunner`** — czyta obiekty przez reader → buduje body → push do `writeEndpoint` (URL z podstawieniem `{token}` = match value) przez SSRF-safe **BackoffRestClient** (P1-09: backoff/retry/dead-letter) → per-record `SyncRunLog` + liczniki (zły rekord nie wywala całego runu).
- **`OutboundSyncHandler`** (`#[AsMessageHandler]`) + **`OutboundSyncMessage`** (`TenantAwareMessage`) na transporcie **`import`**.

## Decyzje / odejścia

- „Które obiekty" w MVP: **wszystkie obiekty `ObjectType`** bindingu (delta/lifecycle = P3-07). Pełen odczyt per run; keyset paging dla 50k = follow-up (jak inbound).
- `Export → Catalog\Domain` reach (CatalogObject/ObjectValue/repos) **baselined** w `deptrac.yaml` — identyczny wzorzec jak istniejące `ValueSerializer`/`SyncExportRunner` (implementacja jest z natury Catalog-data-bound).

## Bramki (kontener api)

- **PHPStan max** ✅ · **Deptrac** 0 (po dodaniu adaptera do baseline Export→Catalog\Domain) ✅ · **PHP-CS-Fixer** 0 ✅
- **PHPUnit** ✅: `PayloadBuilderTest` (unit — nested body, inbound-only/missing skip), `OutboundSyncRunnerTest` (**Integration E2E** — realne obiekty POSTowane jako zmapowane body, push przechwycony), `MessengerRoutingTest` (→ import). Generic unit regresja 120/120.

Refs #1784