### PR TITLE
fix(ui): feedback on connector actions (Test/Sync/Save)

### DIFF
--- a/apps/admin/e2e/1887-api-action-feedback.spec.ts
+++ b/apps/admin/e2e/1887-api-action-feedback.spec.ts
@@ -1,0 +1,72 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, type Route, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * #1887 — connector actions must give feedback. Clicking "Test" on the
+ * connection detail now raises a toast with the probe result (previously the
+ * action fired silently and looked dead). Fully mocked → deterministic/offline.
+ */
+
+const CONNECTION = {
+  '@id': '/api/connections/conn-1',
+  '@type': 'Connection',
+  id: 'conn-1',
+  code: 'idosell',
+  name: 'IdoSell EU',
+  baseUrl: 'https://estetino.pl/api/admin/v5',
+  authType: 'api_key',
+  rateLimitHint: 600,
+  status: 'active',
+  lastHealthCheckAt: null,
+  createdAt: '2026-06-30T10:00:00+00:00',
+  updatedAt: '2026-06-30T10:00:00+00:00',
+};
+
+test('APIC #1887 — Test action shows a result toast', async ({ page }) => {
+  await loginAsAdmin(page);
+
+  // Playwright checks the LAST-registered route first, so the general
+  // connection route goes first and the specific /test route last (it must win
+  // for the POST probe).
+  await page.route('**/api/connections/conn-1**', (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify(CONNECTION),
+    }),
+  );
+  await page.route('**/api/sync_bindings**', (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify({ '@type': 'Collection', member: [], totalItems: 0 }),
+    }),
+  );
+  await page.route('**/api/connections/conn-1/test', (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        http_status: 200,
+        status: 'active',
+        checked_at: '2026-06-30T12:00:00+00:00',
+      }),
+    }),
+  );
+
+  await page.goto('/integrations/api-configurator/connections/conn-1');
+
+  const testButton = page.getByRole('button', { name: /^Test$/ });
+  await expect(testButton).toBeVisible();
+
+  const a11y = await new AxeBuilder({ page }).analyze();
+  expect(a11y.violations).toEqual([]);
+
+  await testButton.click();
+
+  // The probe result surfaces as a toast (the fix — no longer silent).
+  await expect(page.getByText(/Connection works \(HTTP 200\)/i)).toBeVisible();
+});

--- a/apps/admin/src/features/api-configurator/consumer/detail/ConnectionDetailPage.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/detail/ConnectionDetailPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
 
 import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/ui/toast';
 
 import {
   AuthBadge,
@@ -60,8 +61,9 @@ export function ConnectionDetailPage() {
   const connection = connectionQuery.result ?? null;
   const binding = bindingsQuery.result.data[0] ?? null;
 
-  const { mutate: test } = useCustomMutation();
-  const { mutate: runNow } = useCustomMutation();
+  const toast = useToast();
+  const { mutate: test, mutation: testState } = useCustomMutation();
+  const { mutate: runNow, mutation: syncState } = useCustomMutation();
 
   function selectTab(next: DetailTab): void {
     setSearchParams(next === 'overview' ? {} : { tab: next });
@@ -71,14 +73,35 @@ export function ConnectionDetailPage() {
     if (connectionId === '') {
       return;
     }
-    test({ url: `${apiUrl}/connections/${connectionId}/test`, method: 'post', values: {} });
+    test(
+      { url: `${apiUrl}/connections/${connectionId}/test`, method: 'post', values: {} },
+      {
+        onSuccess: ({ data }) => {
+          const result = data as { ok?: boolean; http_status?: number; note?: string };
+          if (result.ok === true) {
+            toast.success(
+              t('api_configurator.detail.toast.test_ok', { status: result.http_status ?? '' }),
+            );
+          } else {
+            toast.error(result.note ?? t('api_configurator.detail.toast.test_fail'));
+          }
+        },
+        onError: () => toast.error(t('api_configurator.detail.toast.action_error')),
+      },
+    );
   }
 
   function triggerSync(): void {
     if (binding === null) {
       return;
     }
-    runNow({ url: `${apiUrl}/sync_bindings/${binding.id}/run`, method: 'post', values: {} });
+    runNow(
+      { url: `${apiUrl}/sync_bindings/${binding.id}/run`, method: 'post', values: {} },
+      {
+        onSuccess: () => toast.success(t('api_configurator.detail.toast.sync_started')),
+        onError: () => toast.error(t('api_configurator.detail.toast.action_error')),
+      },
+    );
   }
 
   return (
@@ -100,11 +123,20 @@ export function ConnectionDetailPage() {
             {connection?.baseUrl ?? ''}
           </p>
         </div>
-        <Button type="button" variant="outline" onClick={triggerTest}>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={triggerTest}
+          disabled={testState.isPending}
+        >
           <Wifi className="mr-1 size-4" aria-hidden="true" />
           {t('api_configurator.detail.test')}
         </Button>
-        <Button type="button" onClick={triggerSync} disabled={binding === null}>
+        <Button
+          type="button"
+          onClick={triggerSync}
+          disabled={binding === null || syncState.isPending}
+        >
           <Play className="mr-1 size-4" aria-hidden="true" />
           {t('api_configurator.detail.sync_now')}
         </Button>

--- a/apps/admin/src/features/api-configurator/consumer/sync/SyncConfigScreen.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/sync/SyncConfigScreen.tsx
@@ -6,6 +6,7 @@ import { useNavigate, useParams } from 'react-router';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { useToast } from '@/components/ui/toast';
 
 import {
   ApiToggle,
@@ -96,9 +97,10 @@ export function SyncConfigScreen({ embedded = false }: { embedded?: boolean } = 
     [endpoints],
   );
 
-  const { mutate: create } = useCreate();
-  const { mutate: update } = useUpdate();
-  const { mutate: runNow } = useCustomMutation();
+  const toast = useToast();
+  const { mutate: create, mutation: createState } = useCreate();
+  const { mutate: update, mutation: updateState } = useUpdate();
+  const { mutate: runNow, mutation: runState } = useCustomMutation();
 
   const [dir, setDir] = useState<SyncDirection>('inbound');
   const [cron, setCron] = useState('');
@@ -147,7 +149,13 @@ export function SyncConfigScreen({ embedded = false }: { embedded?: boolean } = 
         },
         successNotification: false,
       },
-      { onSuccess: refresh },
+      {
+        onSuccess: () => {
+          toast.success(t('api_configurator.sync.toast.created'));
+          refresh();
+        },
+        onError: () => toast.error(t('api_configurator.sync.toast.error')),
+      },
     );
   }
 
@@ -169,7 +177,13 @@ export function SyncConfigScreen({ embedded = false }: { embedded?: boolean } = 
         },
         successNotification: false,
       },
-      { onSuccess: refresh },
+      {
+        onSuccess: () => {
+          toast.success(t('api_configurator.sync.toast.saved'));
+          refresh();
+        },
+        onError: () => toast.error(t('api_configurator.sync.toast.error')),
+      },
     );
   }
 
@@ -179,7 +193,13 @@ export function SyncConfigScreen({ embedded = false }: { embedded?: boolean } = 
     }
     runNow(
       { url: `${apiUrl}/sync_bindings/${binding.id}/run`, method: 'post', values: {} },
-      { onSuccess: refresh },
+      {
+        onSuccess: () => {
+          toast.success(t('api_configurator.sync.toast.run_started'));
+          refresh();
+        },
+        onError: () => toast.error(t('api_configurator.sync.toast.error')),
+      },
     );
   }
 
@@ -227,7 +247,11 @@ export function SyncConfigScreen({ embedded = false }: { embedded?: boolean } = 
                 ))}
               </select>
             </Field>
-            <Button type="button" onClick={createBinding} disabled={newObjectTypeId === ''}>
+            <Button
+              type="button"
+              onClick={createBinding}
+              disabled={newObjectTypeId === '' || createState.isPending}
+            >
               {t('api_configurator.sync.empty.create')}
             </Button>
           </div>
@@ -443,11 +467,16 @@ export function SyncConfigScreen({ embedded = false }: { embedded?: boolean } = 
             </span>
           </div>
           <div className="flex-1" />
-          <Button type="button" variant="outline" onClick={triggerRun}>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={triggerRun}
+            disabled={runState.isPending}
+          >
             <Play className="mr-1 size-4" aria-hidden="true" />
             {t('api_configurator.sync.footer.run_now')}
           </Button>
-          <Button type="button" onClick={save}>
+          <Button type="button" onClick={save} disabled={updateState.isPending}>
             {t('api_configurator.sync.footer.save')}
           </Button>
         </div>

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1944,6 +1944,12 @@
         "paused": "Paused",
         "run_now": "Run now",
         "save": "Save binding"
+      },
+      "toast": {
+        "created": "Sync binding created.",
+        "saved": "Binding saved.",
+        "run_started": "Sync started.",
+        "error": "Action failed. Please try again."
       }
     },
     "detail": {
@@ -1951,6 +1957,12 @@
       "title": "Connection",
       "test": "Test",
       "sync_now": "Sync now",
+      "toast": {
+        "test_ok": "Connection works (HTTP {{status}}).",
+        "test_fail": "Connection test failed.",
+        "sync_started": "Sync started.",
+        "action_error": "Action failed. Please try again."
+      },
       "tabs_label": "Connection tabs",
       "tab": {
         "overview": "Overview",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1992,6 +1992,12 @@
         "paused": "Wstrzymane",
         "run_now": "Uruchom teraz",
         "save": "Zapisz wiązanie"
+      },
+      "toast": {
+        "created": "Utworzono wiązanie synchronizacji.",
+        "saved": "Zapisano wiązanie.",
+        "run_started": "Synchronizacja uruchomiona.",
+        "error": "Akcja nie powiodła się. Spróbuj ponownie."
       }
     },
     "detail": {
@@ -1999,6 +2005,12 @@
       "title": "Połączenie",
       "test": "Testuj",
       "sync_now": "Synchronizuj",
+      "toast": {
+        "test_ok": "Połączenie działa (HTTP {{status}}).",
+        "test_fail": "Test połączenia nieudany.",
+        "sync_started": "Synchronizacja uruchomiona.",
+        "action_error": "Akcja nie powiodła się. Spróbuj ponownie."
+      },
       "tabs_label": "Zakładki połączenia",
       "tab": {
         "overview": "Przegląd",


### PR DESCRIPTION
## Problem (live smoke test PIM→IdoSell)

Akcje detalu połączenia (Testuj / Synchronizuj / Uruchom teraz / Zapisz wiązanie) miały `successNotification:false` i brak spinnera → klik nie dawał żadnego widocznego efektu. Operator klikał wielokrotnie sądząc, że „nic się nie dzieje" (akcja faktycznie leciała, np. 202).

## Fix (FE)

- `ConnectionDetailPage`: Testuj → toast z wynikiem probe (`ok` + HTTP status) / błąd; Synchronizuj → toast „uruchomiono" / błąd. Przyciski disabled w trakcie `isPending`.
- `SyncConfigScreen`: Utwórz / Zapisz wiązanie / Uruchom teraz → toast sukces/błąd + pending.
- i18n PL/EN.

## Testy

`e2e/1887-api-action-feedback.spec.ts` — klik „Test" → toast „Connection works (HTTP 200)" (mock, offline) + axe. typecheck + biome + vitest + max-lines guard zielone.

Closes #1887