### PR TITLE
feat(export): XmlWriterCore streaming XML writer (XMLF-P0-03)

### DIFF
--- a/apps/api/src/Export/Infrastructure/Writer/XmlWriterCore.php
+++ b/apps/api/src/Export/Infrastructure/Writer/XmlWriterCore.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Infrastructure\Writer;
+
+use LogicException;
+use RuntimeException;
+use XMLWriter;
+
+/**
+ * Thin, memory-bounded wrapper over the native {@see XMLWriter} (ADR-0023,
+ * XMLF-P0-03). This is the ONLY class in the Export BC that touches XMLWriter.
+ *
+ * Responsibilities:
+ *   - UTF-8 XML declaration + streaming element/attribute/text emission;
+ *   - auto-escaping of `& < > " '` (delegated to XMLWriter::text/writeAttribute);
+ *   - sanitisation of characters illegal in XML 1.0 (control chars, invalid
+ *     UTF-8 byte sequences) that XMLWriter would otherwise emit raw and break
+ *     well-formedness;
+ *   - CDATA with `]]>` neutralisation so section content can never terminate
+ *     the CDATA block early;
+ *   - memory-bounded operation — never builds a DOM tree; in URI mode the
+ *     internal buffer is flushed periodically to the target stream.
+ *
+ * The always-well-formed guarantee (XMLF-P0-01/P6-01) covers VALUES only.
+ * Element/attribute NAMES are the caller's contract (descriptor / column keys)
+ * and are validated one layer up (FeedDescriptor VO — XMLF-P2-01, GenericXml
+ * key sanitisation — XMLF-P0-04).
+ */
+final class XmlWriterCore
+{
+    /**
+     * Flush the internal buffer to the target every N written elements when in
+     * URI (streaming) mode, so a 50k-SKU feed never accumulates the whole
+     * document in memory (CLAUDE.md §3.10, XMLF-P6-03).
+     */
+    private const int FLUSH_EVERY = 256;
+
+    private int $sinceFlush = 0;
+    private bool $closed = false;
+
+    private function __construct(
+        private readonly XMLWriter $writer,
+        private readonly bool $memoryMode,
+    ) {
+    }
+
+    /**
+     * In-memory mode — the whole document is held in the XMLWriter buffer and
+     * returned by {@see outputMemory()}. Use for preview (XMLF-P4-04) and unit
+     * tests, never for full-catalog feeds.
+     */
+    public static function toMemory(): self
+    {
+        $writer = new XMLWriter();
+        $writer->openMemory();
+
+        return new self($writer, true);
+    }
+
+    /**
+     * Streaming mode — writes to a URI (e.g. a file path or `php://temp`). The
+     * buffer is flushed to the target periodically, keeping peak memory flat.
+     */
+    public static function toUri(string $uri): self
+    {
+        $writer = new XMLWriter();
+        if (!$writer->openUri($uri)) {
+            throw new RuntimeException(sprintf('Unable to open XML target "%s" for writing.', $uri));
+        }
+
+        return new self($writer, false);
+    }
+
+    public function startDocument(bool $indent = false): self
+    {
+        $this->writer->startDocument('1.0', 'UTF-8');
+        if ($indent) {
+            $this->writer->setIndent(true);
+            $this->writer->setIndentString('  ');
+        }
+
+        return $this;
+    }
+
+    public function startElement(string $name): self
+    {
+        $this->writer->startElement($name);
+        $this->tick();
+
+        return $this;
+    }
+
+    /**
+     * Declare an `xmlns:<prefix>` namespace on the current element.
+     */
+    public function namespaceAttribute(string $prefix, string $uri): self
+    {
+        $this->writer->writeAttribute('xmlns:'.$prefix, self::sanitizeText($uri));
+
+        return $this;
+    }
+
+    public function attribute(string $name, string $value): self
+    {
+        // XMLWriter::writeAttribute auto-escapes `& < > " '`; we only strip
+        // characters that are illegal in XML 1.0 regardless of escaping.
+        $this->writer->writeAttribute($name, self::sanitizeText($value));
+
+        return $this;
+    }
+
+    public function text(string $value): self
+    {
+        $this->writer->text(self::sanitizeText($value));
+
+        return $this;
+    }
+
+    public function cdata(string $value): self
+    {
+        $this->writer->writeCdata(self::neutraliseCdata($value));
+
+        return $this;
+    }
+
+    public function endElement(): self
+    {
+        $this->writer->endElement();
+
+        return $this;
+    }
+
+    /**
+     * Convenience: `<name>text</name>` with escaped text.
+     */
+    public function element(string $name, string $value): self
+    {
+        return $this->startElement($name)->text($value)->endElement();
+    }
+
+    /**
+     * Convenience: `<name><![CDATA[...]]></name>` with neutralised CDATA.
+     */
+    public function elementCdata(string $name, string $value): self
+    {
+        return $this->startElement($name)->cdata($value)->endElement();
+    }
+
+    public function endDocument(): self
+    {
+        $this->writer->endDocument();
+        // In URI mode, flush the remaining buffer to the target. In memory
+        // mode we must NOT flush here — flush() empties the memory buffer that
+        // outputMemory() still needs to return.
+        if (!$this->memoryMode) {
+            $this->writer->flush(true);
+        }
+        $this->closed = true;
+
+        return $this;
+    }
+
+    /**
+     * Return the buffered document (memory mode only). Does not require
+     * {@see endDocument()} but callers normally end the document first.
+     */
+    public function outputMemory(): string
+    {
+        if (!$this->memoryMode) {
+            throw new LogicException('outputMemory() is only available in memory mode; use toUri() for streaming.');
+        }
+
+        return $this->writer->outputMemory();
+    }
+
+    /**
+     * Strip characters illegal in XML 1.0 and scrub invalid UTF-8.
+     *
+     * Allowed: #x9, #xA, #xD, #x20-#xD7FF, #xE000-#xFFFD, #x10000-#x10FFFF.
+     * This is what makes the feed well-formed even for garbage product data
+     * (a name containing a vertical tab \x0B, a NUL, or a broken UTF-8 byte).
+     */
+    public static function sanitizeText(string $value): string
+    {
+        if ('' === $value) {
+            return '';
+        }
+
+        // Drop invalid UTF-8 byte sequences first so the /u regex cannot fail
+        // on a malformed string (e.g. a stray 0xFF byte from a bad import).
+        $scrubbed = mb_convert_encoding($value, 'UTF-8', 'UTF-8');
+
+        $clean = preg_replace(
+            '/[^\x{9}\x{A}\x{D}\x{20}-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]/u',
+            '',
+            $scrubbed,
+        );
+
+        // preg_replace returns null only on a PCRE error; fall back to the
+        // scrubbed string so we never propagate null into the writer.
+        return $clean ?? $scrubbed;
+    }
+
+    /**
+     * Neutralise `]]>` inside CDATA content by closing and reopening the
+     * section around the sequence — the standard, loss-free technique.
+     */
+    public static function neutraliseCdata(string $value): string
+    {
+        return str_replace(']]>', ']]]]><![CDATA[>', self::sanitizeText($value));
+    }
+
+    private function tick(): void
+    {
+        if ($this->memoryMode || $this->closed) {
+            return;
+        }
+
+        if (++$this->sinceFlush >= self::FLUSH_EVERY) {
+            // flush(empty: true) writes the buffer to the URI target AND clears
+            // it — this is what keeps peak memory flat for a 50k-SKU feed.
+            $this->writer->flush(true);
+            $this->sinceFlush = 0;
+        }
+    }
+}

--- a/apps/api/tests/Unit/Export/XmlWriterCoreTest.php
+++ b/apps/api/tests/Unit/Export/XmlWriterCoreTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export;
+
+use App\Export\Infrastructure\Writer\XmlWriterCore;
+use DOMDocument;
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * XMLF-P0-03 — XmlWriterCore always emits well-formed XML, even for garbage
+ * product data. Escaping is delegated to XMLWriter; this suite pins the extra
+ * guarantees the wrapper adds (control-char sanitisation, CDATA neutralisation)
+ * and asserts well-formedness by parsing the output with DOMDocument.
+ */
+final class XmlWriterCoreTest extends TestCase
+{
+    private static function isWellFormed(string $xml): bool
+    {
+        $previous = libxml_use_internal_errors(true);
+        $dom = new DOMDocument();
+        $ok = $dom->loadXML($xml);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
+        return false !== $ok;
+    }
+
+    #[Test]
+    public function writesUtf8DeclarationAndBasicElement(): void
+    {
+        $xml = XmlWriterCore::toMemory()
+            ->startDocument()
+            ->element('name', 'Wkręt ciesielski 4.8×38')
+            ->endDocument()
+            ->outputMemory();
+
+        self::assertStringContainsString('<?xml version="1.0" encoding="UTF-8"?>', $xml);
+        self::assertStringContainsString('<name>Wkręt ciesielski 4.8×38</name>', $xml);
+        self::assertTrue(self::isWellFormed($xml));
+    }
+
+    #[Test]
+    public function escapesSpecialCharactersInTextAndAttributes(): void
+    {
+        $xml = XmlWriterCore::toMemory()
+            ->startDocument()
+            ->startElement('item')
+            ->attribute('title', 'A & B "quoted" <tag>')
+            ->text('R&D <script>alert(1)</script> 5 < 6')
+            ->endElement()
+            ->endDocument()
+            ->outputMemory();
+
+        self::assertStringContainsString('&amp;', $xml);
+        self::assertStringContainsString('&lt;script&gt;', $xml);
+        self::assertStringNotContainsString('<script>', $xml);
+        self::assertTrue(self::isWellFormed($xml));
+
+        // Round-trips back to the original literal value.
+        $dom = new DOMDocument();
+        $dom->loadXML($xml);
+        $item = $dom->getElementsByTagName('item')->item(0);
+        self::assertNotNull($item);
+        self::assertSame('R&D <script>alert(1)</script> 5 < 6', $item->textContent);
+        self::assertSame('A & B "quoted" <tag>', $item->getAttribute('title'));
+    }
+
+    #[Test]
+    public function neutralisesCdataTerminatorSoContentCannotEscape(): void
+    {
+        $payload = 'html <b>bold</b> with a trap ]]> and more';
+
+        $xml = XmlWriterCore::toMemory()
+            ->startDocument()
+            ->elementCdata('description', $payload)
+            ->endDocument()
+            ->outputMemory();
+
+        self::assertTrue(self::isWellFormed($xml), 'CDATA with ]]> must stay well-formed');
+        self::assertStringContainsString('<![CDATA[', $xml);
+
+        $dom = new DOMDocument();
+        $dom->loadXML($xml);
+        $desc = $dom->getElementsByTagName('description')->item(0);
+        self::assertNotNull($desc);
+        // Loss-free: the parser reassembles the original payload verbatim.
+        self::assertSame($payload, $desc->textContent);
+    }
+
+    #[Test]
+    public function stripsControlCharactersIllegalInXml(): void
+    {
+        // \x0B (vertical tab) and \x00 (NUL) are illegal in XML 1.0; \t \n stay.
+        $xml = XmlWriterCore::toMemory()
+            ->startDocument()
+            ->element('sku', "KL-\x0B\x00CB\t4838\n")
+            ->endDocument()
+            ->outputMemory();
+
+        self::assertTrue(self::isWellFormed($xml));
+        self::assertStringNotContainsString("\x0B", $xml);
+        self::assertStringNotContainsString("\x00", $xml);
+
+        $dom = new DOMDocument();
+        $dom->loadXML($xml);
+        $sku = $dom->getElementsByTagName('sku')->item(0);
+        self::assertNotNull($sku);
+        self::assertSame("KL-CB\t4838\n", $sku->textContent);
+    }
+
+    #[Test]
+    public function staysWellFormedOnGarbagePayload(): void
+    {
+        // Every hostile ingredient at once: CDATA terminator, markup, control
+        // char, and an invalid UTF-8 byte (0xFF) from a broken import.
+        $garbage = "]]><script>\x0B\xFF evil & <>";
+
+        $xml = XmlWriterCore::toMemory()
+            ->startDocument()
+            ->startElement('product')
+            ->attribute('id', $garbage)
+            ->element('name', $garbage)
+            ->elementCdata('desc', $garbage)
+            ->endElement()
+            ->endDocument()
+            ->outputMemory();
+
+        self::assertTrue(self::isWellFormed($xml), 'feed must be well-formed even for garbage data');
+        self::assertStringNotContainsString("\x0B", $xml);
+        self::assertStringNotContainsString("\xFF", $xml);
+    }
+
+    #[Test]
+    public function streamsToUriAndProducesSameWellFormedDocument(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'pim-xml-');
+        self::assertIsString($path);
+
+        try {
+            XmlWriterCore::toUri($path)
+                ->startDocument()
+                ->startElement('products')
+                ->element('sku', 'KL-CB-4838')
+                ->element('sku', 'KL-KP-9090')
+                ->endElement()
+                ->endDocument();
+
+            $content = (string) file_get_contents($path);
+            self::assertTrue(self::isWellFormed($content));
+            self::assertStringContainsString('<products>', $content);
+            self::assertSame(2, substr_count($content, '<sku>'));
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    #[Test]
+    public function outputMemoryRejectedInUriMode(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'pim-xml-');
+        self::assertIsString($path);
+
+        try {
+            $writer = XmlWriterCore::toUri($path)->startDocument()->element('a', 'b')->endDocument();
+            $this->expectException(LogicException::class);
+            $writer->outputMemory();
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    #[Test]
+    public function writesNamespaceDeclarations(): void
+    {
+        $xml = XmlWriterCore::toMemory()
+            ->startDocument()
+            ->startElement('rss')
+            ->attribute('version', '2.0')
+            ->namespaceAttribute('g', 'http://base.google.com/ns/1.0')
+            ->endElement()
+            ->endDocument()
+            ->outputMemory();
+
+        self::assertStringContainsString('xmlns:g="http://base.google.com/ns/1.0"', $xml);
+        self::assertTrue(self::isWellFormed($xml));
+    }
+}


### PR DESCRIPTION
## XMLF-P0-03 — XmlWriterCore [SEC]

Jedyna klasa w BC Export dotykająca `XMLWriter` (ADR-0023). Rdzeń serializacji, na którym stają `ItemWriter`/`GenericXmlWriter` (P0-04) i `XmlFeedWriter` (P2-05).

### Zakres
- `apps/api/src/Export/Infrastructure/Writer/XmlWriterCore.php` — memory-bounded otoczka nad `XMLWriter`:
  - deklaracja UTF-8, streaming element/atrybut/text, namespaces;
  - **always-well-formed guarantee**: auto-escaping (`XMLWriter`) + sanityzacja znaków nielegalnych w XML 1.0 (control-chars, niepoprawny UTF-8) + neutralizacja `]]>` w CDATA;
  - dual-mode: in-memory (preview/testy) i streaming do URI z okresowym `flush(true)` (nigdy DOM) — pod feed 50k SKU;
- test jednostkowy (8 przypadków) — DOM weryfikuje well-formedness, w tym śmieciowy payload (`]]>` + `<script>` + `\x0B` + bajt `\xFF`).

### Walidacja lokalna (kontener api, PHP 8.4.22)
- ✅ PHP-CS-Fixer: czysto.
- ✅ PHPStan max: **0 errors**.
- ✅ PHPUnit: **8/8, 30 assertions** (`tests/Unit/Export/XmlWriterCoreTest.php`).

### AC
- [x] `XmlWriterCore` streaming, memory-bounded, jedyny punkt styku z `XMLWriter`.
- [x] Auto-escaping `& < > " '` + sanityzacja control-chars + CDATA `]]>` policy.
- [x] **Failing-test-first**: feed well-formed nawet dla śmieciowych danych (DOM parse).

Refs #1904