### PR TITLE
fix(integration): ConnectionTester false-negative on non-2xx base URL

### DIFF
--- a/apps/api/src/Integration/Generic/Application/ConnectionProbeOutcome.php
+++ b/apps/api/src/Integration/Generic/Application/ConnectionProbeOutcome.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application;
+
+use App\Integration\Generic\Domain\Enum\ConnectionStatus;
+
+/**
+ * Interprets a base-URL probe's HTTP status into a connection health outcome
+ * (APIC, fix for the test false-negative #1890).
+ *
+ * A reachable host that returns a non-2xx code on its bare base URL is NOT a
+ * connection failure — many REST APIs (e.g. IdoSell `/api/admin/v5`) serve
+ * nothing at the base and answer `404`, yet the credentials and host are fine.
+ * Only an auth rejection (`401`/`403`) is a real, actionable problem from a
+ * base-URL ping; transport/SSRF failures (no response at all) are handled by
+ * the caller before this mapper runs.
+ */
+final readonly class ConnectionProbeOutcome
+{
+    public function __construct(
+        public ConnectionStatus $status,
+        public bool $reachable,
+        public ?string $note,
+    ) {
+    }
+
+    public static function fromHttpStatus(int $httpStatus): self
+    {
+        if (401 === $httpStatus || 403 === $httpStatus) {
+            return new self(
+                ConnectionStatus::Error,
+                false,
+                'Host responded but rejected authentication — check the API key and its permissions.',
+            );
+        }
+
+        if ($httpStatus >= 200 && $httpStatus < 300) {
+            return new self(ConnectionStatus::Active, true, null);
+        }
+
+        return new self(
+            ConnectionStatus::Active,
+            true,
+            \sprintf(
+                'Host reachable; the base URL returned HTTP %d — expected for an API base path with no resource. Configure a read endpoint to probe a real resource.',
+                $httpStatus,
+            ),
+        );
+    }
+}

--- a/apps/api/src/Integration/Generic/Presentation/Controller/ConnectionTestController.php
+++ b/apps/api/src/Integration/Generic/Presentation/Controller/ConnectionTestController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Integration\Generic\Presentation\Controller;
 
 use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Integration\Generic\Application\ConnectionProbeOutcome;
 use App\Integration\Generic\Domain\Entity\Connection;
 use App\Integration\Generic\Domain\Enum\ConnectionStatus;
 use App\Integration\Generic\Domain\Exception\RemoteRequestFailedException;
@@ -69,12 +70,15 @@ final class ConnectionTestController
             ]);
         }
 
+        $outcome = ConnectionProbeOutcome::fromHttpStatus($response->statusCode);
+
         return $this->finish(
             $connection,
-            $response->isSuccessful() ? ConnectionStatus::Active : ConnectionStatus::Error,
+            $outcome->status,
             [
-                'ok' => $response->isSuccessful(),
+                'ok' => $outcome->reachable,
                 'http_status' => $response->statusCode,
+                'note' => $outcome->note,
                 'latency_ms' => $response->durationMs,
                 'size_bytes' => $response->sizeBytes,
                 'content_type' => $response->contentType(),

--- a/apps/api/tests/Unit/Integration/Generic/Application/ConnectionProbeOutcomeTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Application/ConnectionProbeOutcomeTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Application;
+
+use App\Integration\Generic\Application\ConnectionProbeOutcome;
+use App\Integration\Generic\Domain\Enum\ConnectionStatus;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #1890 — a base-URL probe must not flag a reachable host as failed just because
+ * the bare base returns a non-2xx code (e.g. IdoSell `/api/admin/v5` → 404).
+ */
+final class ConnectionProbeOutcomeTest extends TestCase
+{
+    #[DataProvider('cases')]
+    #[Test]
+    public function mapsHttpStatusToReachability(
+        int $httpStatus,
+        ConnectionStatus $expectedStatus,
+        bool $expectedReachable,
+        bool $expectNote,
+    ): void {
+        $outcome = ConnectionProbeOutcome::fromHttpStatus($httpStatus);
+
+        self::assertSame($expectedStatus, $outcome->status);
+        self::assertSame($expectedReachable, $outcome->reachable);
+        self::assertSame($expectNote, null !== $outcome->note);
+    }
+
+    /**
+     * @return iterable<string, array{int, ConnectionStatus, bool, bool}>
+     */
+    public static function cases(): iterable
+    {
+        yield '200 OK → active, no note' => [200, ConnectionStatus::Active, true, false];
+        yield '204 → active' => [204, ConnectionStatus::Active, true, false];
+        yield '404 base path → active + note' => [404, ConnectionStatus::Active, true, true];
+        yield '500 reachable → active + note' => [500, ConnectionStatus::Active, true, true];
+        yield '301 redirect → active + note' => [301, ConnectionStatus::Active, true, true];
+        yield '401 auth → error' => [401, ConnectionStatus::Error, false, true];
+        yield '403 forbidden → error' => [403, ConnectionStatus::Error, false, true];
+    }
+}


### PR DESCRIPTION
## Problem (live smoke test PIM→IdoSell)

„Testuj połączenie" pingował **gołą bazę** (`GET {baseUrl}`) i wymagał 2xx. IdoSell nie serwuje nic pod `…/api/admin/v5` → **404** → status `error`, mimo poprawnego klucza i hosta. Fałszywy negatyw.

## Fix

`ConnectionProbeOutcome::fromHttpStatus()` (pure, unit-testable):
- **2xx** → Active (reachable),
- **404 / 3xx / 5xx / inne** → Active (reachable) + nota „host osiągalny; baza zwróciła HTTP N",
- **401 / 403** → Error (realny problem auth),
- transport/SSRF (brak odpowiedzi) → Error (bez zmian, w catch).

## Testy

`ConnectionProbeOutcomeTest` — 7 przypadków (200/204/404/500/301/401/403). Istniejący `ConnectionTestApiTest` (ścieżka SSRF→Error) bez zmian. PHPStan max + Deptrac + CS-Fixer zielone.

Closes #1890