### PR TITLE
fix(integration): harmonogram sync — Invalid Date to bez harmonogramu (#1900)

### DIFF
--- a/apps/admin/e2e/1789-api-sync-config.spec.ts
+++ b/apps/admin/e2e/1789-api-sync-config.spec.ts
@@ -126,3 +126,64 @@ test('APIC-P3-11 — sync config: direction panels + save + run-now', async ({ p
   const a11y = await new AxeBuilder({ page }).analyze();
   expect(a11y.violations).toEqual([]);
 });
+
+/**
+ * Regression: a binding with no schedule has `nextRun` ABSENT from the API
+ * response (not `null`), so the FE receives `undefined`. A strict `!== null`
+ * guard fell through to `new Date(undefined)` → "Invalid Date" in the next-run
+ * box; the loose `!= null` must instead show the manual-only copy.
+ */
+test('APIC-P3-11 — sync config: no schedule shows "manual only", never "Invalid Date"', async ({
+  page,
+}) => {
+  await loginAsAdmin(page);
+
+  const binding = {
+    id: 'bind-1',
+    connectionId: 'conn-1',
+    objectTypeId: 'ot-1',
+    readEndpointId: null,
+    writeEndpointId: null,
+    direction: 'inbound',
+    schedule: null,
+    conflictPolicy: 'lww',
+    matchKeyMapping: null,
+    cursor: null,
+    isEnabled: false,
+    // nextRun intentionally omitted — mirrors the API omitting it when unscheduled.
+  };
+
+  await page.route('**/api/sync_bindings**', (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify({ member: [binding], totalItems: 1 }),
+    }),
+  );
+  await page.route('**/api/remote_endpoints**', (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify({ member: [], totalItems: 0 }),
+    }),
+  );
+  await page.route('**/api/object_types**', (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify({ member: [{ id: 'ot-1', code: 'product' }], totalItems: 1 }),
+    }),
+  );
+
+  await page.goto('/integrations/api-configurator/connections/conn-1/sync');
+  await expect(
+    page.getByRole('heading', {
+      name: /konfiguracja synchronizacji|synchronization configuration/i,
+    }),
+  ).toBeVisible();
+
+  // The bug: "Invalid Date" must never render.
+  await expect(page.getByText(/invalid date/i)).toHaveCount(0);
+  // The next-run box shows the manual-only copy instead.
+  await expect(page.getByText(/run manually|uruchamiane ręcznie/i)).toBeVisible();
+});

--- a/apps/admin/src/features/api-configurator/consumer/sync/SyncConfigScreen.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/sync/SyncConfigScreen.tsx
@@ -352,7 +352,12 @@ export function SyncConfigScreen({ embedded = false }: { embedded?: boolean } = 
               <div className="mb-2 text-[10.5px] font-medium uppercase tracking-wider text-zinc-500">
                 {t('api_configurator.sync.schedule.next_run')}
               </div>
-              {binding.nextRun !== null ? (
+              {/* The API omits `nextRun` entirely when the binding has no
+                  schedule, so the value is `undefined` (not `null`) — a strict
+                  `!== null` would fall through to `new Date(undefined)` →
+                  "Invalid Date". Loose `!= null` catches both, matching
+                  DetailOverview. */}
+              {binding.nextRun != null ? (
                 <div className="flex items-center gap-2 text-[12px]">
                   <span className="h-1.5 w-1.5 rounded-full bg-zinc-900" />
                   <span className="font-medium text-zinc-900">


### PR DESCRIPTION
## Problem

Pytanie operatora „czy działa harmonogram?" + screen: box **NAJBLIŻSZE URUCHOMIENIE** pokazuje **„Invalid Date"**.

## Co sprawdziłem (zanim odpowiedziałem „działa")

**Backend harmonogramu DZIAŁA** — zweryfikowane live, nie na słowo:
- `PATCH /api/sync_bindings/{id}` `{schedule:"*/15 * * * *", enabled:true}` → backend policzył `next_run` = `2026-06-30T16:49:27+00:00` (z per-tenant jitterem), DB potwierdza, **API serializuje `nextRun`** (poprawny RFC3339).
- Per-minutowy tick `integration:sync:dispatch-due` (Symfony Scheduler, transport `scheduler_integration_sync`) — **konsumowany przez worker** (po #1899 recreate: `Consuming … import, scheduler_maintenance, scheduler_integration_sync`).
- `SyncBindingProcessor` (Patch) na zmianę `schedule`/`enabled` woła `computeNextRun`; `enabled=false` → `next_run=null`. Poprawne.

## Root cause „Invalid Date" (czysto FE)

API **pomija pole `nextRun`** gdy binding nie ma harmonogramu (`next_run`=NULL) → w FE `undefined`, nie `null`. `SyncConfigScreen` strzegł tylko `!== null` → `undefined` przelatywał do `new Date(undefined).toLocaleString()` → „Invalid Date". `DetailOverview` używał już poprawnie `!= null`.

## Fix

- `SyncConfigScreen.tsx` next-run guard `!== null` → `!= null` (spójnie z `DetailOverview`; Biome dopuszcza `!= null` dla null-checków).
- Regression e2e w `1789-api-sync-config.spec.ts`: binding bez `nextRun` → renderuje „manual only", **nigdy** „Invalid Date". Lokalnie 2/2 zielone + axe czysty.

Zweryfikowane lokalnie: Biome ✅, tsc ✅, Playwright (oba testy 1789) ✅.

Closes #1900
