### PR TITLE
feat(apiconfigurator): per-profile OpenAPI export (APIC-P4-03)

### DIFF
--- a/apps/api/src/ApiConfigurator/Presentation/Controller/ProfileOpenApiController.php
+++ b/apps/api/src/ApiConfigurator/Presentation/Controller/ProfileOpenApiController.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiConfigurator\Presentation\Controller;
+
+use ApiPlatform\OpenApi\Factory\OpenApiFactoryInterface;
+use App\ApiConfigurator\Domain\Entity\ApiProfile;
+use App\ApiConfigurator\Domain\Repository\ApiProfileRepositoryInterface;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * APIC-P4-03 (ADR-0020/0022) — per-profile OpenAPI export.
+ *
+ * `GET /api/docs/profile/{id}.jsonopenapi` returns the canonical OpenAPI
+ * document narrowed to one integrator profile: only the catalog *data* paths a
+ * profile exposes (products / categories / assets / objects — auth, admin,
+ * import/export, configurator + settings surfaces are dropped), tagged with the
+ * profile's scope (`x-pim-object-type-ids` / `x-pim-included-attributes` /
+ * `x-pim-filters`) so an SDK generator targets a single partner's surface.
+ *
+ * The profile is resolved tenant-scoped (Postgres RLS) — a cross-tenant or
+ * unknown id is a 404. Lives under `/api/docs/` (API Platform owns
+ * `/api/api_profiles/...`); the `api_profile.read` permission gates it.
+ *
+ * Per-ObjectType path narrowing (id → kind → exact sugar path) is a follow-up:
+ * it needs a Catalog Contracts kind-resolution seam ApiConfigurator does not own
+ * (Deptrac: Catalog_Contracts only). Until then the scope is advertised via the
+ * `x-pim-*` metadata while all catalog data paths stay visible.
+ */
+final class ProfileOpenApiController
+{
+    /** Catalog data-resource path prefixes a profile can expose (ADR-009 sugar paths). */
+    private const array DATA_PREFIXES = ['/api/products', '/api/categories', '/api/assets', '/api/objects'];
+
+    public function __construct(
+        private readonly ApiProfileRepositoryInterface $profiles,
+        private readonly OpenApiFactoryInterface $openApiFactory,
+    ) {
+    }
+
+    #[Route(
+        '/api/docs/profile/{id}.jsonopenapi',
+        name: 'pim_api_profile_openapi',
+        requirements: ['id' => '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'],
+        methods: ['GET'],
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'api_profile', action: 'read')]
+    public function __invoke(string $id): JsonResponse
+    {
+        try {
+            $profileId = Uuid::fromString($id);
+        } catch (InvalidArgumentException) {
+            throw new NotFoundHttpException(\sprintf('ApiProfile "%s" was not found.', $id));
+        }
+
+        $profile = $this->profiles->findById($profileId);
+        if (!$profile instanceof ApiProfile) {
+            throw new NotFoundHttpException(\sprintf('ApiProfile "%s" was not found.', $id));
+        }
+
+        /** @var array<string, mixed>|false $payload */
+        $payload = json_decode((string) json_encode($this->openApiFactory->__invoke([])), true);
+        if (!\is_array($payload)) {
+            return new JsonResponse(['error' => 'OpenAPI document could not be encoded.'], 500);
+        }
+
+        return new JsonResponse($this->narrow($payload, $profile));
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    private function narrow(array $payload, ApiProfile $profile): array
+    {
+        $info = \is_array($payload['info'] ?? null) ? $payload['info'] : [];
+        $info['title'] = \sprintf('PIM API — profile "%s"', $profile->getCode());
+        $info['x-pim-profile'] = $profile->getCode();
+        $info['x-pim-object-type-ids'] = $profile->getObjectTypeIds();
+        $info['x-pim-included-attributes'] = $profile->getIncludedAttributes();
+        $info['x-pim-filters'] = $profile->getFilters();
+        $payload['info'] = $info;
+
+        if (\is_array($payload['paths'] ?? null)) {
+            $payload['paths'] = $this->keepDataPaths($payload['paths']);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param array<mixed, mixed> $paths
+     *
+     * @return array<string, mixed>
+     */
+    private function keepDataPaths(array $paths): array
+    {
+        $kept = [];
+        foreach ($paths as $path => $item) {
+            if (!\is_string($path)) {
+                continue;
+            }
+            foreach (self::DATA_PREFIXES as $prefix) {
+                if ($path === $prefix || str_starts_with($path, $prefix.'/') || str_starts_with($path, $prefix.'.')) {
+                    $kept[$path] = $item;
+                    break;
+                }
+            }
+        }
+
+        return $kept;
+    }
+}

--- a/apps/api/src/ApiConfigurator/Presentation/Controller/ProfileOpenApiController.php
+++ b/apps/api/src/ApiConfigurator/Presentation/Controller/ProfileOpenApiController.php
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -42,6 +43,7 @@ final class ProfileOpenApiController
     public function __construct(
         private readonly ApiProfileRepositoryInterface $profiles,
         private readonly OpenApiFactoryInterface $openApiFactory,
+        private readonly NormalizerInterface $normalizer,
     ) {
     }
 
@@ -66,19 +68,21 @@ final class ProfileOpenApiController
             throw new NotFoundHttpException(\sprintf('ApiProfile "%s" was not found.', $id));
         }
 
-        /** @var array<string, mixed>|false $payload */
-        $payload = json_decode((string) json_encode($this->openApiFactory->__invoke([])), true);
+        // Normalize through the OpenApi normalizer (the canonical {openapi, info,
+        // paths, …} shape `api:openapi:export` emits) — plain json_encode of the
+        // OpenApi object does NOT produce that structure.
+        $payload = $this->normalizer->normalize($this->openApiFactory->__invoke([]), 'json');
         if (!\is_array($payload)) {
-            return new JsonResponse(['error' => 'OpenAPI document could not be encoded.'], 500);
+            return new JsonResponse(['error' => 'OpenAPI document could not be normalized.'], 500);
         }
 
         return new JsonResponse($this->narrow($payload, $profile));
     }
 
     /**
-     * @param array<string, mixed> $payload
+     * @param array<mixed, mixed> $payload
      *
-     * @return array<string, mixed>
+     * @return array<mixed, mixed>
      */
     private function narrow(array $payload, ApiProfile $profile): array
     {

--- a/apps/api/tests/Api/ApiConfigurator/ProfileOpenApiApiTest.php
+++ b/apps/api/tests/Api/ApiConfigurator/ProfileOpenApiApiTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\ApiConfigurator;
+
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Identity\Domain\Entity\User;
+use App\Shared\Domain\Tenant;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * APIC-P4-03 — `GET /api/docs/profile/{id}.jsonopenapi` returns the OpenAPI
+ * document scoped to one profile (profile-scope metadata + catalog data paths
+ * only).
+ */
+final class ProfileOpenApiApiTest extends ApiConfiguratorApiTestCase
+{
+    #[Test]
+    public function exportsProfileScopedOpenApi(): void
+    {
+        $id = $this->createProfile();
+
+        $body = $this->authenticatedClient()->request('GET', "/api/docs/profile/{$id}.jsonopenapi")->toArray();
+
+        self::assertResponseStatusCodeSame(200);
+        self::assertArrayHasKey('openapi', $body);
+        $info = $body['info'] ?? [];
+        self::assertIsArray($info);
+        self::assertSame('storefront', $info['x-pim-profile'] ?? null);
+        self::assertSame(['name', 'sku'], $info['x-pim-included-attributes'] ?? null);
+
+        // Only catalog data paths survive; auth/admin surfaces are dropped.
+        $paths = $body['paths'] ?? [];
+        self::assertIsArray($paths);
+        foreach (array_keys($paths) as $path) {
+            self::assertMatchesRegularExpression(
+                '#^/api/(products|categories|assets|objects)#',
+                (string) $path,
+                \sprintf('Unexpected non-data path in profile OpenAPI: %s', (string) $path),
+            );
+        }
+    }
+
+    #[Test]
+    public function unknownProfileIs404(): void
+    {
+        $this->authenticatedClient()->request(
+            'GET',
+            '/api/docs/profile/01234567-1234-7000-8000-000000000000.jsonopenapi',
+        );
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    #[Test]
+    public function unauthenticatedIs401(): void
+    {
+        $id = $this->createProfile();
+        static::createClient()->request('GET', "/api/docs/profile/{$id}.jsonopenapi");
+        self::assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    #[Test]
+    public function limitedUserIs403(): void
+    {
+        $id = $this->createProfile();
+        $this->limitedClient()->request('GET', "/api/docs/profile/{$id}.jsonopenapi");
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    private function createProfile(): string
+    {
+        $body = $this->authenticatedClient()->request('POST', '/api/api_profiles', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'storefront',
+                'name' => 'Storefront',
+                'outputFormat' => 'json_ld',
+                'objectTypeIds' => [],
+                'includedAttributes' => ['name', 'sku'],
+            ], JSON_THROW_ON_ERROR),
+        ])->toArray(false);
+
+        $id = $body['id'] ?? null;
+        \assert(\is_string($id));
+
+        return $id;
+    }
+
+    private function limitedClient(): Client
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $email = 'limited-openapi@demo.localhost';
+        $stub = new User($tenant, $email, '', ['ROLE_USER']);
+        $user = new User($tenant, $email, $hasher->hashPassword($stub, 'changeme'), ['ROLE_USER']);
+        $em = $this->em();
+        $em->persist($user);
+        $em->flush();
+
+        $jwt = self::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+
+        $client = static::createClient();
+        $client->setDefaultOptions(['headers' => ['authorization' => 'Bearer '.$jwt]]);
+
+        return $client;
+    }
+}


### PR DESCRIPTION
## APIC-P4-03 — per-profile OpenAPI export

`GET /api/docs/profile/{id}.jsonopenapi` → dokument OpenAPI zawężony do jednego profilu integratora.

### Zawężenie
- **Ścieżki**: tylko katalogowe data-resources (`/api/products|categories|assets|objects` + itemy); auth/admin/import/export/configurator/settings odrzucone → partner-scoped doc.
- **Metadata scope**: `info.x-pim-profile` + `x-pim-object-type-ids` + `x-pim-included-attributes` + `x-pim-filters`.

### Świadome decyzje
- Profil resolved **tenant-scoped** (RLS → cross-tenant/unknown id = 404); gate `api_profile.read`.
- Ścieżka pod `/api/docs/` (AP posiada `/api/api_profiles/`) — i jak inne `/api/docs/*` jest **wykluczona z głównego speca** przez `CustomRouteOpenApiFactory`, więc **brak v0.json drift** (export == committed).
- Per-ObjectType narrowing (id→kind→sugar path) = follow-up (wymaga Catalog Contracts kind-resolution seam, którego ApiConfigurator nie posiada — Deptrac). Do tego czasu scope ogłaszany przez `x-pim-*`.
- Istniejący `/api/profiles/{code}/openapi.json` (ProfileTestController) zostaje (back-compat); ten jest kanoniczny per-id z zawężeniem ścieżek.

### Testy / gates
- ApiTestCase `ProfileOpenApiApiTest`: export (200 + `openapi` + `x-pim-profile`/`x-pim-included-attributes` + tylko data-paths), unknown→404, unauth→401, limited→403.
- PHPStan max ✅, Deptrac 0 ✅ (ApiConfigurator→Catalog_Contracts), CS-Fixer ✅, brak v0.json drift.

Closes #1793