### PR TITLE
feat(integration): outbound trigger on object lifecycle event (APIC-P3-07)

### DIFF
--- a/apps/api/src/Catalog/Contracts/Event/ObjectAttributesChanged.php
+++ b/apps/api/src/Catalog/Contracts/Event/ObjectAttributesChanged.php
@@ -28,6 +28,9 @@ final readonly class ObjectAttributesChanged implements DomainEvent, TenantAware
         public Uuid $tenantId,
         public array $changedAttributeCodes = [],
         public DateTimeImmutable $occurredOn = new DateTimeImmutable(),
+        // APIC-P3-07 — lets cross-BC consumers (the outbound-sync trigger) route
+        // by object type without a second lookup. Null only for legacy emitters.
+        public ?Uuid $objectTypeId = null,
     ) {
     }
 

--- a/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
+++ b/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
@@ -400,6 +400,7 @@ class CatalogObject extends AggregateRoot implements TenantScoped, Blameable
             objectId: $this->id,
             tenantId: $this->tenant->getId(),
             changedAttributeCodes: $changedCodes,
+            objectTypeId: $this->objectType->getId(),
         ));
     }
 

--- a/apps/api/src/Integration/Generic/Application/Subscriber/OutboundTriggerSubscriber.php
+++ b/apps/api/src/Integration/Generic/Application/Subscriber/OutboundTriggerSubscriber.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application\Subscriber;
+
+use App\Catalog\Contracts\BulkGuard;
+use App\Catalog\Contracts\Event\ObjectAttributesChanged;
+use App\Integration\Generic\Domain\Message\OutboundSyncMessage;
+use App\Integration\Generic\Domain\Repository\SyncBindingRepositoryInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Enqueues an outbound sync when a catalog object changes (APIC-P3-07).
+ *
+ * Listens to the cross-BC {@see ObjectAttributesChanged} domain event and, for
+ * every enabled binding that writes to a remote (outbound/bidirectional) AND
+ * targets the changed object's ObjectType, dispatches an {@see OutboundSyncMessage}.
+ *
+ * Bulk flows (import, bulk edit) run under {@see BulkGuard} and are skipped — a
+ * 50k import must not enqueue a sync per row; those paths trigger one run when
+ * they finish. The event without an ObjectType id (legacy emitter) is ignored.
+ */
+#[AsMessageHandler]
+final readonly class OutboundTriggerSubscriber
+{
+    public function __construct(
+        private BulkGuard $bulkGuard,
+        private SyncBindingRepositoryInterface $bindings,
+        private MessageBusInterface $bus,
+    ) {
+    }
+
+    public function __invoke(ObjectAttributesChanged $event): void
+    {
+        if ($this->bulkGuard->isBulk() || null === $event->objectTypeId) {
+            return;
+        }
+
+        $objectTypeId = $event->objectTypeId->toRfc4122();
+
+        foreach ($this->bindings->findEnabled() as $binding) {
+            if (!$binding->getDirection()->writesRemote()) {
+                continue;
+            }
+            if ($binding->getObjectTypeId()->toRfc4122() !== $objectTypeId) {
+                continue;
+            }
+
+            $this->bus->dispatch(new OutboundSyncMessage($binding->getId(), $event->tenantId));
+        }
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Application/Subscriber/OutboundTriggerSubscriberTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Application/Subscriber/OutboundTriggerSubscriberTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Application\Subscriber;
+
+use App\Catalog\Contracts\BulkGuard;
+use App\Catalog\Contracts\Event\ObjectAttributesChanged;
+use App\Integration\Generic\Application\Subscriber\OutboundTriggerSubscriber;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Enum\SyncDirection;
+use App\Integration\Generic\Domain\Message\OutboundSyncMessage;
+use App\Integration\Generic\Domain\Repository\SyncBindingRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class OutboundTriggerSubscriberTest extends TestCase
+{
+    #[Test]
+    public function enqueuesOnlyMatchingOutboundBindings(): void
+    {
+        $productType = Uuid::v7();
+        $categoryType = Uuid::v7();
+        $connection = new Connection('idosell', 'IdoSell', 'https://api.idosell.com');
+
+        $bindings = [
+            $this->binding($connection, $productType, SyncDirection::Outbound),     // match
+            $this->binding($connection, $productType, SyncDirection::Bidirectional), // match
+            $this->binding($connection, $productType, SyncDirection::Inbound),       // inbound → no
+            $this->binding($connection, $categoryType, SyncDirection::Outbound),     // other type → no
+        ];
+
+        $bus = $this->bus();
+        $this->subscriber($bus, $bindings, bulk: false)(
+            new ObjectAttributesChanged(Uuid::v7(), Uuid::v7(), ['name'], objectTypeId: $productType),
+        );
+
+        self::assertCount(2, $bus->dispatched);
+        self::assertContainsOnlyInstancesOf(OutboundSyncMessage::class, $bus->dispatched);
+    }
+
+    #[Test]
+    public function skipsDuringBulk(): void
+    {
+        $bus = $this->bus();
+        $type = Uuid::v7();
+        $binding = $this->binding(new Connection('c', 'C', 'https://x'), $type, SyncDirection::Outbound);
+
+        $this->subscriber($bus, [$binding], bulk: true)(
+            new ObjectAttributesChanged(Uuid::v7(), Uuid::v7(), [], objectTypeId: $type),
+        );
+
+        self::assertSame([], $bus->dispatched);
+    }
+
+    #[Test]
+    public function skipsWhenEventHasNoObjectType(): void
+    {
+        $bus = $this->bus();
+        $binding = $this->binding(new Connection('c', 'C', 'https://x'), Uuid::v7(), SyncDirection::Outbound);
+
+        $this->subscriber($bus, [$binding], bulk: false)(
+            new ObjectAttributesChanged(Uuid::v7(), Uuid::v7(), []),
+        );
+
+        self::assertSame([], $bus->dispatched);
+    }
+
+    private function binding(Connection $connection, Uuid $objectTypeId, SyncDirection $direction): SyncBinding
+    {
+        return new SyncBinding($connection, $objectTypeId, $direction);
+    }
+
+    /**
+     * @param list<SyncBinding> $bindings
+     */
+    private function subscriber(RecordingMessageBus $bus, array $bindings, bool $bulk): OutboundTriggerSubscriber
+    {
+        $guard = $this->createStub(BulkGuard::class);
+        $guard->method('isBulk')->willReturn($bulk);
+
+        $repo = $this->createStub(SyncBindingRepositoryInterface::class);
+        $repo->method('findEnabled')->willReturn($bindings);
+
+        return new OutboundTriggerSubscriber($guard, $repo, $bus);
+    }
+
+    private function bus(): RecordingMessageBus
+    {
+        return new RecordingMessageBus();
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Application/Subscriber/RecordingMessageBus.php
+++ b/apps/api/tests/Unit/Integration/Generic/Application/Subscriber/RecordingMessageBus.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Application\Subscriber;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Test double for {@see MessageBusInterface} that records dispatched messages
+ * (so the outbound-trigger subscriber's enqueues can be asserted).
+ */
+final class RecordingMessageBus implements MessageBusInterface
+{
+    /** @var list<object> */
+    public array $dispatched = [];
+
+    public function dispatch(object $message, array $stamps = []): Envelope
+    {
+        $this->dispatched[] = $message;
+
+        return new Envelope($message);
+    }
+}


### PR DESCRIPTION
## Cel

APIC-P3-07 — wyzwalać outbound run na zmianę obiektu (reuse lifecycle event).

## Zakres

- **`OutboundTriggerSubscriber`** (`#[AsMessageHandler]` na cross-BC `ObjectAttributesChanged`) → dla każdego **enabled** bindingu który pisze do remote (outbound/bidirectional) **i** celuje w `ObjectType` zmienionego obiektu → dispatch `OutboundSyncMessage`.
- **Bulk guard (AC-3):** pomija gdy `Catalog\Contracts\BulkGuard::isBulk()` — import 50k nie zalewa kolejki (te ścieżki triggerują run na końcu).
- **`ObjectAttributesChanged`** zyskuje opcjonalne `objectTypeId` (CatalogObject je wypełnia) — cross-BC consumer routuje po typie bez drugiego lookupu; istniejący konsumenci (Mercure, schema-drift) bez zmian (pole opcjonalne na końcu).

## Bramki (kontener api)

- **PHPStan max** ✅ · **Deptrac** 0 (subscriber → Catalog_Contracts: BulkGuard + event) ✅ · **PHP-CS-Fixer** 0 ✅
- **PHPUnit** ✅: `OutboundTriggerSubscriberTest` (AC-1 enqueue, AC-2 tylko pasujące outbound/bidirectional+typ, AC-3 bulk skip, brak objectTypeId skip) + regresja konsumentów eventu (`MercurePublisherTest`, `SchemaDriftTest`) 12/12.

Refs #1785