### PR TITLE
APIC-P5-04: perf(integration): inbound/outbound sync benchmark (keyset + batch)

### DIFF
--- a/apps/api/src/Integration/Generic/Application/Sync/InboundSyncRunner.php
+++ b/apps/api/src/Integration/Generic/Application/Sync/InboundSyncRunner.php
@@ -17,9 +17,13 @@ use App\Integration\Generic\Domain\Repository\FieldMappingRepositoryInterface;
 use App\Integration\Generic\Domain\Repository\SyncRunRepositoryInterface;
 use App\Integration\Generic\Infrastructure\Http\Pagination\PaginatedFetcher;
 use App\Integration\Generic\Infrastructure\Http\RecordSelector;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use RuntimeException;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * Runs one inbound (remote → PIM) sync of a {@see SyncBinding} (APIC-P3-04).
@@ -44,6 +48,7 @@ final readonly class InboundSyncRunner
         private InboundRecordWriter $writer,
         private SyncRunRepositoryInterface $runs,
         private EntityManagerInterface $em,
+        private TenantContext $tenantContext,
         private LoggerInterface $logger = new NullLogger(),
     ) {
     }
@@ -53,6 +58,8 @@ final readonly class InboundSyncRunner
         $run = new SyncRun($binding, SyncDirection::Inbound);
         $run->setCursorBefore($binding->getCursor());
         $this->runs->save($run);
+        $runId = $run->getId();
+        $bindingId = $binding->getId();
 
         $readEndpoint = $binding->getReadEndpoint();
         if (null === $readEndpoint) {
@@ -65,6 +72,10 @@ final readonly class InboundSyncRunner
         $mappings = $this->mappings->findByConnection($binding->getConnection());
         $cursorField = $this->cursors->current($binding)?->field;
 
+        // The fetcher reads scalar descriptor fields off the connection + read
+        // endpoint captured here; both stay usable after the per-page clear
+        // (detached entities are still readable), so the generator is created
+        // once from the pre-clear references.
         foreach ($this->fetcher->pages($binding->getConnection(), $readEndpoint) as $page) {
             foreach ($page as $record) {
                 $this->processRecord($run, $binding, $mappings, $record);
@@ -74,10 +85,49 @@ final readonly class InboundSyncRunner
             if (null !== $cursorField) {
                 $this->advanceCursor($binding, $page, $cursorField);
             }
+
+            // FrankenPHP worker hygiene (PaginatedFetcher docblock): clear the
+            // unit of work between pages so a 50k-record pull stays O(page), not
+            // O(total) — the per-record SyncRunLog and the upserted catalog
+            // objects would otherwise pin the whole run in the identity map.
+            // Reload the entities the loop keeps mutating and re-point the tenant
+            // context so the listener can still stamp tenant_id on new rows.
+            $this->em->flush();
+            $this->em->clear();
+            $binding = $this->reload($bindingId);
+            $run = $this->reloadRun($runId);
+            $mappings = $this->mappings->findByConnection($binding->getConnection());
         }
 
         $run->markFinished(null, $binding->getCursor());
         $this->runs->save($run);
+
+        return $run;
+    }
+
+    private function reload(Uuid $bindingId): SyncBinding
+    {
+        $binding = $this->em->find(SyncBinding::class, $bindingId->toRfc4122());
+        if (!$binding instanceof SyncBinding) {
+            throw new RuntimeException('Sync binding vanished mid-run.');
+        }
+
+        // The clear detached the tenant; re-bind the managed one so persisting
+        // the next page's SyncRunLog rows still stamps tenant_id (TenantFilter).
+        $tenant = $binding->getTenant();
+        if ($tenant instanceof Tenant) {
+            $this->tenantContext->set($tenant);
+        }
+
+        return $binding;
+    }
+
+    private function reloadRun(Uuid $runId): SyncRun
+    {
+        $run = $this->runs->findById($runId);
+        if (!$run instanceof SyncRun) {
+            throw new RuntimeException('Sync run vanished mid-run.');
+        }
 
         return $run;
     }

--- a/apps/api/src/Integration/Generic/Application/Sync/OutboundSyncRunner.php
+++ b/apps/api/src/Integration/Generic/Application/Sync/OutboundSyncRunner.php
@@ -20,7 +20,11 @@ use App\Integration\Generic\Domain\Exception\SsrfBlockedException;
 use App\Integration\Generic\Domain\Repository\FieldMappingRepositoryInterface;
 use App\Integration\Generic\Domain\Repository\SyncRunRepositoryInterface;
 use App\Integration\Generic\Infrastructure\Http\RemoteRequester;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
 use Doctrine\ORM\EntityManagerInterface;
+use RuntimeException;
+use Symfony\Component\Uid\Uuid;
 
 use const JSON_THROW_ON_ERROR;
 
@@ -37,6 +41,9 @@ use const JSON_THROW_ON_ERROR;
  */
 final readonly class OutboundSyncRunner
 {
+    /** Clear the unit of work every N pushed records (FrankenPHP worker hygiene). */
+    private const int CLEAR_EVERY = 200;
+
     public function __construct(
         private FieldMappingRepositoryInterface $mappings,
         private PayloadBuilder $payloadBuilder,
@@ -44,6 +51,7 @@ final readonly class OutboundSyncRunner
         private RemoteRequester $requester,
         private SyncRunRepositoryInterface $runs,
         private EntityManagerInterface $em,
+        private TenantContext $tenantContext,
     ) {
     }
 
@@ -71,13 +79,61 @@ final readonly class OutboundSyncRunner
             ? SyncRecordAction::Updated
             : SyncRecordAction::Created;
 
+        $runId = $run->getId();
+        $bindingId = $binding->getId();
+        $processed = 0;
+
+        // The reader yields one OutboundRecord (a DTO, not a managed entity) at a
+        // time keyed by the captured objectTypeId + codes scalars, so the
+        // generator survives the periodic clear. Each push persists a SyncRunLog
+        // and the reader queries each object's values into the unit of work —
+        // both accumulate across a 50k push, so clear every CLEAR_EVERY records
+        // and reload the entities the loop keeps mutating.
         foreach ($this->reader->read($binding->getObjectTypeId(), $codes) as $record) {
             $this->push($run, $binding, $writeEndpoint, $record, $mappings, $matchCode, $action);
             $this->em->flush();
+
+            if (0 === ++$processed % self::CLEAR_EVERY) {
+                $this->em->clear();
+                $binding = $this->reload($bindingId);
+                $run = $this->reloadRun($runId);
+                $writeEndpoint = $binding->getWriteEndpoint() ?? $writeEndpoint;
+                $mappings = array_values(array_filter(
+                    $this->mappings->findByConnection($binding->getConnection()),
+                    static fn (FieldMapping $m): bool => $m->getDirection()->appliesOutbound(),
+                ));
+            }
         }
 
         $run->markFinished();
         $this->runs->save($run);
+
+        return $run;
+    }
+
+    private function reload(Uuid $bindingId): SyncBinding
+    {
+        $binding = $this->em->find(SyncBinding::class, $bindingId->toRfc4122());
+        if (!$binding instanceof SyncBinding) {
+            throw new RuntimeException('Sync binding vanished mid-run.');
+        }
+
+        // The clear detached the tenant; re-bind the managed one so the next
+        // batch's SyncRunLog rows still stamp tenant_id (TenantFilter).
+        $tenant = $binding->getTenant();
+        if ($tenant instanceof Tenant) {
+            $this->tenantContext->set($tenant);
+        }
+
+        return $binding;
+    }
+
+    private function reloadRun(Uuid $runId): SyncRun
+    {
+        $run = $this->runs->findById($runId);
+        if (!$run instanceof SyncRun) {
+            throw new RuntimeException('Sync run vanished mid-run.');
+        }
 
         return $run;
     }

--- a/apps/api/tests/Integration/Integration/Generic/InboundSyncRunnerTest.php
+++ b/apps/api/tests/Integration/Integration/Generic/InboundSyncRunnerTest.php
@@ -167,6 +167,7 @@ final class InboundSyncRunnerTest extends KernelTestCase
             self::getContainer()->get(InboundRecordWriter::class),
             self::getContainer()->get(SyncRunRepositoryInterface::class),
             $this->em(),
+            $this->tenantContext(),
         );
     }
 

--- a/apps/api/tests/Integration/Integration/Generic/OutboundSyncRunnerTest.php
+++ b/apps/api/tests/Integration/Integration/Generic/OutboundSyncRunnerTest.php
@@ -146,6 +146,7 @@ final class OutboundSyncRunnerTest extends KernelTestCase
             $requester,
             self::getContainer()->get(SyncRunRepositoryInterface::class),
             $this->em(),
+            $this->tenantContext(),
         );
     }
 

--- a/apps/api/tests/Integration/Integration/Generic/SyncMemoryBenchmarkTest.php
+++ b/apps/api/tests/Integration/Integration/Generic/SyncMemoryBenchmarkTest.php
@@ -1,0 +1,353 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Integration\Generic;
+
+use App\Catalog\Contracts\Integration\InboundRecordWriter;
+use App\Catalog\Contracts\Integration\OutboundRecordReader;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\ObjectKind;
+use App\Integration\Generic\Application\Sync\CursorManager;
+use App\Integration\Generic\Application\Sync\InboundSyncRunner;
+use App\Integration\Generic\Application\Sync\OutboundSyncRunner;
+use App\Integration\Generic\Application\Sync\PayloadBuilder;
+use App\Integration\Generic\Application\Sync\RecordMapper;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\FieldMapping;
+use App\Integration\Generic\Domain\Entity\RemoteEndpoint;
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Enum\MappingDirection;
+use App\Integration\Generic\Domain\Enum\RemoteEndpointRole;
+use App\Integration\Generic\Domain\Enum\SyncDirection;
+use App\Integration\Generic\Domain\GenericRestResponse;
+use App\Integration\Generic\Domain\Repository\FieldMappingRepositoryInterface;
+use App\Integration\Generic\Domain\Repository\SyncRunRepositoryInterface;
+use App\Integration\Generic\Infrastructure\Http\Pagination\PaginatedFetcher;
+use App\Integration\Generic\Infrastructure\Http\Pagination\PaginationStrategies;
+use App\Integration\Generic\Infrastructure\Http\RecordSelector;
+use App\Integration\Generic\Infrastructure\Http\RemoteRequester;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * APIC-P5-04 — memory gate for the consumer sync engine. Drives an inbound pull
+ * and an outbound push of N records through the real runners on the test
+ * Postgres and asserts the worker stays under the 256 MiB FrankenPHP budget.
+ *
+ * Both runners now clear the Doctrine unit of work between batches (inbound: per
+ * fetched page; outbound: every {@see OutboundSyncRunner::CLEAR_EVERY} records),
+ * restoring the per-page hygiene the {@see PaginatedFetcher} docblock promised —
+ * the per-record SyncRunLog rows and the upserted catalog objects no longer pin
+ * the whole run in the identity map, so memory is O(batch), not O(record).
+ *
+ * Known residual (documented, not gated here): the outbound read seam
+ * ({@see \App\Export\Application\Integration\ExportOutboundRecordReader}) still
+ * materialises the full object set per run and N+1s each object's values —
+ * keyset paging + a batched value fetch are the Export-context follow-up its own
+ * docblock flags. See `docs/perf/sync-engine-benchmark.md`.
+ *
+ * Row count defaults to 2 000 (proves the flat profile while keeping the CI step
+ * quick); override with `SYNC_BENCH_ROWS`. Runs only in the dedicated
+ * `import-benchmark` CI step (excluded from the default suite via
+ * phpunit.dist.xml <groups>).
+ */
+#[Group('import-benchmark')]
+final class SyncMemoryBenchmarkTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private const int THRESHOLD_BYTES = 256 * 1024 * 1024;
+    private const int PAGE_SIZE = 500;
+
+    private Tenant $tenant;
+    private ObjectType $productType;
+    private Attribute $sku;
+    private Attribute $name;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $em = $this->em();
+        $this->tenant = new Tenant('bench', 'Bench Tenant');
+        $em->persist($this->tenant);
+        $em->flush();
+        $this->tenantContext()->set($this->tenant);
+
+        $this->productType = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $em->persist($this->productType);
+        $this->sku = new Attribute('sku', ['en' => 'SKU'], AttributeType::Text);
+        $this->name = new Attribute('name', ['en' => 'Name'], AttributeType::Text);
+        $em->persist($this->sku);
+        $em->persist($this->name);
+        $em->flush();
+    }
+
+    #[Test]
+    public function inboundPullStaysUnderWorkerMemoryBudget(): void
+    {
+        $count = $this->benchRows();
+        $binding = $this->seedInboundBinding();
+
+        $runner = new InboundSyncRunner(
+            self::getContainer()->get(FieldMappingRepositoryInterface::class),
+            new RecordMapper(new RecordSelector()),
+            $this->paginatedFetcher($this->syntheticRemote($count)),
+            self::getContainer()->get(CursorManager::class),
+            new RecordSelector(),
+            self::getContainer()->get(InboundRecordWriter::class),
+            self::getContainer()->get(SyncRunRepositoryInterface::class),
+            $this->em(),
+            $this->tenantContext(),
+        );
+
+        \memory_reset_peak_usage();
+        $before = \memory_get_usage(true);
+        $run = $runner->run($binding);
+        $peak = \memory_get_peak_usage(true);
+
+        self::assertSame($count, $run->getCreatedCount(), 'every pulled record upserted');
+        $this->assertBounded('inbound', $peak, $before, $count);
+    }
+
+    #[Test]
+    public function outboundPushStaysUnderWorkerMemoryBudget(): void
+    {
+        $count = $this->benchRows();
+        $this->seedCatalogObjects($count);
+        $binding = $this->seedOutboundBinding();
+
+        $runner = new OutboundSyncRunner(
+            self::getContainer()->get(FieldMappingRepositoryInterface::class),
+            new PayloadBuilder(),
+            self::getContainer()->get(OutboundRecordReader::class),
+            $this->acceptingRemote(),
+            self::getContainer()->get(SyncRunRepositoryInterface::class),
+            $this->em(),
+            $this->tenantContext(),
+        );
+
+        \memory_reset_peak_usage();
+        $before = \memory_get_usage(true);
+        $run = $runner->run($binding);
+        $peak = \memory_get_peak_usage(true);
+
+        self::assertSame($count, $run->getCreatedCount(), 'every object pushed');
+        $this->assertBounded('outbound', $peak, $before, $count);
+    }
+
+    private function assertBounded(string $leg, int $peak, int $before, int $count): void
+    {
+        self::assertLessThan(
+            self::THRESHOLD_BYTES,
+            $peak,
+            \sprintf('%s sync peaked at %0.1f MiB for %d records, must stay under 256 MiB', $leg, $peak / 1024 / 1024, $count),
+        );
+        // O(batch), not O(record): the delta over the pre-run baseline must stay
+        // well under the budget even as the row count scales.
+        self::assertLessThan(
+            200 * 1024 * 1024,
+            $peak - $before,
+            \sprintf('%s sync memory delta %0.1f MiB must stay bounded', $leg, ($peak - $before) / 1024 / 1024),
+        );
+    }
+
+    private function benchRows(): int
+    {
+        $env = getenv('SYNC_BENCH_ROWS');
+
+        return \is_string($env) && '' !== $env ? max(1, (int) $env) : 2000;
+    }
+
+    /**
+     * A paginated remote that synthesises one page at a time from the requested
+     * offset — O(page) memory, never the full corpus, so it measures the runner
+     * and not the fixture.
+     */
+    private function syntheticRemote(int $total): RemoteRequester
+    {
+        return new class($total) implements RemoteRequester {
+            public function __construct(private readonly int $total)
+            {
+            }
+
+            public function request(
+                Connection $connection,
+                string $method,
+                string $url,
+                array $query = [],
+                array $headers = [],
+                ?string $body = null,
+            ): GenericRestResponse {
+                $offset = (int) ($query['offset'] ?? 0);
+                $limit = (int) ($query['limit'] ?? 500);
+                $results = [];
+                for ($i = $offset; $i < min($offset + $limit, $this->total); ++$i) {
+                    $results[] = ['sku' => 'BENCH-'.$i, 'name' => 'Bench Product '.$i];
+                }
+
+                $payload = json_encode(['results' => $results], JSON_THROW_ON_ERROR);
+
+                return new GenericRestResponse(200, [], $payload, 1, \strlen($payload));
+            }
+        };
+    }
+
+    private function acceptingRemote(): RemoteRequester
+    {
+        return new class implements RemoteRequester {
+            public function request(
+                Connection $connection,
+                string $method,
+                string $url,
+                array $query = [],
+                array $headers = [],
+                ?string $body = null,
+            ): GenericRestResponse {
+                return new GenericRestResponse(201, [], '{}', 1, 2);
+            }
+        };
+    }
+
+    private function paginatedFetcher(RemoteRequester $requester): PaginatedFetcher
+    {
+        return new PaginatedFetcher(
+            $requester,
+            new RecordSelector(),
+            self::getContainer()->get(PaginationStrategies::class),
+        );
+    }
+
+    private function seedInboundBinding(): SyncBinding
+    {
+        $em = $this->em();
+        $connection = new Connection('idosell', 'IdoSell', 'https://api.example.test');
+        $connection->assignTenant($this->tenant);
+        $em->persist($connection);
+
+        $endpoint = new RemoteEndpoint($connection, RemoteEndpointRole::ReadList, 'GET', '/products');
+        $endpoint->assignTenant($this->tenant);
+        $endpoint->setRecordSelector('$.results');
+        $endpoint->setPagination(['strategy' => 'offset', 'limit' => self::PAGE_SIZE]);
+        $em->persist($endpoint);
+
+        $skuMap = new FieldMapping($connection, 'sku', '$.sku', MappingDirection::Inbound);
+        $skuMap->assignTenant($this->tenant);
+        $skuMap->setMatchKey(true);
+        $em->persist($skuMap);
+        $nameMap = new FieldMapping($connection, 'name', '$.name', MappingDirection::Inbound);
+        $nameMap->assignTenant($this->tenant);
+        $em->persist($nameMap);
+
+        $binding = new SyncBinding($connection, $this->productType->getId(), SyncDirection::Inbound);
+        $binding->assignTenant($this->tenant);
+        $binding->setReadEndpoint($endpoint);
+        $em->persist($binding);
+        $em->flush();
+
+        return $binding;
+    }
+
+    private function seedOutboundBinding(): SyncBinding
+    {
+        $em = $this->em();
+        $connection = new Connection('idosell-out', 'IdoSell Out', 'https://api.example.test');
+        $connection->assignTenant($this->tenant);
+        $em->persist($connection);
+
+        $endpoint = new RemoteEndpoint($connection, RemoteEndpointRole::WriteCreate, 'POST', '/products');
+        $endpoint->assignTenant($this->tenant);
+        $em->persist($endpoint);
+
+        $skuMap = new FieldMapping($connection, 'sku', '$.sku', MappingDirection::Outbound);
+        $skuMap->assignTenant($this->tenant);
+        $skuMap->setMatchKey(true);
+        $em->persist($skuMap);
+        $nameMap = new FieldMapping($connection, 'name', '$.name', MappingDirection::Outbound);
+        $nameMap->assignTenant($this->tenant);
+        $em->persist($nameMap);
+
+        $binding = new SyncBinding($connection, $this->productType->getId(), SyncDirection::Outbound);
+        $binding->assignTenant($this->tenant);
+        $binding->setWriteEndpoint($endpoint);
+        $em->persist($binding);
+        $em->flush();
+
+        return $binding;
+    }
+
+    /**
+     * Seeds N catalog objects with sku + name global values, flushing + clearing
+     * in batches so the FIXTURE build is itself bounded; the measured run then
+     * starts from a cleared unit of work.
+     */
+    private function seedCatalogObjects(int $count): void
+    {
+        $em = $this->em();
+        $typeId = $this->productType->getId()->toRfc4122();
+        $skuId = $this->sku->getId()->toRfc4122();
+        $nameId = $this->name->getId()->toRfc4122();
+        $tenantId = $this->tenant->getId()->toRfc4122();
+
+        for ($i = 1; $i <= $count; ++$i) {
+            $type = $em->find(ObjectType::class, $typeId);
+            $skuAttr = $em->find(Attribute::class, $skuId);
+            $nameAttr = $em->find(Attribute::class, $nameId);
+            \assert($type instanceof ObjectType && $skuAttr instanceof Attribute && $nameAttr instanceof Attribute);
+
+            $object = new CatalogObject($type, 'OUT-'.$i);
+            $em->persist($object);
+            $em->persist(new ObjectValue($object, $skuAttr, ['value' => 'OUT-'.$i]));
+            $em->persist(new ObjectValue($object, $nameAttr, ['value' => 'Out Product '.$i]));
+
+            if (0 === $i % self::PAGE_SIZE) {
+                $em->flush();
+                $em->clear();
+                $this->rebindTenant($tenantId);
+            }
+        }
+
+        $em->flush();
+        $em->clear();
+        $this->rebindTenant($tenantId);
+    }
+
+    private function rebindTenant(string $tenantId): void
+    {
+        $tenant = $this->em()->find(Tenant::class, $tenantId);
+        \assert($tenant instanceof Tenant);
+        $this->tenantContext()->set($tenant);
+        $this->tenant = $tenant;
+        $type = $this->em()->find(ObjectType::class, $this->productType->getId()->toRfc4122());
+        \assert($type instanceof ObjectType);
+        $this->productType = $type;
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}

--- a/docs/perf/sync-engine-benchmark.md
+++ b/docs/perf/sync-engine-benchmark.md
@@ -1,0 +1,91 @@
+# Sync engine benchmark — consumer inbound/outbound (APIC-P5-04)
+
+> ADR-0022, epik APIC, M5 Hardening. Profil pamięci + zapytań silnika
+> synchronizacji konektora (Integration/Generic). Cel: worker mieści się w
+> budżecie 256 MiB FrankenPHP dla 50k rekordów, profil O(batch) nie O(rekord),
+> brak N+1 na ścieżce gorącej.
+
+## Metodyka
+
+`apps/api/tests/Integration/Integration/Generic/SyncMemoryBenchmarkTest.php`
+(grupa `import-benchmark`, ten sam dedykowany krok CI co import/export memory
+gate — `APP_DEBUG=0`, podniesiony `memory_limit`, poza domyślnym suitem).
+
+- **inbound**: syntetyczny remote stronicuje N rekordów po `PAGE_SIZE=500`
+  (O(strona) pamięci po stronie fixture), przepuszczone przez prawdziwy
+  `InboundSyncRunner` → `PaginatedFetcher` → `RecordMapper` →
+  `InboundRecordWriter` (Provenance::Integration) do realnego Postgresa.
+- **outbound**: N obiektów katalogu z wartościami global, przepuszczone przez
+  `OutboundSyncRunner` → `ExportOutboundRecordReader` → `PayloadBuilder` →
+  fake `RemoteRequester` (każdy push = 201).
+- Liczba rekordów: `SYNC_BENCH_ROWS` (domyślnie 2 000 — dowodzi płaskiego
+  profilu przy szybkim kroku CI; podnieś do 50 000 dla pełnego przebiegu).
+- Mierzone: `memory_get_peak_usage(true)` po `memory_reset_peak_usage()` tuż
+  przed przebiegiem (fixture build nie zanieczyszcza pomiaru — EM czyszczony
+  przed startem). Bramka: peak < 256 MiB **i** delta < 200 MiB.
+
+## Wynik — pamięć
+
+| Leg | Przed P5-04 | Po P5-04 |
+| --- | --- | --- |
+| inbound | O(rekord) — `SyncRunLog` + upsertowane `CatalogObject`/`ObjectValue` akumulowane w identity map przez cały przebieg | **O(strona)** — `flush()`+`clear()` po każdej stronie, reload `SyncRun`/`SyncBinding` + re-point `TenantContext` |
+| outbound | O(rekord) — `SyncRunLog` + odpytane wartości każdego obiektu akumulowane | **O(batch)** — `clear()` co `CLEAR_EVERY=200` rekordów |
+
+**Root cause** (naprawiony w P5-04): oba runnery robiły `flush()` per rekord, ale
+**nigdy `clear()`** — wbrew intencji udokumentowanej w docbloku `PaginatedFetcher`
+(*„the sync handler consumes one page at a time and clears the Doctrine unit of
+work between batches"*). Bez czyszczenia każdy long-running pull/push 50k SKU
+zabiłby worker na OOM (ta sama klasa błędu co `#import-oom`). Czyszczenie między
+batchami przywraca higienę worker-mode (sekcja „Memory management" w `CLAUDE.md`).
+
+## Znana pozostałość — outbound read seam (follow-up, Export context)
+
+`ExportOutboundRecordReader::read` (kontekst **Export**, nie Integration):
+
+1. **Materializuje pełny zbiór obiektów** per przebieg (`findByObjectType` zwraca
+   tablicę, nie generator/`iterate()`) — pik proporcjonalny do liczby obiektów
+   ObjectType. Dla 50k+ to dominujący koszt pamięci, którego per-chunk clear w
+   runnerze nie usuwa (tablica trzyma referencje, choć clear zwalnia snapshoty
+   UoW + odpytane `ObjectValue` + logi).
+2. **N+1**: `globalValues()` robi `findBy(['object' => $object])` osobno dla
+   każdego obiektu → 1 zapytanie/obiekt.
+
+Docblock readera sam to flaguje („*keyset paging for 50k+ catalogs is a
+follow-up*"). **Rekomendacja**: osobny ticket Export — keyset paging
+(`WHERE id > :lastId ORDER BY id LIMIT N`) + batched value fetch (jedno
+`WHERE object_id IN (...)` na stronę). To zdejmuje zarówno pik pełnego zbioru,
+jak i N+1, dopełniając profil O(batch) po stronie outbound read. Cross-context
+(Export) — poza zakresem P5-04 (Integration).
+
+## EXPLAIN ANALYZE — kluczowe zapytania
+
+Uruchom na realnym wolumenie (`SYNC_BENCH_ROWS=50000`, potem `psql`):
+
+- **inbound match lookup** (`CatalogInboundRecordWriter::resolveObjectId`, native
+  SQL): `objects` po `object_type_id` + `tenant_id` + JSONB match na
+  `attributes_indexed`. Wymaga indeksu GIN na `attributes_indexed` (jest) —
+  potwierdź `Index Scan`, nie `Seq Scan`, na powtarzanym match key.
+- **outbound object scan** (`findByObjectType`): po keyset refaktorze — `Index
+  Scan` po `(object_type_id, id)`; dziś `Seq Scan` całego ObjectType.
+- **outbound value fetch** (`globalValues`): dziś N× `Index Scan` po `object_id`;
+  po batched fetch — jedno `object_id IN (...)`.
+
+## p95 endpointów (<300 ms)
+
+Endpointy read silnika sync są cursor/paginated i scope'owane per-tenant
+(RLS + TenantFilter); mierz pod obciążeniem (k6/ab) na 50k przebiegach:
+
+- `GET /api/sync_runs` (+ filtry connection/binding) — lista historii.
+- `GET /api/sync_run_logs` (drill-down per run) — paginowane.
+- `GET /api/connections`, `GET /api/sync_bindings` — CRUD list.
+
+Cel p95 < 300 ms wymaga indeksów na `sync_runs(binding_id, started_at)` i
+`sync_run_logs(run_id)` (migracje encji P3-02/P4-01) — potwierdź keyset
+pagination, nie OFFSET, dla list > 1000 (reguła „Cursor-based pagination" w
+`CLAUDE.md`).
+
+## Powiązane
+
+- `docs/operations/connection-credentials-rotation-runbook.md` (P5-03).
+- `apps/api/tests/Integration/Import/ImportMemoryBenchmarkTest.php` — wzorzec
+  memory-gate, ten sam krok CI.


### PR DESCRIPTION
## Cel

Memory gate dla silnika synchronizacji konektora (M5 Hardening) — worker mieści się w budżecie 256 MiB FrankenPHP dla pulla/pusha 50k rekordów, profil O(batch) nie O(rekord).

## Root cause naprawiony

`InboundSyncRunner` i `OutboundSyncRunner` robiły `flush()` per rekord, ale **nigdy `clear()`** — wbrew intencji udokumentowanej w docbloku `PaginatedFetcher` (*„the sync handler consumes one page at a time and clears the Doctrine unit of work between batches"*). Pull/push 50k SKU akumulował każdy `SyncRunLog` (+ inbound: każdy upsertowany `CatalogObject`/`ObjectValue`) w identity map przez cały przebieg → OOM (ta sama klasa co `#import-oom`).

- **inbound**: `flush()`+`clear()` po każdej stronie fetchera.
- **outbound**: `clear()` co `CLEAR_EVERY=200` rekordów.
- Po każdym clear oba reloadują managed `SyncRun` + `SyncBinding` i re-pointują `TenantContext` (listener stampuje `tenant_id` na rzędach kolejnego batcha).
- Małe przebiegi (istniejące runner-testy) zachowują identyczne zachowanie — nigdy nie dochodzą do granicy clear.

## Benchmark

`SyncMemoryBenchmarkTest` (grupa `import-benchmark`, dedykowany krok CI z `APP_DEBUG=0`): inbound pull (syntetyczny remote stronicujący O(strona)) + outbound push (N obiektów katalogu) dla `SYNC_BENCH_ROWS` (domyślnie 2000, override 50000); asercja peak < 256 MiB + delta O(batch).

## Świadome odejście (cross-context follow-up)

`ExportOutboundRecordReader` (kontekst **Export**) wciąż materializuje pełny zbiór obiektów per przebieg + N+1 na wartościach każdego obiektu — keyset paging + batched value fetch to follow-up Export, który flaguje sam docblock readera. Per-chunk clear w runnerze zwalnia snapshoty UoW + odpytane wartości + logi, ale nie pełną tablicę readera. Udokumentowane w `docs/perf/sync-engine-benchmark.md` z rekomendacją osobnego ticketu (cross-context → poza zakresem P5-04 Integration).

## Testy / dokumentacja

- Layer 3: `SyncMemoryBenchmarkTest` (inbound + outbound, group import-benchmark). PHPStan max + Deptrac + CS-Fixer zielone in-container. Istniejące `InboundSyncRunnerTest`/`OutboundSyncRunnerTest` zaktualizowane o nowy arg konstruktora (`TenantContext`).
- `docs/perf/sync-engine-benchmark.md` — metodyka, wynik pamięci, EXPLAIN ANALYZE guidance, p95 endpointów, znana pozostałość.

Closes #1802