### PR TITLE
feat(ui): build SyncBinding configuration screen (APIC-P3-11)

### DIFF
--- a/apps/admin/e2e/1789-api-sync-config.spec.ts
+++ b/apps/admin/e2e/1789-api-sync-config.spec.ts
@@ -105,13 +105,15 @@ test('APIC-P3-11 — sync config: direction panels + save + run-now', async ({ p
     }),
   ).toBeVisible();
 
-  // Inbound: cursor card present, conflict card absent.
+  // Inbound: cursor card present, conflict card absent. Target the conflict
+  // card's unique Last-write-wins option (the section title phrase also appears
+  // in the page subtitle, so it is not a reliable presence signal).
   await expect(page.getByText(/cursor \(inkrementalny|cursor \(incremental/i)).toBeVisible();
-  await expect(page.getByText(/polityka konfliktów|conflict policy/i)).toHaveCount(0);
+  await expect(page.getByRole('button', { name: /last-write-wins/i })).toHaveCount(0);
 
   // Switch to bidirectional → the conflict policy card appears.
   await page.getByRole('button', { name: /dwukierunkowy|bidirectional/i }).click();
-  await expect(page.getByText(/polityka konfliktów|conflict policy/i)).toBeVisible();
+  await expect(page.getByRole('button', { name: /last-write-wins/i })).toBeVisible();
 
   // Save the binding.
   await page.getByRole('button', { name: /zapisz wiązanie|save binding/i }).click();

--- a/apps/admin/e2e/1789-api-sync-config.spec.ts
+++ b/apps/admin/e2e/1789-api-sync-config.spec.ts
@@ -1,0 +1,126 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, type Route, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * APIC-P3-11 (#1789) — the SyncBinding configuration screen. The binding CRUD +
+ * run action are mocked (stateful), so the test is deterministic and offline:
+ * switch direction (conditional panels), save, and run-now.
+ */
+test('APIC-P3-11 — sync config: direction panels + save + run-now', async ({ page }) => {
+  await loginAsAdmin(page);
+
+  const binding: Record<string, unknown> = {
+    id: 'bind-1',
+    connectionId: 'conn-1',
+    objectTypeId: 'ot-1',
+    readEndpointId: null,
+    writeEndpointId: null,
+    direction: 'inbound',
+    schedule: '0 2 * * *',
+    conflictPolicy: 'lww',
+    matchKeyMapping: 'sku',
+    cursor: { field: 'updated_at', type: 'updated_at', state: '2026-05-11T13:58:22Z' },
+    isEnabled: true,
+    nextRun: '2026-12-01T02:00:00+00:00',
+  };
+  let patched = false;
+  let ran = false;
+
+  await page.route('**/api/sync_bindings**', (route: Route) => {
+    const url = route.request().url();
+    const method = route.request().method();
+
+    if (method === 'POST' && url.includes('/run')) {
+      ran = true;
+      return route.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: JSON.stringify({ dispatched: true, direction: binding.direction, next_run: null }),
+      });
+    }
+
+    if (method === 'PATCH') {
+      patched = true;
+      const body = route.request().postDataJSON() as Record<string, unknown>;
+      Object.assign(binding, body);
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/ld+json',
+        body: JSON.stringify(binding),
+      });
+    }
+
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify({ member: [binding], totalItems: 1 }),
+    });
+  });
+
+  await page.route('**/api/remote_endpoints**', (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify({
+        member: [
+          {
+            id: 'ep-read',
+            connectionId: 'conn-1',
+            role: 'read_list',
+            httpMethod: 'GET',
+            pathTemplate: '/products',
+            pagination: { strategy: 'none' },
+            recordSelector: '$.results',
+          },
+          {
+            id: 'ep-write',
+            connectionId: 'conn-1',
+            role: 'write_update',
+            httpMethod: 'PUT',
+            pathTemplate: '/products/{id}',
+            pagination: { strategy: 'none' },
+            recordSelector: null,
+          },
+        ],
+        totalItems: 2,
+      }),
+    }),
+  );
+
+  await page.route('**/api/object_types**', (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify({ member: [{ id: 'ot-1', code: 'product' }], totalItems: 1 }),
+    }),
+  );
+
+  await page.goto('/integrations/api-configurator/connections/conn-1/sync');
+
+  await expect(
+    page.getByRole('heading', {
+      name: /konfiguracja synchronizacji|synchronization configuration/i,
+    }),
+  ).toBeVisible();
+
+  // Inbound: cursor card present, conflict card absent.
+  await expect(page.getByText(/cursor \(inkrementalny|cursor \(incremental/i)).toBeVisible();
+  await expect(page.getByText(/polityka konfliktów|conflict policy/i)).toHaveCount(0);
+
+  // Switch to bidirectional → the conflict policy card appears.
+  await page.getByRole('button', { name: /dwukierunkowy|bidirectional/i }).click();
+  await expect(page.getByText(/polityka konfliktów|conflict policy/i)).toBeVisible();
+
+  // Save the binding.
+  await page.getByRole('button', { name: /zapisz wiązanie|save binding/i }).click();
+  await expect.poll(() => patched).toBe(true);
+
+  // Run now.
+  await page.getByRole('button', { name: /uruchom teraz|run now/i }).click();
+  await expect.poll(() => ran).toBe(true);
+
+  const a11y = await new AxeBuilder({ page }).analyze();
+  expect(a11y.violations).toEqual([]);
+});

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -64,6 +64,10 @@ const MappingScreen = lazyPage(
   () => import('@/features/api-configurator/consumer/mapping/MappingScreen'),
   'MappingScreen',
 );
+const SyncConfigScreen = lazyPage(
+  () => import('@/features/api-configurator/consumer/sync/SyncConfigScreen'),
+  'SyncConfigScreen',
+);
 const ApiMonitorPlaceholder = lazyPage(
   () => import('@/features/api-configurator/monitor/ApiMonitorPlaceholder'),
   'ApiMonitorPlaceholder',
@@ -643,6 +647,10 @@ function App() {
                     <Route
                       path="/integrations/api-configurator/connections/:id/mapping"
                       element={<MappingScreen />}
+                    />
+                    <Route
+                      path="/integrations/api-configurator/connections/:id/sync"
+                      element={<SyncConfigScreen />}
                     />
                     <Route
                       path="/integrations/api-configurator/monitor"

--- a/apps/admin/src/features/api-configurator/components/primitives/layout.tsx
+++ b/apps/admin/src/features/api-configurator/components/primitives/layout.tsx
@@ -71,7 +71,7 @@ export function SecurityNote({
 export function SectionLabel({ children, right }: { children: ReactNode; right?: ReactNode }) {
   return (
     <div className="mb-3 flex items-center gap-3">
-      <div className="text-[11px] font-medium uppercase tracking-wider text-zinc-400">
+      <div className="text-[11px] font-medium uppercase tracking-wider text-zinc-500">
         {children}
       </div>
       <div className="h-px flex-1 bg-zinc-100" />

--- a/apps/admin/src/features/api-configurator/consumer/sync/SyncConfigScreen.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/sync/SyncConfigScreen.tsx
@@ -325,7 +325,7 @@ export function SyncConfigScreen() {
               </div>
             </div>
             <div className="rounded-xl border border-zinc-100 bg-zinc-50/60 p-3">
-              <div className="mb-2 text-[10.5px] font-medium uppercase tracking-wider text-zinc-400">
+              <div className="mb-2 text-[10.5px] font-medium uppercase tracking-wider text-zinc-500">
                 {t('api_configurator.sync.schedule.next_run')}
               </div>
               {binding.nextRun !== null ? (
@@ -349,7 +349,7 @@ export function SyncConfigScreen() {
           <section className="soft-shadow rounded-2xl border border-zinc-200 bg-white p-5">
             <SectionLabel
               right={
-                <span className="text-[11px] text-zinc-400">
+                <span className="text-[11px] text-zinc-500">
                   {t('api_configurator.sync.cursor.tag')}
                 </span>
               }
@@ -387,7 +387,7 @@ export function SyncConfigScreen() {
           <section className="soft-shadow rounded-2xl border border-zinc-200 bg-white p-5">
             <SectionLabel
               right={
-                <span className="text-[11px] text-zinc-400">
+                <span className="text-[11px] text-zinc-500">
                   {t('api_configurator.sync.conflict.tag')}
                 </span>
               }

--- a/apps/admin/src/features/api-configurator/consumer/sync/SyncConfigScreen.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/sync/SyncConfigScreen.tsx
@@ -1,0 +1,543 @@
+import { useApiUrl, useCreate, useCustomMutation, useList, useUpdate } from '@refinedev/core';
+import { ArrowLeft, Info, Play, Shield } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useParams } from 'react-router';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+import {
+  ApiToggle,
+  Field,
+  SectionLabel,
+  SecurityNote,
+  Segmented,
+  type SyncDirection,
+} from '../../components/primitives';
+import type { RemoteEndpointRow } from '../wizard/steps/StepEndpoints';
+
+type ConflictPolicy = 'lww' | 'pim_wins' | 'remote_wins';
+
+interface SyncBindingRow {
+  id: string;
+  connectionId: string;
+  objectTypeId: string;
+  readEndpointId: string | null;
+  writeEndpointId: string | null;
+  direction: SyncDirection;
+  schedule: string | null;
+  conflictPolicy: ConflictPolicy;
+  matchKeyMapping: string | null;
+  cursor: { field?: string; type?: string; state?: unknown } | null;
+  isEnabled: boolean;
+  nextRun: string | null;
+}
+
+interface ObjectTypeRow {
+  id: string;
+  code: string;
+}
+
+const HUB = '/integrations/api-configurator/connections';
+
+const CRON_PRESETS = [
+  { key: 'every_15m', cron: '*/15 * * * *' },
+  { key: 'every_30m', cron: '*/30 * * * *' },
+  { key: 'hourly', cron: '0 * * * *' },
+  { key: 'daily_2', cron: '0 2 * * *' },
+] as const;
+
+/**
+ * APIC-P3-11 — the SyncBinding configuration screen (`integracje/api-sync.jsx`).
+ * Edits the connection's binding: direction (with conditional read/write
+ * endpoint selects), cron schedule, conflict policy (bidirectional only), and
+ * the active toggle, against the P3-10 CRUD + run action.
+ *
+ * Cursor field/type and the match key are surfaced read-only: the cursor is
+ * owned by the sync engine (P3-03) and the match key is set in the Mapping tab
+ * (P2-09) — neither is part of the binding write contract, so the screen never
+ * pretends to persist them.
+ */
+export function SyncConfigScreen() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const apiUrl = useApiUrl();
+  const { id: connectionId = null } = useParams();
+
+  const bindingsQuery = useList<SyncBindingRow>({
+    resource: 'sync_bindings',
+    filters:
+      connectionId === null ? [] : [{ field: 'connection', operator: 'eq', value: connectionId }],
+    queryOptions: { enabled: connectionId !== null },
+    pagination: { mode: 'off' },
+  });
+  const endpointsQuery = useList<RemoteEndpointRow>({
+    resource: 'remote_endpoints',
+    filters:
+      connectionId === null ? [] : [{ field: 'connection', operator: 'eq', value: connectionId }],
+    queryOptions: { enabled: connectionId !== null },
+    pagination: { mode: 'off' },
+  });
+  const objectTypesQuery = useList<ObjectTypeRow>({
+    resource: 'object_types',
+    pagination: { mode: 'off' },
+  });
+
+  const binding = bindingsQuery.result.data[0] ?? null;
+  const endpoints = endpointsQuery.result.data;
+  const readEndpoints = useMemo(
+    () => endpoints.filter((e) => e.role.startsWith('read')),
+    [endpoints],
+  );
+  const writeEndpoints = useMemo(
+    () => endpoints.filter((e) => e.role.startsWith('write')),
+    [endpoints],
+  );
+
+  const { mutate: create } = useCreate();
+  const { mutate: update } = useUpdate();
+  const { mutate: runNow } = useCustomMutation();
+
+  const [dir, setDir] = useState<SyncDirection>('inbound');
+  const [cron, setCron] = useState('');
+  const [conflict, setConflict] = useState<ConflictPolicy>('lww');
+  const [readEndpointId, setReadEndpointId] = useState('');
+  const [writeEndpointId, setWriteEndpointId] = useState('');
+  const [enabled, setEnabled] = useState(true);
+  const [newObjectTypeId, setNewObjectTypeId] = useState('');
+
+  // Hydrate the form from the loaded binding.
+  useEffect(() => {
+    if (binding === null) {
+      return;
+    }
+    setDir(binding.direction);
+    setCron(binding.schedule ?? '');
+    setConflict(binding.conflictPolicy);
+    setReadEndpointId(binding.readEndpointId ?? '');
+    setWriteEndpointId(binding.writeEndpointId ?? '');
+    setEnabled(binding.isEnabled);
+  }, [binding]);
+
+  const cronHuman =
+    CRON_PRESETS.find((p) => p.cron === cron) !== undefined
+      ? t(`api_configurator.sync.schedule.preset.${CRON_PRESETS.find((p) => p.cron === cron)?.key}`)
+      : cron.trim() === ''
+        ? t('api_configurator.sync.schedule.manual')
+        : t('api_configurator.sync.schedule.custom');
+
+  function refresh(): void {
+    void bindingsQuery.query.refetch();
+  }
+
+  function createBinding(): void {
+    if (connectionId === null || newObjectTypeId === '') {
+      return;
+    }
+    create(
+      {
+        resource: 'sync_bindings',
+        values: {
+          connection: connectionId,
+          objectTypeId: newObjectTypeId,
+          direction: 'inbound',
+          conflictPolicy: 'lww',
+        },
+        successNotification: false,
+      },
+      { onSuccess: refresh },
+    );
+  }
+
+  function save(): void {
+    if (binding === null) {
+      return;
+    }
+    update(
+      {
+        resource: 'sync_bindings',
+        id: binding.id,
+        values: {
+          direction: dir,
+          schedule: cron.trim() === '' ? null : cron.trim(),
+          conflictPolicy: conflict,
+          readEndpoint: dir === 'outbound' ? null : readEndpointId === '' ? null : readEndpointId,
+          writeEndpoint: dir === 'inbound' ? null : writeEndpointId === '' ? null : writeEndpointId,
+          enabled,
+        },
+        successNotification: false,
+      },
+      { onSuccess: refresh },
+    );
+  }
+
+  function triggerRun(): void {
+    if (binding === null) {
+      return;
+    }
+    runNow(
+      { url: `${apiUrl}/sync_bindings/${binding.id}/run`, method: 'post', values: {} },
+      { onSuccess: refresh },
+    );
+  }
+
+  const header = (
+    <div className="flex items-center gap-3">
+      <Button
+        variant="outline"
+        size="icon"
+        onClick={() => navigate(HUB)}
+        aria-label={t('api_configurator.sync.back')}
+      >
+        <ArrowLeft className="size-4" aria-hidden="true" />
+      </Button>
+      <div className="min-w-0 flex-1">
+        <h1 className="font-display text-[22px] font-semibold tracking-tight">
+          {t('api_configurator.sync.title')}
+        </h1>
+        <p className="text-[12.5px] text-zinc-500">{t('api_configurator.sync.subtitle')}</p>
+      </div>
+    </div>
+  );
+
+  if (binding === null) {
+    return (
+      <div className="space-y-5">
+        {header}
+        <div className="soft-shadow max-w-[680px] rounded-2xl border border-dashed border-zinc-300 bg-white p-6">
+          <SectionLabel>{t('api_configurator.sync.empty.title')}</SectionLabel>
+          <p className="mb-4 text-[12.5px] leading-relaxed text-zinc-600">
+            {t('api_configurator.sync.empty.body')}
+          </p>
+          <div className="flex items-end gap-3">
+            <Field label={t('api_configurator.sync.empty.object_type')}>
+              <select
+                value={newObjectTypeId}
+                onChange={(e) => setNewObjectTypeId(e.target.value)}
+                aria-label={t('api_configurator.sync.empty.object_type')}
+                className="focus-ring h-10 w-64 rounded-xl border border-zinc-200 bg-white px-3 text-[13px]"
+              >
+                <option value="">{t('api_configurator.sync.empty.object_type_placeholder')}</option>
+                {objectTypesQuery.result.data.map((ot) => (
+                  <option key={ot.id} value={ot.id}>
+                    {ot.code}
+                  </option>
+                ))}
+              </select>
+            </Field>
+            <Button type="button" onClick={createBinding} disabled={newObjectTypeId === ''}>
+              {t('api_configurator.sync.empty.create')}
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      {header}
+      <div className="max-w-[980px] space-y-4">
+        {/* Direction */}
+        <section className="soft-shadow rounded-2xl border border-zinc-200 bg-white p-5">
+          <SectionLabel>{t('api_configurator.sync.direction.title')}</SectionLabel>
+          <div className="grid grid-cols-1 items-center gap-5 lg:grid-cols-[260px_1fr]">
+            <DirDiagram dir={dir} apiLabel={t('api_configurator.sync.direction.api')} />
+            <div className="space-y-3">
+              <Segmented
+                full
+                ariaLabel={t('api_configurator.sync.direction.title')}
+                value={dir}
+                onChange={setDir}
+                options={[
+                  { value: 'inbound', label: t('api_configurator.sync.direction.inbound') },
+                  { value: 'outbound', label: t('api_configurator.sync.direction.outbound') },
+                  {
+                    value: 'bidirectional',
+                    label: t('api_configurator.sync.direction.bidirectional'),
+                  },
+                ]}
+              />
+              <p className="text-[12.5px] leading-relaxed text-zinc-600">
+                {t(`api_configurator.sync.direction.hint.${dir}`)}
+              </p>
+            </div>
+          </div>
+          <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {dir !== 'outbound' ? (
+              <Field label={t('api_configurator.sync.direction.read_endpoint')}>
+                <EndpointSelect
+                  value={readEndpointId}
+                  onChange={setReadEndpointId}
+                  endpoints={readEndpoints}
+                  placeholder={t('api_configurator.sync.direction.endpoint_placeholder')}
+                  ariaLabel={t('api_configurator.sync.direction.read_endpoint')}
+                />
+              </Field>
+            ) : null}
+            {dir !== 'inbound' ? (
+              <Field label={t('api_configurator.sync.direction.write_endpoint')}>
+                <EndpointSelect
+                  value={writeEndpointId}
+                  onChange={setWriteEndpointId}
+                  endpoints={writeEndpoints}
+                  placeholder={t('api_configurator.sync.direction.endpoint_placeholder')}
+                  ariaLabel={t('api_configurator.sync.direction.write_endpoint')}
+                />
+              </Field>
+            ) : null}
+          </div>
+        </section>
+
+        {/* Schedule */}
+        <section className="soft-shadow rounded-2xl border border-zinc-200 bg-white p-5">
+          <SectionLabel>{t('api_configurator.sync.schedule.title')}</SectionLabel>
+          <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <Input
+                  value={cron}
+                  onChange={(e) => setCron(e.target.value)}
+                  placeholder="0 2 * * *"
+                  aria-label={t('api_configurator.sync.schedule.cron')}
+                  className="h-9 w-44 font-mono"
+                />
+                <div className="text-[12.5px] text-zinc-600">{cronHuman}</div>
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {CRON_PRESETS.map((p) => (
+                  <button
+                    key={p.cron}
+                    type="button"
+                    onClick={() => setCron(p.cron)}
+                    aria-pressed={cron === p.cron}
+                    className={`h-7 rounded-lg border px-2.5 text-[11.5px] font-medium transition ${cron === p.cron ? 'border-zinc-900 bg-zinc-900 text-white' : 'border-zinc-200 bg-white text-zinc-600 hover:bg-zinc-50'}`}
+                  >
+                    {t(`api_configurator.sync.schedule.preset.${p.key}`)}
+                  </button>
+                ))}
+              </div>
+              <div className="flex items-center gap-1.5 text-[11.5px] text-zinc-500">
+                <Info className="size-3.5 text-zinc-400" aria-hidden="true" />
+                {t('api_configurator.sync.schedule.jitter')}
+              </div>
+            </div>
+            <div className="rounded-xl border border-zinc-100 bg-zinc-50/60 p-3">
+              <div className="mb-2 text-[10.5px] font-medium uppercase tracking-wider text-zinc-400">
+                {t('api_configurator.sync.schedule.next_run')}
+              </div>
+              {binding.nextRun !== null ? (
+                <div className="flex items-center gap-2 text-[12px]">
+                  <span className="h-1.5 w-1.5 rounded-full bg-zinc-900" />
+                  <span className="font-medium text-zinc-900">
+                    {new Date(binding.nextRun).toLocaleString()}
+                  </span>
+                </div>
+              ) : (
+                <div className="text-[12px] text-zinc-500">
+                  {t('api_configurator.sync.schedule.manual_only')}
+                </div>
+              )}
+            </div>
+          </div>
+        </section>
+
+        {/* Cursor — inbound / bidirectional, read-only (engine-owned) */}
+        {dir !== 'outbound' ? (
+          <section className="soft-shadow rounded-2xl border border-zinc-200 bg-white p-5">
+            <SectionLabel
+              right={
+                <span className="text-[11px] text-zinc-400">
+                  {t('api_configurator.sync.cursor.tag')}
+                </span>
+              }
+            >
+              {t('api_configurator.sync.cursor.title')}
+            </SectionLabel>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+              <Field label={t('api_configurator.sync.cursor.field')}>
+                <ReadonlyValue value={binding.cursor?.field ?? '—'} mono />
+              </Field>
+              <Field label={t('api_configurator.sync.cursor.type')}>
+                <ReadonlyValue value={binding.cursor?.type ?? '—'} mono />
+              </Field>
+              <Field label={t('api_configurator.sync.cursor.state')}>
+                <ReadonlyValue
+                  value={
+                    binding.cursor?.state !== undefined && binding.cursor?.state !== null
+                      ? String(binding.cursor.state)
+                      : '—'
+                  }
+                  mono
+                />
+              </Field>
+            </div>
+            <div className="mt-3">
+              <SecurityNote tone="zinc" icon={<Info className="size-4" />}>
+                {t('api_configurator.sync.cursor.note')}
+              </SecurityNote>
+            </div>
+          </section>
+        ) : null}
+
+        {/* Conflict — bidirectional only */}
+        {dir === 'bidirectional' ? (
+          <section className="soft-shadow rounded-2xl border border-zinc-200 bg-white p-5">
+            <SectionLabel
+              right={
+                <span className="text-[11px] text-zinc-400">
+                  {t('api_configurator.sync.conflict.tag')}
+                </span>
+              }
+            >
+              {t('api_configurator.sync.conflict.title')}
+            </SectionLabel>
+            <Segmented
+              ariaLabel={t('api_configurator.sync.conflict.title')}
+              value={conflict}
+              onChange={setConflict}
+              options={[
+                { value: 'lww', label: t('api_configurator.sync.conflict.lww') },
+                { value: 'pim_wins', label: t('api_configurator.sync.conflict.pim_wins') },
+                { value: 'remote_wins', label: t('api_configurator.sync.conflict.remote_wins') },
+              ]}
+            />
+            <p className="mt-3 text-[12.5px] leading-relaxed text-zinc-600">
+              {t(`api_configurator.sync.conflict.hint.${conflict}`)}
+            </p>
+            <div className="mt-3">
+              <SecurityNote tone="emerald" icon={<Shield className="size-4" />}>
+                {t('api_configurator.sync.conflict.anti_loop')}
+              </SecurityNote>
+            </div>
+          </section>
+        ) : null}
+
+        {/* Match key — read-only (set in the Mapping tab) */}
+        <section className="soft-shadow rounded-2xl border border-zinc-200 bg-white p-5">
+          <SectionLabel>{t('api_configurator.sync.match_key.title')}</SectionLabel>
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="inline-flex items-center gap-2 rounded-xl border border-zinc-200 bg-zinc-50 px-3 py-2">
+              <span className="text-[13px] font-semibold">{binding.matchKeyMapping ?? '—'}</span>
+            </div>
+            <span className="text-[12px] text-zinc-500">
+              {t('api_configurator.sync.match_key.hint')}
+            </span>
+          </div>
+        </section>
+
+        {/* Footer */}
+        <div className="flex items-center gap-3 pt-1">
+          <div className="flex items-center gap-2.5">
+            <ApiToggle
+              on={enabled}
+              onChange={setEnabled}
+              ariaLabel={t('api_configurator.sync.footer.toggle')}
+            />
+            <span className="text-[13px] font-medium">
+              {enabled
+                ? t('api_configurator.sync.footer.active')
+                : t('api_configurator.sync.footer.paused')}
+            </span>
+          </div>
+          <div className="flex-1" />
+          <Button type="button" variant="outline" onClick={triggerRun}>
+            <Play className="mr-1 size-4" aria-hidden="true" />
+            {t('api_configurator.sync.footer.run_now')}
+          </Button>
+          <Button type="button" onClick={save}>
+            {t('api_configurator.sync.footer.save')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EndpointSelect({
+  value,
+  onChange,
+  endpoints,
+  placeholder,
+  ariaLabel,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  endpoints: RemoteEndpointRow[];
+  placeholder: string;
+  ariaLabel: string;
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      aria-label={ariaLabel}
+      className="focus-ring h-10 w-full rounded-xl border border-zinc-200 bg-white px-3 text-[13px]"
+    >
+      <option value="">{placeholder}</option>
+      {endpoints.map((ep) => (
+        <option key={ep.id} value={ep.id}>
+          {ep.httpMethod} {ep.pathTemplate} · {ep.role}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function ReadonlyValue({ value, mono = false }: { value: string; mono?: boolean }) {
+  return (
+    <div
+      className={`flex h-10 items-center truncate rounded-xl border border-zinc-200 bg-zinc-50/60 px-3 text-[12px] text-zinc-700 ${mono ? 'font-mono' : ''}`}
+    >
+      {value}
+    </div>
+  );
+}
+
+function DirDiagram({ dir, apiLabel }: { dir: SyncDirection; apiLabel: string }) {
+  const meta = {
+    inbound: { top: '←', bottom: null as string | null, label: 'API → PIM' },
+    outbound: { top: '→', bottom: null as string | null, label: 'PIM → API' },
+    bidirectional: { top: '→', bottom: '←', label: 'PIM ↔ API' },
+  }[dir];
+
+  return (
+    <div className="rounded-2xl border border-zinc-100 bg-zinc-50/70 p-4">
+      <div className="flex items-center justify-between gap-2">
+        <DiagramNode label="PIM" sub="hub" dark />
+        <div className="flex flex-1 flex-col items-center gap-1">
+          <div className="flex w-full items-center gap-1">
+            <div className="h-px flex-1 bg-zinc-300" />
+            <span className="font-mono text-[16px] leading-none text-zinc-700">{meta.top}</span>
+            <div className="h-px flex-1 bg-zinc-300" />
+          </div>
+          {meta.bottom !== null ? (
+            <div className="flex w-full items-center gap-1">
+              <div className="h-px flex-1 bg-zinc-300" />
+              <span className="font-mono text-[16px] leading-none text-zinc-700">
+                {meta.bottom}
+              </span>
+              <div className="h-px flex-1 bg-zinc-300" />
+            </div>
+          ) : null}
+        </div>
+        <DiagramNode label={apiLabel} sub="spoke" />
+      </div>
+      <div className="mt-3 text-center font-mono text-[11px] text-zinc-400">{meta.label}</div>
+    </div>
+  );
+}
+
+function DiagramNode({ label, sub, dark = false }: { label: string; sub: string; dark?: boolean }) {
+  return (
+    <div
+      className={`grid h-14 w-16 shrink-0 place-items-center rounded-xl ${dark ? 'bg-zinc-900 text-white' : 'border border-zinc-200 bg-white text-zinc-700'}`}
+    >
+      <div className="text-[13px] font-bold">{label}</div>
+      <div className={`font-mono text-[9px] ${dark ? 'text-white/50' : 'text-zinc-400'}`}>
+        {sub}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/api-configurator/consumer/sync/SyncConfigScreen.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/sync/SyncConfigScreen.tsx
@@ -16,6 +16,7 @@ import {
   type SyncDirection,
 } from '../../components/primitives';
 import type { RemoteEndpointRow } from '../wizard/steps/StepEndpoints';
+import { DirDiagram, EndpointSelect, ReadonlyValue } from './sync-components';
 
 type ConflictPolicy = 'lww' | 'pim_wins' | 'remote_wins';
 
@@ -450,93 +451,6 @@ export function SyncConfigScreen() {
             {t('api_configurator.sync.footer.save')}
           </Button>
         </div>
-      </div>
-    </div>
-  );
-}
-
-function EndpointSelect({
-  value,
-  onChange,
-  endpoints,
-  placeholder,
-  ariaLabel,
-}: {
-  value: string;
-  onChange: (next: string) => void;
-  endpoints: RemoteEndpointRow[];
-  placeholder: string;
-  ariaLabel: string;
-}) {
-  return (
-    <select
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      aria-label={ariaLabel}
-      className="focus-ring h-10 w-full rounded-xl border border-zinc-200 bg-white px-3 text-[13px]"
-    >
-      <option value="">{placeholder}</option>
-      {endpoints.map((ep) => (
-        <option key={ep.id} value={ep.id}>
-          {ep.httpMethod} {ep.pathTemplate} · {ep.role}
-        </option>
-      ))}
-    </select>
-  );
-}
-
-function ReadonlyValue({ value, mono = false }: { value: string; mono?: boolean }) {
-  return (
-    <div
-      className={`flex h-10 items-center truncate rounded-xl border border-zinc-200 bg-zinc-50/60 px-3 text-[12px] text-zinc-700 ${mono ? 'font-mono' : ''}`}
-    >
-      {value}
-    </div>
-  );
-}
-
-function DirDiagram({ dir, apiLabel }: { dir: SyncDirection; apiLabel: string }) {
-  const meta = {
-    inbound: { top: '←', bottom: null as string | null, label: 'API → PIM' },
-    outbound: { top: '→', bottom: null as string | null, label: 'PIM → API' },
-    bidirectional: { top: '→', bottom: '←', label: 'PIM ↔ API' },
-  }[dir];
-
-  return (
-    <div className="rounded-2xl border border-zinc-100 bg-zinc-50/70 p-4">
-      <div className="flex items-center justify-between gap-2">
-        <DiagramNode label="PIM" sub="hub" dark />
-        <div className="flex flex-1 flex-col items-center gap-1">
-          <div className="flex w-full items-center gap-1">
-            <div className="h-px flex-1 bg-zinc-300" />
-            <span className="font-mono text-[16px] leading-none text-zinc-700">{meta.top}</span>
-            <div className="h-px flex-1 bg-zinc-300" />
-          </div>
-          {meta.bottom !== null ? (
-            <div className="flex w-full items-center gap-1">
-              <div className="h-px flex-1 bg-zinc-300" />
-              <span className="font-mono text-[16px] leading-none text-zinc-700">
-                {meta.bottom}
-              </span>
-              <div className="h-px flex-1 bg-zinc-300" />
-            </div>
-          ) : null}
-        </div>
-        <DiagramNode label={apiLabel} sub="spoke" />
-      </div>
-      <div className="mt-3 text-center font-mono text-[11px] text-zinc-400">{meta.label}</div>
-    </div>
-  );
-}
-
-function DiagramNode({ label, sub, dark = false }: { label: string; sub: string; dark?: boolean }) {
-  return (
-    <div
-      className={`grid h-14 w-16 shrink-0 place-items-center rounded-xl ${dark ? 'bg-zinc-900 text-white' : 'border border-zinc-200 bg-white text-zinc-700'}`}
-    >
-      <div className="text-[13px] font-bold">{label}</div>
-      <div className={`font-mono text-[9px] ${dark ? 'text-white/50' : 'text-zinc-400'}`}>
-        {sub}
       </div>
     </div>
   );

--- a/apps/admin/src/features/api-configurator/consumer/sync/sync-components.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/sync/sync-components.tsx
@@ -1,0 +1,95 @@
+import type { SyncDirection } from '../../components/primitives';
+import type { RemoteEndpointRow } from '../wizard/steps/StepEndpoints';
+
+/**
+ * APIC-P3-11 — presentational pieces of the sync-config screen, extracted from
+ * SyncConfigScreen so the page stays a thin composition (ADR-0021 readability
+ * guard).
+ */
+
+export function EndpointSelect({
+  value,
+  onChange,
+  endpoints,
+  placeholder,
+  ariaLabel,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  endpoints: RemoteEndpointRow[];
+  placeholder: string;
+  ariaLabel: string;
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      aria-label={ariaLabel}
+      className="focus-ring h-10 w-full rounded-xl border border-zinc-200 bg-white px-3 text-[13px]"
+    >
+      <option value="">{placeholder}</option>
+      {endpoints.map((ep) => (
+        <option key={ep.id} value={ep.id}>
+          {ep.httpMethod} {ep.pathTemplate} · {ep.role}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+export function ReadonlyValue({ value, mono = false }: { value: string; mono?: boolean }) {
+  return (
+    <div
+      className={`flex h-10 items-center truncate rounded-xl border border-zinc-200 bg-zinc-50/60 px-3 text-[12px] text-zinc-700 ${mono ? 'font-mono' : ''}`}
+    >
+      {value}
+    </div>
+  );
+}
+
+export function DirDiagram({ dir, apiLabel }: { dir: SyncDirection; apiLabel: string }) {
+  const meta = {
+    inbound: { top: '←', bottom: null as string | null, label: 'API → PIM' },
+    outbound: { top: '→', bottom: null as string | null, label: 'PIM → API' },
+    bidirectional: { top: '→', bottom: '←', label: 'PIM ↔ API' },
+  }[dir];
+
+  return (
+    <div className="rounded-2xl border border-zinc-100 bg-zinc-50/70 p-4">
+      <div className="flex items-center justify-between gap-2">
+        <DiagramNode label="PIM" sub="hub" dark />
+        <div className="flex flex-1 flex-col items-center gap-1">
+          <div className="flex w-full items-center gap-1">
+            <div className="h-px flex-1 bg-zinc-300" />
+            <span className="font-mono text-[16px] leading-none text-zinc-700">{meta.top}</span>
+            <div className="h-px flex-1 bg-zinc-300" />
+          </div>
+          {meta.bottom !== null ? (
+            <div className="flex w-full items-center gap-1">
+              <div className="h-px flex-1 bg-zinc-300" />
+              <span className="font-mono text-[16px] leading-none text-zinc-700">
+                {meta.bottom}
+              </span>
+              <div className="h-px flex-1 bg-zinc-300" />
+            </div>
+          ) : null}
+        </div>
+        <DiagramNode label={apiLabel} sub="spoke" />
+      </div>
+      <div className="mt-3 text-center font-mono text-[11px] text-zinc-400">{meta.label}</div>
+    </div>
+  );
+}
+
+function DiagramNode({ label, sub, dark = false }: { label: string; sub: string; dark?: boolean }) {
+  return (
+    <div
+      className={`grid h-14 w-16 shrink-0 place-items-center rounded-xl ${dark ? 'bg-zinc-900 text-white' : 'border border-zinc-200 bg-white text-zinc-700'}`}
+    >
+      <div className="text-[13px] font-bold">{label}</div>
+      <div className={`font-mono text-[9px] ${dark ? 'text-white/50' : 'text-zinc-400'}`}>
+        {sub}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/api-configurator/consumer/sync/sync-components.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/sync/sync-components.tsx
@@ -76,7 +76,7 @@ export function DirDiagram({ dir, apiLabel }: { dir: SyncDirection; apiLabel: st
         </div>
         <DiagramNode label={apiLabel} sub="spoke" />
       </div>
-      <div className="mt-3 text-center font-mono text-[11px] text-zinc-400">{meta.label}</div>
+      <div className="mt-3 text-center font-mono text-[11px] text-zinc-500">{meta.label}</div>
     </div>
   );
 }
@@ -87,7 +87,7 @@ function DiagramNode({ label, sub, dark = false }: { label: string; sub: string;
       className={`grid h-14 w-16 shrink-0 place-items-center rounded-xl ${dark ? 'bg-zinc-900 text-white' : 'border border-zinc-200 bg-white text-zinc-700'}`}
     >
       <div className="text-[13px] font-bold">{label}</div>
-      <div className={`font-mono text-[9px] ${dark ? 'text-white/50' : 'text-zinc-400'}`}>
+      <div className={`font-mono text-[9px] ${dark ? 'text-white/50' : 'text-zinc-500'}`}>
         {sub}
       </div>
     </div>

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1866,6 +1866,80 @@
       "all_pim_mapped": "All attributes mapped ✓",
       "unmapped_remote": "Unmapped external fields · {{count}}",
       "all_remote_mapped": "None — all fields used"
+    },
+    "sync": {
+      "back": "Back to connections",
+      "title": "Synchronization configuration",
+      "subtitle": "Direction, schedule and conflict policy for this connection.",
+      "empty": {
+        "title": "No sync binding yet",
+        "body": "This connection has no binding yet. Pick the PIM object type to sync — we'll create an inbound binding you can then configure.",
+        "object_type": "Object type",
+        "object_type_placeholder": "Select an object type…",
+        "create": "Create binding"
+      },
+      "direction": {
+        "title": "Sync direction",
+        "api": "API",
+        "inbound": "Inbound (pull)",
+        "outbound": "Outbound (push)",
+        "bidirectional": "Bidirectional",
+        "read_endpoint": "Read endpoint",
+        "write_endpoint": "Write endpoint",
+        "endpoint_placeholder": "Select an endpoint…",
+        "hint": {
+          "inbound": "PIM pulls data from the API on a schedule (cursor delta) and writes it through the import engine (ValueWriteCore, provenance = integration).",
+          "outbound": "PIM pushes changes to the API (object-change event or schedule). The payload is built by the export engine — no bespoke serializer.",
+          "bidirectional": "Both directions on one binding. Requires a conflict policy; loops are broken by provenance (we never push back changes pulled from the same connection)."
+        }
+      },
+      "schedule": {
+        "title": "Schedule",
+        "cron": "Cron expression",
+        "manual": "manual only",
+        "custom": "custom schedule",
+        "jitter": "per-tenant jitter spreads starts to avoid load spikes.",
+        "next_run": "Next run",
+        "manual_only": "No schedule — run manually.",
+        "preset": {
+          "every_15m": "every 15 min",
+          "every_30m": "every 30 min",
+          "hourly": "hourly",
+          "daily_2": "daily 02:00"
+        }
+      },
+      "cursor": {
+        "title": "Cursor (incremental read)",
+        "tag": "delta-sync · crash-safe",
+        "field": "Cursor field",
+        "type": "Type",
+        "state": "Current state",
+        "note": "The cursor is managed by the sync engine and must advance monotonically — it guards against re-processing and post-crash duplicates (checkpoint like IMP2)."
+      },
+      "conflict": {
+        "title": "Conflict policy",
+        "tag": "2-way: both systems are sources of truth",
+        "lww": "Last-write-wins",
+        "pim_wins": "PIM always wins",
+        "remote_wins": "API wins",
+        "hint": {
+          "lww": "The newer timestamp wins. The origin of the last change is stamped via provenance.",
+          "pim_wins": "The PIM value takes precedence — API changes never overwrite PIM fields on conflict.",
+          "remote_wins": "The API value takes precedence — useful when the external system owns stock levels."
+        },
+        "anti_loop": "Anti-loop: changes with provenance = integration from this connection are not pushed back."
+      },
+      "match_key": {
+        "title": "Match key",
+        "hint": "Records are matched on this mapping. Change the “key” flag in the Mapping tab."
+      },
+      "footer": {
+        "toggle": "Binding active",
+        "active": "Binding active",
+        "paused": "Paused",
+        "run_now": "Run now",
+        "save": "Save binding"
+      }
     }
   },
   "api_profiles": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1914,6 +1914,80 @@
       "all_pim_mapped": "Wszystkie atrybuty zmapowane ✓",
       "unmapped_remote": "Niezmapowane pola zewnętrzne · {{count}}",
       "all_remote_mapped": "Brak — wszystkie pola wykorzystane"
+    },
+    "sync": {
+      "back": "Wróć do połączeń",
+      "title": "Konfiguracja synchronizacji",
+      "subtitle": "Kierunek, harmonogram i polityka konfliktów dla tego połączenia.",
+      "empty": {
+        "title": "Brak wiązania synchronizacji",
+        "body": "To połączenie nie ma jeszcze wiązania. Wybierz typ obiektu PIM, który ma być synchronizowany — utworzymy wiązanie inbound, które potem skonfigurujesz.",
+        "object_type": "Typ obiektu",
+        "object_type_placeholder": "Wybierz typ obiektu…",
+        "create": "Utwórz wiązanie"
+      },
+      "direction": {
+        "title": "Kierunek synchronizacji",
+        "api": "API",
+        "inbound": "Inbound (pull)",
+        "outbound": "Outbound (push)",
+        "bidirectional": "Dwukierunkowy",
+        "read_endpoint": "Endpoint odczytu",
+        "write_endpoint": "Endpoint zapisu",
+        "endpoint_placeholder": "Wybierz endpoint…",
+        "hint": {
+          "inbound": "PIM pobiera dane z API w odstępach (delta po kursorze) i zapisuje przez silnik importu (ValueWriteCore, provenance = integration).",
+          "outbound": "PIM wypycha zmiany do API (event zmiany obiektu lub harmonogram). Payload buduje silnik eksportu — bez własnego serializera.",
+          "bidirectional": "Oba kierunki na jednym wiązaniu. Wymaga polityki konfliktów; pętle przerywa provenance (nie wypychamy zmian zaciągniętych z tego samego connectiona)."
+        }
+      },
+      "schedule": {
+        "title": "Harmonogram",
+        "cron": "Wyrażenie cron",
+        "manual": "tylko ręcznie",
+        "custom": "własny harmonogram",
+        "jitter": "jitter między tenantami rozprasza starty, by uniknąć skoków obciążenia.",
+        "next_run": "Najbliższe uruchomienie",
+        "manual_only": "Bez harmonogramu — uruchamiane ręcznie.",
+        "preset": {
+          "every_15m": "co 15 min",
+          "every_30m": "co 30 min",
+          "hourly": "co godzinę",
+          "daily_2": "codziennie 02:00"
+        }
+      },
+      "cursor": {
+        "title": "Cursor (inkrementalny odczyt)",
+        "tag": "delta-sync · crash-safe",
+        "field": "Pole kursora",
+        "type": "Typ",
+        "state": "Aktualny stan",
+        "note": "Kursor jest zarządzany przez silnik synchronizacji i musi rosnąć monotonicznie — chroni przed re-procesowaniem i duplikatami po awarii (checkpoint jak w IMP2)."
+      },
+      "conflict": {
+        "title": "Polityka konfliktów",
+        "tag": "2-way: oba systemy to źródła prawdy",
+        "lww": "Last-write-wins",
+        "pim_wins": "PIM zawsze wygrywa",
+        "remote_wins": "API wygrywa",
+        "hint": {
+          "lww": "Wygrywa nowszy znacznik czasu. Pochodzenie ostatniej zmiany znakuje provenance.",
+          "pim_wins": "Wartość z PIM ma pierwszeństwo — zmiany z API nie nadpisują pól PIM przy konflikcie.",
+          "remote_wins": "Wartość z API ma pierwszeństwo — przydatne, gdy zewnętrzny system jest źródłem stanów magazynowych."
+        },
+        "anti_loop": "Anti-loop: zmiany z provenance = integration z tego connectiona nie są wypychane z powrotem."
+      },
+      "match_key": {
+        "title": "Klucz parowania (match key)",
+        "hint": "Rekordy parowane po tym mapowaniu. Zmień oznaczenie „key” w zakładce Mapowanie."
+      },
+      "footer": {
+        "toggle": "Aktywność wiązania",
+        "active": "Wiązanie aktywne",
+        "paused": "Wstrzymane",
+        "run_now": "Uruchom teraz",
+        "save": "Zapisz wiązanie"
+      }
     }
   },
   "api_profiles": {


### PR DESCRIPTION
## APIC-P3-11 — ekran konfiguracji synchronizacji (api-sync)

Ekran `/integrations/api-configurator/connections/:id/sync` wg `integracje/api-sync.jsx`, edytujący wiązanie sync danego połączenia (P3-10 CRUD + akcja run).

### Karty (warunkowe per kierunek — AC-2)
- **Kierunek** — `DirDiagram` (live) + segmented inbound/outbound/bidirectional + warunkowe selecty endpointu odczytu (≠outbound) / zapisu (≠inbound) + opis per kierunek.
- **Harmonogram** — cron input + presety (15m/30m/godzina/02:00) + human label + nota o jitterze + panel „najbliższe uruchomienie” (realny `nextRun` z API).
- **Cursor** (inbound/bi) — pole/typ/stan **read-only** (kursorem zarządza silnik P3-03).
- **Konflikty** (tylko bidirectional) — segmented LWW/pim_wins/remote_wins + opis + nota anti-loop.
- **Match key** — read-only (oznaczenie „key” ustawia się w zakładce Mapowanie P2-09).
- **Footer** — toggle aktywności + „Uruchom teraz” (POST /run) + „Zapisz wiązanie” (PATCH).

### Stany
- **Brak wiązania** → empty-state z pickerem ObjectType + „Utwórz wiązanie” (POST inbound default).
- **Wiązanie istnieje** → pełny formularz (hydratacja ze stanu binding).

### Świadome decyzje
- **Cursor field/type + match key read-only** — nie są w kontrakcie zapisu binding (PatchInput P3-10); ekran NIE udaje że je zapisuje (SMOKE TEST RULE — honest UI). Edycja kursora = follow-up (rozszerzenie PatchInput).
- **next-run = realny `nextRun`** z API (pojedynczy), nie 3 atrapy z mockupu — prawdziwe dane > pixel-perfect atrapa.
- Empty-state z ObjectType pickerem dodany poza mockup (mockup zakłada istniejące wiązanie) — konieczny dla funkcjonalnego create end-to-end.

### Testy / gates
- Playwright E2E (`1789-api-sync-config.spec.ts`): inbound→brak karty konfliktów, switch→bidirectional→karta konfliktów, save (PATCH), run-now (202), axe 0 violations.
- tsc ✅, biome ✅, vitest (17) ✅, vite build ✅. i18n pl+en symetryczne.
- Playwright walidowany na CI (lokalny harness bez live stacku).

Closes #1789