### PR TITLE
fix(catalog): cena bez wymaganej waluty — zapis produktu nie blokuje na currency

### DIFF
--- a/apps/admin/src/features/catalog/products/components/attr-row.tsx
+++ b/apps/admin/src/features/catalog/products/components/attr-row.tsx
@@ -378,6 +378,23 @@ export function AttrRow({
               })}
               className="rounded-xl text-[13.5px]"
             />
+          ) : attribute.type === 'price' ? (
+            // #1881 — a price is a plain numeric amount. Currency was a
+            // mockup relic (#394) that the product UI never collected, so
+            // render + emit exactly like `number`; the backend canonicaliser
+            // wraps the bare amount into the `{amount}` envelope.
+            <Input
+              id={`attr-${attribute.code}`}
+              aria-label={label}
+              type="number"
+              inputMode="decimal"
+              value={readPriceAmount(value)}
+              onChange={(event) => {
+                const parsed = Number.parseFloat(event.target.value);
+                onChange(Number.isNaN(parsed) ? null : parsed);
+              }}
+              className="w-full rounded-xl border-zinc-200 bg-white px-3 py-2 text-[13.5px]"
+            />
           ) : (
             <Input
               id={`attr-${attribute.code}`}
@@ -533,6 +550,21 @@ function isHexColor(value: string): boolean {
 }
 
 /**
+ * #1881 — read the numeric amount of a `price` value. The stored envelope is
+ * `{amount, currency?}` (currency optional), but a freshly typed value is a
+ * bare number; tolerate both. Returns `''` so the controlled number input
+ * renders empty when there is no amount.
+ */
+function readPriceAmount(value: unknown): number | '' {
+  if (typeof value === 'number') return value;
+  if (value !== null && typeof value === 'object') {
+    const amount = (value as Record<string, unknown>).amount;
+    if (typeof amount === 'number') return amount;
+  }
+  return '';
+}
+
+/**
  * Read-only display: map option codes to their localized labels so the
  * detail page never shows raw codes (`red`, `new`) when an option label
  * exists. Falls back to the raw value for non-select-like types.
@@ -564,6 +596,19 @@ function renderReadOnlyValue(
   if (attribute.type === 'datetime') {
     const head = readDatetimeValue(value);
     return head === '' ? null : head.replace('T', ' ');
+  }
+  if (attribute.type === 'price') {
+    // #1881 — render the numeric amount; legacy values may still carry a
+    // currency, so append it when present instead of "[object Object]".
+    const amount = readPriceAmount(value);
+    if (amount === '') return null;
+    const currency =
+      value !== null && typeof value === 'object'
+        ? (value as Record<string, unknown>).currency
+        : null;
+    return typeof currency === 'string' && currency !== ''
+      ? `${amount} ${currency}`
+      : String(amount);
   }
   if (value === null || value === undefined || value === '') return null;
   return typeof value === 'string' ? value : String(value);

--- a/apps/api/src/Catalog/Application/Validation/TypeValidator/PriceValidator.php
+++ b/apps/api/src/Catalog/Application/Validation/TypeValidator/PriceValidator.php
@@ -9,15 +9,19 @@ use App\Catalog\Application\Validation\ValidationError;
 use App\Catalog\Domain\Entity\Attribute;
 
 /**
- * `price` AttributeType validator. Shape: `{amount: numeric, currency:
+ * `price` AttributeType validator. Shape: `{amount: numeric, currency?:
  * 'PLN' | 'EUR' | …}`.
+ *
+ * Currency is OPTIONAL (#1881): the product UI never collected one — the
+ * legacy mockup seed (#394) re-introduced a currency requirement that does
+ * not exist in the product, so a price is just a numeric amount. When a
+ * currency IS present (legacy data / API clients) it is still validated as
+ * an ISO 4217 code and against the `currencies` allow-list.
  *
  * Rules:
  *   - `min_amount` (numeric)
- *   - `currencies` (list<string>) — restrict the allowed currency set
- *
- * Cross-check that the currency exists in the global `currencies` table
- * is the API layer's job.
+ *   - `currencies` (list<string>) — restrict the allowed currency set, only
+ *     enforced when a currency is supplied
  */
 final class PriceValidator implements AttributeValueValidatorInterface
 {
@@ -30,7 +34,10 @@ final class PriceValidator implements AttributeValueValidatorInterface
         if (!\is_int($amount) && !\is_float($amount)) {
             $errors[] = new ValidationError('value.amount', 'price.expected_numeric_amount', 'Price amount must be int or float.');
         }
-        if (!\is_string($currency) || 1 !== preg_match('/^[A-Z]{3}$/', $currency)) {
+        // Currency is optional. Validate the format only when one is given —
+        // a bare amount (the product UI's only input) is a valid price.
+        if (null !== $currency && '' !== $currency
+            && (!\is_string($currency) || 1 !== preg_match('/^[A-Z]{3}$/', $currency))) {
             $errors[] = new ValidationError('value.currency', 'price.expected_iso_currency', 'Price currency must be a 3-letter ISO 4217 code (uppercase).');
         }
 

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/PriceValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/PriceValidatorTest.php
@@ -28,6 +28,15 @@ final class PriceValidatorTest extends TestCase
     }
 
     #[Test]
+    public function amountWithoutCurrencyPasses(): void
+    {
+        // #1881 — the product UI submits a bare amount; a price with no
+        // currency is valid (currency is optional).
+        self::assertSame([], $this->validator->validate($this->attribute, ['amount' => 19.99]));
+        self::assertSame([], $this->validator->validate($this->attribute, ['amount' => 19.99, 'currency' => null]));
+    }
+
+    #[Test]
     public function nonNumericAmountAndLowercaseCurrencyBothFail(): void
     {
         $errors = $this->validator->validate($this->attribute, ['amount' => '19.99', 'currency' => 'pln']);


### PR DESCRIPTION
Closes #1881

## Problem

Dodanie produktu padało błędem `Attribute "price": Price currency must be a 3-letter ISO 4217 code (uppercase)` po wpisaniu kwoty w pole `Cena`. Formularz produktu nigdy nie zbierał waluty — wymóg waluty na typie `price` to **relikt mockupu** (`#394 seed VIEW-02: IP rating, VAT, currency`), którego w produkcie nie ma.

## Decyzja (uzgodniona z operatorem)

Zostawiamy typ `price`, ale **bez wymaganej waluty** — cena to po prostu kwota liczbowa.

## Zmiany (2)

1. **`PriceValidator`**: `currency` opcjonalne. Walidacja ISO 4217 + allow-list (`currencies`) uruchamiana TYLKO gdy waluta jest podana (legacy data / API clients dalej walidowane). Kwota wciąż wymagana numerycznie.
2. **`attr-row.tsx`**: gałąź `price` renderuje pole jak `number` (goła kwota) i emituje gołą liczbę. Kanonikalizator zapisu (`ValueWriteCore`) sam pakuje to w envelope `{amount}` — żadna waluta nie jest zapisywana. Read-only pokazuje kwotę (+ walutę tylko gdy legacy wartość ją niesie).

`metric` (jednostki kg/mm/V) bez zmian — operator go nie zgłaszał.

## Testy / weryfikacja

- `PriceValidatorTest`: nowy przypadek — sama kwota (bez waluty / `currency:null`) przechodzi; złe currency gdy podane dalej failuje. Unit Catalog validation 93/93 OK, PHPStan max OK, FE typecheck + Biome OK.
- **Live smoke** (`https://pim.localhost`): `PATCH /api/objects/{id}` z `{"attributes":{"price":99.99}}` → **HTTP 200**, zapisane jako `price: {"amount":99.99}` (bez waluty). Wcześniej 422.