### PR TITLE
fix(integration): outbound 2xx-with-error-body counted as success

### DIFF
--- a/apps/api/src/Integration/Generic/Application/Sync/OutboundSyncRunner.php
+++ b/apps/api/src/Integration/Generic/Application/Sync/OutboundSyncRunner.php
@@ -178,6 +178,15 @@ final readonly class OutboundSyncRunner
         }
 
         if ($response->isSuccessful()) {
+            // A 2xx can still carry a per-record error in the body (#1886).
+            $remoteError = RemoteResponseInspector::errorIn($response->body);
+            if (null !== $remoteError) {
+                $run->recordFailed();
+                $this->log($run, SyncRecordAction::Failed, $matchValue, $body, 'Remote 2xx with error: '.$remoteError);
+
+                return;
+            }
+
             SyncRecordAction::Updated === $successAction ? $run->recordUpdated() : $run->recordCreated();
             $this->log($run, $successAction, $matchValue, $body, null);
 

--- a/apps/api/src/Integration/Generic/Application/Sync/RemoteResponseInspector.php
+++ b/apps/api/src/Integration/Generic/Application/Sync/RemoteResponseInspector.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Generic\Application\Sync;
+
+use JsonException;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Detects an application-level error in a remote 2xx response body (APIC, #1886).
+ *
+ * Many REST APIs answer `HTTP 200` and report per-record failures **in the
+ * body** — IdoSell returns `{"errors":{"faultCode":N,"faultString":"…"}}`,
+ * others use a top-level `error`/`errors`. Trusting only the HTTP status makes
+ * the sync count every record as success even when the remote rejected it.
+ * This inspector surfaces a generic error envelope so {@see OutboundSyncRunner}
+ * can reclassify the record as failed and log the reason.
+ *
+ * Conservative: an unparseable/empty body, or an empty `errors` envelope
+ * (`faultCode:0, faultString:""` / `errors:[]`), is treated as success.
+ */
+final readonly class RemoteResponseInspector
+{
+    public static function errorIn(string $body): ?string
+    {
+        $body = trim($body);
+        if ('' === $body) {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode($body, true, 64, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return null;
+        }
+
+        if (!\is_array($decoded)) {
+            return null;
+        }
+
+        // Top-level `error` string (common REST shape).
+        $error = $decoded['error'] ?? null;
+        if (\is_string($error) && '' !== trim($error)) {
+            return trim($error);
+        }
+
+        $errors = $decoded['errors'] ?? null;
+        if (!\is_array($errors)) {
+            return null;
+        }
+
+        // IdoSell-style fault envelope.
+        $faultString = $errors['faultString'] ?? null;
+        if (\is_string($faultString) && '' !== trim($faultString)) {
+            return trim($faultString);
+        }
+        $faultCode = $errors['faultCode'] ?? null;
+        if ((\is_int($faultCode) && 0 !== $faultCode)
+            || (\is_string($faultCode) && '' !== $faultCode && '0' !== $faultCode)) {
+            return \sprintf('faultCode %s', (string) $faultCode);
+        }
+
+        // A non-empty list of errors (no fault envelope).
+        if (array_is_list($errors) && [] !== $errors) {
+            return \sprintf('remote returned %d error(s)', \count($errors));
+        }
+
+        return null;
+    }
+}

--- a/apps/api/tests/Unit/Integration/Generic/Application/Sync/RemoteResponseInspectorTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Application/Sync/RemoteResponseInspectorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Integration\Generic\Application\Sync;
+
+use App\Integration\Generic\Application\Sync\RemoteResponseInspector;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #1886 — a remote 2xx body can still report a per-record error; the inspector
+ * surfaces a generic error envelope so the sync does not count it as success.
+ */
+final class RemoteResponseInspectorTest extends TestCase
+{
+    #[DataProvider('bodies')]
+    #[Test]
+    public function detectsErrorEnvelopes(string $body, ?string $expected): void
+    {
+        self::assertSame($expected, RemoteResponseInspector::errorIn($body));
+    }
+
+    /**
+     * @return iterable<string, array{string, ?string}>
+     */
+    public static function bodies(): iterable
+    {
+        // Success / no error.
+        yield 'empty body' => ['', null];
+        yield 'non-json' => ['OK', null];
+        yield 'empty object' => ['{}', null];
+        yield 'idosell ok envelope' => ['{"errors":{"faultCode":0,"faultString":""}}', null];
+        yield 'empty errors list' => ['{"errors":[]}', null];
+        yield 'plain result' => ['{"results":[{"productId":6635}]}', null];
+
+        // Errors.
+        yield 'idosell fault string' => [
+            '{"errors":{"faultCode":2,"faultString":"Invalid productRetailPrice"}}',
+            'Invalid productRetailPrice',
+        ];
+        yield 'idosell fault code only' => ['{"errors":{"faultCode":7,"faultString":""}}', 'faultCode 7'];
+        yield 'top-level error string' => ['{"error":"unauthorized"}', 'unauthorized'];
+        yield 'errors list' => ['{"errors":["bad sku","bad price"]}', 'remote returned 2 error(s)'];
+    }
+}


### PR DESCRIPTION
## Problem (live smoke test PIM→IdoSell)

`OutboundSyncRunner` ufał tylko statusowi HTTP. IdoSell zwraca **200 + per-produkt błąd w body** (`{"errors":{"faultString":"…"}}`) → rekord liczony jako `updated`/`created`, błąd niewidoczny. Stąd `updated=1468` mimo odrzuceń.

## Fix (generyczny, bez hardkodu IdoSell)

`RemoteResponseInspector::errorIn()` wykrywa generyczną kopertę błędu: top-level `error`, IdoSell `errors.faultString`/`faultCode`, albo niepustą listę `errors`. Na 2xx z taką kopertą rekord → **failed** + log z powodem. Puste/czyste koperty (`faultCode:0`, `errors:[]`) i body nie-JSON → sukces (zachowawczo).

## Testy

`RemoteResponseInspectorTest` — 10 przypadków (ok envelope, fault string, fault code, top-level error, errors list, empty/non-json). Istniejący `OutboundSyncRunnerTest` (body `{}` → sukces) bez zmian. PHPStan max + Deptrac + CS-Fixer zielone.

Closes #1886