### PR TITLE
feat(export): ExportFormat::Xml + wire XML into runner (XMLF-P0-05)

### DIFF
--- a/apps/api/src/Export/Application/Sync/SyncExportRunner.php
+++ b/apps/api/src/Export/Application/Sync/SyncExportRunner.php
@@ -10,6 +10,7 @@ use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Export\Application\Builder\ColumnResolver;
 use App\Export\Application\Builder\ExportBuilder;
 use App\Export\Application\Builder\PublicationColumnPlanner;
 use App\Export\Application\Builder\Structural\StructuralExportBuilderInterface;
@@ -20,8 +21,13 @@ use App\Export\Domain\Enum\ExportFormat;
 use App\Export\Domain\Enum\ExportTargetScope;
 use App\Export\Domain\Repository\ExportSessionRepositoryInterface;
 use App\Export\Infrastructure\Writer\CsvStreamWriter;
+use App\Export\Infrastructure\Writer\GenericXmlWriter;
+use App\Export\Infrastructure\Writer\PositionalRowSink;
+use App\Export\Infrastructure\Writer\RowSink;
 use App\Export\Infrastructure\Writer\RowWriter;
 use App\Export\Infrastructure\Writer\XlsxStreamWriter;
+use App\Export\Infrastructure\Writer\XmlRowSink;
+use App\Export\Infrastructure\Writer\XmlWriterCore;
 use App\Shared\Domain\Tenant;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
@@ -68,6 +74,7 @@ final class SyncExportRunner
         private readonly FilterDslResolver $filterDsl,
         private readonly Connection $connection,
         private readonly PublicationColumnPlanner $columnPlanner,
+        private readonly ColumnResolver $columnResolver,
         private readonly ObjectTypeRepositoryInterface $objectTypes,
         private readonly EntityManagerInterface $em,
         /** @var iterable<StructuralExportBuilderInterface> */
@@ -342,8 +349,8 @@ final class SyncExportRunner
             $columns = $planned;
         }
 
-        $writer = $this->openWriter($session->getFormat(), $session, $targetPath);
-        $writer->writeHeaders($columns);
+        $sink = $this->openSink($session->getFormat(), $session, $columns, $targetPath);
+        $sink->begin($columns);
 
         $rows = 0;
         try {
@@ -356,11 +363,7 @@ final class SyncExportRunner
                 // (findByIds returns DB order; the plan owns the contract).
                 $page = $this->hydratePageInOrder($idPage);
                 foreach ($this->builder->build($page, $session) as $row) {
-                    $values = [];
-                    foreach ($columns as $key) {
-                        $values[] = $row[$key] ?? '';
-                    }
-                    $writer->writeRow($values);
+                    $sink->accept($row);
                     ++$rows;
                     if (null !== $onChunk && 0 === $rows % self::PROGRESS_CHUNK) {
                         $onChunk($rows);
@@ -370,7 +373,7 @@ final class SyncExportRunner
                 $this->em->clear();
             }
         } finally {
-            $writer->close();
+            $sink->close();
         }
 
         $size = file_exists($targetPath) ? (int) filesize($targetPath) : 0;
@@ -448,24 +451,20 @@ final class SyncExportRunner
             $columns = $builder->columns($tenant);
         }
 
-        $writer = $this->openWriter($session->getFormat(), $session, $targetPath);
-        $writer->writeHeaders($columns);
+        $sink = $this->openSink($session->getFormat(), $session, $columns, $targetPath);
+        $sink->begin($columns);
 
         $rows = 0;
         try {
             foreach ($builder->rows($tenant) as $row) {
-                $values = [];
-                foreach ($columns as $key) {
-                    $values[] = $row[$key] ?? '';
-                }
-                $writer->writeRow($values);
+                $sink->accept($row);
                 ++$rows;
                 if (null !== $onChunk && 0 === $rows % self::PROGRESS_CHUNK) {
                     $onChunk($rows);
                 }
             }
         } finally {
-            $writer->close();
+            $sink->close();
         }
 
         $session->setTargetCount($rows);
@@ -495,6 +494,25 @@ final class SyncExportRunner
         }
 
         return $tenant;
+    }
+
+    /**
+     * Build the {@see RowSink} for the session format. XML (ADR-0023 §6.10)
+     * streams through {@see GenericXmlWriter}, which needs the resolved column
+     * plan (locale/channel scope → element attributes); CSV/XLSX wrap the
+     * positional {@see RowWriter}.
+     *
+     * @param list<string> $columns
+     */
+    private function openSink(ExportFormat $format, ExportSession $session, array $columns, string $path): RowSink
+    {
+        if (ExportFormat::Xml === $format) {
+            $definitions = array_values($this->columnResolver->resolve($columns, $session->getChannels() ?? []));
+
+            return new XmlRowSink(new GenericXmlWriter(XmlWriterCore::toUri($path), $definitions));
+        }
+
+        return new PositionalRowSink($this->openWriter($format, $session, $path));
     }
 
     private function openWriter(ExportFormat $format, ExportSession $session, string $path): RowWriter

--- a/apps/api/src/Export/Domain/Enum/ExportFormat.php
+++ b/apps/api/src/Export/Domain/Enum/ExportFormat.php
@@ -5,20 +5,24 @@ declare(strict_types=1);
 namespace App\Export\Domain\Enum;
 
 /**
- * Output formats supported in MVP (PRD §13.1). XML/JSON deferred to
- * Faza 1 (§13.2). XLSX is the round-trip target with Excel; CSV is
- * the lighter alternative for Marcin's Python pipeline.
+ * Output formats. XLSX is the round-trip target with Excel; CSV is the lighter
+ * alternative for Marcin's Python pipeline. XML (XMLF-P0-05, ADR-0023) is the
+ * ad-hoc export mode 2 — a generic `<products><product>` dump serialized via
+ * {@see \App\Export\Infrastructure\Writer\GenericXmlWriter}; the persistent
+ * feed path (Google/Ceneo/Meta) lives in the Export/Feed sub-area.
  */
 enum ExportFormat: string
 {
     case Xlsx = 'xlsx';
     case Csv = 'csv';
+    case Xml = 'xml';
 
     public function mimeType(): string
     {
         return match ($this) {
             self::Xlsx => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
             self::Csv => 'text/csv',
+            self::Xml => 'application/xml',
         };
     }
 

--- a/apps/api/src/Export/Infrastructure/Writer/PositionalRowSink.php
+++ b/apps/api/src/Export/Infrastructure/Writer/PositionalRowSink.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Infrastructure\Writer;
+
+/**
+ * Adapts the positional {@see RowWriter} (CSV/XLSX) to the associative
+ * {@see RowSink} the runner drives (XMLF-P0-05). Maps each associative row onto
+ * the ordered column list — the mapping the runner used to do inline.
+ */
+final class PositionalRowSink implements RowSink
+{
+    /** @var list<string> */
+    private array $columns = [];
+
+    public function __construct(private readonly RowWriter $writer)
+    {
+    }
+
+    public function begin(array $columns): void
+    {
+        $this->columns = $columns;
+        $this->writer->writeHeaders($columns);
+    }
+
+    public function accept(array $row): void
+    {
+        $values = [];
+        foreach ($this->columns as $key) {
+            $values[] = $row[$key] ?? '';
+        }
+
+        $this->writer->writeRow($values);
+    }
+
+    public function close(): void
+    {
+        $this->writer->close();
+    }
+}

--- a/apps/api/src/Export/Infrastructure/Writer/RowSink.php
+++ b/apps/api/src/Export/Infrastructure/Writer/RowSink.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Infrastructure\Writer;
+
+/**
+ * Row-oriented sink the export runner writes to (XMLF-P0-05).
+ *
+ * The runner yields an ASSOCIATIVE row (`array<string,string>` keyed by column
+ * key) from {@see \App\Export\Application\Builder\ExportBuilder}. A sink hides
+ * the format-specific shape: positional formats (CSV/XLSX) map the row onto the
+ * ordered column list, while XML feeds the associative row straight to an
+ * {@see \App\Export\Contracts\ItemWriter}. This keeps the runner's paging /
+ * clear() / progress loop identical across formats.
+ */
+interface RowSink
+{
+    /**
+     * Open the document + header/wrapper structure.
+     *
+     * @param list<string> $columns ordered export column keys
+     */
+    public function begin(array $columns): void;
+
+    /**
+     * Write one associative row.
+     *
+     * @param array<string, string> $row column-key => serialized value
+     */
+    public function accept(array $row): void;
+
+    public function close(): void;
+}

--- a/apps/api/src/Export/Infrastructure/Writer/XmlRowSink.php
+++ b/apps/api/src/Export/Infrastructure/Writer/XmlRowSink.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Infrastructure\Writer;
+
+use App\Export\Contracts\ItemWriter;
+
+/**
+ * Adapts an {@see ItemWriter} (associative XML writer) to the {@see RowSink}
+ * the runner drives (XMLF-P0-05). The associative row is passed through
+ * unchanged — the writer owns element/attribute naming from its column plan.
+ */
+final class XmlRowSink implements RowSink
+{
+    public function __construct(private readonly ItemWriter $writer)
+    {
+    }
+
+    public function begin(array $columns): void
+    {
+        // The XML writer holds its own column plan / descriptor; the ordered
+        // key list is not needed to open the document.
+        $this->writer->begin();
+    }
+
+    public function accept(array $row): void
+    {
+        $this->writer->writeItem($row);
+    }
+
+    public function close(): void
+    {
+        $this->writer->finish();
+    }
+}

--- a/apps/api/src/Export/Presentation/Controller/ExportSessionController.php
+++ b/apps/api/src/Export/Presentation/Controller/ExportSessionController.php
@@ -430,13 +430,14 @@ final class ExportSessionController
 
     private function contentTypeFor(ExportSession $session): string
     {
-        if (\App\Export\Domain\Enum\ExportFormat::Xlsx === $session->getFormat()) {
-            return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
-        }
-        $encoding = $session->getEncoding();
-        $charset = \App\Export\Domain\Enum\ExportEncoding::Windows1250 === $encoding ? 'windows-1250' : 'utf-8';
-
-        return sprintf('text/csv; charset=%s', $charset);
+        return match ($session->getFormat()) {
+            \App\Export\Domain\Enum\ExportFormat::Xlsx => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            \App\Export\Domain\Enum\ExportFormat::Xml => 'application/xml; charset=utf-8',
+            \App\Export\Domain\Enum\ExportFormat::Csv => sprintf(
+                'text/csv; charset=%s',
+                \App\Export\Domain\Enum\ExportEncoding::Windows1250 === $session->getEncoding() ? 'windows-1250' : 'utf-8',
+            ),
+        };
     }
 
     /**

--- a/apps/api/src/Export/Presentation/Controller/SyncExportController.php
+++ b/apps/api/src/Export/Presentation/Controller/SyncExportController.php
@@ -247,11 +247,11 @@ final class SyncExportController
     {
         $value = $payload['format'] ?? null;
         if (!\is_string($value)) {
-            throw new BadRequestHttpException('format is required (xlsx|csv).');
+            throw new BadRequestHttpException('format is required (xlsx|csv|xml).');
         }
         $format = ExportFormat::tryFrom($value);
         if (null === $format) {
-            throw new BadRequestHttpException(sprintf('Unsupported format "%s" — expected xlsx or csv.', $value));
+            throw new BadRequestHttpException(sprintf('Unsupported format "%s" — expected xlsx, csv or xml.', $value));
         }
 
         return $format;
@@ -279,7 +279,8 @@ final class SyncExportController
      */
     private function parseEncoding(array $payload, ExportFormat $format): ?ExportEncoding
     {
-        if (ExportFormat::Xlsx === $format) {
+        // Encoding is a CSV-only concern; XLSX and XML are always UTF-8.
+        if (ExportFormat::Xlsx === $format || ExportFormat::Xml === $format) {
             return null;
         }
         $value = $payload['encoding'] ?? ExportEncoding::Utf8Bom->value;
@@ -431,11 +432,13 @@ final class SyncExportController
 
     private function contentTypeFor(ExportFormat $format, ?ExportEncoding $encoding): string
     {
-        if (ExportFormat::Xlsx === $format) {
-            return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
-        }
-        $charset = ExportEncoding::Windows1250 === $encoding ? 'windows-1250' : 'utf-8';
-
-        return sprintf('text/csv; charset=%s', $charset);
+        return match ($format) {
+            ExportFormat::Xlsx => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            ExportFormat::Xml => 'application/xml; charset=utf-8',
+            ExportFormat::Csv => sprintf(
+                'text/csv; charset=%s',
+                ExportEncoding::Windows1250 === $encoding ? 'windows-1250' : 'utf-8',
+            ),
+        };
     }
 }

--- a/apps/api/tests/Api/Export/XmlExportApiTest.php
+++ b/apps/api/tests/Api/Export/XmlExportApiTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Export;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * XMLF-P0-05 — XML as an ad-hoc export format (ADR-0023 §6.10). The sync
+ * export endpoint accepts `format=xml` and serves `application/xml`; the
+ * generic `<products><product>` serialization itself is unit-tested
+ * (XmlWriterCore / GenericXmlWriter / RowSink) and smoke-tested end-to-end.
+ */
+final class XmlExportApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function syncXmlExportServesApplicationXml(): void
+    {
+        $this->seedRootProducts(2);
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/products/export', [
+            'json' => [
+                'entity_type' => 'product',
+                'format' => 'xml',
+                'target_scope' => 'all',
+                'selected_columns' => ['sku', 'name'],
+                'include_variants' => false,
+            ],
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+        $contentType = $response->getHeaders(false)['content-type'][0] ?? '';
+        self::assertStringContainsString('application/xml', $contentType);
+    }
+
+    #[Test]
+    public function rejectsUnknownFormat(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/products/export', [
+            'json' => [
+                'format' => 'json',
+                'target_scope' => 'all',
+                'selected_columns' => ['sku'],
+            ],
+        ]);
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    private function seedRootProducts(int $count): void
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $type);
+
+        $repo = self::getContainer()->get(CatalogObjectRepositoryInterface::class);
+        for ($i = 1; $i <= $count; ++$i) {
+            $repo->save(new CatalogObject($type, \sprintf('XMLF-%03d', $i)));
+        }
+
+        $this->em()->clear();
+    }
+}

--- a/apps/api/tests/Unit/Export/RowSinkTest.php
+++ b/apps/api/tests/Unit/Export/RowSinkTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export;
+
+use App\Export\Application\Builder\ColumnDefinition;
+use App\Export\Infrastructure\Writer\GenericXmlWriter;
+use App\Export\Infrastructure\Writer\PositionalRowSink;
+use App\Export\Infrastructure\Writer\RowWriter;
+use App\Export\Infrastructure\Writer\XmlRowSink;
+use App\Export\Infrastructure\Writer\XmlWriterCore;
+use DOMDocument;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * XMLF-P0-05 — the RowSink adapters let the runner drive every format from a
+ * single associative-row loop: positional (CSV/XLSX) maps onto the column
+ * order, XML feeds the row straight to the ItemWriter.
+ */
+final class RowSinkTest extends TestCase
+{
+    #[Test]
+    public function positionalSinkMapsAssociativeRowOntoColumnOrder(): void
+    {
+        $writer = new class implements RowWriter {
+            /** @var list<list<string>> */
+            public array $rows = [];
+
+            public function writeHeaders(array $headers): void
+            {
+                $this->rows[] = $headers;
+            }
+
+            public function writeRow(array $values): void
+            {
+                $this->rows[] = $values;
+            }
+
+            public function close(): void
+            {
+            }
+        };
+
+        $sink = new PositionalRowSink($writer);
+        $sink->begin(['sku', 'name', 'ean']);
+        $sink->accept(['name' => 'Wkręt', 'sku' => 'KL-1']); // out of order, 'ean' missing
+        $sink->close();
+
+        self::assertSame(['sku', 'name', 'ean'], $writer->rows[0]);
+        self::assertSame(['KL-1', 'Wkręt', ''], $writer->rows[1]);
+    }
+
+    #[Test]
+    public function xmlSinkStreamsAssociativeRowsAsWellFormedXml(): void
+    {
+        $xml = XmlWriterCore::toMemory();
+        $columns = [
+            new ColumnDefinition('sku', ColumnDefinition::KIND_BUILT_IN, 'sku'),
+            new ColumnDefinition('name', ColumnDefinition::KIND_BUILT_IN, 'name'),
+        ];
+
+        $sink = new XmlRowSink(new GenericXmlWriter($xml, $columns));
+        $sink->begin(['sku', 'name']);
+        $sink->accept(['sku' => 'KL-1', 'name' => 'A & B']);
+        $sink->accept(['sku' => 'KL-2', 'name' => 'C']);
+        $sink->close();
+
+        $out = $xml->outputMemory();
+        $dom = new DOMDocument();
+        self::assertNotFalse($dom->loadXML($out));
+        self::assertSame(2, $dom->getElementsByTagName('product')->length);
+        self::assertSame('A & B', $dom->getElementsByTagName('name')->item(0)?->textContent);
+    }
+}


### PR DESCRIPTION
## XMLF-P0-05 — XML jako format eksportu ad-hoc (tryb 2)

Wpina `GenericXmlWriter` w silnik eksportu → jednorazowy dump XML obok XLSX/CSV.

### Zmiany
- `ExportFormat::Xml` (mime `application/xml`).
- **`RowSink`** — abstrakcja wiersza asocjacyjnego; obie pętle runnera (katalog + strukturalna) jadą jednym sinkiem: `PositionalRowSink` (opakowuje `RowWriter` CSV/XLSX), `XmlRowSink` (podaje wiersz do `GenericXmlWriter`). Runner: wstrzyknięty `ColumnResolver` (locale/channel → atrybuty elementu), `openSink()`.
- **Fix 2 bugów Content-Type**: `SyncExportController` i `ExportSessionController` (async download) miały fallthrough → `text/csv` dla każdego nie-XLSX; teraz exhaustive `match` z arm `Xml` → `application/xml`. `parseEncoding` zwraca null dla xml; komunikaty `parseFormat` uwzględniają xml.
- Testy: `RowSinkTest` (unit — mapowanie positional + XML), `XmlExportApiTest` (200 + application/xml; odrzucenie nieznanego formatu).

### Walidacja
- ✅ CS-Fixer · PHPStan max **0 errors** · PHPUnit Unit/Export **91/91** · Deptrac **0**.
- ✅ **Live smoke `pim.localhost`**: `POST /api/products/export` `format=xml` `scope=all` → **200 `application/xml`**, **95 produktów**, **well-formed (`xmllint --noout` ✓)**, `.locale` scope jako `<description locale="pl">`.

### AC
- [x] `ExportFormat::Xml` + wpięcie w sync/async runner (bez zmiany routingu <100/≥100).
- [x] Generyczny wrapper, download jak XLSX/CSV, poprawny Content-Type (sync + async).
- [x] CSV/XLSX niezregresowane (ta sama pętla przez `PositionalRowSink`; istniejące Api-testy eksportu na CI).

Refs #1906