### PR TITLE
feat(ui): build connection detail with 5 tabs (APIC-P3-12)

### DIFF
--- a/apps/admin/e2e/1790-api-connection-detail.spec.ts
+++ b/apps/admin/e2e/1790-api-connection-detail.spec.ts
@@ -1,0 +1,153 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, type Route, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * APIC-P3-12 (#1790) — the connection detail with five deep-linkable tabs. All
+ * resources are mocked, so the test is deterministic and offline: switch tabs
+ * (overview → endpoints → history) and drill into a run's records.
+ */
+test('APIC-P3-12 — connection detail: tab navigation + history drill-down', async ({ page }) => {
+  await loginAsAdmin(page);
+
+  const connection = {
+    id: 'conn-1',
+    code: 'idosell',
+    name: 'IdoSell EU',
+    baseUrl: 'https://api.idosell.example',
+    authType: 'api_key',
+    rateLimitHint: 40,
+    status: 'active',
+  };
+  const binding = {
+    id: 'bind-1',
+    connectionId: 'conn-1',
+    direction: 'inbound',
+    schedule: '0 2 * * *',
+    conflictPolicy: 'lww',
+    matchKeyMapping: 'sku',
+    cursor: { field: 'updated_at', type: 'updated_at', state: 'x' },
+    isEnabled: true,
+    nextRun: '2026-12-01T02:00:00+00:00',
+  };
+  const run = {
+    id: 'run-1',
+    bindingId: 'bind-1',
+    direction: 'inbound',
+    startedAt: '2026-06-20T10:00:00+00:00',
+    finishedAt: '2026-06-20T10:01:00+00:00',
+    status: 'success',
+    createdCount: 3,
+    updatedCount: 2,
+    skippedCount: 0,
+    failedCount: 0,
+    cursorAfter: { state: 'y' },
+  };
+
+  await page.route('**/api/connections/conn-1**', (r: Route) => {
+    if (r.request().url().includes('/test')) {
+      return r.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' });
+    }
+    return r.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify(connection),
+    });
+  });
+  await page.route('**/api/sync_bindings**', (r: Route) => {
+    if (r.request().url().includes('/run')) {
+      return r.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: '{"dispatched":true}',
+      });
+    }
+    return r.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify({ member: [binding], totalItems: 1 }),
+    });
+  });
+  await page.route('**/api/sync_runs**', (r: Route) =>
+    r.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify({ member: [run], totalItems: 1 }),
+    }),
+  );
+  await page.route('**/api/sync_run_logs**', (r: Route) =>
+    r.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify({
+        member: [
+          {
+            id: 'log-1',
+            runId: 'run-1',
+            matchKey: 'SKU-1',
+            action: 'created',
+            message: null,
+            createdAt: run.startedAt,
+          },
+        ],
+        totalItems: 1,
+      }),
+    }),
+  );
+  await page.route('**/api/remote_endpoints**', (r: Route) =>
+    r.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify({
+        member: [
+          {
+            id: 'ep-1',
+            connectionId: 'conn-1',
+            role: 'read_list',
+            httpMethod: 'GET',
+            pathTemplate: '/products',
+            pagination: { strategy: 'none' },
+            recordSelector: '$.results',
+          },
+        ],
+        totalItems: 1,
+      }),
+    }),
+  );
+  await page.route('**/api/field_mappings**', (r: Route) =>
+    r.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: '{"member":[],"totalItems":0}',
+    }),
+  );
+  await page.route('**/api/object_types**', (r: Route) =>
+    r.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: '{"member":[{"id":"ot-1","code":"product"}],"totalItems":1}',
+    }),
+  );
+
+  await page.goto('/integrations/api-configurator/connections/conn-1');
+
+  // Header identity.
+  await expect(page.getByRole('heading', { name: 'IdoSell EU' })).toBeVisible();
+
+  // Overview (default tab): recent-runs section.
+  await expect(page.getByText(/ostatnie synchronizacje|recent syncs/i)).toBeVisible();
+
+  // Endpoints tab.
+  await page.getByRole('tab', { name: /endpointy|endpoints/i }).click();
+  await expect(page.getByText('/products', { exact: true })).toBeVisible();
+
+  // History tab → drill into the run.
+  await page.getByRole('tab', { name: /historia|history/i }).click();
+  const runRow = page.getByRole('button', { name: /success|sukces/i }).first();
+  await runRow.click();
+  await expect(page.getByText('SKU-1', { exact: true })).toBeVisible();
+
+  const a11y = await new AxeBuilder({ page }).analyze();
+  expect(a11y.violations).toEqual([]);
+});

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -25,11 +25,14 @@ import { dataProvider } from '@/lib/data-provider';
  * binding (`export function FooPage`). React.lazy itself only
  * accepts default exports, so we adapt with a tiny mapping step.
  */
-function lazyPage<K extends string, T extends Record<K, ComponentType<unknown>>>(
+// The constraint uses ComponentType<never> rather than <unknown> so page
+// components that accept optional props (e.g. the api-configurator screens with
+// an `embedded?` flag, rendered prop-less by the router) still satisfy it.
+function lazyPage<K extends string, T extends Record<K, ComponentType<never>>>(
   loader: () => Promise<T>,
   exportName: K,
 ): LazyExoticComponent<ComponentType<unknown>> {
-  return lazy(() => loader().then((m) => ({ default: m[exportName] })));
+  return lazy(() => loader().then((m) => ({ default: m[exportName] as ComponentType<unknown> })));
 }
 
 const ApiProfileCreatePage = lazyPage(
@@ -67,6 +70,10 @@ const MappingScreen = lazyPage(
 const SyncConfigScreen = lazyPage(
   () => import('@/features/api-configurator/consumer/sync/SyncConfigScreen'),
   'SyncConfigScreen',
+);
+const ConnectionDetailPage = lazyPage(
+  () => import('@/features/api-configurator/consumer/detail/ConnectionDetailPage'),
+  'ConnectionDetailPage',
 );
 const ApiMonitorPlaceholder = lazyPage(
   () => import('@/features/api-configurator/monitor/ApiMonitorPlaceholder'),
@@ -651,6 +658,10 @@ function App() {
                     <Route
                       path="/integrations/api-configurator/connections/:id/sync"
                       element={<SyncConfigScreen />}
+                    />
+                    <Route
+                      path="/integrations/api-configurator/connections/:id"
+                      element={<ConnectionDetailPage />}
                     />
                     <Route
                       path="/integrations/api-configurator/monitor"

--- a/apps/admin/src/features/api-configurator/consumer/detail/ConnectionDetailPage.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/detail/ConnectionDetailPage.tsx
@@ -1,0 +1,164 @@
+import { useApiUrl, useCustomMutation, useList, useOne } from '@refinedev/core';
+import { ArrowLeft, Play, Wifi } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useParams, useSearchParams } from 'react-router';
+
+import { Button } from '@/components/ui/button';
+
+import {
+  AuthBadge,
+  type AuthType,
+  type ConnectionStatus,
+  ConnStatusPill,
+  DirectionBadge,
+} from '../../components/primitives';
+import { MappingScreen } from '../mapping/MappingScreen';
+import { SyncConfigScreen } from '../sync/SyncConfigScreen';
+import { DetailEndpoints } from './DetailEndpoints';
+import { DetailHistory } from './DetailHistory';
+import { DetailOverview } from './DetailOverview';
+import { DETAIL_TABS, type DetailTab, type SyncBindingRow, toDetailTab } from './types';
+
+interface ConnectionRow {
+  id: string;
+  code: string;
+  name: string;
+  baseUrl: string;
+  authType: AuthType;
+  rateLimitHint: number | null;
+  status: ConnectionStatus;
+}
+
+const HUB = '/integrations/api-configurator/connections';
+
+/**
+ * APIC-P3-12 — the full-screen connection detail with five deep-linkable tabs
+ * (`?tab=`): Overview, Endpoints, Mapping (embeds P2-09), Sync (embeds P3-11),
+ * History (P4-01). The header carries identity + status/direction/auth and the
+ * Test (P1-05) + Sync-now (P3-10 run) actions.
+ */
+export function ConnectionDetailPage() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const apiUrl = useApiUrl();
+  const { id: connectionId = '' } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tab = toDetailTab(searchParams.get('tab'));
+
+  const connectionQuery = useOne<ConnectionRow>({
+    resource: 'connections',
+    id: connectionId,
+    queryOptions: { enabled: connectionId !== '' },
+  });
+  const bindingsQuery = useList<SyncBindingRow>({
+    resource: 'sync_bindings',
+    filters: [{ field: 'connection', operator: 'eq', value: connectionId }],
+    pagination: { mode: 'off' },
+    queryOptions: { enabled: connectionId !== '' },
+  });
+
+  const connection = connectionQuery.result ?? null;
+  const binding = bindingsQuery.result.data[0] ?? null;
+
+  const { mutate: test } = useCustomMutation();
+  const { mutate: runNow } = useCustomMutation();
+
+  function selectTab(next: DetailTab): void {
+    setSearchParams(next === 'overview' ? {} : { tab: next });
+  }
+
+  function triggerTest(): void {
+    if (connectionId === '') {
+      return;
+    }
+    test({ url: `${apiUrl}/connections/${connectionId}/test`, method: 'post', values: {} });
+  }
+
+  function triggerSync(): void {
+    if (binding === null) {
+      return;
+    }
+    runNow({ url: `${apiUrl}/sync_bindings/${binding.id}/run`, method: 'post', values: {} });
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center gap-3">
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={() => navigate(HUB)}
+          aria-label={t('api_configurator.detail.back')}
+        >
+          <ArrowLeft className="size-4" aria-hidden="true" />
+        </Button>
+        <div className="min-w-0 flex-1">
+          <h1 className="font-display text-[22px] font-semibold tracking-tight">
+            {connection?.name ?? t('api_configurator.detail.title')}
+          </h1>
+          <p className="truncate font-mono text-[12px] text-zinc-500">
+            {connection?.baseUrl ?? ''}
+          </p>
+        </div>
+        <Button type="button" variant="outline" onClick={triggerTest}>
+          <Wifi className="mr-1 size-4" aria-hidden="true" />
+          {t('api_configurator.detail.test')}
+        </Button>
+        <Button type="button" onClick={triggerSync} disabled={binding === null}>
+          <Play className="mr-1 size-4" aria-hidden="true" />
+          {t('api_configurator.detail.sync_now')}
+        </Button>
+      </div>
+
+      {connection !== null ? (
+        <div className="flex flex-wrap items-center gap-2.5">
+          <ConnStatusPill
+            status={connection.status}
+            label={t(`api_configurator.hub.status.${connection.status}`)}
+          />
+          {binding !== null ? (
+            <DirectionBadge dir={binding.direction} label={binding.direction} />
+          ) : null}
+          <AuthBadge type={connection.authType} />
+        </div>
+      ) : null}
+
+      <div
+        role="tablist"
+        aria-label={t('api_configurator.detail.tabs_label')}
+        className="flex flex-wrap gap-1 border-b border-zinc-200"
+      >
+        {DETAIL_TABS.map((id) => {
+          const active = tab === id;
+          return (
+            <button
+              key={id}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => selectTab(id)}
+              className={`-mb-px border-b-2 px-3 py-2 text-[13px] font-medium transition ${active ? 'border-zinc-900 text-zinc-900' : 'border-transparent text-zinc-500 hover:text-zinc-800'}`}
+            >
+              {t(`api_configurator.detail.tab.${id}`)}
+            </button>
+          );
+        })}
+      </div>
+
+      <div>
+        {tab === 'overview' ? (
+          <DetailOverview
+            connectionId={connectionId}
+            binding={binding}
+            rateLimitHint={connection?.rateLimitHint ?? null}
+            onOpenTab={selectTab}
+          />
+        ) : null}
+        {tab === 'endpoints' ? <DetailEndpoints connectionId={connectionId} /> : null}
+        {tab === 'mapping' ? <MappingScreen embedded /> : null}
+        {tab === 'sync' ? <SyncConfigScreen embedded /> : null}
+        {tab === 'history' ? <DetailHistory connectionId={connectionId} /> : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/api-configurator/consumer/detail/DetailEndpoints.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/detail/DetailEndpoints.tsx
@@ -1,0 +1,64 @@
+import { useList } from '@refinedev/core';
+import { useTranslation } from 'react-i18next';
+
+import {
+  type EndpointRole,
+  type HttpMethod,
+  MethodPill,
+  type PaginationKind,
+  PaginationPill,
+  RolePill,
+  SectionLabel,
+} from '../../components/primitives';
+import type { RemoteEndpointRow } from '../wizard/steps/StepEndpoints';
+
+/**
+ * APIC-P3-12 — the connection-detail Endpoints tab: a read-only list of the
+ * connection's REST descriptor endpoints. Editing happens in the wizard.
+ */
+export function DetailEndpoints({ connectionId }: { connectionId: string }) {
+  const { t } = useTranslation();
+
+  const query = useList<RemoteEndpointRow>({
+    resource: 'remote_endpoints',
+    filters: [{ field: 'connection', operator: 'eq', value: connectionId }],
+    pagination: { mode: 'off' },
+    queryOptions: { enabled: connectionId !== '' },
+  });
+
+  const endpoints = query.result.data;
+
+  return (
+    <section className="soft-shadow rounded-2xl border border-zinc-200 bg-white p-5">
+      <SectionLabel>{t('api_configurator.detail.endpoints.title')}</SectionLabel>
+      {endpoints.length === 0 ? (
+        <p className="text-[12.5px] text-zinc-500">
+          {t('api_configurator.detail.endpoints.empty')}
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {endpoints.map((ep) => (
+            <div key={ep.id} className="rounded-xl border border-zinc-200 bg-white p-3.5">
+              <div className="flex flex-wrap items-center gap-2.5">
+                <RolePill value={ep.role as EndpointRole} />
+                <MethodPill method={ep.httpMethod as HttpMethod} />
+                <span className="font-mono text-[13px] text-zinc-800">{ep.pathTemplate}</span>
+                <span className="ml-auto">
+                  <PaginationPill kind={(ep.pagination?.strategy ?? 'none') as PaginationKind} />
+                </span>
+              </div>
+              {ep.recordSelector != null && ep.recordSelector !== '' ? (
+                <div className="mt-2 flex items-center gap-2 text-[11.5px]">
+                  <span className="text-[10px] uppercase tracking-wider text-zinc-400">
+                    {t('api_configurator.detail.endpoints.selector')}
+                  </span>
+                  <span className="font-mono text-zinc-600">{ep.recordSelector}</span>
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/admin/src/features/api-configurator/consumer/detail/DetailHistory.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/detail/DetailHistory.tsx
@@ -1,0 +1,103 @@
+import { useList } from '@refinedev/core';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { DirectionBadge, SectionLabel } from '../../components/primitives';
+import { RunStatusDot, RunStatusPill, toRunStatus } from './RunStatus';
+import type { SyncRunLogRow, SyncRunRow } from './types';
+
+/**
+ * APIC-P3-12 — the connection-detail History tab: the SyncRun list (P4-01)
+ * with a per-run drill-down into the SyncRunLog records.
+ */
+export function DetailHistory({ connectionId }: { connectionId: string }) {
+  const { t } = useTranslation();
+  const [openRunId, setOpenRunId] = useState<string | null>(null);
+
+  const runsQuery = useList<SyncRunRow>({
+    resource: 'sync_runs',
+    filters: [{ field: 'connection', operator: 'eq', value: connectionId }],
+    pagination: { mode: 'off' },
+    queryOptions: { enabled: connectionId !== '' },
+  });
+  const logsQuery = useList<SyncRunLogRow>({
+    resource: 'sync_run_logs',
+    filters: openRunId === null ? [] : [{ field: 'run', operator: 'eq', value: openRunId }],
+    pagination: { mode: 'off' },
+    queryOptions: { enabled: openRunId !== null },
+  });
+
+  const runs = runsQuery.result.data;
+
+  return (
+    <section className="soft-shadow overflow-hidden rounded-2xl border border-zinc-200 bg-white">
+      <div className="border-b border-zinc-100 px-5 py-3">
+        <SectionLabel>{t('api_configurator.detail.history.title')}</SectionLabel>
+        {runs.length === 0 ? (
+          <p className="text-[12.5px] text-zinc-500">
+            {t('api_configurator.detail.history.empty')}
+          </p>
+        ) : null}
+      </div>
+      <div className="divide-y divide-zinc-50">
+        {runs.map((run) => {
+          const status = toRunStatus(run.status);
+          const open = openRunId === run.id;
+          return (
+            <div key={run.id}>
+              <button
+                type="button"
+                onClick={() => setOpenRunId(open ? null : run.id)}
+                aria-expanded={open}
+                className="flex w-full items-center gap-3 px-5 py-3 text-left transition hover:bg-zinc-50/70"
+              >
+                <RunStatusDot status={status} />
+                <div className="min-w-0">
+                  <div className="text-[12.5px] text-zinc-800">
+                    {new Date(run.startedAt).toLocaleString()}
+                  </div>
+                  <div className="font-mono text-[10.5px] text-zinc-500">
+                    +{run.createdCount} ~{run.updatedCount}
+                    {run.skippedCount > 0 ? ` ⤳${run.skippedCount}` : ''}
+                    {run.failedCount > 0 ? ` ✕${run.failedCount}` : ''}
+                  </div>
+                </div>
+                <span className="ml-auto flex items-center gap-3">
+                  <DirectionBadge dir={run.direction} label={run.direction} />
+                  <RunStatusPill
+                    status={status}
+                    label={t(`api_configurator.detail.run_status.${status}`)}
+                  />
+                </span>
+              </button>
+
+              {open ? (
+                <div className="bg-zinc-50/50 px-5 py-3">
+                  {logsQuery.result.data.length === 0 ? (
+                    <p className="text-[11.5px] text-zinc-500">
+                      {t('api_configurator.detail.history.no_records')}
+                    </p>
+                  ) : (
+                    <div className="space-y-1">
+                      {logsQuery.result.data.map((log) => (
+                        <div key={log.id} className="flex items-center gap-2 text-[11.5px]">
+                          <span className="font-mono text-zinc-700">{log.matchKey ?? '—'}</span>
+                          <span className="rounded bg-white px-1.5 py-0.5 text-[10px] text-zinc-600">
+                            {log.action}
+                          </span>
+                          {log.message != null ? (
+                            <span className="truncate text-zinc-500">{log.message}</span>
+                          ) : null}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/admin/src/features/api-configurator/consumer/detail/DetailOverview.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/detail/DetailOverview.tsx
@@ -1,0 +1,176 @@
+import { useList } from '@refinedev/core';
+import { Info } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { CoverageBar, SectionLabel, SecurityNote, TypeCompat } from '../../components/primitives';
+import { RunStatusDot, RunStatusPill, toRunStatus } from './RunStatus';
+import type { SyncBindingRow, SyncRunRow } from './types';
+
+interface FieldMappingRow {
+  id: string;
+}
+
+/** Common PIM targets (mirrors the mapper's coverage denominator). */
+const PIM_TARGET_TOTAL = 6;
+
+/**
+ * APIC-P3-12 — the connection-detail Overview tab: info tiles, recent runs,
+ * mapping coverage and a static security posture card.
+ */
+export function DetailOverview({
+  connectionId,
+  binding,
+  rateLimitHint,
+  onOpenTab,
+}: {
+  connectionId: string;
+  binding: SyncBindingRow | null;
+  rateLimitHint: number | null;
+  onOpenTab: (tab: 'mapping' | 'history') => void;
+}) {
+  const { t } = useTranslation();
+
+  const runsQuery = useList<SyncRunRow>({
+    resource: 'sync_runs',
+    filters: [{ field: 'connection', operator: 'eq', value: connectionId }],
+    pagination: { mode: 'off' },
+    queryOptions: { enabled: connectionId !== '' },
+  });
+  const mappingsQuery = useList<FieldMappingRow>({
+    resource: 'field_mappings',
+    filters: [{ field: 'connection', operator: 'eq', value: connectionId }],
+    pagination: { mode: 'off' },
+    queryOptions: { enabled: connectionId !== '' },
+  });
+
+  const runs = runsQuery.result.data.slice(0, 4);
+  const lastRun = runs[0] ?? null;
+  const mappedCount = mappingsQuery.result.data.length;
+
+  const dash = '—';
+  const tiles = [
+    {
+      label: t('api_configurator.detail.overview.last_sync'),
+      main: lastRun !== null ? new Date(lastRun.startedAt).toLocaleString() : dash,
+    },
+    {
+      label: t('api_configurator.detail.overview.next_run'),
+      main: binding?.nextRun != null ? new Date(binding.nextRun).toLocaleString() : dash,
+    },
+    {
+      label: t('api_configurator.detail.overview.cursor'),
+      main: binding?.cursor?.field ?? dash,
+      mono: true,
+    },
+    {
+      label: t('api_configurator.detail.overview.rate_limit'),
+      main: rateLimitHint !== null ? String(rateLimitHint) : dash,
+      sub: t('api_configurator.detail.overview.rate_limit_sub'),
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1.6fr_1fr]">
+      <div className="space-y-4">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          {tiles.map((tile) => (
+            <div
+              key={tile.label}
+              className="soft-shadow rounded-2xl border border-zinc-200 bg-white p-4"
+            >
+              <div className="text-[10.5px] font-medium uppercase tracking-wider text-zinc-500">
+                {tile.label}
+              </div>
+              <div className={`mt-1 text-[13px] text-zinc-900 ${tile.mono ? 'font-mono' : ''}`}>
+                {tile.main}
+              </div>
+              {tile.sub != null ? (
+                <div className="text-[10.5px] text-zinc-500">{tile.sub}</div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+
+        <section className="soft-shadow rounded-2xl border border-zinc-200 bg-white p-5">
+          <SectionLabel
+            right={
+              <button
+                type="button"
+                onClick={() => onOpenTab('history')}
+                className="text-[11.5px] font-medium text-zinc-600 hover:text-zinc-900"
+              >
+                {t('api_configurator.detail.overview.all_history')}
+              </button>
+            }
+          >
+            {t('api_configurator.detail.overview.recent_runs')}
+          </SectionLabel>
+          {runs.length === 0 ? (
+            <p className="text-[12.5px] text-zinc-500">
+              {t('api_configurator.detail.overview.no_runs')}
+            </p>
+          ) : (
+            <div className="space-y-1.5">
+              {runs.map((run) => (
+                <div key={run.id} className="flex items-center gap-2.5 text-[12.5px]">
+                  <RunStatusDot status={toRunStatus(run.status)} />
+                  <span className="text-zinc-800">{new Date(run.startedAt).toLocaleString()}</span>
+                  <span className="font-mono text-[10.5px] text-zinc-500">
+                    +{run.createdCount} ~{run.updatedCount}
+                    {run.failedCount > 0 ? ` ✕${run.failedCount}` : ''}
+                  </span>
+                  <span className="ml-auto">
+                    <RunStatusPill
+                      status={toRunStatus(run.status)}
+                      label={t(`api_configurator.detail.run_status.${toRunStatus(run.status)}`)}
+                    />
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+
+      <div className="space-y-4">
+        <section className="soft-shadow rounded-2xl border border-zinc-200 bg-white p-5">
+          <SectionLabel>{t('api_configurator.detail.overview.coverage')}</SectionLabel>
+          <div className="flex items-center gap-3">
+            <CoverageBar
+              mapped={mappedCount}
+              total={PIM_TARGET_TOTAL}
+              width={140}
+              ariaLabel={t('api_configurator.detail.overview.coverage')}
+            />
+            <button
+              type="button"
+              onClick={() => onOpenTab('mapping')}
+              className="text-[11.5px] font-medium text-zinc-600 hover:text-zinc-900"
+            >
+              {t('api_configurator.detail.overview.edit_mapping')}
+            </button>
+          </div>
+        </section>
+
+        <section className="soft-shadow rounded-2xl border border-zinc-200 bg-white p-5">
+          <SectionLabel>{t('api_configurator.detail.overview.security')}</SectionLabel>
+          <div className="space-y-2.5">
+            {['ssrf', 'secrets', 'tenant', 'auth'].map((key) => (
+              <div key={key} className="flex items-center gap-2.5">
+                <TypeCompat ok title={t(`api_configurator.detail.security.${key}`)} />
+                <span className="flex-1 text-[12.5px] text-zinc-700">
+                  {t(`api_configurator.detail.security.${key}`)}
+                </span>
+              </div>
+            ))}
+          </div>
+          <div className="mt-3">
+            <SecurityNote tone="zinc" icon={<Info className="size-4" />}>
+              {t('api_configurator.detail.security.note')}
+            </SecurityNote>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/api-configurator/consumer/detail/RunStatus.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/detail/RunStatus.tsx
@@ -1,0 +1,44 @@
+import { cn } from '@/lib/utils';
+
+/**
+ * APIC-P3-12 — run-status indicators for the connection-detail Overview +
+ * History tabs. Keyed on the SyncRunStatus enum (running / success / partial /
+ * failed).
+ */
+export type RunStatus = 'running' | 'success' | 'partial' | 'failed';
+
+const DOT: Record<RunStatus, string> = {
+  running: 'bg-zinc-400',
+  success: 'bg-emerald-500',
+  partial: 'bg-amber-500',
+  failed: 'bg-rose-500',
+};
+
+const PILL: Record<RunStatus, string> = {
+  running: 'bg-zinc-100 text-zinc-600',
+  success: 'bg-emerald-50 text-emerald-700',
+  partial: 'bg-amber-50 text-amber-800',
+  failed: 'bg-rose-50 text-rose-700',
+};
+
+export function RunStatusDot({ status }: { status: RunStatus }) {
+  return <span className={cn('h-1.5 w-1.5 shrink-0 rounded-full', DOT[status])} aria-hidden />;
+}
+
+export function RunStatusPill({ status, label }: { status: RunStatus; label: string }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-md px-2 py-0.5 text-[11.5px] font-medium',
+        PILL[status],
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+/** Coerce an arbitrary API status string into a known RunStatus (defensive). */
+export function toRunStatus(value: string): RunStatus {
+  return value === 'success' || value === 'partial' || value === 'failed' ? value : 'running';
+}

--- a/apps/admin/src/features/api-configurator/consumer/detail/types.ts
+++ b/apps/admin/src/features/api-configurator/consumer/detail/types.ts
@@ -1,0 +1,46 @@
+import type { SyncDirection } from '../../components/primitives';
+
+/**
+ * APIC-P3-12 — shared row types + tab ids for the connection-detail view.
+ */
+export const DETAIL_TABS = ['overview', 'endpoints', 'mapping', 'sync', 'history'] as const;
+export type DetailTab = (typeof DETAIL_TABS)[number];
+
+export function toDetailTab(value: string | null): DetailTab {
+  return DETAIL_TABS.includes(value as DetailTab) ? (value as DetailTab) : 'overview';
+}
+
+export interface SyncBindingRow {
+  id: string;
+  connectionId: string;
+  direction: SyncDirection;
+  schedule: string | null;
+  conflictPolicy: string;
+  matchKeyMapping: string | null;
+  cursor: { field?: string; type?: string; state?: unknown } | null;
+  isEnabled: boolean;
+  nextRun: string | null;
+}
+
+export interface SyncRunRow {
+  id: string;
+  bindingId: string;
+  direction: SyncDirection;
+  startedAt: string;
+  finishedAt: string | null;
+  status: string;
+  createdCount: number;
+  updatedCount: number;
+  skippedCount: number;
+  failedCount: number;
+  cursorAfter: { state?: unknown } | null;
+}
+
+export interface SyncRunLogRow {
+  id: string;
+  runId: string;
+  matchKey: string | null;
+  action: string;
+  message: string | null;
+  createdAt: string;
+}

--- a/apps/admin/src/features/api-configurator/consumer/mapping/MappingScreen.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/mapping/MappingScreen.tsx
@@ -70,7 +70,7 @@ const toApi = (d: SyncDirection): ApiDirection => (d === 'bidirectional' ? 'both
  * (the common single-stream case); multi-endpoint pooling lands with the
  * connection detail view (P3-12).
  */
-export function MappingScreen() {
+export function MappingScreen({ embedded = false }: { embedded?: boolean } = {}) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const apiUrl = useApiUrl();
@@ -193,36 +193,38 @@ export function MappingScreen() {
 
   return (
     <div className="space-y-5">
-      <div className="flex items-center gap-3">
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={() => navigate(HUB)}
-          aria-label={t('api_configurator.mapping.back')}
-        >
-          <ArrowLeft className="size-4" aria-hidden="true" />
-        </Button>
-        <div className="min-w-0 flex-1">
-          <h1 className="font-display text-[22px] font-semibold tracking-tight">
-            {t('api_configurator.mapping.title')}
-          </h1>
-          <p className="text-[12.5px] text-zinc-500">{t('api_configurator.mapping.subtitle')}</p>
+      {embedded ? null : (
+        <div className="flex items-center gap-3">
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => navigate(HUB)}
+            aria-label={t('api_configurator.mapping.back')}
+          >
+            <ArrowLeft className="size-4" aria-hidden="true" />
+          </Button>
+          <div className="min-w-0 flex-1">
+            <h1 className="font-display text-[22px] font-semibold tracking-tight">
+              {t('api_configurator.mapping.title')}
+            </h1>
+            <p className="text-[12.5px] text-zinc-500">{t('api_configurator.mapping.subtitle')}</p>
+          </div>
+          <div className="flex items-center gap-4">
+            {warningCount > 0 ? (
+              <span className="inline-flex items-center gap-1.5 text-[11.5px] font-medium text-amber-800">
+                <TriangleAlert className="size-4 text-amber-600" aria-hidden="true" />
+                {t('api_configurator.mapping.warnings', { count: warningCount })}
+              </span>
+            ) : null}
+            <CoverageBar
+              mapped={mappings.length}
+              total={PIM_TARGETS.length}
+              width={160}
+              ariaLabel={t('api_configurator.mapping.coverage')}
+            />
+          </div>
         </div>
-        <div className="flex items-center gap-4">
-          {warningCount > 0 ? (
-            <span className="inline-flex items-center gap-1.5 text-[11.5px] font-medium text-amber-800">
-              <TriangleAlert className="size-4 text-amber-600" aria-hidden="true" />
-              {t('api_configurator.mapping.warnings', { count: warningCount })}
-            </span>
-          ) : null}
-          <CoverageBar
-            mapped={mappings.length}
-            total={PIM_TARGETS.length}
-            width={160}
-            ariaLabel={t('api_configurator.mapping.coverage')}
-          />
-        </div>
-      </div>
+      )}
 
       {validation !== null && !validation.valid ? (
         <div className="rounded-xl border border-rose-200 bg-rose-50/60 p-3 text-[12.5px] text-rose-800">

--- a/apps/admin/src/features/api-configurator/consumer/sync/SyncConfigScreen.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/sync/SyncConfigScreen.tsx
@@ -60,7 +60,7 @@ const CRON_PRESETS = [
  * (P2-09) — neither is part of the binding write contract, so the screen never
  * pretends to persist them.
  */
-export function SyncConfigScreen() {
+export function SyncConfigScreen({ embedded = false }: { embedded?: boolean } = {}) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const apiUrl = useApiUrl();
@@ -205,7 +205,7 @@ export function SyncConfigScreen() {
   if (binding === null) {
     return (
       <div className="space-y-5">
-        {header}
+        {embedded ? null : header}
         <div className="soft-shadow max-w-[680px] rounded-2xl border border-dashed border-zinc-300 bg-white p-6">
           <SectionLabel>{t('api_configurator.sync.empty.title')}</SectionLabel>
           <p className="mb-4 text-[12.5px] leading-relaxed text-zinc-600">
@@ -238,7 +238,7 @@ export function SyncConfigScreen() {
 
   return (
     <div className="space-y-5">
-      {header}
+      {embedded ? null : header}
       <div className="max-w-[980px] space-y-4">
         {/* Direction */}
         <section className="soft-shadow rounded-2xl border border-zinc-200 bg-white p-5">

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1940,6 +1940,56 @@
         "run_now": "Run now",
         "save": "Save binding"
       }
+    },
+    "detail": {
+      "back": "Back to connections",
+      "title": "Connection",
+      "test": "Test",
+      "sync_now": "Sync now",
+      "tabs_label": "Connection tabs",
+      "tab": {
+        "overview": "Overview",
+        "endpoints": "Endpoints",
+        "mapping": "Mapping",
+        "sync": "Synchronization",
+        "history": "History"
+      },
+      "overview": {
+        "last_sync": "Last sync",
+        "next_run": "Next run",
+        "cursor": "Cursor",
+        "rate_limit": "Rate limit",
+        "rate_limit_sub": "honours 429 + backoff",
+        "recent_runs": "Recent syncs",
+        "all_history": "Full history →",
+        "no_runs": "No runs yet.",
+        "coverage": "Mapping coverage",
+        "edit_mapping": "Edit →",
+        "security": "Security"
+      },
+      "endpoints": {
+        "title": "Endpoints · REST descriptor",
+        "empty": "No endpoints — add them in the connection wizard.",
+        "selector": "selector"
+      },
+      "history": {
+        "title": "Sync history",
+        "empty": "No runs yet.",
+        "no_records": "No records in this run."
+      },
+      "run_status": {
+        "running": "Running",
+        "success": "Success",
+        "partial": "Partial",
+        "failed": "Failed"
+      },
+      "security": {
+        "ssrf": "SSRF guard — active",
+        "secrets": "Secrets — AES-GCM, never returned by the API",
+        "tenant": "Tenant isolation — RLS + GUC",
+        "auth": "Authorization — verified",
+        "note": "The connection is protected by the SSRF guard, secret encryption and tenant isolation (RLS)."
+      }
     }
   },
   "api_profiles": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1988,6 +1988,56 @@
         "run_now": "Uruchom teraz",
         "save": "Zapisz wiązanie"
       }
+    },
+    "detail": {
+      "back": "Wróć do połączeń",
+      "title": "Połączenie",
+      "test": "Testuj",
+      "sync_now": "Synchronizuj",
+      "tabs_label": "Zakładki połączenia",
+      "tab": {
+        "overview": "Przegląd",
+        "endpoints": "Endpointy",
+        "mapping": "Mapowanie",
+        "sync": "Synchronizacja",
+        "history": "Historia"
+      },
+      "overview": {
+        "last_sync": "Ostatnia synchronizacja",
+        "next_run": "Następne uruchomienie",
+        "cursor": "Cursor",
+        "rate_limit": "Limit żądań",
+        "rate_limit_sub": "respekt 429 + backoff",
+        "recent_runs": "Ostatnie synchronizacje",
+        "all_history": "Cała historia →",
+        "no_runs": "Brak uruchomień.",
+        "coverage": "Pokrycie mapowania",
+        "edit_mapping": "Edytuj →",
+        "security": "Bezpieczeństwo"
+      },
+      "endpoints": {
+        "title": "Endpointy · descriptor REST",
+        "empty": "Brak endpointów — dodaj je w kreatorze połączenia.",
+        "selector": "selector"
+      },
+      "history": {
+        "title": "Historia synchronizacji",
+        "empty": "Brak uruchomień.",
+        "no_records": "Brak rekordów w tym uruchomieniu."
+      },
+      "run_status": {
+        "running": "W toku",
+        "success": "Sukces",
+        "partial": "Częściowo",
+        "failed": "Błąd"
+      },
+      "security": {
+        "ssrf": "SSRF guard — aktywny",
+        "secrets": "Sekrety — AES-GCM, nie wracają w API",
+        "tenant": "Izolacja tenantów — RLS + GUC",
+        "auth": "Autoryzacja — zweryfikowana",
+        "note": "Połączenie chroni SSRF guard, szyfrowanie sekretów i izolacja tenantów (RLS)."
+      }
     }
   },
   "api_profiles": {


### PR DESCRIPTION
## APIC-P3-12 — detal połączenia (5 zakładek, api-detail)

Pełnoekranowy widok `/connections/:id` z 5 zakładkami deep-linkowalnymi przez `?tab=`.

### Header
Tożsamość (nazwa + baseUrl) + `ConnStatusPill` / `DirectionBadge` (z bindingu) / `AuthBadge` + akcje **Testuj** (POST `/connections/{id}/test`, P1-05) i **Synchronizuj** (POST `/sync_bindings/{id}/run`, P3-10).

### Zakładki (AC-1 + AC-3)
- **Przegląd** — kafelki (ostatnia sync / następne uruchomienie / cursor / limit żądań) + ostatnie runy (P4-01) + pasek pokrycia mapowania + karta bezpieczeństwa.
- **Endpointy** — read-only lista descriptora REST (RolePill/MethodPill/path/PaginationPill/selector).
- **Mapowanie** — osadza `<MappingScreen embedded />` (P2-09).
- **Synchronizacja** — osadza `<SyncConfigScreen embedded />` (P3-11).
- **Historia** — lista runów (P4-01) → klik wiersza → drill-down rekordów (`sync_run_logs?run=`).

### Świadome decyzje
- **`embedded` prop** na MappingScreen + SyncConfigScreen ukrywa ich standalone header/back gdy są w zakładce; standalone trasy `/mapping` i `/sync` nadal działają.
- **`lazyPage` constraint** poszerzony z `ComponentType<unknown>` → `<never>` by ekrany z opcjonalnym propem (`embedded?`) renderowane prop-less przez router nadal spełniały typ.
- Deep-link zakładek przez `?tab=` (overview = brak param); nawigacja zakładek = `setSearchParams`.
- Karta bezpieczeństwa statyczna (SSRF/sekrety/RLS/auth) — odzwierciedla realne gwarancje backendu, nie udaje per-request checków.

### Testy / gates
- Playwright E2E (`1790-api-connection-detail.spec.ts`): nawigacja zakładek (overview → endpoints → history) + history drill-down + axe 0 violations.
- tsc ✅, biome ✅, vitest (17) ✅, vite build ✅, max-lines guard ✅ (split na DetailOverview/Endpoints/History/RunStatus/types). i18n pl+en symetryczne.

Closes #1790