### PR TITLE
fix(integration): coerce numeric outbound values to JSON numbers

### DIFF
--- a/apps/api/src/Integration/Generic/Application/Sync/PayloadBuilder.php
+++ b/apps/api/src/Integration/Generic/Application/Sync/PayloadBuilder.php
@@ -13,6 +13,12 @@ use App\Integration\Generic\Domain\Entity\FieldMapping;
  * Each outbound mapping writes its value into the body at the remote field's
  * dot path (`$.price.amount` → `{"price": {"amount": …}}`), so a 1:1 mapping
  * reconstructs the remote's nested shape. Inbound-only mappings are ignored.
+ *
+ * Values arrive serialized as strings (the Export cell serializer), but many
+ * remote APIs are strictly typed — IdoSell rejects a quoted `"99.99"` where
+ * `productRetailPrice` expects a number, and matches `productId` only against a
+ * numeric id. {@see coerce()} therefore emits canonical integer/decimal literals
+ * as JSON numbers; non-numeric codes and leading-zero strings stay strings.
  */
 final readonly class PayloadBuilder
 {
@@ -56,7 +62,29 @@ final readonly class PayloadBuilder
             }
             $ref = &$ref[$segment];
         }
-        $ref[$last] = $value;
+        $ref[$last] = self::coerce($value);
+    }
+
+    /**
+     * Emit a JSON-native scalar so strictly-typed remotes accept the value.
+     * Only canonical integer/decimal literals convert; a leading zero (`0012`),
+     * a non-numeric code (`SEM-23`) or an over-long int (precision loss) stays a
+     * string. Booleans are left to the transform-engine hook (§7).
+     */
+    private static function coerce(string $value): string|int|float
+    {
+        if (1 === preg_match('/^-?(?:0|[1-9]\d*)$/', $value)) {
+            $asInt = (int) $value;
+
+            // Reject values that do not round-trip (beyond PHP_INT_MAX).
+            return (string) $asInt === $value ? $asInt : $value;
+        }
+
+        if (1 === preg_match('/^-?(?:0|[1-9]\d*)\.\d+$/', $value)) {
+            return (float) $value;
+        }
+
+        return $value;
     }
 
     /**

--- a/apps/api/tests/Unit/Integration/Generic/Application/Sync/PayloadBuilderTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Application/Sync/PayloadBuilderTest.php
@@ -37,7 +37,42 @@ final class PayloadBuilderTest extends TestCase
         self::assertSame([
             'sku' => 'A-1',
             'title' => 'Widget',
-            'price' => ['amount' => '1999'],
+            'price' => ['amount' => 1999], // numeric literal coerced to a JSON number
+        ], $body);
+    }
+
+    #[Test]
+    public function coercesNumericValuesToJsonNumbers(): void
+    {
+        $mappings = [
+            $this->mapping('productId', '$.params.products.0.productId', MappingDirection::Outbound),
+            $this->mapping('price', '$.params.products.0.productRetailPrice', MappingDirection::Outbound),
+            $this->mapping('sku', '$.params.products.0.productIndex', MappingDirection::Outbound),
+            $this->mapping('zip', '$.params.products.0.zip', MappingDirection::Outbound),
+            $this->mapping('lang', '$.params.products.0.langId', MappingDirection::Outbound),
+        ];
+        $values = [
+            'productId' => '6635',      // → int
+            'price' => '79.99',         // → float
+            'sku' => 'SEM-23-777',      // non-numeric → string
+            'zip' => '00123',           // leading zero → string
+            'lang' => 'pol',            // → string
+        ];
+
+        $body = $this->builder->build($values, $mappings);
+
+        self::assertSame([
+            'params' => [
+                'products' => [
+                    [
+                        'productId' => 6635,            // int
+                        'productRetailPrice' => 79.99,  // float
+                        'productIndex' => 'SEM-23-777', // non-numeric → string
+                        'zip' => '00123',               // leading zero → string
+                        'langId' => 'pol',              // → string
+                    ],
+                ],
+            ],
         ], $body);
     }
 


### PR DESCRIPTION
## Problem (live smoke test PIM→IdoSell)

Wartości outbound serializowane jako stringi → strictly-typed remote (IdoSell) odrzuca cudzysłowione liczby: `productRetailPrice` jako `"99.99"` ląduje jako **0**, match po `productId` wymaga liczby. Potwierdzone na żywo na produkcie 6635 — cena weszła dopiero gdy poszła jako number.

## Fix

`PayloadBuilder.coerce()` zamienia kanoniczne literały int/decimal na JSON number przy zapisie do payloadu. Leading-zero (`00123`), kody nienumeryczne (`SEM-23`) i inty poza zakresem round-trip → zostają stringami. Booleany → hook §7.

## Testy

`PayloadBuilderTest`: `coercesNumericValuesToJsonNumbers` (6635→int, 79.99→float, SEM-23→string, 00123→string, pol→string) + zaktualizowany `buildsNestedBodyFromOutboundMappings`. PHPStan max + Deptrac + CS-Fixer zielone in-container.

Closes #1891