### PR TITLE
feat(integration): SyncRun history API + per-record drill-down (APIC-P4-01)

### DIFF
--- a/apps/api/src/Identity/Infrastructure/Security/SyncRunLogVoter.php
+++ b/apps/api/src/Identity/Infrastructure/Security/SyncRunLogVoter.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Security;
+
+/**
+ * RBAC voter for the API Configurator SyncRunLog read resource (APIC-P4-01).
+ * Reuses the legacy `integration` RbacMatrix resource — the same surface that
+ * gates the rest of the consumer. The subject is named by its FQCN string (no
+ * cross-BC class import), so this stays Deptrac-clean.
+ */
+final class SyncRunLogVoter extends AbstractRbacVoter
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function attributeMap(): array
+    {
+        return [
+            'READ' => 'read',
+            'CREATE' => 'write',
+            'UPDATE' => 'write',
+            'WRITE' => 'write',
+            'DELETE' => 'delete',
+        ];
+    }
+
+    protected function resource(): string
+    {
+        return 'integration';
+    }
+
+    protected function subjectClass(): string
+    {
+        return 'App\\Integration\\Generic\\Domain\\Entity\\SyncRunLog';
+    }
+}

--- a/apps/api/src/Identity/Infrastructure/Security/SyncRunVoter.php
+++ b/apps/api/src/Identity/Infrastructure/Security/SyncRunVoter.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Security;
+
+/**
+ * RBAC voter for the API Configurator SyncRun read resource (APIC-P4-01).
+ * Reuses the legacy `integration` RbacMatrix resource — the same surface that
+ * gates the rest of the consumer. The subject is named by its FQCN string (no
+ * cross-BC class import), so this stays Deptrac-clean.
+ */
+final class SyncRunVoter extends AbstractRbacVoter
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function attributeMap(): array
+    {
+        return [
+            'READ' => 'read',
+            'CREATE' => 'write',
+            'UPDATE' => 'write',
+            'WRITE' => 'write',
+            'DELETE' => 'delete',
+        ];
+    }
+
+    protected function resource(): string
+    {
+        return 'integration';
+    }
+
+    protected function subjectClass(): string
+    {
+        return 'App\\Integration\\Generic\\Domain\\Entity\\SyncRun';
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Filter/SyncRunBindingFilter.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Filter/SyncRunBindingFilter.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\ApiPlatform\Filter;
+
+use ApiPlatform\Doctrine\Orm\Filter\FilterInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * `?binding={id}` on `/api/sync_runs` — scopes the history to one binding's
+ * runs (APIC-P4-01). Tenant scoping still comes from the upstream Doctrine
+ * TenantFilter; this only adds the binding equality predicate.
+ */
+final class SyncRunBindingFilter implements FilterInterface
+{
+    private const string PARAMETER = 'binding';
+
+    public function apply(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $filters = $context['filters'] ?? [];
+        if (!\is_array($filters)) {
+            return;
+        }
+
+        $value = $filters[self::PARAMETER] ?? null;
+        if (!\is_string($value) || '' === $value) {
+            return;
+        }
+
+        $alias = $queryBuilder->getRootAliases()[0] ?? null;
+        if (null === $alias) {
+            return;
+        }
+
+        $parameter = $queryNameGenerator->generateParameterName('bindingId');
+        $queryBuilder
+            ->andWhere(\sprintf('%s.binding = :%s', $alias, $parameter))
+            ->setParameter($parameter, $value);
+    }
+
+    /**
+     * @param class-string $resourceClass
+     *
+     * @return array<string, array{property?: string, type?: string, required?: bool, description?: string, strategy?: string, is_collection?: bool}>
+     */
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            self::PARAMETER => [
+                'property' => 'binding',
+                'type' => 'string',
+                'required' => false,
+                'description' => 'Exact match on the SyncBinding UUID (tenant-scoped).',
+                'strategy' => 'exact',
+            ],
+        ];
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Filter/SyncRunConnectionFilter.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Filter/SyncRunConnectionFilter.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\ApiPlatform\Filter;
+
+use ApiPlatform\Doctrine\Orm\Filter\FilterInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * `?connection={id}` on `/api/sync_runs` — scopes the history to every run of a
+ * connection's bindings (APIC-P4-01; the connection-detail History tab). Joins
+ * SyncRun → binding → connection. Tenant scoping still comes from the upstream
+ * Doctrine TenantFilter.
+ */
+final class SyncRunConnectionFilter implements FilterInterface
+{
+    private const string PARAMETER = 'connection';
+
+    public function apply(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $filters = $context['filters'] ?? [];
+        if (!\is_array($filters)) {
+            return;
+        }
+
+        $value = $filters[self::PARAMETER] ?? null;
+        if (!\is_string($value) || '' === $value) {
+            return;
+        }
+
+        $alias = $queryBuilder->getRootAliases()[0] ?? null;
+        if (null === $alias) {
+            return;
+        }
+
+        $bindingAlias = $queryNameGenerator->generateJoinAlias('binding');
+        $parameter = $queryNameGenerator->generateParameterName('connectionId');
+        $queryBuilder
+            ->join(\sprintf('%s.binding', $alias), $bindingAlias)
+            ->andWhere(\sprintf('%s.connection = :%s', $bindingAlias, $parameter))
+            ->setParameter($parameter, $value);
+    }
+
+    /**
+     * @param class-string $resourceClass
+     *
+     * @return array<string, array{property?: string, type?: string, required?: bool, description?: string, strategy?: string, is_collection?: bool}>
+     */
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            self::PARAMETER => [
+                'property' => 'connection',
+                'type' => 'string',
+                'required' => false,
+                'description' => 'Exact match on the parent Connection UUID via the binding join (tenant-scoped).',
+                'strategy' => 'exact',
+            ],
+        ];
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Filter/SyncRunLogRunFilter.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Filter/SyncRunLogRunFilter.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Infrastructure\ApiPlatform\Filter;
+
+use ApiPlatform\Doctrine\Orm\Filter\FilterInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * `?run={id}` on `/api/sync_run_logs` — drills into one run's per-record log
+ * (APIC-P4-01). Tenant scoping still comes from the upstream Doctrine
+ * TenantFilter; this only adds the run equality predicate.
+ */
+final class SyncRunLogRunFilter implements FilterInterface
+{
+    private const string PARAMETER = 'run';
+
+    public function apply(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $filters = $context['filters'] ?? [];
+        if (!\is_array($filters)) {
+            return;
+        }
+
+        $value = $filters[self::PARAMETER] ?? null;
+        if (!\is_string($value) || '' === $value) {
+            return;
+        }
+
+        $alias = $queryBuilder->getRootAliases()[0] ?? null;
+        if (null === $alias) {
+            return;
+        }
+
+        $parameter = $queryNameGenerator->generateParameterName('runId');
+        $queryBuilder
+            ->andWhere(\sprintf('%s.run = :%s', $alias, $parameter))
+            ->setParameter($parameter, $value);
+    }
+
+    /**
+     * @param class-string $resourceClass
+     *
+     * @return array<string, array{property?: string, type?: string, required?: bool, description?: string, strategy?: string, is_collection?: bool}>
+     */
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            self::PARAMETER => [
+                'property' => 'run',
+                'type' => 'string',
+                'required' => false,
+                'description' => 'Exact match on the parent SyncRun UUID (tenant-scoped).',
+                'strategy' => 'exact',
+            ],
+        ];
+    }
+}

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/SyncRun.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/SyncRun.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns="https://api-platform.com/schema/metadata/resources-3.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata/resources-3.0
+                               https://api-platform.com/schema/metadata/resources-3.0.xsd">
+
+    <resource class="App\Integration\Generic\Domain\Entity\SyncRun"
+              shortName="SyncRun">
+
+        <normalizationContext>
+            <values>
+                <value name="groups">
+                    <values>
+                        <value>admin:read</value>
+                    </values>
+                </value>
+            </values>
+        </normalizationContext>
+
+        <!-- Newest run first (the history list is reverse-chronological). -->
+        <order>
+            <values>
+                <value name="startedAt">DESC</value>
+            </values>
+        </order>
+
+        <!-- `?connection={id}` (all runs of a connection's bindings) and
+             `?binding={id}` (one binding's runs) scope the history list. -->
+        <filters>
+            <filter>App\Integration\Generic\Infrastructure\ApiPlatform\Filter\SyncRunConnectionFilter</filter>
+            <filter>App\Integration\Generic\Infrastructure\ApiPlatform\Filter\SyncRunBindingFilter</filter>
+        </filters>
+
+        <operations>
+            <operation class="ApiPlatform\Metadata\GetCollection"
+                       uriTemplate="/sync_runs{._format}"
+                       security="is_granted('READ', 'App\\Integration\\Generic\\Domain\\Entity\\SyncRun')"/>
+
+            <operation class="ApiPlatform\Metadata\Get"
+                       uriTemplate="/sync_runs/{id}{._format}"
+                       security="is_granted('READ', object)"/>
+        </operations>
+    </resource>
+
+</resources>

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/SyncRunLog.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/SyncRunLog.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns="https://api-platform.com/schema/metadata/resources-3.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata/resources-3.0
+                               https://api-platform.com/schema/metadata/resources-3.0.xsd">
+
+    <resource class="App\Integration\Generic\Domain\Entity\SyncRunLog"
+              shortName="SyncRunLog">
+
+        <normalizationContext>
+            <values>
+                <value name="groups">
+                    <values>
+                        <value>admin:read</value>
+                    </values>
+                </value>
+            </values>
+        </normalizationContext>
+
+        <order>
+            <values>
+                <value name="createdAt">ASC</value>
+            </values>
+        </order>
+
+        <!-- `?run={id}` drills into one run's per-record log. -->
+        <filters>
+            <filter>App\Integration\Generic\Infrastructure\ApiPlatform\Filter\SyncRunLogRunFilter</filter>
+        </filters>
+
+        <operations>
+            <operation class="ApiPlatform\Metadata\GetCollection"
+                       uriTemplate="/sync_run_logs{._format}"
+                       security="is_granted('READ', 'App\\Integration\\Generic\\Domain\\Entity\\SyncRunLog')"/>
+
+            <operation class="ApiPlatform\Metadata\Get"
+                       uriTemplate="/sync_run_logs/{id}{._format}"
+                       security="is_granted('READ', object)"/>
+        </operations>
+    </resource>
+
+</resources>

--- a/apps/api/src/Integration/Generic/Infrastructure/Serializer/SyncRun.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/Serializer/SyncRun.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping
+                                https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd">
+
+    <!-- Read projection for the SyncRun history resource (APIC-P4-01). -->
+    <class name="App\Integration\Generic\Domain\Entity\SyncRun">
+        <attribute name="id">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="bindingId">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="direction">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="startedAt">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="finishedAt">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="status">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="createdCount">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="updatedCount">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="skippedCount">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="failedCount">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="cursorBefore">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="cursorAfter">
+            <group>admin:read</group>
+        </attribute>
+    </class>
+</serializer>

--- a/apps/api/src/Integration/Generic/Infrastructure/Serializer/SyncRunLog.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/Serializer/SyncRunLog.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping
+                                https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd">
+
+    <!-- Read projection for the per-record drill-down (APIC-P4-01). -->
+    <class name="App\Integration\Generic\Domain\Entity\SyncRunLog">
+        <attribute name="id">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="runId">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="matchKey">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="action">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="fields">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="message">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="createdAt">
+            <group>admin:read</group>
+        </attribute>
+    </class>
+</serializer>

--- a/apps/api/tests/Api/Integration/Generic/SyncRunHistoryApiTest.php
+++ b/apps/api/tests/Api/Integration/Generic/SyncRunHistoryApiTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Integration\Generic;
+
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Identity\Domain\Entity\User;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Entity\SyncRun;
+use App\Integration\Generic\Domain\Entity\SyncRunLog;
+use App\Integration\Generic\Domain\Enum\AuthType;
+use App\Integration\Generic\Domain\Enum\SyncDirection;
+use App\Integration\Generic\Domain\Enum\SyncRecordAction;
+use App\Integration\Generic\Domain\Enum\SyncRunStatus;
+use App\Integration\Generic\Domain\Repository\ConnectionRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\SyncBindingRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\SyncRunLogRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\SyncRunRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use App\Tests\Api\ApiConfigurator\ApiConfiguratorApiTestCase;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * APIC-P4-01 — read coverage for the SyncRun history (`/api/sync_runs`) and the
+ * per-record drill-down (`/api/sync_run_logs`). Runs/logs are seeded directly
+ * (the sync engine owns their creation; there is no write API) under the demo
+ * tenant, then queried through the public API.
+ *
+ * @phpstan-type SeedIds array{connectionId: string, bindingId: string, runId: string}
+ */
+final class SyncRunHistoryApiTest extends ApiConfiguratorApiTestCase
+{
+    #[Test]
+    public function historyListsRunsForConnection(): void
+    {
+        $ids = $this->seedRun();
+
+        $body = $this->authenticatedClient()
+            ->request('GET', '/api/sync_runs?connection='.$ids['connectionId'])
+            ->toArray();
+
+        self::assertResponseStatusCodeSame(200);
+        self::assertSame(1, $body['totalItems'] ?? null);
+        $run = $this->firstMember($body);
+        self::assertSame($ids['bindingId'], $run['bindingId'] ?? null);
+        self::assertSame('success', $run['status'] ?? null);
+        self::assertSame(2, $run['createdCount'] ?? null);
+    }
+
+    #[Test]
+    public function historyListsRunsForBinding(): void
+    {
+        $ids = $this->seedRun();
+
+        $body = $this->authenticatedClient()
+            ->request('GET', '/api/sync_runs?binding='.$ids['bindingId'])
+            ->toArray();
+
+        self::assertResponseStatusCodeSame(200);
+        self::assertSame(1, $body['totalItems'] ?? null);
+    }
+
+    #[Test]
+    public function getSingleRunReturnsCounters(): void
+    {
+        $ids = $this->seedRun();
+
+        $body = $this->authenticatedClient()
+            ->request('GET', '/api/sync_runs/'.$ids['runId'])
+            ->toArray();
+
+        self::assertResponseStatusCodeSame(200);
+        self::assertSame('inbound', $body['direction'] ?? null);
+        self::assertSame(2, $body['createdCount'] ?? null);
+        self::assertSame(1, $body['failedCount'] ?? null);
+    }
+
+    #[Test]
+    public function drilldownListsLogsForRun(): void
+    {
+        $ids = $this->seedRun();
+
+        $body = $this->authenticatedClient()
+            ->request('GET', '/api/sync_run_logs?run='.$ids['runId'])
+            ->toArray();
+
+        self::assertResponseStatusCodeSame(200);
+        self::assertSame(1, $body['totalItems'] ?? null);
+        $log = $this->firstMember($body);
+        self::assertSame('created', $log['action'] ?? null);
+        self::assertSame('SKU-1', $log['matchKey'] ?? null);
+    }
+
+    #[Test]
+    public function unauthenticatedListIs401(): void
+    {
+        static::createClient()->request('GET', '/api/sync_runs');
+        self::assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    #[Test]
+    public function limitedUserListIs403(): void
+    {
+        $this->limitedClient()->request('GET', '/api/sync_runs');
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    /**
+     * Narrow the first `member` row of a Hydra collection for offset access.
+     *
+     * @param array<array-key, mixed> $body
+     *
+     * @return array<array-key, mixed>
+     */
+    private function firstMember(array $body): array
+    {
+        $members = $body['member'] ?? [];
+        self::assertIsArray($members);
+        self::assertArrayHasKey(0, $members);
+        $first = $members[0];
+        self::assertIsArray($first);
+
+        return $first;
+    }
+
+    /**
+     * @return SeedIds
+     */
+    private function seedRun(): array
+    {
+        $tenant = $this->demoTenant();
+        $this->activateTenantFilter($tenant);
+
+        $connection = new Connection('idosell', 'IdoSell', 'https://api.example.test', AuthType::ApiKey);
+        $connection->assignTenant($tenant);
+        self::getContainer()->get(ConnectionRepositoryInterface::class)->save($connection);
+
+        $binding = new SyncBinding($connection, Uuid::v7(), SyncDirection::Inbound);
+        $binding->assignTenant($tenant);
+        self::getContainer()->get(SyncBindingRepositoryInterface::class)->save($binding);
+
+        $run = new SyncRun($binding, SyncDirection::Inbound);
+        $run->assignTenant($tenant);
+        $run->recordCreated();
+        $run->recordCreated();
+        $run->recordFailed();
+        $run->markFinished(SyncRunStatus::Success, ['state' => '2026-06-02']);
+        self::getContainer()->get(SyncRunRepositoryInterface::class)->save($run);
+
+        $log = new SyncRunLog($run, SyncRecordAction::Created);
+        $log->assignTenant($tenant);
+        $log->setMatchKey('SKU-1');
+        $log->setFields(['sku' => 'SKU-1']);
+        self::getContainer()->get(SyncRunLogRepositoryInterface::class)->save($log);
+
+        return [
+            'connectionId' => $connection->getId()->toRfc4122(),
+            'bindingId' => $binding->getId()->toRfc4122(),
+            'runId' => $run->getId()->toRfc4122(),
+        ];
+    }
+
+    private function demoTenant(): Tenant
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        return $tenant;
+    }
+
+    private function activateTenantFilter(Tenant $tenant): void
+    {
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+    }
+
+    private function limitedClient(): Client
+    {
+        $tenant = $this->demoTenant();
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $email = 'limited-run@demo.localhost';
+        $stub = new User($tenant, $email, '', ['ROLE_USER']);
+        $user = new User($tenant, $email, $hasher->hashPassword($stub, 'changeme'), ['ROLE_USER']);
+        $em = $this->em();
+        $em->persist($user);
+        $em->flush();
+
+        $jwt = self::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+
+        $client = static::createClient();
+        $client->setDefaultOptions(['headers' => ['authorization' => 'Bearer '.$jwt]]);
+
+        return $client;
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -9019,6 +9019,380 @@
                 }
             }
         },
+        "/api/sync_runs": {
+            "get": {
+                "operationId": "api_sync_runs_get_collection",
+                "tags": [
+                    "SyncRun"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "SyncRun collection",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "description": "SyncRun.jsonld-admin.read collection.",
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/HydraCollectionBaseSchema"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "member"
+                                            ],
+                                            "properties": {
+                                                "member": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/SyncRun.jsonld-admin.read"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/SyncRun-admin.read"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Retrieves the collection of SyncRun resources.",
+                "description": "Retrieves the collection of SyncRun resources.",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "The collection page number",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        },
+                        "style": "form",
+                        "explode": true
+                    },
+                    {
+                        "name": "connection",
+                        "in": "query",
+                        "description": "Exact match on the parent Connection UUID via the binding join (tenant-scoped).",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "binding",
+                        "in": "query",
+                        "description": "Exact match on the SyncBinding UUID (tenant-scoped).",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    }
+                ]
+            }
+        },
+        "/api/sync_runs/{id}": {
+            "get": {
+                "operationId": "api_sync_runs_id_get",
+                "tags": [
+                    "SyncRun"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "SyncRun resource",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SyncRun.jsonld-admin.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SyncRun-admin.read"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Retrieves a SyncRun resource.",
+                "description": "Retrieves a SyncRun resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "SyncRun identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ]
+            }
+        },
+        "/api/sync_run_logs": {
+            "get": {
+                "operationId": "api_sync_run_logs_get_collection",
+                "tags": [
+                    "SyncRunLog"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "SyncRunLog collection",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "description": "SyncRunLog.jsonld-admin.read collection.",
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/HydraCollectionBaseSchema"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "member"
+                                            ],
+                                            "properties": {
+                                                "member": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/SyncRunLog.jsonld-admin.read"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/SyncRunLog-admin.read"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Retrieves the collection of SyncRunLog resources.",
+                "description": "Retrieves the collection of SyncRunLog resources.",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "The collection page number",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        },
+                        "style": "form",
+                        "explode": true
+                    },
+                    {
+                        "name": "run",
+                        "in": "query",
+                        "description": "Exact match on the parent SyncRun UUID (tenant-scoped).",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    }
+                ]
+            }
+        },
+        "/api/sync_run_logs/{id}": {
+            "get": {
+                "operationId": "api_sync_run_logs_id_get",
+                "tags": [
+                    "SyncRunLog"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "SyncRunLog resource",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SyncRunLog.jsonld-admin.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SyncRunLog-admin.read"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Retrieves a SyncRunLog resource.",
+                "description": "Retrieves a SyncRunLog resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "SyncRunLog identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ]
+            }
+        },
         "/api/admin/break-glass": {
             "post": {
                 "operationId": "api_admin_break_glass_post",
@@ -23197,6 +23571,314 @@
                     }
                 ],
                 "description": "The heart of a sync: what (ObjectType) is synced where (Connection endpoints),\nhow (direction + conflict policy + match key) and how often (cron schedule) \u2014\nADR-0022, epic APIC, ticket APIC-P3-01.\n\n`objectTypeId` is a validated loose reference, not a Doctrine/DB FK: the\ntarget ObjectType lives in the Catalog context and ADR-0022 keeps cross-BC\ncoupling to Contracts only, so no migration-level FK ties Integration to the\nCatalog schema (the binding API validates the id exists). The read/write\nendpoints and the connection are same-context FKs.\n\n`cursor` is the delta-sync state envelope (`{field, type, state}`) maintained\nby the cursor manager (APIC-P3-03). `TenantScoped` + Postgres RLS isolate\nevery binding to its tenant."
+            },
+            "SyncRun-admin.read": {
+                "type": "object",
+                "description": "The audit record of one sync execution of a {@see SyncBinding} (ADR-0022,\nepic APIC, ticket APIC-P3-02; mirrors `ImportScheduleRun` + `sync_job_logs`).\n\nCaptures the direction, lifecycle status, per-outcome counters and the cursor\nbefore/after the run (so a delta sync is auditable and resumable). Per-record\ndetail lives in {@see SyncRunLog}. `TenantScoped` + Postgres RLS isolate every\nrun to its tenant.",
+                "properties": {
+                    "id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uuid"
+                    },
+                    "direction": {
+                        "type": "string",
+                        "enum": [
+                            "inbound",
+                            "outbound",
+                            "bidirectional"
+                        ]
+                    },
+                    "startedAt": {
+                        "readOnly": true,
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "finishedAt": {
+                        "readOnly": true,
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date-time"
+                    },
+                    "status": {
+                        "readOnly": true,
+                        "default": "running",
+                        "type": "string"
+                    },
+                    "createdCount": {
+                        "readOnly": true,
+                        "default": 0,
+                        "type": "integer"
+                    },
+                    "updatedCount": {
+                        "readOnly": true,
+                        "default": 0,
+                        "type": "integer"
+                    },
+                    "skippedCount": {
+                        "readOnly": true,
+                        "default": 0,
+                        "type": "integer"
+                    },
+                    "failedCount": {
+                        "readOnly": true,
+                        "default": 0,
+                        "type": "integer"
+                    },
+                    "cursorBefore": {
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "additionalProperties": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "cursorAfter": {
+                        "readOnly": true,
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "additionalProperties": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "bindingId": {
+                        "readOnly": true,
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                }
+            },
+            "SyncRun.jsonld-admin.read": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/HydraItemBaseSchema"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "uuid"
+                            },
+                            "direction": {
+                                "type": "string",
+                                "enum": [
+                                    "inbound",
+                                    "outbound",
+                                    "bidirectional"
+                                ]
+                            },
+                            "startedAt": {
+                                "readOnly": true,
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "finishedAt": {
+                                "readOnly": true,
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "date-time"
+                            },
+                            "status": {
+                                "readOnly": true,
+                                "default": "running",
+                                "type": "string"
+                            },
+                            "createdCount": {
+                                "readOnly": true,
+                                "default": 0,
+                                "type": "integer"
+                            },
+                            "updatedCount": {
+                                "readOnly": true,
+                                "default": 0,
+                                "type": "integer"
+                            },
+                            "skippedCount": {
+                                "readOnly": true,
+                                "default": 0,
+                                "type": "integer"
+                            },
+                            "failedCount": {
+                                "readOnly": true,
+                                "default": 0,
+                                "type": "integer"
+                            },
+                            "cursorBefore": {
+                                "type": [
+                                    "object",
+                                    "null"
+                                ],
+                                "additionalProperties": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "cursorAfter": {
+                                "readOnly": true,
+                                "type": [
+                                    "object",
+                                    "null"
+                                ],
+                                "additionalProperties": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "bindingId": {
+                                "readOnly": true,
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        }
+                    }
+                ],
+                "description": "The audit record of one sync execution of a {@see SyncBinding} (ADR-0022,\nepic APIC, ticket APIC-P3-02; mirrors `ImportScheduleRun` + `sync_job_logs`).\n\nCaptures the direction, lifecycle status, per-outcome counters and the cursor\nbefore/after the run (so a delta sync is auditable and resumable). Per-record\ndetail lives in {@see SyncRunLog}. `TenantScoped` + Postgres RLS isolate every\nrun to its tenant."
+            },
+            "SyncRunLog-admin.read": {
+                "type": "object",
+                "description": "Per-record detail of a {@see SyncRun} (ADR-0022, epic APIC, ticket APIC-P3-02):\nthe match key that identified the row, the action taken, the fields touched\nand an optional message (the error text for a failed record).\n\n`TenantScoped` + Postgres RLS isolate every log line to its tenant; the FK to\nSyncRun cascades on delete.",
+                "properties": {
+                    "id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uuid"
+                    },
+                    "matchKey": {
+                        "maxLength": 255,
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "action": {
+                        "type": "string",
+                        "enum": [
+                            "created",
+                            "updated",
+                            "skipped",
+                            "failed"
+                        ]
+                    },
+                    "fields": {
+                        "description": "The fields written/compared for this record; null for skips/failures.",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "additionalProperties": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "message": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "createdAt": {
+                        "readOnly": true,
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "runId": {
+                        "readOnly": true,
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                }
+            },
+            "SyncRunLog.jsonld-admin.read": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/HydraItemBaseSchema"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "uuid"
+                            },
+                            "matchKey": {
+                                "maxLength": 255,
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "action": {
+                                "type": "string",
+                                "enum": [
+                                    "created",
+                                    "updated",
+                                    "skipped",
+                                    "failed"
+                                ]
+                            },
+                            "fields": {
+                                "description": "The fields written/compared for this record; null for skips/failures.",
+                                "type": [
+                                    "object",
+                                    "null"
+                                ],
+                                "additionalProperties": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "message": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "createdAt": {
+                                "readOnly": true,
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "runId": {
+                                "readOnly": true,
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        }
+                    }
+                ],
+                "description": "Per-record detail of a {@see SyncRun} (ADR-0022, epic APIC, ticket APIC-P3-02):\nthe match key that identified the row, the action taken, the fields touched\nand an optional message (the error text for a failed record).\n\n`TenantScoped` + Postgres RLS isolate every log line to its tenant; the FK to\nSyncRun cascades on delete."
             }
         },
         "responses": {},
@@ -23294,6 +23976,14 @@
         {
             "name": "SyncBinding",
             "description": "The heart of a sync: what (ObjectType) is synced where (Connection endpoints),\nhow (direction + conflict policy + match key) and how often (cron schedule) \u2014\nADR-0022, epic APIC, ticket APIC-P3-01.\n\n`objectTypeId` is a validated loose reference, not a Doctrine/DB FK: the\ntarget ObjectType lives in the Catalog context and ADR-0022 keeps cross-BC\ncoupling to Contracts only, so no migration-level FK ties Integration to the\nCatalog schema (the binding API validates the id exists). The read/write\nendpoints and the connection are same-context FKs.\n\n`cursor` is the delta-sync state envelope (`{field, type, state}`) maintained\nby the cursor manager (APIC-P3-03). `TenantScoped` + Postgres RLS isolate\nevery binding to its tenant."
+        },
+        {
+            "name": "SyncRun",
+            "description": "The audit record of one sync execution of a {@see SyncBinding} (ADR-0022,\nepic APIC, ticket APIC-P3-02; mirrors `ImportScheduleRun` + `sync_job_logs`).\n\nCaptures the direction, lifecycle status, per-outcome counters and the cursor\nbefore/after the run (so a delta sync is auditable and resumable). Per-record\ndetail lives in {@see SyncRunLog}. `TenantScoped` + Postgres RLS isolate every\nrun to its tenant."
+        },
+        {
+            "name": "SyncRunLog",
+            "description": "Per-record detail of a {@see SyncRun} (ADR-0022, epic APIC, ticket APIC-P3-02):\nthe match key that identified the row, the action taken, the fields touched\nand an optional message (the error text for a failed record).\n\n`TenantScoped` + Postgres RLS isolate every log line to its tenant; the FK to\nSyncRun cascades on delete."
         }
     ],
     "webhooks": {}


### PR DESCRIPTION
## APIC-P4-01 — SyncRun history API + drill-down

Read-only powierzchnia audytu synchronizacji (zasila zakładkę Historia w P3-12 + monitor P4-02).

### Zasoby
- **`/api/sync_runs`** (GetCollection + Get) — newest-first (`startedAt DESC`), filtry `?connection={id}` (join przez binding) i `?binding={id}`. Projekcja: bindingId, direction, started/finishedAt, status, created/updated/skipped/failedCount, cursorBefore/After.
- **`/api/sync_run_logs`** (GetCollection + Get) — `?run={id}` drill-down per rekord. Projekcja: runId, matchKey, action, fields, message, createdAt.

### RBAC + bezpieczeństwo
- `SyncRunVoter` / `SyncRunLogVoter` (reużywają zasób `integration` RbacMatrix) gejtują `is_granted('READ', …)`.
- Bez write API — runy/logi tworzy wyłącznie silnik sync (P3-04/06). Tenant-scoped (TenantFilter + RLS).

### Testy / gates
- ApiTestCase: history per connection / per binding, GET single run (countery), drill-down logów per run, 401 unauth, 403 limited user. Seed runów/logów bezpośrednio (brak write API) pod demo tenantem.
- PHPStan max ✅, Deptrac 0 ✅, CS-Fixer ✅, OpenAPI snapshot ✅ (+4 ścieżki; reszta diffu = alfabetyczne przesunięcia schematów).

Closes #1791