### PR TITLE
feat(export): ItemWriter contract + GenericXmlWriter (XMLF-P0-04)

### DIFF
--- a/apps/api/src/Export/Contracts/ItemWriter.php
+++ b/apps/api/src/Export/Contracts/ItemWriter.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Contracts;
+
+/**
+ * Associative item writer contract (ADR-0023, XMLF-P0-04).
+ *
+ * The existing {@see \App\Export\Infrastructure\Writer\RowWriter} is positional
+ * (a flat list of strings) and cannot name elements — insufficient for XML,
+ * where a column key becomes an element/attribute name. ItemWriter is the
+ * parallel, key-aware contract: it consumes the same
+ * `Generator<array<string,string>>` the {@see \App\Export\Application\Builder\ExportBuilder}
+ * yields, but keeps CSV/XLSX untouched.
+ *
+ * Two implementations:
+ *   - {@see \App\Export\Infrastructure\Writer\GenericXmlWriter} — ad-hoc export
+ *     mode 2 (generic `<products><product>…` wrapper), lives in Export core;
+ *   - `XmlFeedWriter` (XMLF-P2-05) — descriptor-driven feed serialization,
+ *     lives in the `Export/Feed` sub-area.
+ *
+ * The output structure/config (root element, descriptor, column plan) is
+ * implementation state passed via the constructor — never through this
+ * contract — so both the generic and the feed writer share one lifecycle.
+ */
+interface ItemWriter
+{
+    /**
+     * Open the document and any wrapping/header structure (generic root, or a
+     * feed's `channel` + header nodes).
+     */
+    public function begin(): void;
+
+    /**
+     * Serialize one item.
+     *
+     * @param array<string, string> $item column-key => already-serialized value
+     *                                    (as produced by ExportBuilder / ValueSerializer)
+     */
+    public function writeItem(array $item): void;
+
+    /**
+     * Close the wrapping structure and finalize the document.
+     */
+    public function finish(): void;
+}

--- a/apps/api/src/Export/Infrastructure/Writer/GenericXmlWriter.php
+++ b/apps/api/src/Export/Infrastructure/Writer/GenericXmlWriter.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Infrastructure\Writer;
+
+use App\Export\Application\Builder\ColumnDefinition;
+use App\Export\Contracts\ItemWriter;
+
+/**
+ * Generic XML writer for the ad-hoc export mode (XMLF-P0-04/P0-05, ADR-0023
+ * §6.10). Produces a schema-less `<products><product>…</product></products>`
+ * dump — no feed template, no transformations. The feed path uses the
+ * descriptor-driven `XmlFeedWriter` (XMLF-P2-05) instead.
+ *
+ * Each column becomes an element named after its attribute/built-in code; a
+ * `.locale` / `.channel` scoped column carries the scope as element attributes
+ * (`<description locale="pl">`, `<price channel="shopify">`) because `.` is not
+ * a legal XML element name character. Multi-value cells keep the pipe join
+ * ExportBuilder/ValueSerializer already produced, so the XML dump round-trips
+ * consistently with CSV/XLSX.
+ *
+ * All serialization goes through {@see XmlWriterCore}, so the output is always
+ * well-formed (escaping + control-char sanitisation) even for garbage data.
+ */
+final class GenericXmlWriter implements ItemWriter
+{
+    /**
+     * @param list<ColumnDefinition> $columns resolved export column plan
+     */
+    public function __construct(
+        private readonly XmlWriterCore $xml,
+        private readonly array $columns,
+        private readonly string $rootElement = 'products',
+        private readonly string $itemElement = 'product',
+    ) {
+    }
+
+    public function begin(): void
+    {
+        $this->xml->startDocument()->startElement($this->rootElement);
+    }
+
+    public function writeItem(array $item): void
+    {
+        $this->xml->startElement($this->itemElement);
+
+        foreach ($this->columns as $column) {
+            $value = $item[$column->key] ?? '';
+
+            $this->xml->startElement(self::elementName($column->code));
+            if (null !== $column->locale) {
+                $this->xml->attribute('locale', $column->locale);
+            }
+            if (null !== $column->channel) {
+                $this->xml->attribute('channel', $column->channel);
+            }
+            $this->xml->text($value);
+            $this->xml->endElement();
+        }
+
+        $this->xml->endElement();
+    }
+
+    public function finish(): void
+    {
+        $this->xml->endElement()->endDocument();
+    }
+
+    /**
+     * Coerce a column code into a legal XML element name (NCName): start with a
+     * letter or underscore, then letters / digits / `-` / `_`. Attribute codes
+     * are normally already valid; this is a defensive fallback.
+     */
+    private static function elementName(string $code): string
+    {
+        $name = preg_replace('/[^A-Za-z0-9_-]/', '_', $code) ?? '';
+
+        if ('' === $name || 1 !== preg_match('/^[A-Za-z_]/', $name)) {
+            $name = '_'.$name;
+        }
+
+        return $name;
+    }
+}

--- a/apps/api/tests/Unit/Export/GenericXmlWriterTest.php
+++ b/apps/api/tests/Unit/Export/GenericXmlWriterTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export;
+
+use App\Export\Application\Builder\ColumnDefinition;
+use App\Export\Infrastructure\Writer\GenericXmlWriter;
+use App\Export\Infrastructure\Writer\XmlWriterCore;
+use DOMDocument;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * XMLF-P0-04 — GenericXmlWriter emits the ad-hoc `<products><product>` dump:
+ * one element per column, `.locale`/`.channel` scope as attributes, always
+ * well-formed (via XmlWriterCore).
+ */
+final class GenericXmlWriterTest extends TestCase
+{
+    /**
+     * @param list<ColumnDefinition> $columns
+     * @param array<string, string>  $item
+     */
+    private static function render(array $columns, array $item): string
+    {
+        $xml = XmlWriterCore::toMemory();
+        $writer = new GenericXmlWriter($xml, $columns);
+        $writer->begin();
+        $writer->writeItem($item);
+        $writer->finish();
+
+        return $xml->outputMemory();
+    }
+
+    private static function dom(string $xml): DOMDocument
+    {
+        $dom = new DOMDocument();
+        self::assertNotFalse($dom->loadXML($xml), 'output must be well-formed');
+
+        return $dom;
+    }
+
+    #[Test]
+    public function wrapsItemsAndMapsColumnsToElements(): void
+    {
+        $columns = [
+            new ColumnDefinition('sku', ColumnDefinition::KIND_BUILT_IN, 'sku'),
+            new ColumnDefinition('description.pl', ColumnDefinition::KIND_ATTRIBUTE, 'description', 'pl'),
+            new ColumnDefinition('price.shopify', ColumnDefinition::KIND_ATTRIBUTE, 'price', null, 'shopify'),
+        ];
+
+        $xml = self::render($columns, [
+            'sku' => 'KL-CB-4838',
+            'description.pl' => 'Wkręt ciesielski',
+            'price.shopify' => '19.90 PLN',
+        ]);
+
+        $dom = self::dom($xml);
+        self::assertSame(1, $dom->getElementsByTagName('products')->length);
+        self::assertSame(1, $dom->getElementsByTagName('product')->length);
+
+        $desc = $dom->getElementsByTagName('description')->item(0);
+        self::assertNotNull($desc);
+        self::assertSame('pl', $desc->getAttribute('locale'));
+        self::assertSame('Wkręt ciesielski', $desc->textContent);
+
+        $price = $dom->getElementsByTagName('price')->item(0);
+        self::assertNotNull($price);
+        self::assertSame('shopify', $price->getAttribute('channel'));
+        self::assertSame('19.90 PLN', $price->textContent);
+    }
+
+    #[Test]
+    public function escapesHostileValuesAndStaysWellFormed(): void
+    {
+        $columns = [new ColumnDefinition('name', ColumnDefinition::KIND_BUILT_IN, 'name')];
+
+        $xml = self::render($columns, ['name' => 'A & B <script> ]]> "x"']);
+
+        self::assertStringNotContainsString('<script>', $xml);
+        $dom = self::dom($xml);
+        $name = $dom->getElementsByTagName('name')->item(0);
+        self::assertNotNull($name);
+        self::assertSame('A & B <script> ]]> "x"', $name->textContent);
+    }
+
+    #[Test]
+    public function missingCellRendersEmptyElement(): void
+    {
+        $columns = [
+            new ColumnDefinition('sku', ColumnDefinition::KIND_BUILT_IN, 'sku'),
+            new ColumnDefinition('ean', ColumnDefinition::KIND_ATTRIBUTE, 'ean'),
+        ];
+
+        $xml = self::render($columns, ['sku' => 'KL-1']); // no 'ean' key
+
+        $dom = self::dom($xml);
+        $ean = $dom->getElementsByTagName('ean')->item(0);
+        self::assertNotNull($ean);
+        self::assertSame('', $ean->textContent);
+    }
+
+    #[Test]
+    public function sanitisesIllegalElementNameFromCode(): void
+    {
+        // A code with characters illegal in an XML element name.
+        $columns = [new ColumnDefinition('weird', ColumnDefinition::KIND_ATTRIBUTE, '1 bad:name')];
+
+        $xml = self::render($columns, ['weird' => 'v']);
+
+        $dom = self::dom($xml); // must not throw / must be well-formed
+        // Leading digit gets an underscore prefix; illegal chars become '_'.
+        self::assertMatchesRegularExpression('/<_1_bad_name>v<\/_1_bad_name>/', $xml);
+        self::assertNotNull($dom->documentElement);
+    }
+}


### PR DESCRIPTION
## XMLF-P0-04 — ItemWriter (asocjacyjny) + GenericXmlWriter

Pozycyjny `RowWriter` nie zna nazw elementów — XML potrzebuje kontraktu klucz→wartość. `ItemWriter` to równoległy seam; oba konsumują ten sam `Generator<array<string,string>>` z `ExportBuilder`, CSV/XLSX zostają czyste.

### Zakres
- `apps/api/src/Export/Contracts/ItemWriter.php` — kontrakt `begin()/writeItem(array<string,string>)/finish()` (seam `Export/Contracts`).
- `apps/api/src/Export/Infrastructure/Writer/GenericXmlWriter.php` — tryb ad-hoc (ADR-0023 §6.10): generyczny `<products><product>`, element per kolumna, `.locale`/`.channel` jako atrybuty elementu (`<description locale="pl">`), multi-value pipe (spójnie z eksportem), sanityzacja nazwy elementu (NCName). Cała serializacja przez `XmlWriterCore` → always-well-formed.
- Test jednostkowy (4 przypadki: mapowanie kolumn+scope, escaping/`]]>`/`<script>`, pusta komórka, sanityzacja nielegalnej nazwy).
- `XmlFeedWriter` (P2-05) zaimplementuje ten sam kontrakt dla feedów descriptor-driven.

### Walidacja lokalna (kontener api, PHP 8.4.22)
- ✅ CS-Fixer czysto · PHPStan max **0 errors** · PHPUnit **4/4, 19 assertions** · **Deptrac 0 violations / 0 uncovered** (Export core → `Export_Contracts` OK).

### AC
- [x] `ItemWriter` asocjacyjny; `RowWriter` nietknięty.
- [x] `GenericXmlWriter`: klucz→element, locale/channel jako atrybuty, multi-value pipe.
- [x] Zawsze well-formed (przez `XmlWriterCore`).

Refs #1905