### PR TITLE
feat(apiconfigurator): webhook delivery retry + delivery-history (APIC-P4-05)

### DIFF
--- a/apps/api/config/packages/messenger.yaml
+++ b/apps/api/config/packages/messenger.yaml
@@ -166,6 +166,11 @@ framework:
             # consume it, so no docker-compose change is needed.
             App\Export\Domain\Message\RunExportMessage: import
 
+            # APIC-P4-05 — producer webhook delivery. Async so the originating
+            # write never blocks on a slow integrator; the `async` retry strategy
+            # (5×, exponential) backs off failures and dead-letters to `failed`.
+            App\ApiConfigurator\Domain\Message\WebhookDeliveryMessage: async
+
             # Imports MVP (#447). pgBackRest snapshot can take 5-30
             # minutes — handler runs out-of-band so `POST /api/backups`
             # returns 202 immediately and the wizard polls

--- a/apps/api/migrations/Version20260629140000.php
+++ b/apps/api/migrations/Version20260629140000.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * APIC-P4-05 (ADR-0022, epic APIC) — add `api_webhook_deliveries`: the audit
+ * trail of producer webhook deliveries (event, target, payload, status,
+ * attempts, last error, timing). TenantScoped with the W1-1 FORCE RLS pattern;
+ * `profile_id` is a same-context loose reference (no FK so a profile delete
+ * keeps the delivery history).
+ */
+final class Version20260629140000 extends AbstractMigration
+{
+    private const string TABLE = 'api_webhook_deliveries';
+
+    public function getDescription(): string
+    {
+        return 'APIC-P4-05: add api_webhook_deliveries (webhook delivery audit) + FORCE RLS.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE api_webhook_deliveries (
+                id UUID NOT NULL,
+                tenant_id UUID NOT NULL,
+                profile_id UUID NOT NULL,
+                event_type VARCHAR(128) NOT NULL,
+                target_url VARCHAR(2048) NOT NULL,
+                payload JSONB NOT NULL,
+                status VARCHAR(16) NOT NULL,
+                attempts INT DEFAULT 0 NOT NULL,
+                http_status INT DEFAULT NULL,
+                duration_ms INT DEFAULT NULL,
+                last_error TEXT DEFAULT NULL,
+                created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+                updated_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+                PRIMARY KEY (id)
+            )
+            SQL);
+        $this->addSql('CREATE INDEX api_webhook_deliveries_tenant_idx ON api_webhook_deliveries (tenant_id)');
+        $this->addSql('CREATE INDEX api_webhook_deliveries_tenant_profile_idx ON api_webhook_deliveries (tenant_id, profile_id)');
+        $this->addSql('CREATE INDEX api_webhook_deliveries_tenant_created_idx ON api_webhook_deliveries (tenant_id, created_at)');
+        $this->addSql(
+            'ALTER TABLE api_webhook_deliveries ADD CONSTRAINT FK_api_webhook_deliveries_tenant '
+            .'FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE RESTRICT NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+
+        $predicate = "tenant_id = NULLIF(current_setting('app.current_tenant', true), '')::uuid";
+        $this->addSql(\sprintf('ALTER TABLE %s ENABLE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s FORCE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf(
+            'CREATE POLICY tenant_isolation_%s ON %s USING (%s) WITH CHECK (%s)',
+            self::TABLE,
+            self::TABLE,
+            $predicate,
+            $predicate,
+        ));
+        $this->addSql(\sprintf(
+            "CREATE POLICY super_admin_bypass_%s ON %s "
+            ."USING (current_setting('app.is_super_admin', true) = 'true') "
+            ."WITH CHECK (current_setting('app.is_super_admin', true) = 'true')",
+            self::TABLE,
+            self::TABLE,
+        ));
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(\sprintf('DROP POLICY IF EXISTS super_admin_bypass_%s ON %s', self::TABLE, self::TABLE));
+        $this->addSql(\sprintf('DROP POLICY IF EXISTS tenant_isolation_%s ON %s', self::TABLE, self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s NO FORCE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s DISABLE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql('DROP TABLE api_webhook_deliveries');
+    }
+}

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -129,6 +129,7 @@ parameters:
               - src/Asset/Domain/Entity/Asset.php
               - src/ApiConfigurator/Domain/Entity/ApiProfile.php
               - src/ApiConfigurator/Domain/Entity/ApiKey.php
+              - src/ApiConfigurator/Domain/Entity/WebhookDelivery.php
               - src/Identity/Domain/Entity/TenantAgentConfig.php
               - src/Catalog/Domain/Entity/MenuConfiguration.php
               # Import/Domain entities extend AggregateRoot — their

--- a/apps/api/src/ApiConfigurator/Application/Handler/WebhookDeliveryHandler.php
+++ b/apps/api/src/ApiConfigurator/Application/Handler/WebhookDeliveryHandler.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiConfigurator\Application\Handler;
+
+use App\ApiConfigurator\Application\WebhookDeliveryClient;
+use App\ApiConfigurator\Domain\Message\WebhookDeliveryMessage;
+use App\ApiConfigurator\Domain\Repository\ApiProfileRepositoryInterface;
+use App\ApiConfigurator\Domain\Repository\WebhookDeliveryRepositoryInterface;
+use RuntimeException;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Attempts one webhook delivery and records the outcome (APIC-P4-05).
+ *
+ * Loads the {@see \App\ApiConfigurator\Domain\Entity\WebhookDelivery} + the
+ * profile's current signing secret, POSTs the stored payload via
+ * {@see WebhookDeliveryClient}, and marks the row delivered (2xx) or failed.
+ * A failed attempt is recorded then re-thrown so the message's transport retry
+ * strategy backs off and eventually dead-letters — a missing profile/secret is
+ * a permanent failure (recorded, NOT re-thrown, so it doesn't churn retries).
+ */
+#[AsMessageHandler]
+final readonly class WebhookDeliveryHandler
+{
+    public function __construct(
+        private WebhookDeliveryRepositoryInterface $deliveries,
+        private ApiProfileRepositoryInterface $profiles,
+        private WebhookDeliveryClient $client,
+    ) {
+    }
+
+    public function __invoke(WebhookDeliveryMessage $message): void
+    {
+        $delivery = $this->deliveries->findById($message->deliveryId);
+        if (null === $delivery) {
+            return;
+        }
+
+        $profile = $this->profiles->findById($delivery->getProfileId());
+        $secret = $profile?->getWebhookSecret();
+        if (null === $secret) {
+            // Permanent: the profile or its secret is gone. Record and stop —
+            // re-throwing would only burn retries on an unrecoverable state.
+            $delivery->markFailed(null, 0, 'Profile or webhook secret no longer available.');
+            $this->deliveries->save($delivery);
+
+            return;
+        }
+
+        $result = $this->client->deliver($delivery->getTargetUrl(), $secret, $delivery->getPayload());
+        $status = $result['statusCode'];
+
+        if ($status >= 200 && $status < 300) {
+            $delivery->markDelivered($status, $result['durationMs']);
+            $this->deliveries->save($delivery);
+
+            return;
+        }
+
+        $error = 0 === $status
+            ? 'Transport failure (no HTTP response).'
+            : \sprintf('Remote returned HTTP %d.', $status);
+        $delivery->markFailed(0 === $status ? null : $status, $result['durationMs'], $error);
+        $this->deliveries->save($delivery);
+
+        // Re-throw so Messenger applies the retry/backoff strategy and, once
+        // exhausted, dead-letters the envelope to the `failed` transport.
+        throw new RuntimeException($error);
+    }
+}

--- a/apps/api/src/ApiConfigurator/Application/Subscriber/WebhookDeliverySubscriber.php
+++ b/apps/api/src/ApiConfigurator/Application/Subscriber/WebhookDeliverySubscriber.php
@@ -4,37 +4,49 @@ declare(strict_types=1);
 
 namespace App\ApiConfigurator\Application\Subscriber;
 
-use App\ApiConfigurator\Application\WebhookDeliveryClient;
+use App\ApiConfigurator\Domain\Entity\WebhookDelivery;
+use App\ApiConfigurator\Domain\Message\WebhookDeliveryMessage;
 use App\ApiConfigurator\Domain\Repository\ApiProfileRepositoryInterface;
+use App\ApiConfigurator\Domain\Repository\WebhookDeliveryRepositoryInterface;
 use App\Catalog\Contracts\BulkGuard;
 use App\Catalog\Contracts\Event\ObjectArchived;
 use App\Catalog\Contracts\Event\ObjectAttributesChanged;
 use App\Catalog\Contracts\Event\ObjectCreated;
 use App\Catalog\Contracts\Event\ObjectEnabledChanged;
 use App\Catalog\Contracts\Event\ObjectPublished;
+use App\Shared\Application\TenantContext;
 use App\Shared\Domain\DomainEvent;
 use DateTimeInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Throwable;
 
 /**
- * Fans Catalog domain events out to per-profile outbound webhooks.
+ * Fans Catalog domain events out to per-profile outbound webhooks (APIC-P4-05).
  *
- * Mirrors {@see \App\Catalog\Application\Subscriber\MercurePublisher}
- * — same event surface, different delivery channel. Each profile with
- * a configured `webhookUrl` + `webhookSecret` and a matching event
- * code in `webhookEvents` receives an HMAC-signed POST.
+ * Each matching profile gets a {@see WebhookDelivery} audit row (status
+ * `pending`) and a {@see WebhookDeliveryMessage} dispatched to the async
+ * transport, where {@see \App\ApiConfigurator\Application\Handler\WebhookDeliveryHandler}
+ * POSTs the signed body with retry + dead-letter. This replaces the previous
+ * inline best-effort POST (#93 follow-up): history is now durable and failures
+ * back off instead of being dropped after one try.
  *
- * Webhooks are best-effort: client failures are logged inside
- * {@see WebhookDeliveryClient}, never thrown — a stuck integrator
- * MUST NOT block the originating write path. Retry policy via
- * Symfony Messenger transport lands in #93 follow-up.
+ * Still best-effort toward the originating write: dispatch is wrapped so a
+ * synchronous-transport failure (dev/test, where `async` aliases `sync://`)
+ * never bubbles into the write path. In production the dispatch only enqueues;
+ * the worker owns retry. Bulk flows are skipped (see {@see fanOut}).
  */
 final readonly class WebhookDeliverySubscriber
 {
     public function __construct(
         private ApiProfileRepositoryInterface $profiles,
-        private WebhookDeliveryClient $client,
+        private WebhookDeliveryRepositoryInterface $deliveries,
+        private MessageBusInterface $bus,
         private BulkGuard $bulkContext,
+        private TenantContext $tenantContext,
+        private LoggerInterface $logger = new NullLogger(),
     ) {
     }
 
@@ -88,12 +100,14 @@ final readonly class WebhookDeliverySubscriber
     private function fanOut(string $eventType, DomainEvent $event, array $data): void
     {
         // Bulk flows (import, bulk-edit/-delete) emit one event per object on the
-        // SYNC bus; one webhook POST each would pile up HTTP responses and starve
-        // the 256 MiB worker. Per-object webhooks during a bulk run are both
-        // impractical (thousands of inline POSTs) and rarely what an integrator
-        // wants — a batch/summary delivery is the right shape (follow-up). Skip
-        // here, mirroring MercurePublisher's BulkContext opt-out.
+        // SYNC bus; one webhook POST each would pile up + starve the 256 MiB
+        // worker. A batch/summary delivery is the right shape (follow-up).
         if ($this->bulkContext->isBulk()) {
+            return;
+        }
+
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
             return;
         }
 
@@ -104,16 +118,31 @@ final readonly class WebhookDeliverySubscriber
 
         foreach ($subscribers as $profile) {
             $url = $profile->getWebhookUrl();
-            $secret = $profile->getWebhookSecret();
-            if (null === $url || null === $secret) {
+            if (null === $url || null === $profile->getWebhookSecret()) {
                 continue;
             }
-            $this->client->deliver($url, $secret, [
+
+            $payload = [
                 'event' => $eventType,
                 'occurredOn' => $event->occurredOn()->format(DateTimeInterface::RFC3339_EXTENDED),
                 'profileCode' => $profile->getCode(),
                 'data' => $data,
-            ]);
+            ];
+
+            $delivery = new WebhookDelivery($profile->getId(), $eventType, $url, $payload);
+            $this->deliveries->save($delivery);
+
+            try {
+                $this->bus->dispatch(new WebhookDeliveryMessage($delivery->getId(), $tenant->getId()));
+            } catch (Throwable $exception) {
+                // Best-effort toward the write path: a synchronous-transport
+                // delivery failure must not bubble out. The audit row already
+                // records the attempt; production retry runs off the worker.
+                $this->logger->warning('Webhook delivery dispatch failed', [
+                    'deliveryId' => $delivery->getId()->toRfc4122(),
+                    'error' => $exception->getMessage(),
+                ]);
+            }
         }
     }
 }

--- a/apps/api/src/ApiConfigurator/Domain/Entity/WebhookDelivery.php
+++ b/apps/api/src/ApiConfigurator/Domain/Entity/WebhookDelivery.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiConfigurator\Domain\Entity;
+
+use App\ApiConfigurator\Domain\Enum\WebhookDeliveryStatus;
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Audit record of one outbound webhook delivery (APIC-P4-05).
+ *
+ * Created `pending` by the {@see \App\ApiConfigurator\Application\Subscriber\WebhookDeliverySubscriber}
+ * when a domain event fans out to a profile, then driven to `delivered`/`failed`
+ * by {@see \App\ApiConfigurator\Application\Handler\WebhookDeliveryHandler} as
+ * Messenger retries the {@see \App\ApiConfigurator\Domain\Message\WebhookDeliveryMessage}.
+ * The signed `payload` is stored so each retry re-sends the exact body.
+ * `TenantScoped` + Postgres RLS isolate every record to its tenant.
+ */
+class WebhookDelivery implements TenantScoped
+{
+    private Uuid $id;
+
+    private ?Tenant $tenant = null;
+
+    private Uuid $profileId;
+
+    private string $eventType;
+
+    private string $targetUrl;
+
+    /** @var array<string, mixed> */
+    private array $payload;
+
+    private string $status = WebhookDeliveryStatus::Pending->value;
+
+    private int $attempts = 0;
+
+    private ?int $httpStatus = null;
+
+    private ?int $durationMs = null;
+
+    private ?string $lastError = null;
+
+    private DateTimeImmutable $createdAt;
+
+    private DateTimeImmutable $updatedAt;
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function __construct(
+        Uuid $profileId,
+        string $eventType,
+        string $targetUrl,
+        array $payload,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->profileId = $profileId;
+        $this->eventType = $eventType;
+        $this->targetUrl = $targetUrl;
+        $this->payload = $payload;
+        $this->createdAt = new DateTimeImmutable();
+        $this->updatedAt = $this->createdAt;
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant is already assigned and cannot be reassigned.');
+        }
+
+        $this->tenant = $tenant;
+    }
+
+    public function getProfileId(): Uuid
+    {
+        return $this->profileId;
+    }
+
+    public function getEventType(): string
+    {
+        return $this->eventType;
+    }
+
+    public function getTargetUrl(): string
+    {
+        return $this->targetUrl;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getPayload(): array
+    {
+        return $this->payload;
+    }
+
+    public function getStatus(): WebhookDeliveryStatus
+    {
+        return WebhookDeliveryStatus::from($this->status);
+    }
+
+    public function getAttempts(): int
+    {
+        return $this->attempts;
+    }
+
+    public function getHttpStatus(): ?int
+    {
+        return $this->httpStatus;
+    }
+
+    public function getDurationMs(): ?int
+    {
+        return $this->durationMs;
+    }
+
+    public function getLastError(): ?string
+    {
+        return $this->lastError;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function markDelivered(int $httpStatus, int $durationMs): void
+    {
+        ++$this->attempts;
+        $this->status = WebhookDeliveryStatus::Delivered->value;
+        $this->httpStatus = $httpStatus;
+        $this->durationMs = $durationMs;
+        $this->lastError = null;
+        $this->touch();
+    }
+
+    public function markFailed(?int $httpStatus, int $durationMs, string $error): void
+    {
+        ++$this->attempts;
+        $this->status = WebhookDeliveryStatus::Failed->value;
+        $this->httpStatus = $httpStatus;
+        $this->durationMs = $durationMs;
+        $this->lastError = mb_substr($error, 0, 1000);
+        $this->touch();
+    }
+
+    private function touch(): void
+    {
+        $this->updatedAt = new DateTimeImmutable();
+    }
+}

--- a/apps/api/src/ApiConfigurator/Domain/Enum/WebhookDeliveryStatus.php
+++ b/apps/api/src/ApiConfigurator/Domain/Enum/WebhookDeliveryStatus.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiConfigurator\Domain\Enum;
+
+/**
+ * Lifecycle of a webhook delivery attempt record (APIC-P4-05).
+ *
+ * `pending` — enqueued, not yet attempted. `delivered` — the remote returned a
+ * 2xx. `failed` — the last attempt failed; while Messenger still has retries the
+ * row stays `failed` with a rising `attempts`, and once retries are exhausted
+ * the envelope dead-letters to the `failed` transport (the row's terminal state
+ * is `failed` with `attempts` at the retry ceiling).
+ */
+enum WebhookDeliveryStatus: string
+{
+    case Pending = 'pending';
+    case Delivered = 'delivered';
+    case Failed = 'failed';
+}

--- a/apps/api/src/ApiConfigurator/Domain/Message/WebhookDeliveryMessage.php
+++ b/apps/api/src/ApiConfigurator/Domain/Message/WebhookDeliveryMessage.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiConfigurator\Domain\Message;
+
+use App\Shared\Application\TenantAwareMessage;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Async trigger to (re)attempt one webhook delivery (APIC-P4-05). Carries only
+ * the {@see \App\ApiConfigurator\Domain\Entity\WebhookDelivery} id; the handler
+ * loads the stored payload + the profile's secret. {@see TenantAwareMessage} so
+ * the rebinding + RLS-GUC middleware restore tenant context on the worker.
+ *
+ * Routed to a transport with an exponential retry strategy; exhausted retries
+ * dead-letter to the `failed` transport.
+ */
+final readonly class WebhookDeliveryMessage implements TenantAwareMessage
+{
+    public function __construct(
+        public Uuid $deliveryId,
+        public Uuid $tenant,
+    ) {
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenant;
+    }
+}

--- a/apps/api/src/ApiConfigurator/Domain/Repository/WebhookDeliveryRepositoryInterface.php
+++ b/apps/api/src/ApiConfigurator/Domain/Repository/WebhookDeliveryRepositoryInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiConfigurator\Domain\Repository;
+
+use App\ApiConfigurator\Domain\Entity\WebhookDelivery;
+use Symfony\Component\Uid\Uuid;
+
+interface WebhookDeliveryRepositoryInterface
+{
+    public function save(WebhookDelivery $delivery): void;
+
+    public function findById(Uuid $id): ?WebhookDelivery;
+
+    /**
+     * Most recent deliveries for a profile (history view).
+     *
+     * @return list<WebhookDelivery>
+     */
+    public function findByProfile(Uuid $profileId, int $limit = 50): array;
+}

--- a/apps/api/src/ApiConfigurator/Infrastructure/Doctrine/Orm/Mapping/WebhookDelivery.orm.xml
+++ b/apps/api/src/ApiConfigurator/Infrastructure/Doctrine/Orm/Mapping/WebhookDelivery.orm.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\ApiConfigurator\Domain\Entity\WebhookDelivery"
+            table="api_webhook_deliveries"
+            repository-class="App\ApiConfigurator\Infrastructure\Doctrine\Repository\DoctrineWebhookDeliveryRepository">
+
+        <indexes>
+            <index name="api_webhook_deliveries_tenant_idx" columns="tenant_id"/>
+            <index name="api_webhook_deliveries_tenant_profile_idx" columns="tenant_id,profile_id"/>
+            <index name="api_webhook_deliveries_tenant_created_idx" columns="tenant_id,created_at"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <field name="profileId" type="uuid" column="profile_id"/>
+        <field name="eventType" type="string" length="128" column="event_type"/>
+        <field name="targetUrl" type="string" length="2048" column="target_url"/>
+        <field name="payload" type="json" column="payload">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+        <field name="status" type="string" length="16" column="status"/>
+        <field name="attempts" type="integer" column="attempts">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+        <field name="httpStatus" type="integer" column="http_status" nullable="true"/>
+        <field name="durationMs" type="integer" column="duration_ms" nullable="true"/>
+        <field name="lastError" type="text" column="last_error" nullable="true"/>
+        <field name="createdAt" type="datetimetz_immutable" column="created_at"/>
+        <field name="updatedAt" type="datetimetz_immutable" column="updated_at"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/ApiConfigurator/Infrastructure/Doctrine/Repository/DoctrineWebhookDeliveryRepository.php
+++ b/apps/api/src/ApiConfigurator/Infrastructure/Doctrine/Repository/DoctrineWebhookDeliveryRepository.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiConfigurator\Infrastructure\Doctrine\Repository;
+
+use App\ApiConfigurator\Domain\Entity\WebhookDelivery;
+use App\ApiConfigurator\Domain\Repository\WebhookDeliveryRepositoryInterface;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<WebhookDelivery>
+ */
+class DoctrineWebhookDeliveryRepository extends ServiceEntityRepository implements WebhookDeliveryRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, WebhookDelivery::class);
+    }
+
+    public function save(WebhookDelivery $delivery): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($delivery);
+        $em->flush();
+    }
+
+    public function findById(Uuid $id): ?WebhookDelivery
+    {
+        return parent::find($id->toRfc4122());
+    }
+
+    /**
+     * @return list<WebhookDelivery>
+     */
+    public function findByProfile(Uuid $profileId, int $limit = 50): array
+    {
+        $qb = $this->createQueryBuilder('d')
+            ->where('d.profileId = :profileId')
+            ->orderBy('d.createdAt', 'DESC')
+            ->setMaxResults($limit)
+            ->setParameter('profileId', $profileId->toRfc4122());
+
+        /** @var list<WebhookDelivery> $result */
+        $result = $qb->getQuery()->getResult();
+
+        return $result;
+    }
+}

--- a/apps/api/tests/Unit/ApiConfigurator/Application/Handler/InMemoryWebhookDeliveryRepository.php
+++ b/apps/api/tests/Unit/ApiConfigurator/Application/Handler/InMemoryWebhookDeliveryRepository.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\ApiConfigurator\Application\Handler;
+
+use App\ApiConfigurator\Domain\Entity\WebhookDelivery;
+use App\ApiConfigurator\Domain\Repository\WebhookDeliveryRepositoryInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * In-memory {@see WebhookDeliveryRepositoryInterface} for the delivery-handler
+ * unit tests.
+ */
+final class InMemoryWebhookDeliveryRepository implements WebhookDeliveryRepositoryInterface
+{
+    /** @var array<string, WebhookDelivery> */
+    private array $store = [];
+
+    /** @var list<WebhookDelivery> */
+    public array $saved = [];
+
+    public function save(WebhookDelivery $delivery): void
+    {
+        $this->store[$delivery->getId()->toRfc4122()] = $delivery;
+        $this->saved[] = $delivery;
+    }
+
+    public function findById(Uuid $id): ?WebhookDelivery
+    {
+        return $this->store[$id->toRfc4122()] ?? null;
+    }
+
+    /**
+     * @return list<WebhookDelivery>
+     */
+    public function findByProfile(Uuid $profileId, int $limit = 50): array
+    {
+        return array_values(
+            array_filter(
+                $this->store,
+                static fn (WebhookDelivery $d): bool => $d->getProfileId()->equals($profileId),
+            ),
+        );
+    }
+}

--- a/apps/api/tests/Unit/ApiConfigurator/Application/Handler/WebhookDeliveryHandlerTest.php
+++ b/apps/api/tests/Unit/ApiConfigurator/Application/Handler/WebhookDeliveryHandlerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\ApiConfigurator\Application\Handler;
+
+use App\ApiConfigurator\Application\Handler\WebhookDeliveryHandler;
+use App\ApiConfigurator\Application\WebhookDeliveryClient;
+use App\ApiConfigurator\Domain\Entity\ApiProfile;
+use App\ApiConfigurator\Domain\Entity\WebhookDelivery;
+use App\ApiConfigurator\Domain\Enum\WebhookDeliveryStatus;
+use App\ApiConfigurator\Domain\Message\WebhookDeliveryMessage;
+use App\ApiConfigurator\Domain\Repository\ApiProfileRepositoryInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Uid\Uuid;
+
+#[CoversClass(WebhookDeliveryHandler::class)]
+final class WebhookDeliveryHandlerTest extends TestCase
+{
+    /**
+     * @return array{WebhookDeliveryHandler, InMemoryWebhookDeliveryRepository, WebhookDelivery}
+     */
+    private function handlerFor(int $httpCode, ?string $secret = 'shhh'): array
+    {
+        $deliveries = new InMemoryWebhookDeliveryRepository();
+
+        $profile = $this->createStub(ApiProfile::class);
+        $profile->method('getWebhookSecret')->willReturn($secret);
+        $profiles = $this->createStub(ApiProfileRepositoryInterface::class);
+        $profiles->method('findById')->willReturn($profile);
+
+        // http_code 0 → simulate a transport failure (the client catches it and
+        // reports statusCode 0); otherwise a normal mocked HTTP status.
+        $response = 0 === $httpCode
+            ? new MockResponse('', ['error' => 'Connection refused'])
+            : new MockResponse('', ['http_code' => $httpCode]);
+        $client = new WebhookDeliveryClient(new MockHttpClient($response));
+
+        $handler = new WebhookDeliveryHandler($deliveries, $profiles, $client);
+
+        $delivery = new WebhookDelivery(Uuid::v7(), 'object.created.product', 'https://hook.test/in', ['event' => 'x']);
+        $deliveries->save($delivery);
+
+        return [$handler, $deliveries, $delivery];
+    }
+
+    public function testRecordsDeliveredOn2xx(): void
+    {
+        [$handler, , $delivery] = $this->handlerFor(200);
+
+        ($handler)(new WebhookDeliveryMessage($delivery->getId(), Uuid::v7()));
+
+        self::assertSame(WebhookDeliveryStatus::Delivered, $delivery->getStatus());
+        self::assertSame(1, $delivery->getAttempts());
+        self::assertSame(200, $delivery->getHttpStatus());
+        self::assertNull($delivery->getLastError());
+    }
+
+    public function testRecordsFailureAndRethrowsOnNon2xx(): void
+    {
+        [$handler, , $delivery] = $this->handlerFor(500);
+
+        try {
+            ($handler)(new WebhookDeliveryMessage($delivery->getId(), Uuid::v7()));
+            self::fail('Expected the handler to re-throw so Messenger retries.');
+        } catch (RuntimeException) {
+            // expected — drives the transport retry/backoff.
+        }
+
+        self::assertSame(WebhookDeliveryStatus::Failed, $delivery->getStatus());
+        self::assertSame(1, $delivery->getAttempts());
+        self::assertSame(500, $delivery->getHttpStatus());
+        self::assertNotNull($delivery->getLastError());
+    }
+
+    public function testTransportFailureRethrowsWithNullHttpStatus(): void
+    {
+        // MockResponse with http_code 0 surfaces as a transport failure in the client.
+        [$handler, , $delivery] = $this->handlerFor(0);
+
+        $this->expectException(RuntimeException::class);
+
+        try {
+            ($handler)(new WebhookDeliveryMessage($delivery->getId(), Uuid::v7()));
+        } finally {
+            self::assertSame(WebhookDeliveryStatus::Failed, $delivery->getStatus());
+            self::assertNull($delivery->getHttpStatus());
+        }
+    }
+
+    public function testMissingSecretIsPermanentFailureNoRethrow(): void
+    {
+        [$handler, , $delivery] = $this->handlerFor(200, secret: null);
+
+        // Must NOT throw — a gone profile/secret is unrecoverable, retrying is waste.
+        ($handler)(new WebhookDeliveryMessage($delivery->getId(), Uuid::v7()));
+
+        self::assertSame(WebhookDeliveryStatus::Failed, $delivery->getStatus());
+        self::assertSame(1, $delivery->getAttempts());
+    }
+
+    public function testUnknownDeliveryIsNoOp(): void
+    {
+        [$handler] = $this->handlerFor(200);
+
+        // A delivery id that was never persisted (e.g. purged) is a silent no-op.
+        ($handler)(new WebhookDeliveryMessage(Uuid::v7(), Uuid::v7()));
+
+        $this->expectNotToPerformAssertions();
+    }
+}


### PR DESCRIPTION
## APIC-P4-05 — webhook delivery retry + historia dostaw

Trwałe webhooki producenta: audyt + retry/backoff zamiast jednorazowego best-effort POST (domknięcie follow-upu #93).

### Co dochodzi
- **Encja `WebhookDelivery`** (audyt: profileId, event, targetUrl, signed payload, status, attempts, httpStatus, lastError, durationMs) + migracja FORCE RLS (`api_webhook_deliveries`).
- **Subscriber** tworzy wiersz `pending` + dispatch `WebhookDeliveryMessage` na transport `async` (best-effort wobec ścieżki zapisu — dispatch w try/catch, w prod tylko enqueue).
- **`WebhookDeliveryHandler`** POST-uje podpisany body, zapisuje `delivered` (2xx) / `failed`; **re-throw** na błędzie → retry 5× exponential transportu `async` → dead-letter na `failed`. Brak profilu/sekretu = trwała porażka (zapis bez retry).

### AC
- AC-1 historia zapisywana ✅ (encja + recording per attempt).
- AC-2 retry + dead-letter ✅ (transport `async` retry_strategy + `failed`).
- AC-3 test delivery ✅ (istniejący `POST /api/api_profiles/{id}/test_webhook`, bez zmian).

### Świadome decyzje
- Read API historii dostaw → P4-06 (producer hub FE, jego konsument); P4-05 dostarcza encję + recording (zgodnie z Files ticketu).
- "Dead-letter" = transport `failed` (istniejący) po wyczerpaniu retry; status wiersza terminalny `failed` z `attempts` na suficie.

### Testy / gates
- Unit `WebhookDeliveryHandlerTest`: delivered (2xx), failed+rethrow (non-2xx), transport-fail (null httpStatus)+rethrow, permanent (no secret, no rethrow), unknown delivery no-op. 5/5 ✅.
- PHPStan max ✅ (entity dodana do tenant `?Tenant` ignore-list), Deptrac 0 ✅, CS-Fixer ✅, migracja zaaplikowana + mapping w sync.

Closes #1795