### PR TITLE
feat(exports): unblock XML export format tile (XMLF-P0-06)

### DIFF
--- a/apps/admin/e2e/xmlf-p0-06-xml-export-format.spec.ts
+++ b/apps/admin/e2e/xmlf-p0-06-xml-export-format.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * XMLF-P0-06 — XML is unblocked as an ad-hoc export format (ADR-0023 §6.10).
+ * It used to render as a disabled "wkrótce" tile; it is now active and
+ * selectable alongside XLSX/CSV. The backend serialization + application/xml
+ * response are covered by the API test + live smoke on POST /api/products/export.
+ */
+test('XML is an enabled, selectable export format tile', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/integrations/exports/new');
+
+  // Step 0 — entity type: pick Products, then advance to the scope + format step.
+  await page
+    .getByRole('radio', { name: /Produkty|Products/ })
+    .first()
+    .click();
+  await page.getByRole('button', { name: /Dalej|Next/ }).click();
+
+  // Step 1 — format tiles. XML is now an active radio, not a disabled tile.
+  const xmlTile = page.getByRole('radio', { name: /XML/ }).first();
+  await expect(xmlTile).toBeVisible();
+  await expect(xmlTile).not.toHaveAttribute('aria-disabled', 'true');
+
+  await xmlTile.click();
+  await expect(xmlTile).toHaveAttribute('aria-checked', 'true');
+});

--- a/apps/admin/src/features/exports/hooks/useExportSessions.ts
+++ b/apps/admin/src/features/exports/hooks/useExportSessions.ts
@@ -13,7 +13,7 @@ export interface ExportSessionRow {
     | 'categories'
     | string;
   object_type_id: string | null;
-  format: 'xlsx' | 'csv';
+  format: 'xlsx' | 'csv' | 'xml';
   target_scope: string;
   target_count: number;
   success_count: number;

--- a/apps/admin/src/features/exports/wizard/ExportWizardPage.tsx
+++ b/apps/admin/src/features/exports/wizard/ExportWizardPage.tsx
@@ -95,7 +95,10 @@ function WizardContent() {
           profileName: profile.name,
           entityType: profile.entity_type,
           objectTypeId: profile.object_type_id,
-          format: profile.config.format === 'csv' ? 'csv' : 'xlsx',
+          format:
+            profile.config.format === 'csv' || profile.config.format === 'xml'
+              ? profile.config.format
+              : 'xlsx',
           columns: profile.config.selected_columns ?? [],
           locales: profile.config.locales ?? null,
           channels: profile.config.channels ?? null,

--- a/apps/admin/src/features/exports/wizard/steps/StepScopeFormat.tsx
+++ b/apps/admin/src/features/exports/wizard/steps/StepScopeFormat.tsx
@@ -44,10 +44,11 @@ interface ProfilesResponse {
 const ACTIVE_FORMATS: Array<{ id: ExportFormat; descKey: string }> = [
   { id: 'xlsx', descKey: 'exports.wizard.format_desc.xlsx' },
   { id: 'csv', descKey: 'exports.wizard.format_desc.csv' },
+  { id: 'xml', descKey: 'exports.wizard.format_desc.xml' },
 ];
 
 /** D1 — visible but disabled format tiles ("wkrótce"), never sent in payloads. */
-const SOON_FORMATS = ['xml', 'json', 'gsheets', 'pdf'] as const;
+const SOON_FORMATS = ['json', 'gsheets', 'pdf'] as const;
 
 /**
  * EXR-10 — wizard step 2 (screen 3): saved profile select, format
@@ -105,7 +106,10 @@ export function StepScopeFormat() {
   const applyProfile = (profileId: string) => {
     const profile = matchingProfiles.find((row) => row.id === profileId);
     if (!profile) return;
-    const format = profile.config.format === 'csv' ? 'csv' : 'xlsx';
+    const format =
+      profile.config.format === 'csv' || profile.config.format === 'xml'
+        ? profile.config.format
+        : 'xlsx';
     const filterDsl = profile.config.filter ?? null;
     dispatch({
       type: 'APPLY_PROFILE',

--- a/apps/admin/src/features/exports/wizard/types.ts
+++ b/apps/admin/src/features/exports/wizard/types.ts
@@ -9,7 +9,7 @@ export type ExportEntityType =
   | 'attribute_groups'
   | 'categories';
 
-export type ExportFormat = 'xlsx' | 'csv';
+export type ExportFormat = 'xlsx' | 'csv' | 'xml';
 
 export type ExportTargetScope = 'all' | 'filter' | 'selected';
 

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -3091,16 +3091,15 @@
       "format_group_aria": "File format",
       "format_desc": {
         "xlsx": "Excel spreadsheet",
-        "csv": "Comma-separated values"
+        "csv": "Comma-separated values",
+        "xml": "Hierarchical XML feed (generic wrapper)"
       },
       "format_soon": {
-        "xml": "XML",
         "json": "JSON",
         "gsheets": "Google Sheets",
         "pdf": "PDF"
       },
       "format_soon_desc": {
-        "xml": "Hierarchical feed",
         "json": "Structured data / API",
         "gsheets": "Cloud spreadsheet",
         "pdf": "Catalog / price list"

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -3143,16 +3143,15 @@
       "format_group_aria": "Format pliku",
       "format_desc": {
         "xlsx": "Arkusz kalkulacyjny Excel",
-        "csv": "Wartości rozdzielane przecinkiem"
+        "csv": "Wartości rozdzielane przecinkiem",
+        "xml": "Hierarchiczny feed XML (generyczny wrapper)"
       },
       "format_soon": {
-        "xml": "XML",
         "json": "JSON",
         "gsheets": "Google Sheets",
         "pdf": "PDF"
       },
       "format_soon_desc": {
-        "xml": "Feed hierarchiczny",
         "json": "Dane strukturalne / API",
         "gsheets": "Arkusz w chmurze",
         "pdf": "Katalog / cennik"


### PR DESCRIPTION
## XMLF-P0-06 — odblokowanie kafelka XML (tryb 2, FE)

Domyka tryb 2: XML jako jednorazowy dump w kreatorze eksportu, teraz klikalny obok XLSX/CSV (backend P0-05 już serwuje).

### Zmiany
- `StepScopeFormat.tsx`: `xml` z `SOON_FORMATS` (disabled „wkrótce") → `ACTIVE_FORMATS`.
- Typ FE `ExportFormat` + `'xml'`; koercja formatu z zapisanego profilu xml-aware (`ExportWizardPage`, `StepScopeFormat`); typ w `useExportSessions`.
- i18n `format_desc.xml` (en/pl); usunięte `format_soon.xml`/`format_soon_desc.xml`.
- Playwright E2E: kafelek XML widoczny, **nie disabled**, wybieralny (`aria-checked`).

### Walidacja lokalna
- ✅ biome czysto · `tsc -b --noEmit` czysto.
- ✅ **Playwright E2E passed (3.6s)** na żywym stacku (`loginAsAdmin` → kreator → wybór kafelka XML).
- ✅ Backend (P0-05) live smoke: `POST /api/products/export` format=xml → 200 application/xml, well-formed.

Closes #1907