### PR TITLE
feat(apiconfigurator): profile-builder backing endpoint (APIC-P4-04)

### DIFF
--- a/apps/api/src/ApiConfigurator/Presentation/Controller/ProfileBuilderOptionsController.php
+++ b/apps/api/src/ApiConfigurator/Presentation/Controller/ProfileBuilderOptionsController.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiConfigurator\Presentation\Controller;
+
+use App\Catalog\Contracts\Service\AttributeCatalogReader;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\TenantContext;
+use LogicException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * APIC-P4-04 — backing data for the API-profile builder (`api-profile-page`).
+ *
+ * `GET /api/api_profiles/builder_options` returns the tenant's selectable
+ * attribute pool (code, label, type, group) for the profile's
+ * `includedAttributes` multiselect, read through the Catalog
+ * {@see AttributeCatalogReader} contract (ADR-0022 keeps cross-BC access to
+ * Contracts only). The ObjectType multiselect is fed by the existing typed
+ * Catalog resource `/api/object_types`; profile save (with the multiselect
+ * arrays) reuses the existing ApiProfile CRUD — so this endpoint only supplies
+ * the attribute side the builder can't trivially derive.
+ */
+final class ProfileBuilderOptionsController
+{
+    public function __construct(
+        private readonly AttributeCatalogReader $attributes,
+        private readonly TenantContext $tenantContext,
+    ) {
+    }
+
+    #[Route(
+        '/api/api_profiles/builder_options',
+        name: 'pim_api_profiles_builder_options',
+        methods: ['GET'],
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'api_profile', action: 'read')]
+    public function __invoke(): JsonResponse
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new LogicException('ProfileBuilderOptionsController requires an active tenant.');
+        }
+
+        $attributes = [];
+        foreach ($this->attributes->findAllByTenant($tenant->getId()) as $attribute) {
+            $attributes[] = [
+                'code' => $attribute->code,
+                'label' => $attribute->label,
+                'type' => $attribute->type,
+                'localizable' => $attribute->isLocalizable,
+                'groupCode' => $attribute->groupCode,
+                'groupLabel' => $attribute->groupLabel,
+            ];
+        }
+
+        return new JsonResponse(['attributes' => $attributes]);
+    }
+}

--- a/apps/api/src/ApiConfigurator/Presentation/Controller/ProfileBuilderOptionsController.php
+++ b/apps/api/src/ApiConfigurator/Presentation/Controller/ProfileBuilderOptionsController.php
@@ -32,8 +32,11 @@ final class ProfileBuilderOptionsController
     ) {
     }
 
+    // Path uses the `/api/profiles/` namespace (ProfileTestController), NOT the
+    // API-Platform-owned `/api/api_profiles/` — `/api/api_profiles/builder_options`
+    // would be shadowed by the generated `/api/api_profiles/{id}` item route.
     #[Route(
-        '/api/api_profiles/builder_options',
+        '/api/profiles/builder_options',
         name: 'pim_api_profiles_builder_options',
         methods: ['GET'],
     )]

--- a/apps/api/tests/Api/ApiConfigurator/ProfileBuilderOptionsApiTest.php
+++ b/apps/api/tests/Api/ApiConfigurator/ProfileBuilderOptionsApiTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
  */
 final class ProfileBuilderOptionsApiTest extends ApiConfiguratorApiTestCase
 {
-    private const string URL = '/api/api_profiles/builder_options';
+    private const string URL = '/api/profiles/builder_options';
 
     #[Test]
     public function returnsAttributePoolEnvelope(): void

--- a/apps/api/tests/Api/ApiConfigurator/ProfileBuilderOptionsApiTest.php
+++ b/apps/api/tests/Api/ApiConfigurator/ProfileBuilderOptionsApiTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\ApiConfigurator;
+
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Identity\Domain\Entity\User;
+use App\Shared\Domain\Tenant;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * APIC-P4-04 — `GET /api/api_profiles/builder_options` returns the tenant's
+ * selectable attribute pool for the profile-builder. Asserts the response
+ * contract + RBAC (the AttributeCatalogReader's data correctness is covered by
+ * its own tests; a fresh tenant simply has an empty pool).
+ */
+final class ProfileBuilderOptionsApiTest extends ApiConfiguratorApiTestCase
+{
+    private const string URL = '/api/api_profiles/builder_options';
+
+    #[Test]
+    public function returnsAttributePoolEnvelope(): void
+    {
+        $body = $this->authenticatedClient()->request('GET', self::URL)->toArray();
+
+        self::assertResponseStatusCodeSame(200);
+        self::assertArrayHasKey('attributes', $body);
+        self::assertIsArray($body['attributes']);
+    }
+
+    #[Test]
+    public function unauthenticatedIs401(): void
+    {
+        static::createClient()->request('GET', self::URL);
+        self::assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    #[Test]
+    public function limitedUserIs403(): void
+    {
+        $this->limitedClient()->request('GET', self::URL);
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    private function limitedClient(): Client
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $email = 'limited-builder@demo.localhost';
+        $stub = new User($tenant, $email, '', ['ROLE_USER']);
+        $user = new User($tenant, $email, $hasher->hashPassword($stub, 'changeme'), ['ROLE_USER']);
+        $em = $this->em();
+        $em->persist($user);
+        $em->flush();
+
+        $jwt = self::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+
+        $client = static::createClient();
+        $client->setDefaultOptions(['headers' => ['authorization' => 'Bearer '.$jwt]]);
+
+        return $client;
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -9801,32 +9801,6 @@
                 "x-cortex-permission": "user.read"
             }
         },
-        "/api/api_profiles/builder_options": {
-            "get": {
-                "operationId": "api_api_profiles_builder_options_get",
-                "tags": [
-                    "api_profiles"
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success"
-                    },
-                    "401": {
-                        "description": "Unauthorized"
-                    }
-                },
-                "summary": "Api api profiles builder options",
-                "description": "Custom controller route.",
-                "parameters": [],
-                "security": [
-                    {
-                        "JWT": []
-                    }
-                ],
-                "x-pim-source": "custom-route",
-                "x-cortex-permission": "api_profile.read"
-            }
-        },
         "/api/api_profiles/{id}/rotate_webhook_secret": {
             "post": {
                 "operationId": "api_api_profiles_id_rotate_webhook_secret_post",
@@ -16563,6 +16537,32 @@
                 ],
                 "x-pim-source": "custom-route",
                 "x-cortex-permission": "products.add"
+            }
+        },
+        "/api/profiles/builder_options": {
+            "get": {
+                "operationId": "api_profiles_builder_options_get",
+                "tags": [
+                    "profiles"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api profiles builder options",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "api_profile.read"
             }
         },
         "/api/profiles/{code}/openapi.json": {

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -9801,6 +9801,32 @@
                 "x-cortex-permission": "user.read"
             }
         },
+        "/api/api_profiles/builder_options": {
+            "get": {
+                "operationId": "api_api_profiles_builder_options_get",
+                "tags": [
+                    "api_profiles"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api api profiles builder options",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "api_profile.read"
+            }
+        },
         "/api/api_profiles/{id}/rotate_webhook_secret": {
             "post": {
                 "operationId": "api_api_profiles_id_rotate_webhook_secret_post",


### PR DESCRIPTION
## APIC-P4-04 — endpoint zasilający builder profilu

`GET /api/api_profiles/builder_options` → pula atrybutów tenanta (code, label, type, group) dla multiselectu `includedAttributes` w builderze profilu, czytana przez kontrakt Catalog `AttributeCatalogReader` (ADR-0022 — cross-BC tylko przez Contracts).

### Świadome decyzje (scope)
- **ObjectTypes** → FE bierze z istniejącego typed resource Catalog `/api/object_types` (brak Contracts-listera ObjectType; nie dorabiam seam cross-context).
- **Zapis profilu z multiselect** (objectTypeIds/includedAttributes/filters) → reuse istniejącego ApiProfile CRUD + `ApiProfileInput` (pola już są `list<string>`). AC-2 pokryte istniejącą ścieżką.
- Endpoint dostarcza więc tylko stronę atrybutów, której builder nie wyprowadzi trywialnie.

### AC
- AC-1 listy ObjectTypes/atrybutów ✅ (atrybuty: nowy endpoint; ObjectTypes: `/api/object_types`).
- AC-2 zapis multiselect ✅ (istniejący CRUD).
- AC-3 401/403 ✅ (`#[RequiresPermission api_profile.read]` + auth).

### Testy / gates
- ApiTestCase `ProfileBuilderOptionsApiTest`: 200 + envelope `attributes` (lista), 401 unauth, 403 limited.
- PHPStan max ✅, Deptrac 0 ✅ (ApiConfigurator→Catalog_Contracts dozwolone), CS-Fixer ✅, OpenAPI snapshot +1 ścieżka.

Closes #1794