### PR TITLE
feat(ui): build sync monitor screen (APIC-P4-02)

### DIFF
--- a/apps/admin/e2e/1792-api-sync-monitor.spec.ts
+++ b/apps/admin/e2e/1792-api-sync-monitor.spec.ts
@@ -1,0 +1,99 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, type Route, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * APIC-P4-02 (#1792) — the tenant-wide sync monitor. Runs + logs + binding
+ * actions are mocked, so the test is deterministic and offline: assert the KPI
+ * strip, filter by status, drill into a run and re-run it.
+ */
+test('APIC-P4-02 — sync monitor: KPI + status filter + drill-down + re-run', async ({ page }) => {
+  await loginAsAdmin(page);
+
+  const runs = [
+    {
+      id: 'run-ok',
+      bindingId: 'bind-1',
+      direction: 'inbound',
+      startedAt: '2026-06-28T10:00:00+00:00',
+      finishedAt: '2026-06-28T10:01:00+00:00',
+      status: 'success',
+      createdCount: 5,
+      updatedCount: 2,
+      skippedCount: 0,
+      failedCount: 0,
+      cursorAfter: { state: 'a' },
+    },
+    {
+      id: 'run-err',
+      bindingId: 'bind-2',
+      direction: 'outbound',
+      startedAt: '2026-06-28T09:00:00+00:00',
+      finishedAt: '2026-06-28T09:00:30+00:00',
+      status: 'failed',
+      createdCount: 0,
+      updatedCount: 1,
+      skippedCount: 0,
+      failedCount: 3,
+      cursorAfter: null,
+    },
+  ];
+  let reran = false;
+
+  await page.route('**/api/sync_runs**', (r: Route) =>
+    r.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify({ member: runs, totalItems: runs.length }),
+    }),
+  );
+  await page.route('**/api/sync_run_logs**', (r: Route) =>
+    r.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify({
+        member: [
+          { id: 'log-1', runId: 'run-ok', matchKey: 'SKU-9', action: 'created', message: null },
+        ],
+        totalItems: 1,
+      }),
+    }),
+  );
+  await page.route('**/api/sync_bindings/**/run', (r: Route) => {
+    reran = true;
+    return r.fulfill({ status: 202, contentType: 'application/json', body: '{"dispatched":true}' });
+  });
+  await page.route('**/api/sync_bindings/**/pause', (r: Route) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '{"enabled":false}' }),
+  );
+
+  await page.goto('/integrations/api-configurator/monitor');
+
+  // Monitor screen loaded.
+  await expect(
+    page.getByRole('heading', { name: /monitor synchronizacji|sync monitor/i }),
+  ).toBeVisible();
+
+  // Both runs listed initially (run rows carry a distinct aria-label, so they
+  // are counted apart from the status filter buttons).
+  const runRows = page.getByRole('button', { name: /otwórz szczegóły|open run details/i });
+  await expect(runRows).toHaveCount(2);
+
+  // Filter to errors → only the failed run remains in the table.
+  await page.getByRole('button', { name: /^błędy$|^errors$/i }).click();
+  await expect(runRows).toHaveCount(1);
+
+  // Reset filter, drill into the successful run.
+  await page.getByRole('button', { name: /^wszystkie$|^all$/i }).click();
+  await expect(runRows).toHaveCount(2);
+  await runRows.filter({ hasText: /success|sukces/i }).click();
+  await expect(page.getByText('SKU-9', { exact: true })).toBeVisible();
+
+  // Re-run from the drill footer.
+  await page.getByRole('button', { name: /uruchom ponownie|re-run/i }).click();
+  await expect.poll(() => reran).toBe(true);
+
+  const a11y = await new AxeBuilder({ page }).analyze();
+  expect(a11y.violations).toEqual([]);
+});

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -75,9 +75,9 @@ const ConnectionDetailPage = lazyPage(
   () => import('@/features/api-configurator/consumer/detail/ConnectionDetailPage'),
   'ConnectionDetailPage',
 );
-const ApiMonitorPlaceholder = lazyPage(
-  () => import('@/features/api-configurator/monitor/ApiMonitorPlaceholder'),
-  'ApiMonitorPlaceholder',
+const SyncMonitorScreen = lazyPage(
+  () => import('@/features/api-configurator/monitor/SyncMonitorScreen'),
+  'SyncMonitorScreen',
 );
 const AssetsListPage = lazyPage(() => import('@/features/asset/assets/list'), 'AssetsListPage');
 const AssetShowPage = lazyPage(() => import('@/features/asset/assets/show'), 'AssetShowPage');
@@ -665,7 +665,7 @@ function App() {
                     />
                     <Route
                       path="/integrations/api-configurator/monitor"
-                      element={<ApiMonitorPlaceholder />}
+                      element={<SyncMonitorScreen />}
                     />
                     <Route
                       path="/integrations/api-configurator/:id/edit"

--- a/apps/admin/src/features/api-configurator/monitor/RunDrillSheet.tsx
+++ b/apps/admin/src/features/api-configurator/monitor/RunDrillSheet.tsx
@@ -1,0 +1,152 @@
+import { useApiUrl, useCustomMutation, useList } from '@refinedev/core';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
+
+import { DirectionBadge } from '../components/primitives';
+import { RunStatusPill, toRunStatus } from '../consumer/detail/RunStatus';
+import type { MonitorRunRow } from './monitor-bits';
+
+interface RunLogRow {
+  id: string;
+  matchKey: string | null;
+  action: string;
+  message: string | null;
+}
+
+/**
+ * APIC-P4-02 — the run drill-down Sheet: KPI grid + meta + per-record table,
+ * with footer actions (CSV export of the loaded records, pause + re-run on the
+ * run's binding).
+ */
+export function RunDrillSheet({
+  run,
+  onClose,
+}: {
+  run: MonitorRunRow | null;
+  onClose: () => void;
+}) {
+  const { t } = useTranslation();
+  const apiUrl = useApiUrl();
+  const { mutate: act } = useCustomMutation();
+
+  const logsQuery = useList<RunLogRow>({
+    resource: 'sync_run_logs',
+    filters: run === null ? [] : [{ field: 'run', operator: 'eq', value: run.id }],
+    pagination: { mode: 'off' },
+    queryOptions: { enabled: run !== null },
+  });
+  const logs = logsQuery.result.data;
+
+  function bindingAction(action: 'run' | 'pause'): void {
+    if (run === null) {
+      return;
+    }
+    act({ url: `${apiUrl}/sync_bindings/${run.bindingId}/${action}`, method: 'post', values: {} });
+  }
+
+  function downloadCsv(): void {
+    if (run === null) {
+      return;
+    }
+    const header = 'match_key,action,message';
+    const rows = logs.map(
+      (l) => `${l.matchKey ?? ''},${l.action},${(l.message ?? '').replace(/[\r\n,]+/g, ' ')}`,
+    );
+    const blob = new Blob([`${header}\n${rows.join('\n')}\n`], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `sync-run-${run.id}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  const status = run !== null ? toRunStatus(run.status) : 'running';
+
+  return (
+    <Sheet open={run !== null} onOpenChange={(open) => (open ? undefined : onClose())}>
+      <SheetContent
+        side="right"
+        closeLabel={t('api_configurator.monitor.drill.close')}
+        className="flex w-full max-w-2xl flex-col gap-4 overflow-y-auto"
+      >
+        {run !== null ? (
+          <>
+            <SheetTitle className="flex items-center gap-2.5">
+              {t('api_configurator.monitor.drill.title')}
+              <RunStatusPill
+                status={status}
+                label={t(`api_configurator.detail.run_status.${status}`)}
+              />
+              <DirectionBadge dir={run.direction} label={run.direction} />
+            </SheetTitle>
+
+            <div className="grid grid-cols-4 gap-2">
+              {[
+                { label: t('api_configurator.monitor.drill.created'), v: run.createdCount },
+                { label: t('api_configurator.monitor.drill.updated'), v: run.updatedCount },
+                { label: t('api_configurator.monitor.drill.skipped'), v: run.skippedCount },
+                { label: t('api_configurator.monitor.drill.failed'), v: run.failedCount },
+              ].map((c) => (
+                <div
+                  key={c.label}
+                  className="rounded-xl border border-zinc-200 bg-zinc-50/60 p-2.5"
+                >
+                  <div className="text-[10px] uppercase tracking-wider text-zinc-500">
+                    {c.label}
+                  </div>
+                  <div className="text-[16px] font-semibold tabular-nums">{c.v}</div>
+                </div>
+              ))}
+            </div>
+
+            <div className="text-[11.5px] text-zinc-500">
+              {t('api_configurator.monitor.drill.started')}:{' '}
+              {new Date(run.startedAt).toLocaleString()}
+            </div>
+
+            <div className="rounded-xl border border-zinc-200">
+              <div className="border-b border-zinc-100 px-3 py-2 text-[10.5px] font-medium uppercase tracking-wider text-zinc-500">
+                {t('api_configurator.monitor.drill.records', { count: logs.length })}
+              </div>
+              <div className="max-h-[40vh] divide-y divide-zinc-50 overflow-y-auto">
+                {logs.length === 0 ? (
+                  <div className="px-3 py-4 text-[12px] text-zinc-500">
+                    {t('api_configurator.monitor.drill.no_records')}
+                  </div>
+                ) : (
+                  logs.map((l) => (
+                    <div key={l.id} className="flex items-center gap-2 px-3 py-2 text-[11.5px]">
+                      <span className="font-mono text-zinc-700">{l.matchKey ?? '—'}</span>
+                      <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] text-zinc-600">
+                        {l.action}
+                      </span>
+                      {l.message != null ? (
+                        <span className="truncate text-zinc-500">{l.message}</span>
+                      ) : null}
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+
+            <div className="mt-auto flex items-center gap-2 pt-2">
+              <Button type="button" variant="outline" onClick={downloadCsv}>
+                {t('api_configurator.monitor.drill.download_csv')}
+              </Button>
+              <div className="flex-1" />
+              <Button type="button" variant="outline" onClick={() => bindingAction('pause')}>
+                {t('api_configurator.monitor.drill.pause')}
+              </Button>
+              <Button type="button" onClick={() => bindingAction('run')}>
+                {t('api_configurator.monitor.drill.rerun')}
+              </Button>
+            </div>
+          </>
+        ) : null}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/admin/src/features/api-configurator/monitor/SyncMonitorScreen.tsx
+++ b/apps/admin/src/features/api-configurator/monitor/SyncMonitorScreen.tsx
@@ -1,0 +1,173 @@
+import { useList } from '@refinedev/core';
+import { Search } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Input } from '@/components/ui/input';
+
+import { DirectionBadge } from '../components/primitives';
+import {
+  type RunStatus,
+  RunStatusDot,
+  RunStatusPill,
+  toRunStatus,
+} from '../consumer/detail/RunStatus';
+import { computeKpis, KpiCell, type MonitorRunRow, ResultBar } from './monitor-bits';
+import { RunDrillSheet } from './RunDrillSheet';
+
+type StatusFilter = 'all' | RunStatus;
+
+const FILTERS: StatusFilter[] = ['all', 'success', 'partial', 'failed'];
+
+/**
+ * APIC-P4-02 — the tenant-wide sync monitor (`integracje/api-monitor.jsx`): KPI
+ * strip, a status filter + search toolbar, the run history table, and a
+ * per-run drill-down Sheet. Reads the P4-01 SyncRun history API; KPIs are
+ * derived client-side from the run list.
+ */
+export function SyncMonitorScreen() {
+  const { t } = useTranslation();
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [search, setSearch] = useState('');
+  const [openRun, setOpenRun] = useState<MonitorRunRow | null>(null);
+
+  const runsQuery = useList<MonitorRunRow>({
+    resource: 'sync_runs',
+    pagination: { mode: 'off' },
+  });
+  const runs = runsQuery.result.data;
+
+  const kpis = useMemo(() => computeKpis(runs, Date.now()), [runs]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return runs.filter((run) => {
+      if (statusFilter !== 'all' && toRunStatus(run.status) !== statusFilter) {
+        return false;
+      }
+      if (q !== '' && !run.bindingId.toLowerCase().includes(q) && !run.direction.includes(q)) {
+        return false;
+      }
+      return true;
+    });
+  }, [runs, statusFilter, search]);
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h1 className="font-display text-[22px] font-semibold tracking-tight">
+          {t('api_configurator.monitor.title')}
+        </h1>
+        <p className="text-[12.5px] text-zinc-500">{t('api_configurator.monitor.subtitle')}</p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <KpiCell
+          label={t('api_configurator.monitor.kpi.syncs_24h')}
+          value={String(kpis.syncs24h)}
+        />
+        <KpiCell
+          label={t('api_configurator.monitor.kpi.records_in')}
+          value={kpis.recordsIn.toLocaleString()}
+          tone="sky"
+        />
+        <KpiCell
+          label={t('api_configurator.monitor.kpi.records_out')}
+          value={kpis.recordsOut.toLocaleString()}
+          tone="violet"
+        />
+        <KpiCell
+          label={t('api_configurator.monitor.kpi.errors_24h')}
+          value={String(kpis.errors24h)}
+          tone="rose"
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative">
+          <Search
+            className="-translate-y-1/2 absolute top-1/2 left-2.5 size-4 text-zinc-400"
+            aria-hidden="true"
+          />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={t('api_configurator.monitor.search')}
+            aria-label={t('api_configurator.monitor.search')}
+            className="h-9 w-64 pl-8"
+          />
+        </div>
+        <div className="flex items-center gap-1">
+          {FILTERS.map((f) => (
+            <button
+              key={f}
+              type="button"
+              onClick={() => setStatusFilter(f)}
+              aria-pressed={statusFilter === f}
+              className={`h-7 rounded-lg px-2.5 text-[11.5px] font-medium transition ${statusFilter === f ? 'bg-zinc-900 text-white' : 'text-zinc-600 hover:bg-zinc-100'}`}
+            >
+              {t(`api_configurator.monitor.filter.${f}`)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="soft-shadow overflow-hidden rounded-2xl border border-zinc-200 bg-white">
+        <div className="grid grid-cols-[16px_1.4fr_110px_1fr_110px] gap-3 border-b border-zinc-100 bg-zinc-50/40 px-5 py-2.5 text-[10.5px] font-medium uppercase tracking-wider text-zinc-500">
+          <div />
+          <div>{t('api_configurator.monitor.col.started')}</div>
+          <div>{t('api_configurator.monitor.col.direction')}</div>
+          <div>{t('api_configurator.monitor.col.result')}</div>
+          <div>{t('api_configurator.monitor.col.status')}</div>
+        </div>
+        <div className="divide-y divide-zinc-50">
+          {filtered.map((run) => {
+            const status = toRunStatus(run.status);
+            return (
+              <button
+                key={run.id}
+                type="button"
+                onClick={() => setOpenRun(run)}
+                aria-label={t('api_configurator.monitor.open_run')}
+                className="grid w-full grid-cols-[16px_1.4fr_110px_1fr_110px] items-center gap-3 px-5 py-3 text-left transition hover:bg-zinc-50/70"
+              >
+                <RunStatusDot status={status} />
+                <div className="text-[12.5px] text-zinc-800">
+                  {new Date(run.startedAt).toLocaleString()}
+                </div>
+                <div>
+                  <DirectionBadge dir={run.direction} label={run.direction} />
+                </div>
+                <div className="flex items-center gap-2">
+                  <ResultBar
+                    ok={run.createdCount + run.updatedCount}
+                    warn={run.skippedCount}
+                    err={run.failedCount}
+                    label={t('api_configurator.monitor.col.result')}
+                  />
+                  <span className="font-mono text-[10.5px] text-zinc-500">
+                    +{run.createdCount} ~{run.updatedCount}
+                    {run.failedCount > 0 ? ` ✕${run.failedCount}` : ''}
+                  </span>
+                </div>
+                <div>
+                  <RunStatusPill
+                    status={status}
+                    label={t(`api_configurator.detail.run_status.${status}`)}
+                  />
+                </div>
+              </button>
+            );
+          })}
+          {filtered.length === 0 ? (
+            <div className="px-5 py-8 text-center text-[13px] text-zinc-400">
+              {t('api_configurator.monitor.empty')}
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <RunDrillSheet run={openRun} onClose={() => setOpenRun(null)} />
+    </div>
+  );
+}

--- a/apps/admin/src/features/api-configurator/monitor/monitor-bits.tsx
+++ b/apps/admin/src/features/api-configurator/monitor/monitor-bits.tsx
@@ -1,0 +1,116 @@
+import type { SyncDirection } from '../components/primitives';
+
+/**
+ * APIC-P4-02 — small presentational pieces + row type for the sync monitor.
+ */
+export interface MonitorRunRow {
+  id: string;
+  bindingId: string;
+  direction: SyncDirection;
+  startedAt: string;
+  finishedAt: string | null;
+  status: string;
+  createdCount: number;
+  updatedCount: number;
+  skippedCount: number;
+  failedCount: number;
+  cursorAfter: { state?: unknown } | null;
+}
+
+export interface MonitorKpis {
+  syncs24h: number;
+  recordsIn: number;
+  recordsOut: number;
+  errors24h: number;
+}
+
+/**
+ * Aggregate KPIs from the run list. "in" = records of inbound legs, "out" =
+ * outbound legs (bidirectional counts on both). 24h windows use `now`.
+ */
+export function computeKpis(runs: MonitorRunRow[], nowMs: number): MonitorKpis {
+  const dayAgo = nowMs - 24 * 60 * 60 * 1000;
+  let syncs24h = 0;
+  let recordsIn = 0;
+  let recordsOut = 0;
+  let errors24h = 0;
+
+  for (const run of runs) {
+    const startedMs = Date.parse(run.startedAt);
+    const within24h = !Number.isNaN(startedMs) && startedMs >= dayAgo;
+    if (within24h) {
+      syncs24h += 1;
+      if (run.failedCount > 0 || run.status === 'failed') {
+        errors24h += 1;
+      }
+    }
+    const records = run.createdCount + run.updatedCount;
+    if (run.direction === 'inbound' || run.direction === 'bidirectional') {
+      recordsIn += records;
+    }
+    if (run.direction === 'outbound' || run.direction === 'bidirectional') {
+      recordsOut += records;
+    }
+  }
+
+  return { syncs24h, recordsIn, recordsOut, errors24h };
+}
+
+export function KpiCell({
+  label,
+  value,
+  tone = 'zinc',
+  sub,
+}: {
+  label: string;
+  value: string;
+  tone?: 'zinc' | 'sky' | 'violet' | 'rose';
+  sub?: string;
+}) {
+  const toneCls = {
+    zinc: 'text-zinc-900',
+    sky: 'text-sky-700',
+    violet: 'text-violet-700',
+    rose: 'text-rose-700',
+  }[tone];
+
+  return (
+    <div className="soft-shadow rounded-2xl border border-zinc-200 bg-white p-4">
+      <div className="text-[10.5px] font-medium uppercase tracking-wider text-zinc-500">
+        {label}
+      </div>
+      <div className={`mt-1 text-[20px] font-semibold tabular-nums ${toneCls}`}>{value}</div>
+      {sub != null ? <div className="text-[10.5px] text-zinc-500">{sub}</div> : null}
+    </div>
+  );
+}
+
+/** Stacked ok/warn/err proportion bar (replaces the prototype ResultBar). */
+export function ResultBar({
+  ok,
+  warn,
+  err,
+  width = 110,
+  label,
+}: {
+  ok: number;
+  warn: number;
+  err: number;
+  width?: number;
+  label: string;
+}) {
+  const total = Math.max(1, ok + warn + err);
+  const pct = (n: number) => `${(n / total) * 100}%`;
+  return (
+    <div
+      className="flex h-2 overflow-hidden rounded-full bg-zinc-100"
+      style={{ width }}
+      role="img"
+      aria-label={label}
+    >
+      {ok > 0 ? <span className="h-full bg-emerald-500" style={{ width: pct(ok) }} /> : null}
+      {warn > 0 ? <span className="h-full bg-amber-500" style={{ width: pct(warn) }} /> : null}
+      {err > 0 ? <span className="h-full bg-rose-500" style={{ width: pct(err) }} /> : null}
+    </div>
+  );
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1990,6 +1990,45 @@
         "auth": "Authorization — verified",
         "note": "The connection is protected by the SSRF guard, secret encryption and tenant isolation (RLS)."
       }
+    },
+    "monitor": {
+      "title": "Sync monitor",
+      "subtitle": "Run history across all connections + per-record drill-down.",
+      "search": "Search (binding, direction)…",
+      "empty": "No runs match the filter.",
+      "kpi": {
+        "syncs_24h": "Syncs · 24h",
+        "records_in": "Records ← inbound",
+        "records_out": "Records → outbound",
+        "errors_24h": "Errors · 24h"
+      },
+      "filter": {
+        "all": "all",
+        "success": "success",
+        "partial": "partial",
+        "failed": "errors"
+      },
+      "col": {
+        "started": "Started",
+        "direction": "Direction",
+        "result": "Breakdown",
+        "status": "Status"
+      },
+      "drill": {
+        "title": "Run details",
+        "created": "Created",
+        "updated": "Updated",
+        "skipped": "Skipped",
+        "failed": "Failed",
+        "started": "Started",
+        "records": "Records · {{count}}",
+        "no_records": "No records in this run.",
+        "download_csv": "Download CSV log",
+        "pause": "Pause",
+        "rerun": "Re-run",
+        "close": "Close"
+      },
+      "open_run": "Open run details"
     }
   },
   "api_profiles": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -2038,6 +2038,45 @@
         "auth": "Autoryzacja — zweryfikowana",
         "note": "Połączenie chroni SSRF guard, szyfrowanie sekretów i izolacja tenantów (RLS)."
       }
+    },
+    "monitor": {
+      "title": "Monitor synchronizacji",
+      "subtitle": "Historia runów wszystkich połączeń + drill-down per rekord.",
+      "search": "Szukaj (binding, kierunek)…",
+      "empty": "Brak runów pasujących do filtra.",
+      "kpi": {
+        "syncs_24h": "Synchronizacje · 24h",
+        "records_in": "Rekordy ← inbound",
+        "records_out": "Rekordy → outbound",
+        "errors_24h": "Błędy · 24h"
+      },
+      "filter": {
+        "all": "wszystkie",
+        "success": "sukces",
+        "partial": "częściowo",
+        "failed": "błędy"
+      },
+      "col": {
+        "started": "Start",
+        "direction": "Kierunek",
+        "result": "Rozkład",
+        "status": "Status"
+      },
+      "drill": {
+        "title": "Szczegóły uruchomienia",
+        "created": "Utworzone",
+        "updated": "Zaktualizowane",
+        "skipped": "Pominięte",
+        "failed": "Błędy",
+        "started": "Start",
+        "records": "Rekordy · {{count}}",
+        "no_records": "Brak rekordów w tym uruchomieniu.",
+        "download_csv": "Pobierz log CSV",
+        "pause": "Wstrzymaj",
+        "rerun": "Uruchom ponownie",
+        "close": "Zamknij"
+      },
+      "open_run": "Otwórz szczegóły uruchomienia"
     }
   },
   "api_profiles": {


### PR DESCRIPTION
## APIC-P4-02 — monitor synchronizacji (api-monitor)

Tenant-wide monitor pod `/integrations/api-configurator/monitor` (zastępuje placeholder).

### Zawartość
- **KPI strip** — synchronizacje 24h / rekordy ← inbound / rekordy → outbound / błędy 24h, liczone client-side z historii runów (P4-01).
- **Toolbar** — search (binding/kierunek) + filtr statusu (all/success/partial/errors).
- **Tabela runów** — `RunStatusDot`, `ResultBar` (ok/skip/fail), kierunek, status pill; wiersze klikalne.
- **Drill-down Sheet** — grid liczników + meta + tabela rekordów (`sync_run_logs?run=`) + footer: **Pobierz log CSV** (z załadowanych rekordów), **Wstrzymaj** + **Uruchom ponownie** (akcje bindingu P3-10).

### Świadome decyzje
- KPI 24h liczone z listy runów (brak dedykowanego endpointu KPI) — realne dane.
- Wiersze runów mają `aria-label` (odróżnialne od przycisków filtra w testach + a11y); Sheet close button dostaje `closeLabel`.
- Reuse `RunStatus` (Dot/Pill) z detalu połączenia (P3-12).
- CSV generowany client-side z załadowanych logów (bez nowego endpointu).

### Testy / gates
- Playwright E2E (`1792-api-sync-monitor.spec.ts`): KPI strip + filtr statusu (2→1 wiersze) + drill-down (rekord SKU-9) + re-run + axe 0 violations.
- tsc ✅, biome ✅, vitest (17) ✅, vite build ✅, max-lines guard ✅. i18n pl+en.

Closes #1792