### PR TITLE
feat(integration): SyncBinding CRUD API + run/pause/resume (APIC-P3-10)

### DIFF
--- a/apps/api/src/Identity/Infrastructure/Security/SyncBindingVoter.php
+++ b/apps/api/src/Identity/Infrastructure/Security/SyncBindingVoter.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Security;
+
+/**
+ * RBAC voter for the API Configurator consumer `SyncBinding` resource
+ * (APIC-P3-10). Reuses the legacy `integration` RbacMatrix resource — the same
+ * surface that gates Connection/endpoint/mapping management. The subject is
+ * named by its FQCN string (no cross-BC class import), so this stays
+ * Deptrac-clean while living in the Identity security layer alongside the other
+ * resource voters.
+ */
+final class SyncBindingVoter extends AbstractRbacVoter
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function attributeMap(): array
+    {
+        return [
+            'READ' => 'read',
+            'CREATE' => 'write',
+            'UPDATE' => 'write',
+            'WRITE' => 'write',
+            'DELETE' => 'delete',
+        ];
+    }
+
+    protected function resource(): string
+    {
+        return 'integration';
+    }
+
+    protected function subjectClass(): string
+    {
+        return 'App\\Integration\\Generic\\Domain\\Entity\\SyncBinding';
+    }
+}

--- a/apps/api/src/Integration/Generic/Domain/Entity/SyncBinding.php
+++ b/apps/api/src/Integration/Generic/Domain/Entity/SyncBinding.php
@@ -135,6 +135,16 @@ class SyncBinding extends AggregateRoot implements TenantScoped
         return $this->readEndpoint;
     }
 
+    public function getReadEndpointId(): ?Uuid
+    {
+        return $this->readEndpoint?->getId();
+    }
+
+    public function getWriteEndpointId(): ?Uuid
+    {
+        return $this->writeEndpoint?->getId();
+    }
+
     public function setReadEndpoint(?RemoteEndpoint $readEndpoint): void
     {
         $this->readEndpoint = $readEndpoint;

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Filter/SyncBindingConnectionFilter.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Filter/SyncBindingConnectionFilter.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\ApiPlatform\Filter;
+
+use ApiPlatform\Doctrine\Orm\Filter\FilterInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * `?connection={id}` on `/api/sync_bindings` — scopes the binding list to one
+ * connection (APIC-P3-10; FE sync-config + connection-detail screens). Tenant
+ * scoping still comes from the upstream Doctrine TenantFilter; this only adds
+ * the connection equality predicate.
+ */
+final class SyncBindingConnectionFilter implements FilterInterface
+{
+    private const string PARAMETER = 'connection';
+
+    public function apply(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $filters = $context['filters'] ?? [];
+        if (!\is_array($filters)) {
+            return;
+        }
+
+        $value = $filters[self::PARAMETER] ?? null;
+        if (!\is_string($value) || '' === $value) {
+            return;
+        }
+
+        $alias = $queryBuilder->getRootAliases()[0] ?? null;
+        if (null === $alias) {
+            return;
+        }
+
+        $parameter = $queryNameGenerator->generateParameterName('connectionId');
+        $queryBuilder
+            ->andWhere(\sprintf('%s.connection = :%s', $alias, $parameter))
+            ->setParameter($parameter, $value);
+    }
+
+    /**
+     * @param class-string $resourceClass
+     *
+     * @return array<string, array{property?: string, type?: string, required?: bool, description?: string, strategy?: string, is_collection?: bool}>
+     */
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            self::PARAMETER => [
+                'property' => 'connection',
+                'type' => 'string',
+                'required' => false,
+                'description' => 'Exact match on the parent Connection UUID (tenant-scoped).',
+                'strategy' => 'exact',
+            ],
+        ];
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/SyncBinding.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/SyncBinding.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns="https://api-platform.com/schema/metadata/resources-3.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata/resources-3.0
+                               https://api-platform.com/schema/metadata/resources-3.0.xsd">
+
+    <resource class="App\Integration\Generic\Domain\Entity\SyncBinding"
+              shortName="SyncBinding">
+
+        <normalizationContext>
+            <values>
+                <value name="groups">
+                    <values>
+                        <value>admin:read</value>
+                    </values>
+                </value>
+            </values>
+        </normalizationContext>
+
+        <!-- `?connection={id}` scopes the binding list to one connection (FE sync + detail screens). -->
+        <filters>
+            <filter>App\Integration\Generic\Infrastructure\ApiPlatform\Filter\SyncBindingConnectionFilter</filter>
+        </filters>
+
+        <operations>
+            <operation class="ApiPlatform\Metadata\GetCollection"
+                       uriTemplate="/sync_bindings{._format}"
+                       security="is_granted('READ', 'App\\Integration\\Generic\\Domain\\Entity\\SyncBinding')"/>
+
+            <operation class="ApiPlatform\Metadata\Get"
+                       uriTemplate="/sync_bindings/{id}{._format}"
+                       security="is_granted('READ', object)"/>
+
+            <operation class="ApiPlatform\Metadata\Post"
+                       uriTemplate="/sync_bindings{._format}"
+                       input="App\Integration\Generic\Infrastructure\ApiPlatform\Resource\SyncBindingInput"
+                       processor="App\Integration\Generic\Infrastructure\ApiPlatform\State\SyncBindingProcessor"
+                       security="is_granted('CREATE', 'App\\Integration\\Generic\\Domain\\Entity\\SyncBinding')">
+                <denormalizationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>sync_binding:create</value>
+                            </values>
+                        </value>
+                    </values>
+                </denormalizationContext>
+            </operation>
+
+            <operation class="ApiPlatform\Metadata\Patch"
+                       uriTemplate="/sync_bindings/{id}{._format}"
+                       input="App\Integration\Generic\Infrastructure\ApiPlatform\Resource\SyncBindingPatchInput"
+                       processor="App\Integration\Generic\Infrastructure\ApiPlatform\State\SyncBindingProcessor"
+                       security="is_granted('UPDATE', object)">
+                <denormalizationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>sync_binding:patch</value>
+                            </values>
+                        </value>
+                    </values>
+                </denormalizationContext>
+            </operation>
+
+            <operation class="ApiPlatform\Metadata\Delete"
+                       uriTemplate="/sync_bindings/{id}{._format}"
+                       processor="App\Integration\Generic\Infrastructure\ApiPlatform\State\SyncBindingProcessor"
+                       security="is_granted('DELETE', object)"/>
+        </operations>
+    </resource>
+
+</resources>

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/SyncBindingInput.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/SyncBindingInput.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\ApiPlatform\Resource;
+
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * POST input shape for `/api/sync_bindings` (APIC-P3-10). The tenant-stamped
+ * {@see \App\Integration\Generic\Domain\Entity\SyncBinding} is built by
+ * {@see \App\Integration\Generic\Infrastructure\ApiPlatform\State\SyncBindingProcessor}.
+ *
+ * `connection` and the read/write endpoints are UUID references resolved
+ * tenant-scoped by the processor. `objectTypeId` is a loose reference to a
+ * Catalog ObjectType (no FK, per ADR-0022 / APIC-P3-01): only its UUID shape is
+ * validated here.
+ */
+final class SyncBindingInput
+{
+    #[Assert\NotBlank]
+    #[Assert\Uuid]
+    #[Groups(['sync_binding:create'])]
+    public string $connection = '';
+
+    #[Assert\NotBlank]
+    #[Assert\Uuid]
+    #[Groups(['sync_binding:create'])]
+    public string $objectTypeId = '';
+
+    #[Assert\Choice(choices: ['inbound', 'outbound', 'bidirectional'])]
+    #[Groups(['sync_binding:create'])]
+    public string $direction = 'inbound';
+
+    #[Assert\Uuid]
+    #[Groups(['sync_binding:create'])]
+    public ?string $readEndpoint = null;
+
+    #[Assert\Uuid]
+    #[Groups(['sync_binding:create'])]
+    public ?string $writeEndpoint = null;
+
+    #[Assert\Length(max: 255)]
+    #[Groups(['sync_binding:create'])]
+    public ?string $schedule = null;
+
+    #[Assert\Choice(choices: ['lww', 'pim_wins', 'remote_wins'])]
+    #[Groups(['sync_binding:create'])]
+    public string $conflictPolicy = 'lww';
+
+    #[Assert\Length(max: 255)]
+    #[Groups(['sync_binding:create'])]
+    public ?string $matchKeyMapping = null;
+
+    #[Groups(['sync_binding:create'])]
+    public bool $enabled = true;
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/SyncBindingPatchInput.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/SyncBindingPatchInput.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\ApiPlatform\Resource;
+
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * PATCH (RFC 7396 merge) input for `/api/sync_bindings/{id}` (APIC-P3-10). Every
+ * field is nullable — null means "leave unchanged". The parent `connection` is
+ * immutable and omitted. Re-enabling or changing the schedule recomputes the
+ * next run in the processor.
+ */
+final class SyncBindingPatchInput
+{
+    #[Assert\Uuid]
+    #[Groups(['sync_binding:patch'])]
+    public ?string $objectTypeId = null;
+
+    #[Assert\Choice(choices: ['inbound', 'outbound', 'bidirectional'])]
+    #[Groups(['sync_binding:patch'])]
+    public ?string $direction = null;
+
+    #[Assert\Uuid]
+    #[Groups(['sync_binding:patch'])]
+    public ?string $readEndpoint = null;
+
+    #[Assert\Uuid]
+    #[Groups(['sync_binding:patch'])]
+    public ?string $writeEndpoint = null;
+
+    #[Assert\Length(max: 255)]
+    #[Groups(['sync_binding:patch'])]
+    public ?string $schedule = null;
+
+    #[Assert\Choice(choices: ['lww', 'pim_wins', 'remote_wins'])]
+    #[Groups(['sync_binding:patch'])]
+    public ?string $conflictPolicy = null;
+
+    #[Assert\Length(max: 255)]
+    #[Groups(['sync_binding:patch'])]
+    public ?string $matchKeyMapping = null;
+
+    #[Groups(['sync_binding:patch'])]
+    public ?bool $enabled = null;
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/State/SyncBindingProcessor.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/State/SyncBindingProcessor.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\ApiPlatform\State;
+
+use ApiPlatform\Metadata\DeleteOperationInterface;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\State\ProcessorInterface;
+use App\Integration\Generic\Application\Schedule\SyncScheduleDispatcher;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\RemoteEndpoint;
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Enum\ConflictPolicy;
+use App\Integration\Generic\Domain\Enum\SyncDirection;
+use App\Integration\Generic\Domain\Repository\ConnectionRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\RemoteEndpointRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\SyncBindingRepositoryInterface;
+use App\Integration\Generic\Infrastructure\ApiPlatform\Resource\SyncBindingInput;
+use App\Integration\Generic\Infrastructure\ApiPlatform\Resource\SyncBindingPatchInput;
+use InvalidArgumentException;
+use LogicException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Write path for the `SyncBinding` resource (APIC-P3-10). Resolves the parent
+ * connection and the optional read/write endpoints tenant-scoped (a cross-tenant
+ * or missing id is a 404) and persists. After every create/update the schedule
+ * dispatcher refreshes `nextRun`, so a newly-scheduled or re-enabled binding is
+ * picked up by the per-minute tick. The tenant is stamped on persist.
+ *
+ * @implements ProcessorInterface<SyncBindingInput|SyncBindingPatchInput|SyncBinding, SyncBinding|null>
+ */
+final readonly class SyncBindingProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private SyncBindingRepositoryInterface $bindings,
+        private ConnectionRepositoryInterface $connections,
+        private RemoteEndpointRepositoryInterface $endpoints,
+        private SyncScheduleDispatcher $dispatcher,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     * @param array<string, mixed> $context
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): ?SyncBinding
+    {
+        if ($operation instanceof DeleteOperationInterface) {
+            $this->bindings->remove($this->require($uriVariables));
+
+            return null;
+        }
+
+        if ($operation instanceof Post) {
+            return $this->handlePost($data);
+        }
+
+        if ($operation instanceof Patch) {
+            return $this->handlePatch($data, $uriVariables);
+        }
+
+        throw new LogicException(\sprintf('SyncBindingProcessor cannot handle operation "%s".', $operation::class));
+    }
+
+    private function handlePost(mixed $data): SyncBinding
+    {
+        if (!$data instanceof SyncBindingInput) {
+            throw new LogicException('SyncBindingProcessor expects SyncBindingInput on Post.');
+        }
+
+        $connection = $this->requireConnection($data->connection);
+
+        $binding = new SyncBinding($connection, $this->parseId($data->objectTypeId, 'objectTypeId'), SyncDirection::from($data->direction));
+        $binding->setReadEndpoint($this->resolveEndpoint($data->readEndpoint, $connection));
+        $binding->setWriteEndpoint($this->resolveEndpoint($data->writeEndpoint, $connection));
+        $binding->setSchedule($data->schedule);
+        $binding->setConflictPolicy(ConflictPolicy::from($data->conflictPolicy));
+        $binding->setMatchKeyMapping($data->matchKeyMapping);
+        $binding->setEnabled($data->enabled);
+
+        // Persist first so the tenant is stamped, then compute the (jittered)
+        // next run off the assigned tenant.
+        $this->bindings->save($binding);
+        $this->dispatcher->computeNextRun($binding);
+
+        return $binding;
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     */
+    private function handlePatch(mixed $data, array $uriVariables): SyncBinding
+    {
+        if (!$data instanceof SyncBindingPatchInput) {
+            throw new LogicException('SyncBindingProcessor expects SyncBindingPatchInput on Patch.');
+        }
+
+        $binding = $this->require($uriVariables);
+        $rescheduleNeeded = false;
+
+        if (null !== $data->objectTypeId) {
+            $binding->setObjectTypeId($this->parseId($data->objectTypeId, 'objectTypeId'));
+        }
+        if (null !== $data->direction) {
+            $binding->setDirection(SyncDirection::from($data->direction));
+        }
+        if (null !== $data->readEndpoint) {
+            $binding->setReadEndpoint($this->resolveEndpoint($data->readEndpoint, $binding->getConnection()));
+        }
+        if (null !== $data->writeEndpoint) {
+            $binding->setWriteEndpoint($this->resolveEndpoint($data->writeEndpoint, $binding->getConnection()));
+        }
+        if (null !== $data->schedule) {
+            $binding->setSchedule($data->schedule);
+            $rescheduleNeeded = true;
+        }
+        if (null !== $data->conflictPolicy) {
+            $binding->setConflictPolicy(ConflictPolicy::from($data->conflictPolicy));
+        }
+        if (null !== $data->matchKeyMapping) {
+            $binding->setMatchKeyMapping($data->matchKeyMapping);
+        }
+        if (null !== $data->enabled) {
+            $binding->setEnabled($data->enabled);
+            $rescheduleNeeded = true;
+        }
+
+        $this->bindings->save($binding);
+
+        // Disabled bindings never fire; clear the slot. Otherwise refresh it when
+        // the schedule or enabled flag changed.
+        if (!$binding->isEnabled()) {
+            $binding->setNextRun(null);
+            $this->bindings->save($binding);
+        } elseif ($rescheduleNeeded) {
+            $this->dispatcher->computeNextRun($binding);
+        }
+
+        return $binding;
+    }
+
+    private function requireConnection(string $id): Connection
+    {
+        $connection = $this->connections->findById($this->parseId($id, 'connection'));
+        if (!$connection instanceof Connection) {
+            throw new NotFoundHttpException('Connection was not found.');
+        }
+
+        return $connection;
+    }
+
+    /**
+     * Resolve an endpoint reference, asserting it belongs to the binding's
+     * connection (an endpoint from another connection is a 422).
+     */
+    private function resolveEndpoint(?string $id, Connection $connection): ?RemoteEndpoint
+    {
+        if (null === $id) {
+            return null;
+        }
+
+        $endpoint = $this->endpoints->findById($this->parseId($id, 'endpoint'));
+        if (!$endpoint instanceof RemoteEndpoint) {
+            throw new NotFoundHttpException('RemoteEndpoint was not found.');
+        }
+        if ($endpoint->getConnectionId()->toRfc4122() !== $connection->getId()->toRfc4122()) {
+            throw new UnprocessableEntityHttpException('RemoteEndpoint does not belong to the binding connection.');
+        }
+
+        return $endpoint;
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     */
+    private function require(array $uriVariables): SyncBinding
+    {
+        $raw = $uriVariables['id'] ?? null;
+        $id = $raw instanceof Uuid ? $raw : $this->parseId(\is_string($raw) ? $raw : '', 'id');
+
+        $binding = $this->bindings->findById($id);
+        if (!$binding instanceof SyncBinding) {
+            throw new NotFoundHttpException('SyncBinding was not found.');
+        }
+
+        return $binding;
+    }
+
+    private function parseId(string $raw, string $field): Uuid
+    {
+        if ('' === $raw) {
+            throw new NotFoundHttpException(\sprintf('Missing %s identifier.', $field));
+        }
+
+        try {
+            return Uuid::fromString($raw);
+        } catch (InvalidArgumentException) {
+            throw new NotFoundHttpException(\sprintf('Invalid %s identifier.', $field));
+        }
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/Serializer/SyncBinding.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/Serializer/SyncBinding.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping
+                                https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd">
+
+    <!--
+      Read projection for the SyncBinding resource (APIC-P3-10). Relations are
+      exposed as scalar UUIDs (connectionId / readEndpointId / writeEndpointId),
+      never nested entities, so the admin grid stays flat. `cursor` is the
+      delta-sync state envelope, surfaced read-only so the FE can show the last
+      synced position.
+    -->
+    <class name="App\Integration\Generic\Domain\Entity\SyncBinding">
+        <attribute name="id">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="connectionId">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="objectTypeId">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="readEndpointId">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="writeEndpointId">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="direction">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="schedule">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="conflictPolicy">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="matchKeyMapping">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="cursor">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="isEnabled">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="nextRun">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="createdAt">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="updatedAt">
+            <group>admin:read</group>
+        </attribute>
+    </class>
+</serializer>

--- a/apps/api/src/Integration/Generic/Presentation/Controller/SyncBindingActionsController.php
+++ b/apps/api/src/Integration/Generic/Presentation/Controller/SyncBindingActionsController.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Presentation\Controller;
+
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Integration\Generic\Application\Schedule\SyncScheduleDispatcher;
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Repository\SyncBindingRepositoryInterface;
+use DateTimeInterface;
+use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * APIC-P3-10 (ADR-0022) — operator actions on a sync binding that don't fit the
+ * REST CRUD verbs (CQRS procedural endpoints, ADR-0020):
+ *   - `POST /api/sync_bindings/{id}/run`    — fire the binding's leg(s) now.
+ *   - `POST /api/sync_bindings/{id}/pause`  — disable + clear the next run.
+ *   - `POST /api/sync_bindings/{id}/resume` — re-enable + reschedule.
+ *
+ * The binding is resolved tenant-scoped (Postgres RLS), so a cross-tenant id is
+ * a 404; the `settings.integrations.manage` permission gates every action.
+ */
+final class SyncBindingActionsController
+{
+    private const string ID_REQUIREMENT = '[0-9a-fA-F-]{36}';
+
+    public function __construct(
+        private readonly SyncBindingRepositoryInterface $bindings,
+        private readonly SyncScheduleDispatcher $dispatcher,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/sync_bindings/{id}/run',
+        name: 'integration_sync_binding_run',
+        requirements: ['id' => self::ID_REQUIREMENT],
+        methods: ['POST'],
+    )]
+    #[RequiresPermission(module: 'settings.integrations', action: 'manage')]
+    public function run(string $id): JsonResponse
+    {
+        $binding = $this->require($id);
+
+        $this->dispatcher->dispatch($binding);
+
+        return new JsonResponse([
+            'dispatched' => true,
+            'direction' => $binding->getDirection()->value,
+            'next_run' => $binding->getNextRun()?->format(DateTimeInterface::RFC3339_EXTENDED),
+        ], Response::HTTP_ACCEPTED);
+    }
+
+    #[Route(
+        path: '/api/sync_bindings/{id}/pause',
+        name: 'integration_sync_binding_pause',
+        requirements: ['id' => self::ID_REQUIREMENT],
+        methods: ['POST'],
+    )]
+    #[RequiresPermission(module: 'settings.integrations', action: 'manage')]
+    public function pause(string $id): JsonResponse
+    {
+        $binding = $this->require($id);
+
+        $binding->setEnabled(false);
+        $binding->setNextRun(null);
+        $this->bindings->save($binding);
+
+        return new JsonResponse(['enabled' => false, 'next_run' => null], Response::HTTP_OK);
+    }
+
+    #[Route(
+        path: '/api/sync_bindings/{id}/resume',
+        name: 'integration_sync_binding_resume',
+        requirements: ['id' => self::ID_REQUIREMENT],
+        methods: ['POST'],
+    )]
+    #[RequiresPermission(module: 'settings.integrations', action: 'manage')]
+    public function resume(string $id): JsonResponse
+    {
+        $binding = $this->require($id);
+
+        $binding->setEnabled(true);
+        $this->bindings->save($binding);
+        $this->dispatcher->computeNextRun($binding);
+
+        return new JsonResponse([
+            'enabled' => true,
+            'next_run' => $binding->getNextRun()?->format(DateTimeInterface::RFC3339_EXTENDED),
+        ], Response::HTTP_OK);
+    }
+
+    private function require(string $id): SyncBinding
+    {
+        try {
+            $bindingId = Uuid::fromString($id);
+        } catch (InvalidArgumentException) {
+            throw new NotFoundHttpException(\sprintf('SyncBinding "%s" was not found.', $id));
+        }
+
+        $binding = $this->bindings->findById($bindingId);
+        if (!$binding instanceof SyncBinding) {
+            throw new NotFoundHttpException(\sprintf('SyncBinding "%s" was not found.', $id));
+        }
+
+        return $binding;
+    }
+}

--- a/apps/api/tests/Api/Integration/Generic/SyncBindingApiTest.php
+++ b/apps/api/tests/Api/Integration/Generic/SyncBindingApiTest.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Integration\Generic;
+
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Identity\Domain\Entity\User;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\ApiConfigurator\ApiConfiguratorApiTestCase;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * APIC-P3-10 — CRUD coverage for `/api/sync_bindings` plus the run / pause /
+ * resume procedural actions. Reuses the ApiConfigurator RBAC scaffold (admin is
+ * Super Admin; the limited user has no integration permission).
+ */
+final class SyncBindingApiTest extends ApiConfiguratorApiTestCase
+{
+    private const string LD_JSON = 'application/ld+json';
+    private const string MERGE_PATCH = 'application/merge-patch+json';
+    private const string OBJECT_TYPE_ID = '0192a000-0000-7000-8000-000000000001';
+
+    #[Test]
+    public function postCreatesBinding(): void
+    {
+        $connectionId = $this->createConnection();
+
+        $body = $this->createBinding($connectionId, [
+            'direction' => 'inbound',
+            'schedule' => '0 2 * * *',
+            'conflictPolicy' => 'lww',
+            'matchKeyMapping' => 'sku',
+        ]);
+
+        self::assertResponseStatusCodeSame(201);
+        self::assertSame($connectionId, $body['connectionId'] ?? null);
+        self::assertSame(self::OBJECT_TYPE_ID, $body['objectTypeId'] ?? null);
+        self::assertSame('inbound', $body['direction'] ?? null);
+        self::assertSame('0 2 * * *', $body['schedule'] ?? null);
+        self::assertSame('lww', $body['conflictPolicy'] ?? null);
+        self::assertTrue($body['isEnabled'] ?? null);
+        // A scheduled binding gets its next run computed on create.
+        self::assertNotNull($body['nextRun'] ?? null);
+    }
+
+    #[Test]
+    public function manualBindingHasNoNextRun(): void
+    {
+        $connectionId = $this->createConnection();
+
+        $body = $this->createBinding($connectionId, ['schedule' => null]);
+
+        self::assertResponseStatusCodeSame(201);
+        self::assertNull($body['nextRun'] ?? null);
+    }
+
+    #[Test]
+    public function patchUpdatesBinding(): void
+    {
+        $connectionId = $this->createConnection();
+        $id = $this->createBinding($connectionId)['id'] ?? null;
+        \assert(\is_string($id));
+
+        $body = $this->authenticatedClient()->request('PATCH', '/api/sync_bindings/'.$id, [
+            'headers' => ['content-type' => self::MERGE_PATCH],
+            'body' => json_encode(['conflictPolicy' => 'pim_wins', 'direction' => 'bidirectional'], JSON_THROW_ON_ERROR),
+        ])->toArray();
+
+        self::assertResponseStatusCodeSame(200);
+        self::assertSame('pim_wins', $body['conflictPolicy'] ?? null);
+        self::assertSame('bidirectional', $body['direction'] ?? null);
+    }
+
+    #[Test]
+    public function deleteBindingThenGetIs404(): void
+    {
+        $connectionId = $this->createConnection();
+        $id = $this->createBinding($connectionId)['id'] ?? null;
+        \assert(\is_string($id));
+
+        $client = $this->authenticatedClient();
+        $client->request('DELETE', '/api/sync_bindings/'.$id);
+        self::assertResponseStatusCodeSame(204);
+
+        $client->request('GET', '/api/sync_bindings/'.$id);
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    #[Test]
+    public function bindingsListIsScopedByConnection(): void
+    {
+        $first = $this->createConnection('alpha');
+        $second = $this->createConnection('beta');
+        $this->createBinding($first);
+        $this->createBinding($second);
+
+        $body = $this->authenticatedClient()
+            ->request('GET', '/api/sync_bindings?connection='.$first)
+            ->toArray();
+
+        self::assertResponseStatusCodeSame(200);
+        self::assertSame(1, $body['totalItems'] ?? null);
+    }
+
+    #[Test]
+    public function runDispatchesBinding(): void
+    {
+        $connectionId = $this->createConnection();
+        $id = $this->createBinding($connectionId, ['direction' => 'inbound', 'schedule' => '0 2 * * *'])['id'] ?? null;
+        \assert(\is_string($id));
+
+        $body = $this->authenticatedClient()->request('POST', '/api/sync_bindings/'.$id.'/run')->toArray();
+
+        self::assertResponseStatusCodeSame(202);
+        self::assertTrue($body['dispatched'] ?? null);
+        self::assertSame('inbound', $body['direction'] ?? null);
+    }
+
+    #[Test]
+    public function pauseThenResumeTogglesEnabled(): void
+    {
+        $connectionId = $this->createConnection();
+        $id = $this->createBinding($connectionId, ['schedule' => '0 2 * * *'])['id'] ?? null;
+        \assert(\is_string($id));
+
+        $client = $this->authenticatedClient();
+
+        $paused = $client->request('POST', '/api/sync_bindings/'.$id.'/pause')->toArray();
+        self::assertResponseStatusCodeSame(200);
+        self::assertFalse($paused['enabled'] ?? null);
+
+        $after = $client->request('GET', '/api/sync_bindings/'.$id)->toArray();
+        self::assertFalse($after['isEnabled'] ?? null);
+        self::assertNull($after['nextRun'] ?? null);
+
+        $resumed = $client->request('POST', '/api/sync_bindings/'.$id.'/resume')->toArray();
+        self::assertResponseStatusCodeSame(200);
+        self::assertTrue($resumed['enabled'] ?? null);
+        self::assertNotNull($resumed['next_run'] ?? null);
+    }
+
+    #[Test]
+    public function runUnknownBindingIs404(): void
+    {
+        $this->authenticatedClient()->request('POST', '/api/sync_bindings/01234567-1234-7000-8000-000000000000/run');
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    #[Test]
+    public function postWithInvalidDirectionIs422(): void
+    {
+        $connectionId = $this->createConnection();
+
+        $this->authenticatedClient()->request('POST', '/api/sync_bindings', [
+            'headers' => ['content-type' => self::LD_JSON],
+            'body' => json_encode([
+                'connection' => $connectionId,
+                'objectTypeId' => self::OBJECT_TYPE_ID,
+                'direction' => 'sideways',
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(422);
+    }
+
+    #[Test]
+    public function unauthenticatedListIs401(): void
+    {
+        static::createClient()->request('GET', '/api/sync_bindings');
+        self::assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    #[Test]
+    public function limitedUserListIs403(): void
+    {
+        $this->limitedClient()->request('GET', '/api/sync_bindings');
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    private function createConnection(string $code = 'idosell'): string
+    {
+        $body = $this->authenticatedClient()->request('POST', '/api/connections', [
+            'headers' => ['content-type' => self::LD_JSON],
+            'body' => json_encode([
+                'code' => $code,
+                'name' => ucfirst($code),
+                'baseUrl' => 'https://api.idosell.com',
+                'authType' => 'none',
+            ], JSON_THROW_ON_ERROR),
+        ])->toArray(false);
+
+        $id = $body['id'] ?? null;
+        \assert(\is_string($id));
+
+        return $id;
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     *
+     * @return array<array-key, mixed>
+     */
+    private function createBinding(string $connectionId, array $overrides = []): array
+    {
+        $payload = array_merge([
+            'connection' => $connectionId,
+            'objectTypeId' => self::OBJECT_TYPE_ID,
+            'direction' => 'inbound',
+            'conflictPolicy' => 'lww',
+        ], $overrides);
+
+        return $this->authenticatedClient()->request('POST', '/api/sync_bindings', [
+            'headers' => ['content-type' => self::LD_JSON],
+            'body' => json_encode($payload, JSON_THROW_ON_ERROR),
+        ])->toArray(false);
+    }
+
+    private function limitedClient(): Client
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $email = 'limited-binding@demo.localhost';
+        $stub = new User($tenant, $email, '', ['ROLE_USER']);
+        $user = new User($tenant, $email, $hasher->hashPassword($stub, 'changeme'), ['ROLE_USER']);
+        $em = $this->em();
+        $em->persist($user);
+        $em->flush();
+
+        $jwt = self::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+
+        $client = static::createClient();
+        $client->setDefaultOptions(['headers' => ['authorization' => 'Bearer '.$jwt]]);
+
+        return $client;
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -8528,6 +8528,497 @@
                 }
             }
         },
+        "/api/sync_bindings": {
+            "get": {
+                "operationId": "api_sync_bindings_get_collection",
+                "tags": [
+                    "SyncBinding"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "SyncBinding collection",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "description": "SyncBinding.jsonld-admin.read collection.",
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/HydraCollectionBaseSchema"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "member"
+                                            ],
+                                            "properties": {
+                                                "member": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/SyncBinding.jsonld-admin.read"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/SyncBinding-admin.read"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Retrieves the collection of SyncBinding resources.",
+                "description": "Retrieves the collection of SyncBinding resources.",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "The collection page number",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        },
+                        "style": "form",
+                        "explode": true
+                    },
+                    {
+                        "name": "connection",
+                        "in": "query",
+                        "description": "Exact match on the parent Connection UUID (tenant-scoped).",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    }
+                ]
+            },
+            "post": {
+                "operationId": "api_sync_bindings_post",
+                "tags": [
+                    "SyncBinding"
+                ],
+                "responses": {
+                    "201": {
+                        "description": "SyncBinding resource created",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SyncBinding.jsonld-admin.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SyncBinding-admin.read"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "422": {
+                        "description": "An error occurred",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Creates a SyncBinding resource.",
+                "description": "Creates a SyncBinding resource.",
+                "parameters": [],
+                "requestBody": {
+                    "description": "The new SyncBinding resource",
+                    "content": {
+                        "application/ld+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SyncBinding.SyncBindingInput-sync_binding.create"
+                            }
+                        },
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SyncBinding.SyncBindingInput-sync_binding.create"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            }
+        },
+        "/api/sync_bindings/{id}": {
+            "get": {
+                "operationId": "api_sync_bindings_id_get",
+                "tags": [
+                    "SyncBinding"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "SyncBinding resource",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SyncBinding.jsonld-admin.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SyncBinding-admin.read"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Retrieves a SyncBinding resource.",
+                "description": "Retrieves a SyncBinding resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "SyncBinding identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ]
+            },
+            "delete": {
+                "operationId": "api_sync_bindings_id_delete",
+                "tags": [
+                    "SyncBinding"
+                ],
+                "responses": {
+                    "204": {
+                        "description": "SyncBinding resource deleted"
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Removes the SyncBinding resource.",
+                "description": "Removes the SyncBinding resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "SyncBinding identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ]
+            },
+            "patch": {
+                "operationId": "api_sync_bindings_id_patch",
+                "tags": [
+                    "SyncBinding"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "SyncBinding resource updated",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SyncBinding.jsonld-admin.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SyncBinding-admin.read"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "422": {
+                        "description": "An error occurred",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Updates the SyncBinding resource.",
+                "description": "Updates the SyncBinding resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "SyncBinding identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "requestBody": {
+                    "description": "The updated SyncBinding resource",
+                    "content": {
+                        "application/merge-patch+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SyncBinding.SyncBindingPatchInput-sync_binding.patch.jsonMergePatch"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            }
+        },
         "/api/admin/break-glass": {
             "post": {
                 "operationId": "api_admin_break_glass_post",
@@ -16499,6 +16990,123 @@
                 "x-cortex-permission": "imports.run"
             }
         },
+        "/api/sync_bindings/{id}/pause": {
+            "post": {
+                "operationId": "api_sync_bindings_id_pause_post",
+                "tags": [
+                    "sync_bindings"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api sync bindings id pause",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "settings.integrations.manage"
+            }
+        },
+        "/api/sync_bindings/{id}/resume": {
+            "post": {
+                "operationId": "api_sync_bindings_id_resume_post",
+                "tags": [
+                    "sync_bindings"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api sync bindings id resume",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "settings.integrations.manage"
+            }
+        },
+        "/api/sync_bindings/{id}/run": {
+            "post": {
+                "operationId": "api_sync_bindings_id_run_post",
+                "tags": [
+                    "sync_bindings"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api sync bindings id run",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "settings.integrations.manage"
+            }
+        },
         "/api/tenant": {
             "get": {
                 "operationId": "api_tenant_get",
@@ -22216,6 +22824,379 @@
                     }
                 ],
                 "description": "One field of an external API response \u2014 discovered from a sample or entered\nby hand (ADR-0022, epic APIC, ticket APIC-P2-02).\n\nA {@see RemoteEndpoint} owns many fields; each carries the JSONPath that\nlocates it within a record, a human label, the detected {@see RemoteFieldDataType}\nand a textual sample value. These are the left-hand side of the 1:1 field\nmapping (APIC-P2-07/08).\n\n`TenantScoped` + Postgres RLS isolate every field to its tenant; the tenant\nalways matches the parent endpoint's. The FK to RemoteEndpoint cascades on\ndelete."
+            },
+            "SyncBinding-admin.read": {
+                "type": "object",
+                "description": "The heart of a sync: what (ObjectType) is synced where (Connection endpoints),\nhow (direction + conflict policy + match key) and how often (cron schedule) \u2014\nADR-0022, epic APIC, ticket APIC-P3-01.\n\n`objectTypeId` is a validated loose reference, not a Doctrine/DB FK: the\ntarget ObjectType lives in the Catalog context and ADR-0022 keeps cross-BC\ncoupling to Contracts only, so no migration-level FK ties Integration to the\nCatalog schema (the binding API validates the id exists). The read/write\nendpoints and the connection are same-context FKs.\n\n`cursor` is the delta-sync state envelope (`{field, type, state}`) maintained\nby the cursor manager (APIC-P3-03). `TenantScoped` + Postgres RLS isolate\nevery binding to its tenant.",
+                "properties": {
+                    "id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uuid"
+                    },
+                    "objectTypeId": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "direction": {
+                        "default": "inbound",
+                        "type": "string",
+                        "enum": [
+                            "inbound",
+                            "outbound",
+                            "bidirectional"
+                        ]
+                    },
+                    "schedule": {
+                        "maxLength": 255,
+                        "description": "Cron expression for scheduled runs; null = manual-only.",
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "cursor": {
+                        "description": "Delta-sync cursor envelope `{field, type, state}`; null until the first\nrun persists one (APIC-P3-03).",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "additionalProperties": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "conflictPolicy": {
+                        "default": "lww",
+                        "type": "string"
+                    },
+                    "matchKeyMapping": {
+                        "maxLength": 255,
+                        "description": "The PIM target acting as the upsert match key; null until mappings are set.",
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "nextRun": {
+                        "description": "When the scheduler next fires this binding; null = manual-only (no cron)\nor not yet computed. Maintained by the schedule dispatcher (APIC-P3-09),\njittered per tenant so concurrent bindings don't stampede the same remote.",
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "readOnly": true,
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updatedAt": {
+                        "readOnly": true,
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "connectionId": {
+                        "readOnly": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "readEndpointId": {
+                        "readOnly": true,
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uuid"
+                    },
+                    "writeEndpointId": {
+                        "readOnly": true,
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uuid"
+                    },
+                    "isEnabled": {
+                        "readOnly": true,
+                        "description": "Serializer-facing alias so the read projection exposes the flag as\n`isEnabled`, per the ObjectType convention.",
+                        "type": "boolean"
+                    }
+                }
+            },
+            "SyncBinding.SyncBindingInput-sync_binding.create": {
+                "type": "object",
+                "description": "The heart of a sync: what (ObjectType) is synced where (Connection endpoints),\nhow (direction + conflict policy + match key) and how often (cron schedule) \u2014\nADR-0022, epic APIC, ticket APIC-P3-01.\n\n`objectTypeId` is a validated loose reference, not a Doctrine/DB FK: the\ntarget ObjectType lives in the Catalog context and ADR-0022 keeps cross-BC\ncoupling to Contracts only, so no migration-level FK ties Integration to the\nCatalog schema (the binding API validates the id exists). The read/write\nendpoints and the connection are same-context FKs.\n\n`cursor` is the delta-sync state envelope (`{field, type, state}`) maintained\nby the cursor manager (APIC-P3-03). `TenantScoped` + Postgres RLS isolate\nevery binding to its tenant.",
+                "required": [
+                    "connection",
+                    "objectTypeId"
+                ],
+                "properties": {
+                    "connection": {
+                        "format": "uuid",
+                        "externalDocs": {
+                            "url": "https://schema.org/identifier"
+                        },
+                        "default": "",
+                        "type": "string"
+                    },
+                    "objectTypeId": {
+                        "format": "uuid",
+                        "externalDocs": {
+                            "url": "https://schema.org/identifier"
+                        },
+                        "default": "",
+                        "type": "string"
+                    },
+                    "direction": {
+                        "enum": [
+                            "inbound",
+                            "outbound",
+                            "bidirectional"
+                        ],
+                        "default": "inbound",
+                        "type": "string"
+                    },
+                    "readEndpoint": {
+                        "format": "uuid",
+                        "externalDocs": {
+                            "url": "https://schema.org/identifier"
+                        },
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "writeEndpoint": {
+                        "format": "uuid",
+                        "externalDocs": {
+                            "url": "https://schema.org/identifier"
+                        },
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "schedule": {
+                        "maxLength": 255,
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "conflictPolicy": {
+                        "enum": [
+                            "lww",
+                            "pim_wins",
+                            "remote_wins"
+                        ],
+                        "default": "lww",
+                        "type": "string"
+                    },
+                    "matchKeyMapping": {
+                        "maxLength": 255,
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "enabled": {
+                        "default": true,
+                        "type": "boolean"
+                    }
+                }
+            },
+            "SyncBinding.SyncBindingPatchInput-sync_binding.patch.jsonMergePatch": {
+                "type": "object",
+                "description": "The heart of a sync: what (ObjectType) is synced where (Connection endpoints),\nhow (direction + conflict policy + match key) and how often (cron schedule) \u2014\nADR-0022, epic APIC, ticket APIC-P3-01.\n\n`objectTypeId` is a validated loose reference, not a Doctrine/DB FK: the\ntarget ObjectType lives in the Catalog context and ADR-0022 keeps cross-BC\ncoupling to Contracts only, so no migration-level FK ties Integration to the\nCatalog schema (the binding API validates the id exists). The read/write\nendpoints and the connection are same-context FKs.\n\n`cursor` is the delta-sync state envelope (`{field, type, state}`) maintained\nby the cursor manager (APIC-P3-03). `TenantScoped` + Postgres RLS isolate\nevery binding to its tenant.",
+                "properties": {
+                    "objectTypeId": {
+                        "format": "uuid",
+                        "externalDocs": {
+                            "url": "https://schema.org/identifier"
+                        },
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "direction": {
+                        "enum": [
+                            "inbound",
+                            "outbound",
+                            "bidirectional"
+                        ],
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "readEndpoint": {
+                        "format": "uuid",
+                        "externalDocs": {
+                            "url": "https://schema.org/identifier"
+                        },
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "writeEndpoint": {
+                        "format": "uuid",
+                        "externalDocs": {
+                            "url": "https://schema.org/identifier"
+                        },
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "schedule": {
+                        "maxLength": 255,
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "conflictPolicy": {
+                        "enum": [
+                            "lww",
+                            "pim_wins",
+                            "remote_wins"
+                        ],
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "matchKeyMapping": {
+                        "maxLength": 255,
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "enabled": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ]
+                    }
+                }
+            },
+            "SyncBinding.jsonld-admin.read": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/HydraItemBaseSchema"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "uuid"
+                            },
+                            "objectTypeId": {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            "direction": {
+                                "default": "inbound",
+                                "type": "string",
+                                "enum": [
+                                    "inbound",
+                                    "outbound",
+                                    "bidirectional"
+                                ]
+                            },
+                            "schedule": {
+                                "maxLength": 255,
+                                "description": "Cron expression for scheduled runs; null = manual-only.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "cursor": {
+                                "description": "Delta-sync cursor envelope `{field, type, state}`; null until the first\nrun persists one (APIC-P3-03).",
+                                "type": [
+                                    "object",
+                                    "null"
+                                ],
+                                "additionalProperties": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "conflictPolicy": {
+                                "default": "lww",
+                                "type": "string"
+                            },
+                            "matchKeyMapping": {
+                                "maxLength": 255,
+                                "description": "The PIM target acting as the upsert match key; null until mappings are set.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "nextRun": {
+                                "description": "When the scheduler next fires this binding; null = manual-only (no cron)\nor not yet computed. Maintained by the schedule dispatcher (APIC-P3-09),\njittered per tenant so concurrent bindings don't stampede the same remote.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "date-time"
+                            },
+                            "createdAt": {
+                                "readOnly": true,
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "updatedAt": {
+                                "readOnly": true,
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "connectionId": {
+                                "readOnly": true,
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            "readEndpointId": {
+                                "readOnly": true,
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "uuid"
+                            },
+                            "writeEndpointId": {
+                                "readOnly": true,
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "uuid"
+                            },
+                            "isEnabled": {
+                                "readOnly": true,
+                                "description": "Serializer-facing alias so the read projection exposes the flag as\n`isEnabled`, per the ObjectType convention.",
+                                "type": "boolean"
+                            }
+                        }
+                    }
+                ],
+                "description": "The heart of a sync: what (ObjectType) is synced where (Connection endpoints),\nhow (direction + conflict policy + match key) and how often (cron schedule) \u2014\nADR-0022, epic APIC, ticket APIC-P3-01.\n\n`objectTypeId` is a validated loose reference, not a Doctrine/DB FK: the\ntarget ObjectType lives in the Catalog context and ADR-0022 keeps cross-BC\ncoupling to Contracts only, so no migration-level FK ties Integration to the\nCatalog schema (the binding API validates the id exists). The read/write\nendpoints and the connection are same-context FKs.\n\n`cursor` is the delta-sync state envelope (`{field, type, state}`) maintained\nby the cursor manager (APIC-P3-03). `TenantScoped` + Postgres RLS isolate\nevery binding to its tenant."
             }
         },
         "responses": {},
@@ -22309,6 +23290,10 @@
         {
             "name": "RemoteField",
             "description": "One field of an external API response \u2014 discovered from a sample or entered\nby hand (ADR-0022, epic APIC, ticket APIC-P2-02).\n\nA {@see RemoteEndpoint} owns many fields; each carries the JSONPath that\nlocates it within a record, a human label, the detected {@see RemoteFieldDataType}\nand a textual sample value. These are the left-hand side of the 1:1 field\nmapping (APIC-P2-07/08).\n\n`TenantScoped` + Postgres RLS isolate every field to its tenant; the tenant\nalways matches the parent endpoint's. The FK to RemoteEndpoint cascades on\ndelete."
+        },
+        {
+            "name": "SyncBinding",
+            "description": "The heart of a sync: what (ObjectType) is synced where (Connection endpoints),\nhow (direction + conflict policy + match key) and how often (cron schedule) \u2014\nADR-0022, epic APIC, ticket APIC-P3-01.\n\n`objectTypeId` is a validated loose reference, not a Doctrine/DB FK: the\ntarget ObjectType lives in the Catalog context and ADR-0022 keeps cross-BC\ncoupling to Contracts only, so no migration-level FK ties Integration to the\nCatalog schema (the binding API validates the id exists). The read/write\nendpoints and the connection are same-context FKs.\n\n`cursor` is the delta-sync state envelope (`{field, type, state}`) maintained\nby the cursor manager (APIC-P3-03). `TenantScoped` + Postgres RLS isolate\nevery binding to its tenant."
         }
     ],
     "webhooks": {}


### PR DESCRIPTION
## APIC-P3-10 — SyncBinding CRUD API + akcje run/pause/resume

Wystawia `SyncBinding` jako zasób API Platform + endpointy operacyjne harmonogramu.

### CRUD (`/api/sync_bindings`)
- GetCollection / Get / Post / Patch / Delete; read projection `admin:read` (relacje jako skalarne UUID: `connectionId`/`readEndpointId`/`writeEndpointId`, nie zagnieżdżone encje).
- `SyncBindingInput` / `SyncBindingPatchInput` (walidacja: UUID, choice direction/conflictPolicy, długości).
- Filtr `?connection={id}` (FE sync + detail).
- `SyncBindingProcessor` — resolve parent connection + opcjonalne read/write endpointy **tenant-scoped** (endpoint z innego connectiona → 422); po create/update odświeża `nextRun` przez `SyncScheduleDispatcher` (re-enable/zmiana crona → reschedule; disable → `nextRun=null`).

### Akcje proceduralne (ADR-0020 CQRS, `#[RequiresPermission settings.integrations.manage]`)
- `POST /api/sync_bindings/{id}/run` → 202 `{dispatched, direction, next_run}` (odpala leg(i) teraz).
- `POST /api/sync_bindings/{id}/pause` → 200 `{enabled:false}` (disable + clear nextRun).
- `POST /api/sync_bindings/{id}/resume` → 200 `{enabled:true, next_run}` (re-enable + reschedule).

### RBAC + OpenAPI
- `SyncBindingVoter` (reużywa zasób `integration` RbacMatrix) gejtuje REST `is_granted`.
- Snapshot `docs/api-spec/v0.json` zregenerowany — custom routes auto-widoczne przez `CustomRouteOpenApiFactory` (+5 ścieżek; reszta diffu to alfabetyczne przesunięcia bloków schematów).

### Świadome decyzje
- **`objectTypeId` = loose UUID** (walidacja kształtu, bez existence-check) — zgodnie z designem APIC-P3-01; pełna walidacja istnienia wymagałaby nowego seam'u Catalog Contracts ([PM]). Dobrze sformułowany nieznany id po prostu nie matchuje nic (samo-korygujące).
- Dodano `/resume` poza minimum ticketu (run+pause) — symetria UX dla FE toggle (P3-11).

### Testy (ApiTestCase pełny)
- CRUD (201/200/204/404), list scoped by connection, run (202), pause→resume toggle (+ GET potwierdza `isEnabled`/`nextRun`), run unknown→404, invalid direction→422, unauth→401, limited user→403.
- PHPStan max ✅, Deptrac 0 ✅, CS-Fixer ✅, OpenAPI snapshot ✅. (ApiTestCase suite walidowany na CI — lokalny harness nie odpala kernel-suitów.)

Closes #1790