### PR TITLE
APIC-P5-05: docs(integration): consumer connector + producer operator guide

### DIFF
--- a/docs/integration/api-configurator-guide.md
+++ b/docs/integration/api-configurator-guide.md
@@ -1,0 +1,168 @@
+# Konfigurator API — przewodnik konsumenta + producenta
+
+> ADR-0022 (`docs/adr/0022-api-configurator-consumer-producer-boundary.md`),
+> epik APIC. Konfigurator API ma **dwa oblicza** pod jednym shellem
+> (`/integrations/api-configurator`):
+>
+> - **Konsument** — PIM pobiera/wysyła dane z/do **dowolnego zewnętrznego API**
+>   (Połączenia, mapowanie, harmonogram, monitor).
+> - **Producent** — PIM **wystawia własne API** partnerom (profile read-only,
+>   klucze, webhooki).
+>
+> Shell przełącza się zakładkami **Połączenia / Moje API / Monitor**
+> (`KonfiguratorApiLayout`).
+
+---
+
+## Część A — Konsument (PIM ↔ zewnętrzne API)
+
+### A.1 Utworzenie połączenia
+
+- **UI**: zakładka *Połączenia* → *Nowe połączenie* (kreator,
+  `/integrations/api-configurator/connections`). Krok 1–2: base URL + typ
+  uwierzytelnienia (`none` / `api_key` / `basic` / `bearer` / `oauth2_token`)
+  i sekret.
+- **API**: `POST /api/connections` (API Platform). Credentiale są **szyfrowane
+  odwracalnie at-rest** (BYOK AES-256-GCM) — nigdy nie wracają w odpowiedzi API
+  (maskowane przy serializacji).
+- Base URL przechodzi walidację deskryptora (`DescriptorValidator`): tylko
+  absolutne `http(s)` z hostem; bez wstrzyknięć schematu/hosta w szablonach
+  ścieżek.
+
+### A.2 Test połączenia
+
+- **UI**: przycisk *Testuj połączenie* w kreatorze / detalu.
+- **API**: `POST /api/connections/{id}/test` — strzela health/auth-check przez
+  **SSRF-safe klienta**; zwraca status + komunikat. 2xx = OK, 4xx/5xx = błąd do
+  poprawy przed dalszą konfiguracją.
+
+### A.3 Odkrycie schematu (endpointy + pola)
+
+- **UI**: kroki kreatora 3–4 (endpointy + discovery).
+- **API**: `POST /api/connections/{id}/discover` — pobiera próbkę, spłaszcza
+  JSON i proponuje `RemoteField`-y. Endpointy (`RemoteEndpoint`) mają rolę
+  (`read_list` / `write_create` / `write_update`), metodę HTTP, szablon ścieżki,
+  selektor rekordów (np. `$.results`) i strategię paginacji
+  (`none`/`offset`/`page`/`cursor`/`link_header`).
+
+### A.4 Mapowanie pól 1:1
+
+- **UI**: ekran *Mapowanie* (`MappingScreen`).
+- **API**: `FieldMapping` (API Platform) + walidacja
+  `POST /api/connections/{id}/mappings/validate` — ostrzega przy niezgodności
+  typów. Mapowanie ma kierunek (`inbound` / `outbound` / `both`) i flagę
+  `matchKey` (po czym dopasowujemy istniejący obiekt przy upsercie).
+
+### A.5 Synchronizacja: powiązanie + harmonogram
+
+- **UI**: ekran *Synchronizacja* (`SyncConfigScreen`).
+- **API**: `SyncBinding` (API Platform) — wiąże połączenie + `ObjectType` +
+  kierunek; akcje:
+  - `POST /api/sync_bindings/{id}/run` — odpal teraz,
+  - `POST /api/sync_bindings/{id}/pause` / `…/resume` — wstrzymaj/wznów.
+- **Harmonogram**: wyrażenie cron + jitter; due-bindings odpala planowo komenda
+  `integration:sync:dispatch-due` (Symfony Scheduler → transport `import`).
+- **Konflikt bidirectional**: polityka per binding —
+  `last_write_wins` / `pim_wins` / `remote_wins`; anti-loop po `provenance`
+  (zapisy z integracji oznaczone `Provenance::Integration`).
+- **Delta sync**: kursor monotoniczny, crash-safe (advance raz na stronę);
+  re-run pobiera tylko okno od ostatniego kursora (upsert idempotentny).
+
+### A.6 Monitoring
+
+- **UI**: zakładka *Monitor* (`SyncMonitorScreen`) — KPI + lista przebiegów +
+  drill-down per rekord.
+- **API**: `GET /api/sync_runs` (filtry connection/binding) i
+  `GET /api/sync_run_logs` (per run). Każdy przebieg = `SyncRun` z licznikami
+  created/updated/skipped/failed; każdy rekord = `SyncRunLog` (akcja, match key,
+  komunikat).
+
+---
+
+## Część B — Producent (PIM jako API dla partnerów)
+
+### B.1 Profile API
+
+- **UI**: zakładka *Moje API* → builder profilu
+  (`/integrations/api-configurator/create`, `ProfileBuilderPage`). Wybierasz
+  `ObjectType`-y + atrybuty + filtry; profil jest **projekcją read-only** w MVP.
+- **API**: `ApiProfile` (API Platform). Pula atrybutów do buildera:
+  `GET /api/profiles/builder_options`.
+
+### B.2 Per-profile OpenAPI
+
+- `GET /api/docs/profile/{id}.jsonopenapi` — wycinek OpenAPI zawężony do
+  ścieżek `/api/(products|categories|assets|objects)` + metadane `x-pim-*`
+  konkretnego profilu (partner dostaje kontrakt tylko dla swojego zakresu).
+
+### B.3 Klucze API
+
+- Klucze są **hashowane Argon2id** (PIM tylko weryfikuje przychodzący klucz —
+  nie musi go odszyfrować, w przeciwieństwie do credentiali konsumenta).
+- Zakładka *Klucze* w producer hubie — tworzenie/rotacja.
+
+### B.4 Webhooki
+
+- **Test**: `POST /api/api_profiles/{id}/test_webhook` — wysyła testowy fan-out
+  (HMAC-podpisany).
+- **Rotacja sekretu**: `POST /api/api_profiles/{id}/rotate_webhook_secret`.
+- **Dostawy + retry**: `WebhookDelivery` z historią dostaw; nieudane dostawy
+  retry'owane przez transport `async` (5× exponential → dead-letter). Historia:
+  `GET /api/webhook_deliveries` (filtr per profil).
+
+---
+
+## Część C — Noty bezpieczeństwa
+
+### C.1 SSRF (konsument)
+
+Każde wyjście HTTP konsumenta idzie przez dwie warstwy obrony:
+
+1. **`SsrfGuard`** (pre-filter) — odrzuca prywatne (RFC1918), loopback,
+   link-local/metadata (`169.254.169.254`), IPv6 ULA/link-local, schematy inne
+   niż `http(s)`, hostnamy rozwiązujące się w przestrzeń prywatną, URL bez hosta.
+2. **`NoPrivateNetworkHttpClient`** (`generic.ssrf_safe_http_client`) —
+   re-walidacja peer-IP per-redirect (zamyka DNS-rebinding + redirect-to-private).
+
+Zestaw wektorów zweryfikowany adversarialnie w `SsrfAdversarialTest` (APIC-P5-02).
+
+### C.2 Sekrety
+
+- **Konsument**: credentiale szyfrowane odwracalnie (BYOK AES-256-GCM,
+  wersjonowane). Rotacja klucza: zob.
+  `docs/operations/connection-credentials-rotation-runbook.md` (komenda
+  `integration:credentials:rotate`).
+- **Producent**: klucze hashowane Argon2id (jednokierunkowo).
+- Oba mechanizmy współistnieją świadomie (ADR-0022).
+
+### C.3 Rate-limit / backoff
+
+- **Wychodzące** żądania konsumenta retry'owane z **exponential backoff**
+  (`BackoffRestClient`): HTTP 429 / `Retry-After` → sleep → retry, max prób →
+  dead-letter (zgodnie z polityką throttlingu w architekturze §7.3).
+- Limiter `integration_sync` (10/h/tenant, `framework.yaml`) jest skonfigurowany
+  i zarezerwowany dla endpointów sync Fazy 1 (BaseLinker/Shopify).
+
+### C.4 Multi-tenancy
+
+Wszystkie encje konsumenta (`Connection`, `RemoteEndpoint`, `RemoteField`,
+`FieldMapping`, `SyncBinding`, `SyncRun`, `SyncRunLog`) mają `tenant_id` +
+Postgres FORCE RLS + Doctrine `TenantFilter`. Izolacja cross-tenant = 0
+zweryfikowana w `CrossTenantIsolationTest` (APIC-P5-01). Worker sync ustawia GUC
+`app.current_tenant` per wiadomość (RLS dla ścieżki async).
+
+### C.5 Wydajność
+
+Silnik sync czyści unit of work między batchami (O(batch), nie O(rekord)) —
+profil pamięci + EXPLAIN ANALYZE + cele p95 w `docs/perf/sync-engine-benchmark.md`
+(APIC-P5-04).
+
+---
+
+## Powiązane dokumenty
+
+- ADR-0022 — granica konsument/producent, umiejscowienie generycznego konektora.
+- `docs/operations/connection-credentials-rotation-runbook.md` — rotacja BYOK.
+- `docs/perf/sync-engine-benchmark.md` — profil wydajności sync.
+- `docs/api/jsonb-schemas.md` — kontrakt envelope wartości (`provenance`).
+- `Project Plan/feature-api-configurator-tickets.md` — backlog epiku APIC.


### PR DESCRIPTION
## Cel

Przewodnik end-user + operator dla obu obliczy Konfiguratora API (M5 Hardening, domknięcie epiku APIC).

## Zakres

`docs/integration/api-configurator-guide.md`:

- **Konsument**: utworzenie połączenia (`POST /api/connections`, BYOK), test (`/test`), discovery (`/discover`), mapowanie 1:1 + walidacja (`/mappings/validate`), sync binding + akcje (`/run|pause|resume`), harmonogram cron+jitter, polityka konfliktów (LWW/pim_wins/remote_wins), delta cursor, monitor (`/api/sync_runs`, `/api/sync_run_logs`).
- **Producent**: profile read-only + `builder_options`, per-profile OpenAPI (`/api/docs/profile/{id}.jsonopenapi`), klucze Argon2id, webhooki (`test_webhook` / `rotate_webhook_secret` / `/api/webhook_deliveries`).
- **Noty bezpieczeństwa**: dwuwarstwowy SSRF (`SsrfGuard` + `NoPrivateNetworkHttpClient`), sekrety (konsument BYOK AES-GCM vs producent hash Argon2id), backoff wychodzący, rate-limiter `integration_sync`, multi-tenancy (RLS + TenantFilter, cross-tenant = 0), wydajność.

Każdy krok cytuje **realną trasę UI + endpoint API** (zweryfikowane w kodzie). Linkuje ADR-0022, rotation runbook (P5-03), benchmark (P5-04), jsonb-schemas.

## Testy

Zmiana docs-only — brak kodu PHP/TS, brak nowych tras → brak OpenAPI drift. Ścieżki ADR-0022 + jsonb-schemas zweryfikowane jako istniejące.

Closes #1803