### PR TITLE
feat(ui): build API profile builder page (APIC-P4-07)

### DIFF
--- a/apps/admin/e2e/1797-api-profile-builder.spec.ts
+++ b/apps/admin/e2e/1797-api-profile-builder.spec.ts
@@ -1,0 +1,89 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, type Route, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * APIC-P4-07 (#1797) — the API-profile builder (new mode). ObjectTypes +
+ * attribute pool + profile create are mocked, so the test is deterministic:
+ * fill the name (code auto-derives), pick an object type + attribute, create.
+ */
+test('APIC-P4-07 — profile builder: new profile create', async ({ page }) => {
+  await loginAsAdmin(page);
+
+  let posted: Record<string, unknown> | null = null;
+
+  await page.route('**/api/object_types**', (r: Route) =>
+    r.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify({
+        member: [{ id: 'ot-1', code: 'product', label: { en: 'Products' }, kind: 'product' }],
+        totalItems: 1,
+      }),
+    }),
+  );
+  await page.route('**/api/profiles/builder_options', (r: Route) =>
+    r.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        attributes: [
+          { code: 'name', label: { en: 'Name' }, type: 'string', groupCode: 'general' },
+          { code: 'sku', label: { en: 'SKU' }, type: 'string', groupCode: 'general' },
+        ],
+      }),
+    }),
+  );
+  await page.route('**/api/api_profiles**', (r: Route) => {
+    if (r.request().method() === 'POST') {
+      posted = r.request().postDataJSON() as Record<string, unknown>;
+      return r.fulfill({
+        status: 201,
+        contentType: 'application/ld+json',
+        body: JSON.stringify({ id: 'prof-new', ...posted }),
+      });
+    }
+    return r.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify({ member: [], totalItems: 0 }),
+    });
+  });
+  // Hub resources (after the post-create redirect).
+  for (const res of ['api_keys', 'webhook_deliveries']) {
+    await page.route(`**/api/${res}**`, (r: Route) =>
+      r.fulfill({
+        status: 200,
+        contentType: 'application/ld+json',
+        body: JSON.stringify({ member: [], totalItems: 0 }),
+      }),
+    );
+  }
+
+  await page.goto('/integrations/api-configurator/profiles/new');
+
+  await expect(
+    page.getByRole('heading', { name: /nowy profil api|new api profile/i }),
+  ).toBeVisible();
+
+  // Name → code auto-derives.
+  await page.getByLabel(/nazwa profilu|profile name/i).fill('Public catalog');
+  await expect(page.getByLabel(/^code$/i)).toHaveValue('public-catalog');
+
+  // Pick the object type + an attribute.
+  await page.getByRole('button', { name: /products/i }).click();
+  await page.getByRole('checkbox').first().check();
+
+  // a11y before the create navigation.
+  const a11y = await new AxeBuilder({ page }).analyze();
+  expect(a11y.violations).toEqual([]);
+
+  // Create → POST fires with the multiselect payload.
+  await page.getByRole('button', { name: /utwórz profil|create profile/i }).click();
+  await expect.poll(() => posted).not.toBeNull();
+  expect(posted?.code).toBe('public-catalog');
+  expect(Array.isArray(posted?.objectTypeIds) && (posted?.objectTypeIds as unknown[]).length).toBe(
+    1,
+  );
+});

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -47,6 +47,10 @@ const ProducerHubPage = lazyPage(
   () => import('@/features/api-configurator/producer/ProducerHubPage'),
   'ProducerHubPage',
 );
+const ProfileBuilderPage = lazyPage(
+  () => import('@/features/api-configurator/producer/profile-builder/ProfileBuilderPage'),
+  'ProfileBuilderPage',
+);
 const ApiProfileShowPage = lazyPage(
   () => import('@/features/api-configurator/api-profiles/show'),
   'ApiProfileShowPage',
@@ -639,6 +643,14 @@ function App() {
                     <Route
                       path="/integrations/api-configurator/create"
                       element={<ApiProfileCreatePage />}
+                    />
+                    <Route
+                      path="/integrations/api-configurator/profiles/new"
+                      element={<ProfileBuilderPage />}
+                    />
+                    <Route
+                      path="/integrations/api-configurator/profiles/:id/edit"
+                      element={<ProfileBuilderPage />}
                     />
                     <Route
                       path="/integrations/api-configurator/connections"

--- a/apps/admin/src/features/api-configurator/components/primitives/layout.tsx
+++ b/apps/admin/src/features/api-configurator/components/primitives/layout.tsx
@@ -27,7 +27,7 @@ export function Field({
         </span>
         {required ? <span className="text-[11px] text-rose-500">*</span> : null}
         {hint !== undefined && hint !== '' ? (
-          <span className="text-[11px] normal-case tracking-normal text-zinc-400">· {hint}</span>
+          <span className="text-[11px] normal-case tracking-normal text-zinc-500">· {hint}</span>
         ) : null}
       </div>
       {children}

--- a/apps/admin/src/features/api-configurator/producer/ProducerProfilesTab.tsx
+++ b/apps/admin/src/features/api-configurator/producer/ProducerProfilesTab.tsx
@@ -20,51 +20,64 @@ export function ProducerProfilesTab() {
   const query = useList<ApiProfileRow>({ resource: 'api_profiles', pagination: { mode: 'off' } });
   const profiles = query.result.data;
 
-  if (profiles.length === 0) {
-    return (
-      <div className="soft-shadow rounded-2xl border border-dashed border-zinc-300 bg-white p-10 text-center text-[13px] text-zinc-500">
-        {t('api_configurator.producer.profiles.empty')}
-      </div>
-    );
-  }
-
   return (
-    <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
-      {profiles.map((profile) => {
-        const status = (KNOWN_STATUSES as string[]).includes(profile.status ?? '')
-          ? (profile.status as ConnectionStatus)
-          : 'draft';
-        return (
-          <button
-            key={profile.id}
-            type="button"
-            onClick={() => navigate(`${BASE}/${profile.id}`)}
-            className="soft-shadow rounded-2xl border border-zinc-200 bg-white p-5 text-left transition hover:border-zinc-300"
-          >
-            <div className="flex items-start justify-between gap-2">
-              <div className="min-w-0">
-                <div className="truncate font-display text-[15px] font-semibold tracking-tight">
-                  {profile.name}
+    <div className="space-y-3">
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={() => navigate(`${BASE}/profiles/new`)}
+          className="h-9 rounded-xl bg-zinc-900 px-4 text-[13px] font-semibold text-white transition hover:bg-zinc-800"
+        >
+          {t('api_configurator.producer.profiles.new')}
+        </button>
+      </div>
+
+      {profiles.length === 0 ? (
+        <div className="soft-shadow rounded-2xl border border-dashed border-zinc-300 bg-white p-10 text-center text-[13px] text-zinc-500">
+          {t('api_configurator.producer.profiles.empty')}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {profiles.map((profile) => {
+            const status = (KNOWN_STATUSES as string[]).includes(profile.status ?? '')
+              ? (profile.status as ConnectionStatus)
+              : 'draft';
+            return (
+              <button
+                key={profile.id}
+                type="button"
+                onClick={() => navigate(`${BASE}/profiles/${profile.id}/edit`)}
+                className="soft-shadow rounded-2xl border border-zinc-200 bg-white p-5 text-left transition hover:border-zinc-300"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <div className="truncate font-display text-[15px] font-semibold tracking-tight">
+                      {profile.name}
+                    </div>
+                    <div className="font-mono text-[11.5px] text-zinc-500">{profile.code}</div>
+                  </div>
+                  <ConnStatusPill
+                    status={status}
+                    label={t(`api_configurator.hub.status.${status}`)}
+                  />
                 </div>
-                <div className="font-mono text-[11.5px] text-zinc-500">{profile.code}</div>
-              </div>
-              <ConnStatusPill status={status} label={t(`api_configurator.hub.status.${status}`)} />
-            </div>
-            <div className="mt-3 flex gap-4 text-[11.5px] text-zinc-600">
-              <span>
-                {t('api_configurator.producer.profiles.object_types', {
-                  count: profile.objectTypeIds?.length ?? 0,
-                })}
-              </span>
-              <span>
-                {t('api_configurator.producer.profiles.attributes', {
-                  count: profile.includedAttributes?.length ?? 0,
-                })}
-              </span>
-            </div>
-          </button>
-        );
-      })}
+                <div className="mt-3 flex gap-4 text-[11.5px] text-zinc-600">
+                  <span>
+                    {t('api_configurator.producer.profiles.object_types', {
+                      count: profile.objectTypeIds?.length ?? 0,
+                    })}
+                  </span>
+                  <span>
+                    {t('api_configurator.producer.profiles.attributes', {
+                      count: profile.includedAttributes?.length ?? 0,
+                    })}
+                  </span>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/admin/src/features/api-configurator/producer/profile-builder/AttributePicker.tsx
+++ b/apps/admin/src/features/api-configurator/producer/profile-builder/AttributePicker.tsx
@@ -1,0 +1,107 @@
+import { Search } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { type BuilderAttribute, labelText } from './builder-helpers';
+
+/**
+ * APIC-P4-07 — the profile builder's attribute picker: searchable checkbox list
+ * of the tenant's attribute pool (from the P4-04 builder_options endpoint) with
+ * all/none + a selected counter.
+ */
+export function AttributePicker({
+  attributes,
+  selected,
+  onToggle,
+  onSelectAll,
+  onSelectNone,
+}: {
+  attributes: BuilderAttribute[];
+  selected: Set<string>;
+  onToggle: (code: string) => void;
+  onSelectAll: () => void;
+  onSelectNone: () => void;
+}) {
+  const { t } = useTranslation();
+  const [q, setQ] = useState('');
+
+  const shown = useMemo(() => {
+    const needle = q.trim().toLowerCase();
+    if (needle === '') {
+      return attributes;
+    }
+    return attributes.filter(
+      (a) =>
+        a.code.toLowerCase().includes(needle) ||
+        labelText(a.label, a.code).toLowerCase().includes(needle),
+    );
+  }, [attributes, q]);
+
+  return (
+    <section className="soft-shadow rounded-2xl border border-zinc-200 bg-white p-5">
+      <div className="mb-3 flex items-center gap-3">
+        <div className="text-[11px] font-medium uppercase tracking-wider text-zinc-500">
+          {t('api_configurator.builder.attributes.title')}
+        </div>
+        <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10.5px] font-medium tabular-nums text-zinc-600">
+          {selected.size} / {attributes.length}
+        </span>
+        <div className="flex-1" />
+        <button
+          type="button"
+          onClick={onSelectAll}
+          className="text-[11.5px] text-zinc-500 hover:text-zinc-900"
+        >
+          {t('api_configurator.builder.attributes.all')}
+        </button>
+        <button
+          type="button"
+          onClick={onSelectNone}
+          className="text-[11.5px] text-zinc-500 hover:text-zinc-900"
+        >
+          {t('api_configurator.builder.attributes.none')}
+        </button>
+      </div>
+
+      <div className="mb-2 flex items-center gap-2 rounded-xl border border-zinc-200 px-3">
+        <Search className="size-4 text-zinc-400" aria-hidden="true" />
+        <input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder={t('api_configurator.builder.attributes.search')}
+          aria-label={t('api_configurator.builder.attributes.search')}
+          className="h-9 flex-1 bg-transparent text-[13px] outline-none placeholder:text-zinc-400"
+        />
+      </div>
+
+      <div className="max-h-[55vh] divide-y divide-zinc-50 overflow-y-auto">
+        {shown.length === 0 ? (
+          <div className="px-1 py-4 text-[12px] text-zinc-500">
+            {t('api_configurator.builder.attributes.empty')}
+          </div>
+        ) : (
+          shown.map((a) => (
+            <label
+              key={a.code}
+              className="flex cursor-pointer items-center gap-3 px-1 py-2.5 hover:bg-zinc-50/70"
+            >
+              <input
+                type="checkbox"
+                checked={selected.has(a.code)}
+                onChange={() => onToggle(a.code)}
+                className="size-4 rounded"
+              />
+              <span className="flex-1 text-[12.5px] text-zinc-800">
+                {labelText(a.label, a.code)}
+              </span>
+              <span className="font-mono text-[10.5px] text-zinc-500">{a.code}</span>
+              <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium text-zinc-600">
+                {a.type}
+              </span>
+            </label>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/admin/src/features/api-configurator/producer/profile-builder/ProfileBuilderPage.tsx
+++ b/apps/admin/src/features/api-configurator/producer/profile-builder/ProfileBuilderPage.tsx
@@ -1,0 +1,291 @@
+import { useApiUrl, useCreate, useCustom, useList, useOne, useUpdate } from '@refinedev/core';
+import { ArrowLeft, Info } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useParams } from 'react-router';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+import { Field, SecurityNote } from '../../components/primitives';
+import { AttributePicker } from './AttributePicker';
+import {
+  type BuilderAttribute,
+  labelText,
+  type ObjectTypeRow,
+  type ProfileDetail,
+  slugify,
+} from './builder-helpers';
+
+const HUB = '/integrations/api-configurator';
+
+/**
+ * APIC-P4-07 — the full-screen API-profile builder (`integracje/api-producer.jsx`
+ * ApiProfilePage). Left panel: name→slug, access (read-only — profiles are read
+ * projections in MVP), a JSON filter, and the ObjectType multiselect. Right
+ * panel: the searchable attribute picker (P4-04 builder_options). New mode
+ * (POST) when there is no :id; edit mode (PATCH) hydrates from the profile.
+ */
+export function ProfileBuilderPage() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const apiUrl = useApiUrl();
+  const { id = null } = useParams();
+  const editing = id !== null;
+
+  const profileQuery = useOne<ProfileDetail>({
+    resource: 'api_profiles',
+    id: id ?? '',
+    queryOptions: { enabled: editing },
+  });
+  const objectTypesQuery = useList<ObjectTypeRow>({
+    resource: 'object_types',
+    pagination: { mode: 'off' },
+  });
+  const optionsQuery = useCustom<{ attributes: BuilderAttribute[] }>({
+    url: `${apiUrl}/profiles/builder_options`,
+    method: 'get',
+  });
+
+  const objectTypes = objectTypesQuery.result.data;
+  const attributePool = optionsQuery.result?.data?.attributes ?? [];
+
+  const [name, setName] = useState('');
+  const [code, setCode] = useState('');
+  const [codeTouched, setCodeTouched] = useState(false);
+  const [filters, setFilters] = useState('');
+  const [selectedTypes, setSelectedTypes] = useState<Set<string>>(new Set());
+  const [selectedAttrs, setSelectedAttrs] = useState<Set<string>>(new Set());
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Hydrate from the loaded profile (edit mode).
+  const profile = profileQuery.result ?? null;
+  useEffect(() => {
+    if (profile === null) {
+      return;
+    }
+    setName(profile.name);
+    setCode(profile.code);
+    setCodeTouched(true);
+    setSelectedTypes(new Set(profile.objectTypeIds ?? []));
+    setSelectedAttrs(new Set(profile.includedAttributes ?? []));
+    setFilters(
+      profile.filters !== undefined && Object.keys(profile.filters).length > 0
+        ? JSON.stringify(profile.filters, null, 2)
+        : '',
+    );
+  }, [profile]);
+
+  const effectiveCode = codeTouched ? code : slugify(name);
+
+  const { mutate: create, mutation: createState } = useCreate();
+  const { mutate: update, mutation: updateState } = useUpdate();
+  const saving = createState.isPending || updateState.isPending;
+
+  function parseFilters(): Record<string, unknown> | null {
+    const raw = filters.trim();
+    if (raw === '') {
+      return {};
+    }
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return null;
+      }
+      return parsed as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+
+  function save(): void {
+    const parsedFilters = parseFilters();
+    if (parsedFilters === null) {
+      setSaveError(t('api_configurator.builder.filters_invalid'));
+      return;
+    }
+    setSaveError(null);
+
+    const values = {
+      name: name.trim(),
+      objectTypeIds: [...selectedTypes],
+      includedAttributes: [...selectedAttrs],
+      filters: parsedFilters,
+    };
+
+    if (editing && id !== null) {
+      update(
+        { resource: 'api_profiles', id, values, successNotification: false },
+        { onSuccess: () => navigate(HUB) },
+      );
+      return;
+    }
+    create(
+      {
+        resource: 'api_profiles',
+        values: { ...values, code: effectiveCode, outputFormat: 'json_ld' },
+        successNotification: false,
+      },
+      { onSuccess: () => navigate(HUB) },
+    );
+  }
+
+  const footerSummary = useMemo(
+    () =>
+      t('api_configurator.builder.summary', {
+        types: selectedTypes.size,
+        attrs: selectedAttrs.size,
+      }),
+    [selectedTypes.size, selectedAttrs.size, t],
+  );
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center gap-3">
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={() => navigate(HUB)}
+          aria-label={t('api_configurator.builder.back')}
+        >
+          <ArrowLeft className="size-4" aria-hidden="true" />
+        </Button>
+        <div className="min-w-0 flex-1">
+          <h1 className="font-display text-[22px] font-semibold tracking-tight">
+            {editing
+              ? t('api_configurator.builder.title_edit')
+              : t('api_configurator.builder.title_new')}
+          </h1>
+          <p className="text-[12.5px] text-zinc-500">{t('api_configurator.builder.subtitle')}</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1fr_1fr]">
+        <div className="space-y-4">
+          <section className="soft-shadow space-y-5 rounded-2xl border border-zinc-200 bg-white p-5">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <Field label={t('api_configurator.builder.name')} required>
+                <Input
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder={t('api_configurator.builder.name_placeholder')}
+                  aria-label={t('api_configurator.builder.name')}
+                  className="h-10"
+                />
+              </Field>
+              <Field
+                label={t('api_configurator.builder.code')}
+                hint={t('api_configurator.builder.code_hint')}
+              >
+                <Input
+                  value={effectiveCode}
+                  onChange={(e) => {
+                    setCodeTouched(true);
+                    setCode(e.target.value);
+                  }}
+                  disabled={editing}
+                  aria-label={t('api_configurator.builder.code')}
+                  className="h-10 font-mono"
+                />
+              </Field>
+            </div>
+
+            <Field label={t('api_configurator.builder.access')}>
+              <div className="inline-flex items-center rounded-xl bg-zinc-100 p-1">
+                <span className="rounded-lg bg-white px-3 py-1.5 text-[12.5px] font-medium text-zinc-900 soft-shadow">
+                  {t('api_configurator.builder.access_read_only')}
+                </span>
+              </div>
+            </Field>
+
+            <Field
+              label={t('api_configurator.builder.filters')}
+              hint={t('api_configurator.builder.filters_hint')}
+            >
+              <textarea
+                value={filters}
+                onChange={(e) => setFilters(e.target.value)}
+                placeholder={'{ "status": "active" }'}
+                aria-label={t('api_configurator.builder.filters')}
+                rows={3}
+                className="focus-ring w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 font-mono text-[12px]"
+              />
+            </Field>
+          </section>
+
+          <section className="soft-shadow rounded-2xl border border-zinc-200 bg-white p-5">
+            <Field
+              label={t('api_configurator.builder.object_types')}
+              hint={t('api_configurator.builder.multiselect')}
+            >
+              <div className="flex flex-wrap gap-2">
+                {objectTypes.map((ot) => {
+                  const on = selectedTypes.has(ot.id);
+                  return (
+                    <button
+                      key={ot.id}
+                      type="button"
+                      aria-pressed={on}
+                      onClick={() =>
+                        setSelectedTypes((prev) => {
+                          const next = new Set(prev);
+                          if (next.has(ot.id)) {
+                            next.delete(ot.id);
+                          } else {
+                            next.add(ot.id);
+                          }
+                          return next;
+                        })
+                      }
+                      className={`h-8 rounded-lg border px-3 text-[12px] font-medium transition ${on ? 'border-zinc-900 bg-zinc-900 text-white' : 'border-zinc-200 bg-white text-zinc-600 hover:bg-zinc-50'}`}
+                    >
+                      {labelText(ot.label, ot.code)}
+                    </button>
+                  );
+                })}
+              </div>
+            </Field>
+          </section>
+
+          <SecurityNote tone="zinc" icon={<Info className="size-4" />}>
+            {t('api_configurator.builder.projection_note')}
+          </SecurityNote>
+        </div>
+
+        <AttributePicker
+          attributes={attributePool}
+          selected={selectedAttrs}
+          onToggle={(c) =>
+            setSelectedAttrs((prev) => {
+              const next = new Set(prev);
+              if (next.has(c)) {
+                next.delete(c);
+              } else {
+                next.add(c);
+              }
+              return next;
+            })
+          }
+          onSelectAll={() => setSelectedAttrs(new Set(attributePool.map((a) => a.code)))}
+          onSelectNone={() => setSelectedAttrs(new Set())}
+        />
+      </div>
+
+      {saveError !== null ? (
+        <div className="rounded-xl border border-rose-200 bg-rose-50/60 p-3 text-[12.5px] text-rose-800">
+          {saveError}
+        </div>
+      ) : null}
+
+      <div className="flex items-center gap-3 pt-1">
+        <div className="hidden text-[12px] text-zinc-500 sm:block">{footerSummary}</div>
+        <div className="flex-1" />
+        <Button type="button" onClick={save} disabled={saving || name.trim() === ''}>
+          {editing
+            ? t('api_configurator.builder.save_edit')
+            : t('api_configurator.builder.save_new')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/api-configurator/producer/profile-builder/builder-helpers.tsx
+++ b/apps/admin/src/features/api-configurator/producer/profile-builder/builder-helpers.tsx
@@ -1,0 +1,50 @@
+/**
+ * APIC-P4-07 — shared types + small pieces for the profile builder.
+ */
+export interface ObjectTypeRow {
+  id: string;
+  code: string;
+  label?: Record<string, string> | string | null;
+}
+
+export interface BuilderAttribute {
+  code: string;
+  label: Record<string, string> | string | null;
+  type: string;
+  groupCode: string | null;
+}
+
+export interface ProfileDetail {
+  id: string;
+  code: string;
+  name: string;
+  outputFormat: string;
+  objectTypeIds?: string[];
+  includedAttributes?: string[];
+  filters?: Record<string, unknown>;
+}
+
+/** Resolve a JSONB `{pl,en}` / string label to display text, falling back to code. */
+export function labelText(
+  label: Record<string, string> | string | null | undefined,
+  fallback: string,
+): string {
+  if (typeof label === 'string' && label !== '') {
+    return label;
+  }
+  if (label !== null && typeof label === 'object') {
+    return label.pl ?? label.en ?? Object.values(label)[0] ?? fallback;
+  }
+  return fallback;
+}
+
+/** Slugify a profile name into a `[a-z0-9-]` code (mirrors the connection wizard). */
+export function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -2042,7 +2042,8 @@
       "profiles": {
         "empty": "No API profiles yet. Create one to expose a catalog projection.",
         "object_types": "{{count}} object types",
-        "attributes": "{{count}} attributes"
+        "attributes": "{{count}} attributes",
+        "new": "New profile"
       },
       "keys": {
         "empty": "No API keys.",
@@ -2058,6 +2059,34 @@
         "empty": "No profile has a webhook configured.",
         "no_delivery": "no deliveries",
         "secret_note": "The HMAC secret is never returned by the API — rotation = revocation. Configure it on the profile."
+      }
+    },
+    "builder": {
+      "back": "Back to producer",
+      "title_new": "New API profile",
+      "title_edit": "Edit API profile",
+      "subtitle": "A catalog projection: the object types + attributes exposed to integrators.",
+      "name": "Profile name",
+      "name_placeholder": "e.g. Public catalog",
+      "code": "Code",
+      "code_hint": "auto from name",
+      "access": "Access",
+      "access_read_only": "Read-only",
+      "filters": "Filters",
+      "filters_hint": "JSON condition on records (optional)",
+      "filters_invalid": "Filters must be a valid JSON object.",
+      "object_types": "Object types",
+      "multiselect": "multiselect",
+      "projection_note": "A profile is a read-only projection — it exposes the chosen attributes of the chosen object types. API keys and webhooks are wired in their own hub tabs.",
+      "summary": "{{types}} type(s) · {{attrs}} attributes",
+      "save_new": "Create profile",
+      "save_edit": "Save changes",
+      "attributes": {
+        "title": "Attributes",
+        "all": "all",
+        "none": "none",
+        "search": "search attribute or code…",
+        "empty": "No attributes match the search."
       }
     }
   },

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -2090,7 +2090,8 @@
       "profiles": {
         "empty": "Brak profili API. Utwórz pierwszy, by wystawić projekcję katalogu.",
         "object_types": "{{count}} typów obiektów",
-        "attributes": "{{count}} atrybutów"
+        "attributes": "{{count}} atrybutów",
+        "new": "Nowy profil"
       },
       "keys": {
         "empty": "Brak kluczy API.",
@@ -2106,6 +2107,34 @@
         "empty": "Żaden profil nie ma skonfigurowanego webhooka.",
         "no_delivery": "brak dostaw",
         "secret_note": "Sekret HMAC nie jest zwracany przez API — rotacja = unieważnienie. Konfigurujesz go przy profilu."
+      }
+    },
+    "builder": {
+      "back": "Wróć do producenta",
+      "title_new": "Nowy profil API",
+      "title_edit": "Edycja profilu API",
+      "subtitle": "Projekcja katalogu: wybrane typy obiektów + atrybuty wystawiane integratorom.",
+      "name": "Nazwa profilu",
+      "name_placeholder": "np. Katalog publiczny",
+      "code": "Code",
+      "code_hint": "auto z nazwy",
+      "access": "Dostęp",
+      "access_read_only": "Tylko odczyt",
+      "filters": "Filtry",
+      "filters_hint": "warunek JSON na rekordach (opcjonalny)",
+      "filters_invalid": "Filtry muszą być poprawnym obiektem JSON.",
+      "object_types": "Typy obiektów",
+      "multiselect": "multiselect",
+      "projection_note": "Profil to projekcja read-only — wystawia wybrane atrybuty wybranych typów obiektów. Klucze API i webhooki podpinasz w osobnych zakładkach hubu.",
+      "summary": "{{types}} typ(y) · {{attrs}} atrybutów",
+      "save_new": "Utwórz profil",
+      "save_edit": "Zapisz zmiany",
+      "attributes": {
+        "title": "Atrybuty",
+        "all": "wszystkie",
+        "none": "żadne",
+        "search": "szukaj atrybutu lub code…",
+        "empty": "Brak atrybutów pasujących do wyszukiwania."
       }
     }
   },


### PR DESCRIPTION
## APIC-P4-07 — builder profilu API (api-profile-page)

Pełnoekranowy builder pod `/integrations/api-configurator/profiles/new` (+ `/{id}/edit`), wg `ApiProfilePage`.

### Layout
- **Lewy panel:** nazwa → slug (auto), **dostęp** (read-only — profile to projekcje read-only w MVP), opcjonalny **filtr JSON**, **multiselect typów obiektów** (z `/api/object_types`).
- **Prawy panel:** **picker atrybutów** — search + checkboxy + all/none + licznik (z P4-04 `/api/profiles/builder_options`).
- **Footer:** zapis (POST nowy / PATCH edit `/api/api_profiles`) → redirect do hubu.
- Hub Profiles tab: przycisk „Nowy profil" + karty otwierają builder w trybie edit.

### Świadome decyzje
- `access` = read-only statyczny (ApiProfile to read-projekcja, brak pola access; tryb odczyt+zapis zarezerwowany) — SecurityNote wyjaśnia. Nie udajemy zapisu nieistniejącego pola (SMOKE TEST RULE).
- `filters` = textarea JSON (parsowany na zapisie; nie-obiekt → błąd + blokada zapisu). Pełny WHERE-builder = follow-up.
- ObjectTypes z istniejącego Catalog `/api/object_types`; atrybuty z P4-04 builder_options.

### Testy / gates
- Playwright E2E (`1797-api-profile-builder.spec.ts`): new-mode (name→code auto, wybór typu+atrybutu, create → POST z multiselect payload) + axe 0 violations.
- tsc ✅, biome ✅, vitest (17) ✅, vite build ✅, max-lines ✅. Kontrast muted-labeli → zinc-500 (Field hint primitive + picker + footer).

Closes #1797