### PR TITLE
fix(integration): stop false 'not in discovered schema' warning for write paths

### DIFF
--- a/apps/api/src/Integration/Generic/Application/Mapping/MappingValidator.php
+++ b/apps/api/src/Integration/Generic/Application/Mapping/MappingValidator.php
@@ -85,11 +85,17 @@ final readonly class MappingValidator
             $type = $typesByPath[$path] ?? null;
 
             if (null === $type) {
-                $warnings[] = new MappingWarning(
-                    $mapping->getPimTarget(),
-                    $path,
-                    'Remote field path is not in the discovered schema; run discovery or check the path.',
-                );
+                // Discovery reflects the remote's READ schema. An outbound-only
+                // (write) path legitimately differs from it — e.g. IdoSell writes
+                // `productNames` but reads `productDescriptionsLangData` — so only
+                // flag a missing path when the mapping actually reads (#1888).
+                if ($mapping->getDirection()->appliesInbound()) {
+                    $warnings[] = new MappingWarning(
+                        $mapping->getPimTarget(),
+                        $path,
+                        'Remote field path is not in the discovered schema; run discovery or check the path.',
+                    );
+                }
 
                 continue;
             }

--- a/apps/api/tests/Unit/Integration/Generic/Application/Mapping/MappingValidatorTest.php
+++ b/apps/api/tests/Unit/Integration/Generic/Application/Mapping/MappingValidatorTest.php
@@ -103,6 +103,24 @@ final class MappingValidatorTest extends TestCase
         self::assertStringContainsString('not in the discovered schema', $result->warnings[0]->message);
     }
 
+    #[Test]
+    public function outboundWritePathAbsentFromReadSchemaIsNotAWarning(): void
+    {
+        // #1888 — discovery is read-oriented; an outbound (write) path legitimately
+        // differs from the discovered read fields (IdoSell PUT uses productNames,
+        // GET returns productDescriptionsLangData), so it must not warn.
+        $write = new FieldMapping(
+            $this->connection,
+            'name',
+            '$.params.products.0.productNames.productNamesLangData.0.productName',
+            MappingDirection::Outbound,
+        );
+
+        $result = $this->validate([$write], []);
+
+        self::assertSame([], $result->warnings);
+    }
+
     /**
      * @param list<FieldMapping> $mappings
      * @param list<RemoteField>  $fields


### PR DESCRIPTION
## Problem (live smoke test PIM→IdoSell)

Discovery czyta schemat **odczytu (GET)**, ale mapowania outbound używają ścieżek **zapisu (PUT)**, które legalnie się różnią (IdoSell: GET `productDescriptionsLangData` vs PUT `productNames`). `MappingValidator` flagował każdą taką ścieżkę „not in the discovered schema" — fałszywy alarm, który mylił operatora i ukrywał realne problemy.

## Fix

Ostrzeżenie „not in discovered schema" tylko dla mapowań, które **czytają** (inbound/both). Ścieżki outbound-only (write) są akceptowane bez ostrzeżenia.

## Testy

`MappingValidatorTest::outboundWritePathAbsentFromReadSchemaIsNotAWarning` (nowy) + istniejący `unknownPathIsAWarning` (inbound — nadal ostrzega). 6 testów zielonych. PHPStan max + Deptrac + CS-Fixer.

## Follow-up (#1888)

Pełne **write-schema discovery** (pobranie OpenAPI remote API i podpowiadanie pól zapisu) to większa funkcja — świadomie odłożona; ten PR usuwa najbardziej mylący objaw rozbieżności read/write.

Refs #1888