### PR TITLE
APIC-P5-03: chore(integration): secret rotation + needsRotation review

### DIFF
--- a/apps/api/src/Integration/Generic/Application/ConnectionCredentialsCipher.php
+++ b/apps/api/src/Integration/Generic/Application/ConnectionCredentialsCipher.php
@@ -83,4 +83,46 @@ final readonly class ConnectionCredentialsCipher
 
         return $credentials;
     }
+
+    /**
+     * Lazy re-encryption (APIC-P5-03): when the stored credentials were sealed
+     * with a key version older than the active one, decrypt them and re-seal
+     * them under the active key, mutating the connection's ciphertext + version
+     * columns in place. Returns `true` when a rotation happened so the caller
+     * knows to flush.
+     *
+     * This is the same pattern Argon2id uses for password rehash on verify
+     * ({@see EncryptionServiceInterface::needsRotation()}). It is driven by the
+     * `integration:credentials:rotate` sweep after an operator adds a new BYOK
+     * key version; new writes already use the active key via {@see apply()}.
+     */
+    public function rotateIfNeeded(Connection $connection): bool
+    {
+        if (!$this->needsRotation($connection)) {
+            return false;
+        }
+
+        // reveal() decrypts under the stored (old) version; apply() re-encrypts
+        // under the active one and overwrites the ciphertext + version columns.
+        $this->apply($connection, $this->reveal($connection));
+
+        return true;
+    }
+
+    /**
+     * Non-mutating check: `true` when the connection has stored credentials
+     * sealed with a key version older than the active one. Backs the
+     * `--dry-run` sweep without touching any row.
+     */
+    public function needsRotation(Connection $connection): bool
+    {
+        $ciphertext = $connection->getCredentialsCiphertext();
+        $version = $connection->getCredentialsKeyVersion();
+
+        if (null === $ciphertext || null === $version) {
+            return false;
+        }
+
+        return $this->encryption->needsRotation(new EncryptedSecret($ciphertext, $version));
+    }
 }

--- a/apps/api/src/Integration/Generic/Presentation/Command/RotateConnectionCredentialsCommand.php
+++ b/apps/api/src/Integration/Generic/Presentation/Command/RotateConnectionCredentialsCommand.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Presentation\Command;
+
+use App\Integration\Generic\Application\ConnectionCredentialsCipher;
+use App\Integration\Generic\Domain\Repository\ConnectionRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Repository\TenantRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * APIC-P5-03 (ADR-0022, epic APIC) — re-encrypts every stored connection
+ * credential blob that was sealed with a BYOK key version older than the active
+ * one ({@see ConnectionCredentialsCipher::rotateIfNeeded()}).
+ *
+ * Operator workflow (see `docs/operations/connection-credentials-rotation-runbook.md`):
+ * add `APP_BYOK_KEY_V{n}`, deploy (new writes immediately use vN, old rows keep
+ * decrypting with their original key), then run this sweep to upgrade the
+ * at-rest rows so the previous key can be retired. The sweep is idempotent —
+ * a connection already on the active version is skipped.
+ *
+ * Tenant scoping mirrors {@see DispatchDueSyncBindingsCommand}: FORCE RLS hides
+ * `integration_connections` until the `app.current_tenant` GUC is set, so the
+ * scan runs per tenant, binding both {@see TenantContext} (TenantFilter) and the
+ * Postgres GUC (RLS).
+ */
+#[AsCommand(
+    name: 'integration:credentials:rotate',
+    description: 'Re-encrypt connection credentials sealed with a stale BYOK key version (all tenants).',
+)]
+final class RotateConnectionCredentialsCommand extends Command
+{
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly TenantContext $tenantContext,
+        private readonly TenantRepositoryInterface $tenants,
+        private readonly ConnectionRepositoryInterface $connections,
+        private readonly ConnectionCredentialsCipher $cipher,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            'dry-run',
+            null,
+            InputOption::VALUE_NONE,
+            'Report how many connections need rotation without re-encrypting anything.',
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $dryRun = true === $input->getOption('dry-run');
+
+        $rotated = 0;
+        $scanned = 0;
+        foreach ($this->tenants->findAllOrderedByCode() as $tenant) {
+            $this->bindTenant($tenant);
+            try {
+                foreach ($this->connections->findByTenant($tenant) as $connection) {
+                    ++$scanned;
+                    if ($dryRun) {
+                        if ($this->cipher->needsRotation($connection)) {
+                            ++$rotated;
+                        }
+
+                        continue;
+                    }
+
+                    if ($this->cipher->rotateIfNeeded($connection)) {
+                        $this->connections->save($connection);
+                        ++$rotated;
+                    }
+                }
+            } finally {
+                $this->unbindTenant();
+            }
+        }
+
+        $io->success($dryRun
+            ? \sprintf('%d of %d connection(s) need credential rotation.', $rotated, $scanned)
+            : \sprintf('Rotated %d of %d connection(s) to the active key version.', $rotated, $scanned));
+
+        return Command::SUCCESS;
+    }
+
+    private function bindTenant(Tenant $tenant): void
+    {
+        $this->tenantContext->set($tenant);
+        // tenant-safe: infrastructure (establishes the tenant_id RLS policies read in this CLI session; this IS the tenant boundary, not a bypass)
+        $this->connection->executeStatement(
+            "SELECT set_config('app.current_tenant', :tenant_id, false)",
+            ['tenant_id' => $tenant->getId()->toRfc4122()],
+        );
+        // tenant-safe: infrastructure (the rotation CLI never runs as super-admin)
+        $this->connection->executeStatement("SELECT set_config('app.is_super_admin', 'false', false)");
+    }
+
+    private function unbindTenant(): void
+    {
+        $this->tenantContext->clear();
+        // tenant-safe: infrastructure (resets the RLS tenant marker so the next tenant in the sweep starts clean)
+        $this->connection->executeStatement("SELECT set_config('app.current_tenant', '', false)");
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Application/ConnectionCredentialsCipherTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Application/ConnectionCredentialsCipherTest.php
@@ -70,9 +70,83 @@ final class ConnectionCredentialsCipherTest extends TestCase
         self::assertSame([], $cipher->reveal($this->connection()));
     }
 
+    #[Test]
+    public function rotateIfNeededReEncryptsStaleCredentials(): void
+    {
+        $credentials = ['header' => 'X-Api-Key', 'value' => 's3cr3t'];
+
+        // Sealed under key v1.
+        $connection = $this->connection();
+        new ConnectionCredentialsCipher($this->versionedEncryption(1))->apply($connection, $credentials);
+        self::assertSame(1, $connection->getCredentialsKeyVersion());
+
+        // Active key is now v2 — the stale blob must rotate up.
+        $cipher = new ConnectionCredentialsCipher($this->versionedEncryption(2));
+        self::assertTrue($cipher->needsRotation($connection));
+        self::assertTrue($cipher->rotateIfNeeded($connection));
+
+        self::assertSame(2, $connection->getCredentialsKeyVersion());
+        self::assertSame($credentials, $cipher->reveal($connection), 'credentials survive rotation');
+        // Idempotent: a second sweep is a no-op once on the active version.
+        self::assertFalse($cipher->needsRotation($connection));
+        self::assertFalse($cipher->rotateIfNeeded($connection));
+    }
+
+    #[Test]
+    public function rotateIfNeededIsNoopWhenAlreadyOnActiveVersion(): void
+    {
+        $cipher = new ConnectionCredentialsCipher($this->versionedEncryption(2));
+        $connection = $this->connection();
+        $cipher->apply($connection, ['token' => 'abc']);
+        $before = $connection->getCredentialsCiphertext();
+
+        self::assertFalse($cipher->rotateIfNeeded($connection));
+        self::assertSame($before, $connection->getCredentialsCiphertext());
+    }
+
+    #[Test]
+    public function rotateIfNeededIsNoopWhenNoCredentialsStored(): void
+    {
+        $cipher = new ConnectionCredentialsCipher($this->versionedEncryption(2));
+
+        self::assertFalse($cipher->needsRotation($this->connection()));
+        self::assertFalse($cipher->rotateIfNeeded($this->connection()));
+    }
+
     private function connection(): Connection
     {
         return new Connection('idosell', 'IdoSell PL', 'https://api.idosell.com', AuthType::ApiKey);
+    }
+
+    /**
+     * Fake whose active version is configurable and which flags any blob older
+     * than that as needing rotation — mirrors AesGcmEncryptionService's versioned
+     * contract without touching libsodium.
+     */
+    private function versionedEncryption(int $activeVersion): EncryptionServiceInterface
+    {
+        return new class($activeVersion) implements EncryptionServiceInterface {
+            public function __construct(private readonly int $activeVersion)
+            {
+            }
+
+            public function encrypt(string $plaintext): EncryptedSecret
+            {
+                return new EncryptedSecret(base64_encode($plaintext), $this->activeVersion);
+            }
+
+            public function decrypt(EncryptedSecret $secret): string
+            {
+                $decoded = base64_decode($secret->ciphertext, true);
+
+                return false === $decoded ? '' : $decoded;
+            }
+
+            public function needsRotation(EncryptedSecret $secret): bool
+            {
+                return $secret->version < $this->activeVersion;
+            }
+        };
     }
 
     private function fakeEncryption(): EncryptionServiceInterface

--- a/docs/operations/connection-credentials-rotation-runbook.md
+++ b/docs/operations/connection-credentials-rotation-runbook.md
@@ -1,0 +1,136 @@
+# Connection credentials rotation runbook — BYOK key rotacja dla konektorów
+
+> APIC-P5-03 (ADR-0022 / ADR-0017). Jak rotować klucz BYOK, którym szyfrowane
+> są credentiale zewnętrznych API w `integration_connections`, bez przestoju
+> synchronizacji i bez wycieku starego klucza w danych at-rest.
+
+## TL;DR
+
+1. Wygeneruj nowy 32-bajtowy klucz, dodaj go jako `APP_BYOK_KEY_V{n}` (n > obecne).
+2. Deploy — od tej chwili **każdy nowy zapis** credentiali używa `vN`, a stare
+   wiersze nadal się odszyfrowują swoim oryginalnym kluczem (oba klucze załadowane).
+3. `php bin/console integration:credentials:rotate --dry-run` — ile wierszy czeka.
+4. `php bin/console integration:credentials:rotate` — re-encrypt wszystkich starych
+   wierszy do `vN` (idempotentne, per-tenant, RLS-safe).
+5. Gdy `--dry-run` pokazuje `0 of N` — stary klucz `v{n-1}` można wycofać z env.
+
+---
+
+## Model szyfrowania (kontekst)
+
+Credentiale konektora (`{header,value}` / `{user,pass}` / `{token}` zależnie od
+`AuthType`) są szyfrowane **odwracalnie** (AES-256-GCM, libsodium) — w przeciwieństwie
+do kluczy producenta, które są **hashowane** (Argon2id). Runtime synchronizacji
+musi odszyfrować credentiale i odtworzyć je przeciwko zdalnemu API, więc szyfr
+musi być odwracalny. Dwa mechanizmy współistnieją świadomie — patrz ADR-0022.
+
+`AesGcmEncryptionService` trzyma mapę `wersja => 32-bajtowy klucz`. **Najwyższy
+numer wersji jest aktywny** (używany do nowych zapisów); starsze wersje zostają
+załadowane, żeby istniejące wiersze dekryptowały się bez wymuszonego sweepu.
+Kolumny na encji `Connection`: `credentials_ciphertext` (TEXT, base64
+`wersja || ciphertext+tag`) + `credentials_key_version` (INT).
+
+`EncryptionServiceInterface::needsRotation(EncryptedSecret)` zwraca `true`, gdy
+blob był zaszyfrowany wersją starszą niż aktywna — dokładnie wzorzec, którego
+Argon2id używa do `needs_rehash`.
+
+## Lazy re-encrypt
+
+`ConnectionCredentialsCipher::rotateIfNeeded(Connection)` to prymityw lazy
+re-encrypt: jeśli wiersz jest na starej wersji → odszyfrowuje starym kluczem,
+ponownie szyfruje aktywnym i nadpisuje obie kolumny w miejscu, zwracając `true`
+(sygnał dla wołającego, żeby zrobić `flush`). Nowe zapisy (`apply()`, np. przez
+`ConnectionProcessor` przy POST/PATCH) **od razu** używają aktywnego klucza, więc
+rotacji wymagają tylko wiersze nietknięte od czasu dodania nowego klucza — i te
+domyka sweep `integration:credentials:rotate`.
+
+> **Świadome odejście:** rotacja NIE jest wpięta w gorącą ścieżkę odczytu
+> (`GenericRestClient::authHeaders`) — klient HTTP to infrastruktura i nie powinien
+> robić `flush` ORM w pętli pull/push. Rotacja jest sterowana idempotentnym
+> sweepem; on-read auto-rotacja w runtime sync to kandydat na follow-up, gdyby
+> profil rotacji tego wymagał.
+
+---
+
+## Krok po kroku
+
+### 1. Wygeneruj nowy klucz
+
+```bash
+openssl rand -base64 32          # 32 losowe bajty, base64 (format env var)
+```
+
+### 2. Dodaj jako kolejną wersję (NIE nadpisuj poprzedniej)
+
+Klucze BYOK są sekretami runtime → **Symfony Secrets Vault** lub env
+(`%env(...)%`), nigdy w repo. Jeśli aktywne jest `APP_BYOK_KEY_V1`, dodaj
+`APP_BYOK_KEY_V2` — obie zmienne muszą być obecne, żeby stare wiersze nadal się
+dekryptowały:
+
+```dotenv
+APP_BYOK_KEY_V1=<stary base64 32-byte>   # zostaje aż sweep dobiegnie końca
+APP_BYOK_KEY_V2=<nowy base64 32-byte>    # nowa wersja aktywna
+```
+
+Mapowanie env → service: patrz `secrets-runbook.md` (warstwa „application-level
+sekrety czytane w runtime").
+
+### 3. Deploy
+
+Po restarcie procesów (api + worker) aktywną wersją jest najwyższy `V{n}`.
+Od tej chwili każdy nowy/edytowany connection zapisuje się na `vN`; stare wiersze
+działają dalej na swoim kluczu.
+
+### 4. Sprawdź ile wymaga rotacji (dry-run)
+
+```bash
+docker compose exec api php bin/console integration:credentials:rotate --dry-run
+# => "3 of 12 connection(s) need credential rotation."
+```
+
+### 5. Wykonaj sweep
+
+```bash
+docker compose exec api php bin/console integration:credentials:rotate
+# => "Rotated 3 of 12 connection(s) to the active key version."
+```
+
+Sweep jest **per-tenant** (ustawia GUC `app.current_tenant` + `TenantContext`,
+tak jak `integration:sync:dispatch-due`), więc FORCE RLS nie ukrywa wierszy, a
+izolacja tenantów jest zachowana. Jest **idempotentny** — ponowne uruchomienie
+pominie wiersze już na aktywnej wersji.
+
+### 6. Wycofaj stary klucz
+
+Gdy `--dry-run` zwraca `0 of N`, żaden wiersz nie jest już zaszyfrowany starym
+kluczem. Usuń `APP_BYOK_KEY_V{n-1}` z env/vault i zrób deploy. Od teraz tylko
+aktywny klucz jest w pamięci procesu.
+
+---
+
+## Harmonogram / automatyzacja
+
+Sweep jest tani i idempotentny — można go uruchamiać planowo (np. nocny cron
+obok maintenance) albo ad-hoc po każdej rotacji klucza. Nie wymaga okna
+przestoju: synchronizacje w locie działają na starym kluczu aż do momentu, gdy
+sweep podmieni ich wiersz.
+
+## Weryfikacja
+
+- `--dry-run` → `0 of N` po sweepie = wszystkie wiersze na aktywnej wersji.
+- SQL kontrolne (per tenant, z ustawionym GUC):
+  ```sql
+  SELECT credentials_key_version, count(*)
+  FROM integration_connections
+  WHERE credentials_ciphertext IS NOT NULL
+  GROUP BY 1;
+  ```
+  Po sweepie wszystkie wiersze powinny mieć aktywny numer wersji.
+- Smoke: po sweepie wykonaj „Test połączenia" w UI konektora — odszyfrowanie
+  pod nowym kluczem musi dać 2xx z remote (auth nadal działa).
+
+## Powiązane
+
+- `secrets-runbook.md` — gdzie trzymać `APP_BYOK_KEY_V*` (vault vs env).
+- ADR-0017 — algorytm + wersjonowanie BYOK.
+- ADR-0022 — granica konsument/producent, dlaczego szyfr odwracalny (nie hash).


### PR DESCRIPTION
## Cel

Rotacja klucza BYOK, którym szyfrowane są credentiale konektorów, bez przestoju synchronizacji i bez pozostawiania ciphertext-u starego klucza at-rest (M5 Hardening).

## Zakres

- **`ConnectionCredentialsCipher::needsRotation(Connection)`** — niemutujący check „blob na starej wersji klucza".
- **`ConnectionCredentialsCipher::rotateIfNeeded(Connection)`** — lazy re-encrypt: odszyfrowuje starym kluczem, ponownie szyfruje aktywnym, nadpisuje kolumny w miejscu, zwraca `bool` (wzorzec Argon2id `needs_rehash`). Nowe zapisy i tak używają aktywnego klucza przez `apply()`.
- **`integration:credentials:rotate`** — sweep per-tenant (GUC `app.current_tenant` + `TenantContext`, jak `integration:sync:dispatch-due`), idempotentny, z `--dry-run`.
- **Runbook** `docs/operations/connection-credentials-rotation-runbook.md` — workflow add-key → deploy → sweep → retire-key + SQL/smoke weryfikacja.

## Testy

- Layer 1 (unit): `ConnectionCredentialsCipherTest` rozszerzony — re-encrypt stale (v1→v2, credentiale przetrwają, idempotencja), no-op gdy już aktywna wersja, no-op bez credentiali. 7 testów / 19 asercji, zielone in-container. PHPStan max + Deptrac + CS-Fixer czyste.

## Świadome odejście

On-read auto-rotacja w gorącej ścieżce `GenericRestClient` celowo NIE wpięta — klient HTTP to infrastruktura i nie powinien robić `flush` ORM w pętli sync. Rotacja jest sterowana idempotentnym sweepem; on-read jest kandydatem na follow-up.

Closes #1801