### PR TITLE
feat(integration): schedule sync bindings with cron + per-tenant jitter (APIC-P3-09)

### DIFF
--- a/apps/api/migrations/Version20260629130000.php
+++ b/apps/api/migrations/Version20260629130000.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * APIC-P3-09 (ADR-0022, epic APIC) — add the `next_run` column to
+ * `integration_sync_bindings` so the schedule dispatcher can persist (and the
+ * FE can surface) the next jittered fire time of every scheduled binding. A
+ * `(tenant_id, enabled, next_run)` index backs the per-tenant due-bindings scan.
+ *
+ * No RLS change: the column lives on the existing FORCE-RLS table created in
+ * APIC-P3-01.
+ */
+final class Version20260629130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'APIC-P3-09: add integration_sync_bindings.next_run + due index for the schedule dispatcher.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE integration_sync_bindings ADD next_run TIMESTAMP(0) WITH TIME ZONE DEFAULT NULL');
+        $this->addSql('CREATE INDEX integration_sync_bindings_due_idx ON integration_sync_bindings (tenant_id, enabled, next_run)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX integration_sync_bindings_due_idx');
+        $this->addSql('ALTER TABLE integration_sync_bindings DROP next_run');
+    }
+}

--- a/apps/api/src/Integration/Generic/Application/Schedule/SyncScheduleCalculator.php
+++ b/apps/api/src/Integration/Generic/Application/Schedule/SyncScheduleCalculator.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application\Schedule;
+
+use Cron\CronExpression;
+use DateTimeImmutable;
+use DateTimeZone;
+use Throwable;
+
+/**
+ * Next-run arithmetic for scheduled sync bindings (ADR-0022, epic APIC, ticket
+ * APIC-P3-09). A thin wrapper over `dragonmantank/cron-expression` plus a
+ * deterministic per-seed jitter.
+ *
+ * Reuses the cron *library* directly rather than `Import\…\CronExpressionParser`:
+ * the Integration context may not depend on Import (ADR-0022 keeps cross-BC
+ * coupling to Contracts), and the parser is itself only a wrapper over the same
+ * vendor class.
+ *
+ * Jitter: every tenant gets a stable offset derived from its id, so 200 tenants
+ * whose binding fires at `0 2 * * *` don't all hit the same remote API at
+ * 02:00:00 — they spread across a {@see self::maxJitterSeconds}-wide window. The
+ * offset is deterministic (a `crc32` of the seed), so a tenant's fire time stays
+ * predictable run-to-run instead of drifting randomly.
+ */
+final readonly class SyncScheduleCalculator
+{
+    /**
+     * @param int $maxJitterSeconds width of the spread window (default 5 min);
+     *                              0 disables jitter
+     */
+    public function __construct(
+        private int $maxJitterSeconds = 300,
+    ) {
+    }
+
+    public function isValid(string $expression): bool
+    {
+        try {
+            new CronExpression($expression);
+
+            return true;
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    public function nextRun(string $expression, ?DateTimeImmutable $from = null): DateTimeImmutable
+    {
+        $cron = new CronExpression($expression);
+        $reference = $from ?? new DateTimeImmutable('now', new DateTimeZone('UTC'));
+
+        return DateTimeImmutable::createFromMutable($cron->getNextRunDate($reference));
+    }
+
+    /**
+     * The next fire time pushed forward by the seed's stable jitter offset.
+     */
+    public function nextRunWithJitter(string $expression, string $jitterSeed, ?DateTimeImmutable $from = null): DateTimeImmutable
+    {
+        $base = $this->nextRun($expression, $from);
+        $offset = $this->jitterSeconds($jitterSeed);
+        if (0 === $offset) {
+            return $base;
+        }
+
+        return $base->modify(\sprintf('+%d seconds', $offset));
+    }
+
+    /**
+     * Stable offset in `[0, maxJitterSeconds]` for a seed (typically a tenant id).
+     */
+    public function jitterSeconds(string $jitterSeed): int
+    {
+        if ($this->maxJitterSeconds <= 0) {
+            return 0;
+        }
+
+        return crc32($jitterSeed) % ($this->maxJitterSeconds + 1);
+    }
+}

--- a/apps/api/src/Integration/Generic/Application/Schedule/SyncScheduleDispatcher.php
+++ b/apps/api/src/Integration/Generic/Application/Schedule/SyncScheduleDispatcher.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application\Schedule;
+
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Message\InboundSyncMessage;
+use App\Integration\Generic\Domain\Message\OutboundSyncMessage;
+use App\Integration\Generic\Domain\Repository\SyncBindingRepositoryInterface;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Drives a {@see SyncBinding}'s schedule (ADR-0022, epic APIC, ticket APIC-P3-09):
+ * keeps its `nextRun` up to date and fires the actual sync leg(s).
+ *
+ * `computeNextRun()` refreshes the stored next-run from the cron expression
+ * (jittered per tenant); a binding with no — or an invalid — cron is left with a
+ * null `nextRun` (manual-only). `dispatch()` enqueues the per-direction sync
+ * message(s) on the `import` transport and then advances `nextRun` so the
+ * binding rolls forward to its next slot. Bidirectional bindings fire both legs;
+ * the inbound/outbound handlers + {@see \App\Integration\Generic\Application\Sync\ConflictResolver}
+ * reconcile any overlap.
+ */
+final readonly class SyncScheduleDispatcher
+{
+    public function __construct(
+        private SyncScheduleCalculator $calculator,
+        private SyncBindingRepositoryInterface $bindings,
+        private MessageBusInterface $bus,
+    ) {
+    }
+
+    public function computeNextRun(SyncBinding $binding, ?DateTimeImmutable $from = null): void
+    {
+        $schedule = $binding->getSchedule();
+        if (null === $schedule || !$this->calculator->isValid($schedule)) {
+            $binding->setNextRun(null);
+            $this->bindings->save($binding);
+
+            return;
+        }
+
+        $binding->setNextRun($this->calculator->nextRunWithJitter($schedule, $this->jitterSeed($binding), $from));
+        $this->bindings->save($binding);
+    }
+
+    /**
+     * Fire the binding now: enqueue its sync leg(s) and roll `nextRun` forward.
+     */
+    public function dispatch(SyncBinding $binding): void
+    {
+        $tenantId = $this->tenantId($binding);
+        $direction = $binding->getDirection();
+
+        if ($direction->readsRemote()) {
+            $this->bus->dispatch(new InboundSyncMessage($binding->getId(), $tenantId));
+        }
+        if ($direction->writesRemote()) {
+            $this->bus->dispatch(new OutboundSyncMessage($binding->getId(), $tenantId));
+        }
+
+        $this->computeNextRun($binding);
+    }
+
+    private function tenantId(SyncBinding $binding): Uuid
+    {
+        $tenant = $binding->getTenant();
+        if (null === $tenant) {
+            throw new LogicException('Cannot dispatch a sync for a binding without an assigned tenant.');
+        }
+
+        return $tenant->getId();
+    }
+
+    /**
+     * Seed the jitter on the tenant id so every binding of a tenant spreads off
+     * the same offset; fall back to the binding id before the tenant is assigned.
+     */
+    private function jitterSeed(SyncBinding $binding): string
+    {
+        return $binding->getTenant()?->getId()->toRfc4122() ?? $binding->getId()->toRfc4122();
+    }
+}

--- a/apps/api/src/Integration/Generic/Domain/Entity/SyncBinding.php
+++ b/apps/api/src/Integration/Generic/Domain/Entity/SyncBinding.php
@@ -65,6 +65,13 @@ class SyncBinding extends AggregateRoot implements TenantScoped
 
     private bool $enabled = true;
 
+    /**
+     * When the scheduler next fires this binding; null = manual-only (no cron)
+     * or not yet computed. Maintained by the schedule dispatcher (APIC-P3-09),
+     * jittered per tenant so concurrent bindings don't stampede the same remote.
+     */
+    private ?DateTimeImmutable $nextRun = null;
+
     private DateTimeImmutable $createdAt;
 
     private DateTimeImmutable $updatedAt;
@@ -224,6 +231,21 @@ class SyncBinding extends AggregateRoot implements TenantScoped
     {
         $this->enabled = $enabled;
         $this->touch();
+    }
+
+    public function getNextRun(): ?DateTimeImmutable
+    {
+        return $this->nextRun;
+    }
+
+    /**
+     * Set by the schedule dispatcher only. Deliberately does NOT `touch()`
+     * `updatedAt`: the next-run time is recomputed after every fire, and that
+     * housekeeping must not look like a user edit of the binding.
+     */
+    public function setNextRun(?DateTimeImmutable $nextRun): void
+    {
+        $this->nextRun = $nextRun;
     }
 
     public function getCreatedAt(): DateTimeImmutable

--- a/apps/api/src/Integration/Generic/Domain/Repository/SyncBindingRepositoryInterface.php
+++ b/apps/api/src/Integration/Generic/Domain/Repository/SyncBindingRepositoryInterface.php
@@ -6,6 +6,7 @@ namespace App\Integration\Generic\Domain\Repository;
 
 use App\Integration\Generic\Domain\Entity\Connection;
 use App\Integration\Generic\Domain\Entity\SyncBinding;
+use DateTimeImmutable;
 use Symfony\Component\Uid\Uuid;
 
 interface SyncBindingRepositoryInterface
@@ -25,4 +26,13 @@ interface SyncBindingRepositoryInterface
      * @return list<SyncBinding>
      */
     public function findEnabled(): array;
+
+    /**
+     * Enabled, cron-scheduled bindings of the current tenant whose `nextRun` has
+     * arrived (`<= $now`). Runs under the active tenant scope (TenantFilter + RLS
+     * GUC), so the schedule dispatcher must bind one tenant at a time.
+     *
+     * @return list<SyncBinding>
+     */
+    public function findDueForScheduling(DateTimeImmutable $now): array;
 }

--- a/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Orm/Mapping/SyncBinding.orm.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Orm/Mapping/SyncBinding.orm.xml
@@ -11,6 +11,7 @@
         <indexes>
             <index name="integration_sync_bindings_tenant_conn_idx" columns="tenant_id,connection_id"/>
             <index name="integration_sync_bindings_tenant_enabled_idx" columns="tenant_id,enabled"/>
+            <index name="integration_sync_bindings_due_idx" columns="tenant_id,enabled,next_run"/>
         </indexes>
 
         <id name="id" type="uuid" column="id">
@@ -48,6 +49,7 @@
                 <option name="default">true</option>
             </options>
         </field>
+        <field name="nextRun" type="datetimetz_immutable" column="next_run" nullable="true"/>
         <field name="createdAt" type="datetimetz_immutable" column="created_at"/>
         <field name="updatedAt" type="datetimetz_immutable" column="updated_at"/>
 

--- a/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Repository/DoctrineSyncBindingRepository.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Repository/DoctrineSyncBindingRepository.php
@@ -7,6 +7,7 @@ namespace App\Integration\Generic\Infrastructure\Doctrine\Repository;
 use App\Integration\Generic\Domain\Entity\Connection;
 use App\Integration\Generic\Domain\Entity\SyncBinding;
 use App\Integration\Generic\Domain\Repository\SyncBindingRepositoryInterface;
+use DateTimeImmutable;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Uid\Uuid;
@@ -64,6 +65,25 @@ class DoctrineSyncBindingRepository extends ServiceEntityRepository implements S
         $qb = $this->createQueryBuilder('b')
             ->where('b.enabled = true')
             ->orderBy('b.createdAt', 'ASC');
+
+        /** @var list<SyncBinding> $result */
+        $result = $qb->getQuery()->getResult();
+
+        return $result;
+    }
+
+    /**
+     * @return list<SyncBinding>
+     */
+    public function findDueForScheduling(DateTimeImmutable $now): array
+    {
+        $qb = $this->createQueryBuilder('b')
+            ->where('b.enabled = true')
+            ->andWhere('b.schedule IS NOT NULL')
+            ->andWhere('b.nextRun IS NOT NULL')
+            ->andWhere('b.nextRun <= :now')
+            ->orderBy('b.nextRun', 'ASC')
+            ->setParameter('now', $now);
 
         /** @var list<SyncBinding> $result */
         $result = $qb->getQuery()->getResult();

--- a/apps/api/src/Integration/Generic/Infrastructure/Scheduler/SyncSchedule.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/Scheduler/SyncSchedule.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\Scheduler;
+
+use App\Shared\Infrastructure\Scheduler\RunMaintenanceCommand;
+use Symfony\Component\Scheduler\Attribute\AsSchedule;
+use Symfony\Component\Scheduler\RecurringMessage;
+use Symfony\Component\Scheduler\Schedule;
+use Symfony\Component\Scheduler\ScheduleProviderInterface;
+
+/**
+ * APIC-P3-09 (ADR-0022, epic APIC) — the per-minute tick that fires due sync
+ * bindings.
+ *
+ * Per-binding cron lives in the DB ({@see \App\Integration\Generic\Domain\Entity\SyncBinding}),
+ * so a single recurring message can't enumerate them. Instead this schedule ticks
+ * every minute and asks the worker to run `integration:sync:dispatch-due`, which
+ * sweeps every tenant and enqueues the legs whose `nextRun` has arrived. Reuses
+ * Shared's {@see RunMaintenanceCommand} runner (no per-command message class).
+ *
+ * Worker: the `scheduler_integration_sync` transport is auto-registered from the
+ * `#[AsSchedule]` name and drained by `messenger:consume scheduler_integration_sync`
+ * (docker-compose `worker`).
+ */
+#[AsSchedule('integration_sync')]
+final class SyncSchedule implements ScheduleProviderInterface
+{
+    private ?Schedule $schedule = null;
+
+    public function getSchedule(): Schedule
+    {
+        return $this->schedule ??= new Schedule()->add(
+            RecurringMessage::cron('* * * * *', new RunMaintenanceCommand('integration:sync:dispatch-due')),
+        );
+    }
+}

--- a/apps/api/src/Integration/Generic/Presentation/Command/DispatchDueSyncBindingsCommand.php
+++ b/apps/api/src/Integration/Generic/Presentation/Command/DispatchDueSyncBindingsCommand.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Presentation\Command;
+
+use App\Integration\Generic\Application\Schedule\SyncScheduleDispatcher;
+use App\Integration\Generic\Domain\Repository\SyncBindingRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Repository\TenantRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use DateTimeZone;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * APIC-P3-09 (ADR-0022, epic APIC) — fires every scheduled {@see \App\Integration\Generic\Domain\Entity\SyncBinding}
+ * whose `nextRun` has arrived.
+ *
+ * Driven on a per-minute cadence by {@see \App\Integration\Generic\Infrastructure\Scheduler\SyncSchedule}
+ * (Symfony Scheduler → the worker's `scheduler_integration_sync` transport),
+ * mirroring how the maintenance schedule runs its sweeps. Each due binding's
+ * sync leg(s) are enqueued on the `import` transport by the dispatcher; the
+ * actual pull/push runs on the worker.
+ *
+ * Tenant scoping: FORCE RLS hides `integration_sync_bindings` from the app role
+ * until the `app.current_tenant` GUC is set, so the scan runs per tenant — it
+ * binds {@see TenantContext} (TenantFilter) AND the Postgres GUC (RLS), exactly
+ * like {@see \App\Shared\Infrastructure\Messenger\TenantRlsGucMiddleware} does
+ * for workers and like {@see \App\Catalog\Presentation\Command\DetectAttributesDriftCommand}.
+ */
+#[AsCommand(
+    name: 'integration:sync:dispatch-due',
+    description: 'Dispatch every scheduled sync binding whose next run time has arrived (all tenants).',
+)]
+final class DispatchDueSyncBindingsCommand extends Command
+{
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly TenantContext $tenantContext,
+        private readonly TenantRepositoryInterface $tenants,
+        private readonly SyncBindingRepositoryInterface $bindings,
+        private readonly SyncScheduleDispatcher $dispatcher,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+
+        $dispatched = 0;
+        foreach ($this->tenants->findAllOrderedByCode() as $tenant) {
+            $this->bindTenant($tenant);
+            try {
+                foreach ($this->bindings->findDueForScheduling($now) as $binding) {
+                    $this->dispatcher->dispatch($binding);
+                    ++$dispatched;
+                }
+            } finally {
+                $this->unbindTenant();
+            }
+        }
+
+        $io->success(\sprintf('Dispatched %d due sync binding(s).', $dispatched));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Bind the tenant on BOTH isolation layers: the PHP-side {@see TenantContext}
+     * (TenantFilter) and the Postgres `app.current_tenant` GUC (FORCE RLS).
+     */
+    private function bindTenant(Tenant $tenant): void
+    {
+        $this->tenantContext->set($tenant);
+        // tenant-safe: infrastructure (establishes the tenant_id RLS policies read in this CLI session; this IS the tenant boundary, not a bypass)
+        $this->connection->executeStatement(
+            "SELECT set_config('app.current_tenant', :tenant_id, false)",
+            ['tenant_id' => $tenant->getId()->toRfc4122()],
+        );
+        // tenant-safe: infrastructure (the scheduler CLI never runs as super-admin)
+        $this->connection->executeStatement("SELECT set_config('app.is_super_admin', 'false', false)");
+    }
+
+    private function unbindTenant(): void
+    {
+        $this->tenantContext->clear();
+        // tenant-safe: infrastructure (resets the RLS tenant marker so the next tenant in the sweep starts clean)
+        $this->connection->executeStatement("SELECT set_config('app.current_tenant', '', false)");
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Application/Schedule/InMemorySyncBindingRepository.php
+++ b/apps/api/tests/Unit/Integration/Generic/Application/Schedule/InMemorySyncBindingRepository.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Application\Schedule;
+
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Repository\SyncBindingRepositoryInterface;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * In-memory {@see SyncBindingRepositoryInterface} for the schedule dispatcher
+ * unit tests — records `save()` calls so `nextRun` recomputation can be asserted
+ * without a database.
+ */
+final class InMemorySyncBindingRepository implements SyncBindingRepositoryInterface
+{
+    /** @var list<SyncBinding> */
+    public array $saved = [];
+
+    /** @var list<SyncBinding> */
+    public array $due = [];
+
+    public function save(SyncBinding $binding): void
+    {
+        $this->saved[] = $binding;
+    }
+
+    public function remove(SyncBinding $binding): void
+    {
+    }
+
+    public function findById(Uuid $id): ?SyncBinding
+    {
+        return null;
+    }
+
+    public function findByConnection(Connection $connection): array
+    {
+        return [];
+    }
+
+    public function findEnabled(): array
+    {
+        return [];
+    }
+
+    public function findDueForScheduling(DateTimeImmutable $now): array
+    {
+        return $this->due;
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Application/Schedule/SyncScheduleCalculatorTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Application/Schedule/SyncScheduleCalculatorTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Application\Schedule;
+
+use App\Integration\Generic\Application\Schedule\SyncScheduleCalculator;
+use DateTimeImmutable;
+use DateTimeZone;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SyncScheduleCalculator::class)]
+final class SyncScheduleCalculatorTest extends TestCase
+{
+    private function utc(string $at): DateTimeImmutable
+    {
+        return new DateTimeImmutable($at, new DateTimeZone('UTC'));
+    }
+
+    public function testIsValidAcceptsAndRejects(): void
+    {
+        $calc = new SyncScheduleCalculator();
+
+        self::assertTrue($calc->isValid('0 2 * * *'));
+        self::assertTrue($calc->isValid('*/5 * * * *'));
+        self::assertFalse($calc->isValid('not a cron'));
+        self::assertFalse($calc->isValid('99 99 * * *'));
+    }
+
+    public function testNextRunComputesTheNextDailySlot(): void
+    {
+        $calc = new SyncScheduleCalculator();
+
+        $next = $calc->nextRun('0 2 * * *', $this->utc('2026-06-29 12:00:00'));
+
+        self::assertSame('2026-06-30 02:00:00', $next->format('Y-m-d H:i:s'));
+    }
+
+    public function testNextRunComputesTheNextFiveMinuteSlot(): void
+    {
+        $calc = new SyncScheduleCalculator();
+
+        $next = $calc->nextRun('*/5 * * * *', $this->utc('2026-06-29 12:01:00'));
+
+        self::assertSame('2026-06-29 12:05:00', $next->format('Y-m-d H:i:s'));
+    }
+
+    public function testJitterIsDeterministicAndBounded(): void
+    {
+        $calc = new SyncScheduleCalculator(maxJitterSeconds: 300);
+        $seed = 'tenant-abc';
+
+        $first = $calc->jitterSeconds($seed);
+        $second = $calc->jitterSeconds($seed);
+
+        self::assertSame($first, $second, 'same seed must yield the same offset');
+        self::assertGreaterThanOrEqual(0, $first);
+        self::assertLessThanOrEqual(300, $first);
+    }
+
+    public function testJitterDisabledWhenWindowIsZero(): void
+    {
+        $calc = new SyncScheduleCalculator(maxJitterSeconds: 0);
+
+        self::assertSame(0, $calc->jitterSeconds('any-seed'));
+    }
+
+    public function testJitterSpreadsAcrossSeeds(): void
+    {
+        $calc = new SyncScheduleCalculator(maxJitterSeconds: 300);
+
+        $offsets = [];
+        foreach (['t-1', 't-2', 't-3', 't-4', 't-5', 't-6', 't-7', 't-8'] as $seed) {
+            $offsets[] = $calc->jitterSeconds($seed);
+        }
+
+        // AC-2: the jitter must actually disperse starts — not collapse every
+        // tenant onto one offset.
+        self::assertGreaterThan(1, \count(array_unique($offsets)));
+    }
+
+    public function testNextRunWithJitterOffsetsTheBaseSlot(): void
+    {
+        $calc = new SyncScheduleCalculator(maxJitterSeconds: 300);
+        $from = $this->utc('2026-06-29 12:00:00');
+        $seed = 'tenant-xyz';
+
+        $base = $calc->nextRun('0 2 * * *', $from);
+        $jittered = $calc->nextRunWithJitter('0 2 * * *', $seed, $from);
+
+        $expected = $base->modify(\sprintf('+%d seconds', $calc->jitterSeconds($seed)));
+        self::assertEquals($expected, $jittered);
+        self::assertGreaterThanOrEqual($base, $jittered);
+    }
+
+    public function testNextRunWithJitterEqualsBaseWhenWindowIsZero(): void
+    {
+        $calc = new SyncScheduleCalculator(maxJitterSeconds: 0);
+        $from = $this->utc('2026-06-29 12:00:00');
+
+        $base = $calc->nextRun('0 2 * * *', $from);
+        $jittered = $calc->nextRunWithJitter('0 2 * * *', 'tenant-xyz', $from);
+
+        self::assertEquals($base, $jittered);
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Application/Schedule/SyncScheduleDispatcherTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Application/Schedule/SyncScheduleDispatcherTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Application\Schedule;
+
+use App\Integration\Generic\Application\Schedule\SyncScheduleCalculator;
+use App\Integration\Generic\Application\Schedule\SyncScheduleDispatcher;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Enum\SyncDirection;
+use App\Integration\Generic\Domain\Message\InboundSyncMessage;
+use App\Integration\Generic\Domain\Message\OutboundSyncMessage;
+use App\Shared\Domain\Tenant;
+use App\Tests\Unit\Integration\Generic\Application\Subscriber\RecordingMessageBus;
+use DateTimeImmutable;
+use DateTimeZone;
+use LogicException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+#[CoversClass(SyncScheduleDispatcher::class)]
+final class SyncScheduleDispatcherTest extends TestCase
+{
+    private RecordingMessageBus $bus;
+    private InMemorySyncBindingRepository $bindings;
+    private SyncScheduleDispatcher $dispatcher;
+
+    protected function setUp(): void
+    {
+        $this->bus = new RecordingMessageBus();
+        $this->bindings = new InMemorySyncBindingRepository();
+        $this->dispatcher = new SyncScheduleDispatcher(
+            new SyncScheduleCalculator(maxJitterSeconds: 300),
+            $this->bindings,
+            $this->bus,
+        );
+    }
+
+    private function binding(SyncDirection $direction, ?string $schedule, bool $withTenant = true): SyncBinding
+    {
+        $connection = new Connection('shop', 'Shop', 'https://api.example.test');
+        $binding = new SyncBinding($connection, Uuid::v7(), $direction);
+        $binding->setSchedule($schedule);
+        if ($withTenant) {
+            $binding->assignTenant(new Tenant('acme', 'Acme'));
+        }
+
+        return $binding;
+    }
+
+    public function testComputeNextRunSetsSlotForValidCron(): void
+    {
+        $binding = $this->binding(SyncDirection::Inbound, '0 2 * * *');
+
+        $this->dispatcher->computeNextRun($binding, new DateTimeImmutable('2026-06-29 12:00:00', new DateTimeZone('UTC')));
+
+        self::assertNotNull($binding->getNextRun());
+        self::assertGreaterThanOrEqual(
+            new DateTimeImmutable('2026-06-30 02:00:00', new DateTimeZone('UTC')),
+            $binding->getNextRun(),
+        );
+        self::assertSame([$binding], $this->bindings->saved);
+    }
+
+    public function testComputeNextRunClearsSlotWhenNoSchedule(): void
+    {
+        $binding = $this->binding(SyncDirection::Inbound, null);
+
+        $this->dispatcher->computeNextRun($binding);
+
+        self::assertNull($binding->getNextRun());
+        self::assertSame([$binding], $this->bindings->saved);
+    }
+
+    public function testComputeNextRunClearsSlotWhenCronInvalid(): void
+    {
+        $binding = $this->binding(SyncDirection::Inbound, 'not a cron');
+
+        $this->dispatcher->computeNextRun($binding);
+
+        self::assertNull($binding->getNextRun());
+    }
+
+    public function testDispatchInboundEnqueuesInboundMessageOnly(): void
+    {
+        $binding = $this->binding(SyncDirection::Inbound, '0 2 * * *');
+
+        $this->dispatcher->dispatch($binding);
+
+        self::assertCount(1, $this->bus->dispatched);
+        $message = $this->bus->dispatched[0];
+        self::assertInstanceOf(InboundSyncMessage::class, $message);
+        self::assertSame($binding->getId()->toRfc4122(), $message->bindingId->toRfc4122());
+        self::assertSame($binding->getTenant()?->getId()->toRfc4122(), $message->tenant->toRfc4122());
+        // nextRun rolled forward after firing.
+        self::assertNotNull($binding->getNextRun());
+    }
+
+    public function testDispatchOutboundEnqueuesOutboundMessageOnly(): void
+    {
+        $binding = $this->binding(SyncDirection::Outbound, '0 2 * * *');
+
+        $this->dispatcher->dispatch($binding);
+
+        self::assertCount(1, $this->bus->dispatched);
+        self::assertInstanceOf(OutboundSyncMessage::class, $this->bus->dispatched[0]);
+    }
+
+    public function testDispatchBidirectionalEnqueuesBothLegs(): void
+    {
+        $binding = $this->binding(SyncDirection::Bidirectional, '0 2 * * *');
+
+        $this->dispatcher->dispatch($binding);
+
+        self::assertCount(2, $this->bus->dispatched);
+        self::assertInstanceOf(InboundSyncMessage::class, $this->bus->dispatched[0]);
+        self::assertInstanceOf(OutboundSyncMessage::class, $this->bus->dispatched[1]);
+    }
+
+    public function testDispatchWithoutTenantThrows(): void
+    {
+        $binding = $this->binding(SyncDirection::Inbound, '0 2 * * *', withTenant: false);
+
+        $this->expectException(LogicException::class);
+
+        $this->dispatcher->dispatch($binding);
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -222,7 +222,9 @@ services:
     # AUD-051 (W2-11) — also consume `scheduler_maintenance` so the
     # MaintenanceSchedule (export/audit/tenant/staged-file retention) actually
     # fires its daily cron; without a consumer the schedule is inert.
-    command: php bin/console messenger:consume import scheduler_maintenance --time-limit=3600 --memory-limit=256M
+    # APIC-P3-09 — `scheduler_integration_sync` drains the SyncSchedule per-minute
+    # tick that fires due sync bindings (integration:sync:dispatch-due).
+    command: php bin/console messenger:consume import scheduler_maintenance scheduler_integration_sync --time-limit=3600 --memory-limit=256M
     environment:
       APP_ENV: ${APP_ENV:-dev}
       # The worker is a headless background consumer (import/export/reindex) —


### PR DESCRIPTION
## APIC-P3-09 — harmonogram sync (cron + jitter)

Silnik harmonogramowania dla `SyncBinding`: cron per binding → automatyczny fire na workerze.

### Co dochodzi
- **`SyncBinding.nextRun`** (kolumna + indeks `(tenant_id, enabled, next_run)`) — następny czas odpalenia persystowany i widoczny w UI (AC-3).
- **`SyncScheduleCalculator`** — next-run z crona (vendor `dragonmantank/cron-expression`) + **deterministyczny jitter per tenant** (`crc32(seed) % maxJitter`, domyślnie okno 5 min). 200 tenantów z `0 2 * * *` nie uderza w ten sam remote o 02:00:00 (AC-2).
- **`SyncScheduleDispatcher`** — `computeNextRun()` odświeża `nextRun` (jitter; null dla manual-only/niepoprawnego crona); `dispatch()` enqueuje leg(i) per kierunek na transport `import` i przesuwa `nextRun`. Bidirectional odpala oba legi.
- **`DispatchDueSyncBindingsCommand`** (`integration:sync:dispatch-due`) — tick co minutę, **sweep po wszystkich tenantach** (bind `TenantContext` + GUC `app.current_tenant`, jak maintenance sweeps / `DetectAttributesDriftCommand`), odpala bindingi których `nextRun` nadszedł (AC-1).
- **`SyncSchedule`** (`#[AsSchedule('integration_sync')]`) — napędza tick przez transport workera `scheduler_integration_sync`, reużywając runner `RunMaintenanceCommand` z Shared; `docker-compose` worker konsumuje nowy transport.

### Świadome decyzje
- **Reużycie biblioteki crona, nie `Import\…\CronExpressionParser`** — Integration nie może zależeć od Import (ADR-0022, cross-BC tylko przez Contracts); parser i tak jest tylko wrapperem na ten sam vendor.
- **Per-tenant GUC sweep** zamiast message fan-out — FORCE RLS ukrywa `integration_sync_bindings` dopóki GUC nie ustawiony; tick wiąże jeden tenant naraz (wzorzec 1:1 z `DetectAttributesDriftCommand`).
- **Jitter okno 5 min** — sensowny rozrzut dla tick'a minutowego; seed = tenant id (fallback binding id przed przypisaniem tenanta).
- Prod scheduler wiring poza zakresem (overlay prod nie konsumuje też `scheduler_maintenance` — osobny deploy concern).

### Testy
- **Layer 1** (`SyncScheduleCalculatorTest`): isValid, next-run dla `0 2 * * *` / `*/5 * * * *`, jitter deterministyczny+bounded+rozrzut, jitter wyłączony przy oknie 0.
- **Layer 2** (`SyncScheduleDispatcherTest`): computeNextRun (valid/null/invalid cron), dispatch inbound/outbound/bidirectional → właściwe message'e + nextRun przesunięty, dispatch bez tenanta → `LogicException`.
- PHPUnit 15/15 ✅, PHPStan max ✅, Deptrac 0 ✅, CS-Fixer ✅, migracja zaaplikowana czysto + mapping w sync (`next_run` brak w pre-existing drift).

Closes #1789