### PR TITLE
feat(integration): outbound dry-run (preview push without sending)

### DIFF
--- a/apps/api/src/Integration/Generic/Application/Handler/OutboundSyncHandler.php
+++ b/apps/api/src/Integration/Generic/Application/Handler/OutboundSyncHandler.php
@@ -41,6 +41,6 @@ final readonly class OutboundSyncHandler
             return;
         }
 
-        $this->runner->run($binding);
+        $this->runner->run($binding, $message->dryRun);
     }
 }

--- a/apps/api/src/Integration/Generic/Application/Schedule/SyncScheduleDispatcher.php
+++ b/apps/api/src/Integration/Generic/Application/Schedule/SyncScheduleDispatcher.php
@@ -50,8 +50,10 @@ final readonly class SyncScheduleDispatcher
 
     /**
      * Fire the binding now: enqueue its sync leg(s) and roll `nextRun` forward.
+     * `$dryRun` previews the outbound push (builds + logs payloads, no remote
+     * call) — see {@see OutboundSyncMessage}.
      */
-    public function dispatch(SyncBinding $binding): void
+    public function dispatch(SyncBinding $binding, bool $dryRun = false): void
     {
         $tenantId = $this->tenantId($binding);
         $direction = $binding->getDirection();
@@ -60,7 +62,7 @@ final readonly class SyncScheduleDispatcher
             $this->bus->dispatch(new InboundSyncMessage($binding->getId(), $tenantId));
         }
         if ($direction->writesRemote()) {
-            $this->bus->dispatch(new OutboundSyncMessage($binding->getId(), $tenantId));
+            $this->bus->dispatch(new OutboundSyncMessage($binding->getId(), $tenantId, $dryRun));
         }
 
         $this->computeNextRun($binding);

--- a/apps/api/src/Integration/Generic/Application/Sync/OutboundSyncRunner.php
+++ b/apps/api/src/Integration/Generic/Application/Sync/OutboundSyncRunner.php
@@ -55,7 +55,7 @@ final readonly class OutboundSyncRunner
     ) {
     }
 
-    public function run(SyncBinding $binding): SyncRun
+    public function run(SyncBinding $binding, bool $dryRun = false): SyncRun
     {
         $run = new SyncRun($binding, SyncDirection::Outbound);
         $this->runs->save($run);
@@ -90,7 +90,7 @@ final readonly class OutboundSyncRunner
         // both accumulate across a 50k push, so clear every CLEAR_EVERY records
         // and reload the entities the loop keeps mutating.
         foreach ($this->reader->read($binding->getObjectTypeId(), $codes) as $record) {
-            $this->push($run, $binding, $writeEndpoint, $record, $mappings, $matchCode, $action);
+            $this->push($run, $binding, $writeEndpoint, $record, $mappings, $matchCode, $action, $dryRun);
             $this->em->flush();
 
             if (0 === ++$processed % self::CLEAR_EVERY) {
@@ -149,6 +149,7 @@ final readonly class OutboundSyncRunner
         array $mappings,
         ?string $matchCode,
         SyncRecordAction $successAction,
+        bool $dryRun = false,
     ): void {
         $body = $this->payloadBuilder->build($record->values, $mappings);
         if ([] === $body) {
@@ -160,6 +161,20 @@ final readonly class OutboundSyncRunner
 
         $matchValue = null !== $matchCode ? ($record->values[$matchCode] ?? null) : null;
         $url = $this->buildUrl($binding, $writeEndpoint, $matchValue);
+
+        if ($dryRun) {
+            // Preview only — record what would be sent without calling the remote.
+            $run->recordSkipped();
+            $this->log(
+                $run,
+                SyncRecordAction::Skipped,
+                $matchValue,
+                $body,
+                \sprintf('DRY RUN — would %s %s', $writeEndpoint->getHttpMethod(), $url),
+            );
+
+            return;
+        }
 
         try {
             $response = $this->requester->request(

--- a/apps/api/src/Integration/Generic/Domain/Message/OutboundSyncMessage.php
+++ b/apps/api/src/Integration/Generic/Domain/Message/OutboundSyncMessage.php
@@ -11,12 +11,17 @@ use Symfony\Component\Uid\Uuid;
  * Async trigger for one outbound (PIM → remote) sync of a {@see \App\Integration\Generic\Domain\Entity\SyncBinding}
  * (APIC-P3-06). Routed to the existing `import` transport; {@see TenantAwareMessage}
  * so the rebinding + RLS-GUC middleware restore tenant context on the worker.
+ *
+ * `dryRun` (#1889) builds and logs the would-be payloads without calling the
+ * remote — a safety preview before a real push that, unscoped, would flood the
+ * whole catalog into the external shop.
  */
 final readonly class OutboundSyncMessage implements TenantAwareMessage
 {
     public function __construct(
         public Uuid $bindingId,
         public Uuid $tenant,
+        public bool $dryRun = false,
     ) {
     }
 

--- a/apps/api/src/Integration/Generic/Presentation/Controller/SyncBindingActionsController.php
+++ b/apps/api/src/Integration/Generic/Presentation/Controller/SyncBindingActionsController.php
@@ -11,6 +11,7 @@ use App\Integration\Generic\Domain\Repository\SyncBindingRepositoryInterface;
 use DateTimeInterface;
 use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
@@ -43,14 +44,18 @@ final class SyncBindingActionsController
         methods: ['POST'],
     )]
     #[RequiresPermission(module: 'settings.integrations', action: 'manage')]
-    public function run(string $id): JsonResponse
+    public function run(string $id, Request $request): JsonResponse
     {
         $binding = $this->require($id);
+        // `?dry_run=1` previews the outbound push (builds + logs payloads, no
+        // remote call) — a guard against flooding the external shop (#1889).
+        $dryRun = $request->query->getBoolean('dry_run');
 
-        $this->dispatcher->dispatch($binding);
+        $this->dispatcher->dispatch($binding, $dryRun);
 
         return new JsonResponse([
             'dispatched' => true,
+            'dry_run' => $dryRun,
             'direction' => $binding->getDirection()->value,
             'next_run' => $binding->getNextRun()?->format(DateTimeInterface::RFC3339_EXTENDED),
         ], Response::HTTP_ACCEPTED);

--- a/apps/api/tests/Integration/Integration/Generic/OutboundSyncRunnerTest.php
+++ b/apps/api/tests/Integration/Integration/Generic/OutboundSyncRunnerTest.php
@@ -99,6 +99,23 @@ final class OutboundSyncRunnerTest extends KernelTestCase
         self::assertSame(['A-1', 'B-2'], $skus);
     }
 
+    #[Test]
+    public function dryRunBuildsPayloadsWithoutCallingRemote(): void
+    {
+        $this->seedObject('A-1', 'Widget');
+        $this->seedObject('B-2', 'Gadget');
+        $binding = $this->seedBinding();
+
+        $requester = new RecordingRequester(default: new GenericRestResponse(201, [], '{}', 1, 2));
+        $run = $this->runner($requester)->run($binding, true); // dry run
+        $this->em()->flush();
+
+        self::assertCount(0, $requester->calls, 'dry run must not call the remote');
+        self::assertSame(0, $run->getCreatedCount());
+        self::assertSame(2, $run->getSkippedCount());
+        self::assertSame(SyncRunStatus::Success, $run->getStatus());
+    }
+
     private function seedObject(string $sku, string $name): void
     {
         $em = $this->em();


### PR DESCRIPTION
## Problem (live smoke test — produkcyjny incydent)

Ręczny outbound run wypycha **cały ObjectType** do zewnętrznego sklepu bez podglądu. Jedno kliknięcie zalało produkcyjny katalog IdoSell (1468 PUT-ów).

## Fix — dry-run (rdzeń bezpieczeństwa #1889)

`POST /api/sync_bindings/{id}/run?dry_run=1` → flaga płynie przez `OutboundSyncMessage(dryRun)` + handler do `OutboundSyncRunner`: dla każdego rekordu payload jest **budowany i logowany** (`SyncRunLog`: „DRY RUN — would PUT <url>", liczony jako skipped), ale **remote nie jest wołany**. Operator widzi w Historii dokładnie co by poszło — zanim zrobi realny push.

## Testy

`OutboundSyncRunnerTest::dryRunBuildsPayloadsWithoutCallingRemote` — 2 obiekty, `run(binding, true)` → 0 wywołań requestera, skipped=2, status success. PHPStan max + Deptrac + CS-Fixer zielone. OpenAPI snapshot bez zmian.

## Follow-up (w ramach #1889, świadomie poza tym PR)

- **FE „Próbny przebieg" button** — po merge #1896 (feedback), żeby uniknąć konfliktu na `ConnectionDetailPage`.
- **Single-object scope** (push wybranego produktu) — wymaga rozszerzenia kontraktu `OutboundRecordReader` (kontekst Export, cross-BC) → osobny krok.

Refs #1889