### PR TITLE
feat(export): FeedDescriptor value object + slot model (XMLF-P2-01)

### DIFF
--- a/apps/api/src/Export/Feed/Domain/Descriptor/FeedDescriptor.php
+++ b/apps/api/src/Export/Feed/Domain/Descriptor/FeedDescriptor.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Domain\Descriptor;
+
+/**
+ * Declarative XML feed structure (ADR-0023 §6.3, XMLF-P2-01) — the canonical,
+ * validated shape of `feed_profiles.descriptor`. The UI edits it (XMLF-P2-07),
+ * the writer executes it (XMLF-P2-05), the generator validates products against
+ * its slot rules (XMLF-P2-04). This VO is the single source of truth for the
+ * descriptor shape; the persist-time guard (XMLF-P1-04) delegates to it.
+ *
+ * Supports the RSS-like shape (root `rss` → `channel` → `item`, Google/Meta)
+ * and the flat shape (root `offers` → `o`, Ceneo) — `channel` is optional.
+ */
+final class FeedDescriptor
+{
+    private const string XML_NAME = '/^([A-Za-z_][A-Za-z0-9_-]*:)?[A-Za-z_][A-Za-z0-9_-]*$/';
+
+    /**
+     * @param array<string, string>      $rootAttributes
+     * @param array<string, string>      $namespaces     prefix => URI
+     * @param list<array<string, mixed>> $header         channel header nodes (element + source)
+     * @param list<FeedSlot>             $slots
+     */
+    public function __construct(
+        public readonly string $rootElement,
+        public readonly array $rootAttributes,
+        public readonly array $namespaces,
+        public readonly ?string $channelElement,
+        public readonly array $header,
+        public readonly string $itemElement,
+        public readonly array $slots,
+    ) {
+    }
+
+    /**
+     * @param array<mixed, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $root = \is_array($data['root'] ?? null) ? $data['root'] : [];
+        $rootElement = \is_string($root['element'] ?? null) ? $root['element'] : '';
+        self::assertXmlName($rootElement, 'root element');
+
+        $rootAttributes = self::stringMap($root['attributes'] ?? null);
+        $namespaces = self::stringMap($root['namespaces'] ?? null);
+        foreach (array_keys($namespaces) as $prefix) {
+            self::assertXmlName($prefix, 'namespace prefix');
+        }
+
+        $channel = \is_array($data['channel'] ?? null) ? $data['channel'] : null;
+        $channelElement = null;
+        $header = [];
+        $itemSource = $data['item'] ?? null;
+        if (null !== $channel) {
+            $channelElement = \is_string($channel['element'] ?? null) ? $channel['element'] : 'channel';
+            self::assertXmlName($channelElement, 'channel element');
+            $header = self::headerNodes($channel['header'] ?? null);
+            $itemSource = $channel['item'] ?? $itemSource;
+        }
+
+        if (!\is_array($itemSource)) {
+            throw new InvalidDescriptorException('Descriptor is missing an "item" definition.');
+        }
+        $itemElement = \is_string($itemSource['element'] ?? null) ? $itemSource['element'] : '';
+        self::assertXmlName($itemElement, 'item element');
+
+        $slots = self::slots($itemSource['slots'] ?? null);
+
+        return new self($rootElement, $rootAttributes, $namespaces, $channelElement, $header, $itemElement, $slots);
+    }
+
+    public function findSlot(string $target): ?FeedSlot
+    {
+        foreach ($this->slots as $slot) {
+            if ($slot->target === $target) {
+                return $slot;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $root = ['element' => $this->rootElement];
+        if ([] !== $this->rootAttributes) {
+            $root['attributes'] = $this->rootAttributes;
+        }
+        if ([] !== $this->namespaces) {
+            $root['namespaces'] = $this->namespaces;
+        }
+
+        $item = [
+            'element' => $this->itemElement,
+            'slots' => array_map(static fn (FeedSlot $s): array => $s->toArray(), $this->slots),
+        ];
+
+        if (null === $this->channelElement) {
+            return ['root' => $root, 'item' => $item];
+        }
+
+        return [
+            'root' => $root,
+            'channel' => ['element' => $this->channelElement, 'header' => $this->header, 'item' => $item],
+        ];
+    }
+
+    /**
+     * @return list<FeedSlot>
+     */
+    private static function slots(mixed $raw): array
+    {
+        if (!\is_array($raw)) {
+            throw new InvalidDescriptorException('Descriptor item is missing a "slots" list.');
+        }
+
+        $slots = [];
+        $targets = [];
+        foreach ($raw as $slotData) {
+            if (!\is_array($slotData)) {
+                throw new InvalidDescriptorException('Each slot must be an object.');
+            }
+            $slot = FeedSlot::fromArray($slotData);
+            if (isset($targets[$slot->target])) {
+                throw new InvalidDescriptorException(sprintf('Duplicate slot target "%s".', $slot->target));
+            }
+            $targets[$slot->target] = true;
+            $slots[] = $slot;
+        }
+
+        // requiredOneOf references must point at existing slot targets.
+        foreach ($slots as $slot) {
+            foreach ($slot->rule->requiredOneOf as $ref) {
+                if (!isset($targets[$ref])) {
+                    throw new InvalidDescriptorException(sprintf('Slot "%s": requiredOneOf references unknown slot "%s".', $slot->target, $ref));
+                }
+            }
+        }
+
+        return $slots;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private static function headerNodes(mixed $raw): array
+    {
+        if (!\is_array($raw)) {
+            return [];
+        }
+
+        $nodes = [];
+        foreach ($raw as $node) {
+            if (!\is_array($node)) {
+                continue;
+            }
+            $element = \is_string($node['element'] ?? null) ? $node['element'] : '';
+            self::assertXmlName($element, 'header element');
+            $clean = [];
+            foreach ($node as $key => $value) {
+                if (\is_string($key)) {
+                    $clean[$key] = $value;
+                }
+            }
+            $nodes[] = $clean;
+        }
+
+        return $nodes;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function stringMap(mixed $raw): array
+    {
+        if (!\is_array($raw)) {
+            return [];
+        }
+
+        $map = [];
+        foreach ($raw as $key => $value) {
+            if (\is_string($key) && \is_scalar($value)) {
+                $map[$key] = (string) $value;
+            }
+        }
+
+        return $map;
+    }
+
+    private static function assertXmlName(string $name, string $context): void
+    {
+        if (1 !== preg_match(self::XML_NAME, $name)) {
+            throw new InvalidDescriptorException(sprintf('%s "%s" is not a valid XML name.', ucfirst($context), $name));
+        }
+    }
+}

--- a/apps/api/src/Export/Feed/Domain/Descriptor/FeedSlot.php
+++ b/apps/api/src/Export/Feed/Domain/Descriptor/FeedSlot.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Domain\Descriptor;
+
+/**
+ * One output field of a feed's `<item>` (ADR-0023 §6.3, XMLF-P2-01).
+ *
+ * `target` is the logical key mappings reference (`g:id`, `ceneo_image`);
+ * `element` is the XML element/attribute local name (a valid NCName / QName —
+ * this is what makes `description.pl` illegal as a raw element and forces the
+ * feed to use clean slot names). `parent` names the element an Attribute node
+ * hangs off (Ceneo `<o price="…">`); `wrapIn` names an optional grouping
+ * element (Ceneo `<imgs>` around repeated `<i>`).
+ */
+final class FeedSlot
+{
+    /** XML name: optional single namespace prefix + NCName local part; no dots. */
+    private const string XML_NAME = '/^([A-Za-z_][A-Za-z0-9_-]*:)?[A-Za-z_][A-Za-z0-9_-]*$/';
+
+    public function __construct(
+        public readonly string $target,
+        public readonly SlotNodeKind $node,
+        public readonly string $element,
+        public readonly ?string $parent,
+        public readonly ?string $wrapIn,
+        public readonly SlotValidationRule $rule,
+    ) {
+    }
+
+    /**
+     * @param array<mixed, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $target = $data['target'] ?? $data['slot'] ?? null;
+        if (!\is_string($target) || '' === $target) {
+            throw new InvalidDescriptorException('Feed slot is missing a non-empty "target".');
+        }
+
+        $nodeRaw = \is_string($data['node'] ?? null) ? $data['node'] : 'element';
+        $node = SlotNodeKind::tryFrom($nodeRaw);
+        if (null === $node) {
+            throw new InvalidDescriptorException(sprintf('Slot "%s": unknown node kind "%s".', $target, $nodeRaw));
+        }
+
+        $element = \is_string($data['element'] ?? null) ? $data['element'] : $target;
+        if (1 !== preg_match(self::XML_NAME, $element)) {
+            throw new InvalidDescriptorException(sprintf('Slot "%s": "%s" is not a valid XML element name.', $target, $element));
+        }
+
+        $parent = \is_string($data['parent'] ?? null) ? $data['parent'] : null;
+        if (SlotNodeKind::Attribute === $node && (null === $parent || '' === $parent)) {
+            throw new InvalidDescriptorException(sprintf('Slot "%s": an attribute node requires a "parent" element.', $target));
+        }
+        if (null !== $parent && 1 !== preg_match(self::XML_NAME, $parent)) {
+            throw new InvalidDescriptorException(sprintf('Slot "%s": parent "%s" is not a valid XML element name.', $target, $parent));
+        }
+
+        $wrapIn = \is_string($data['wrapIn'] ?? null) ? $data['wrapIn'] : null;
+        if (null !== $wrapIn && 1 !== preg_match(self::XML_NAME, $wrapIn)) {
+            throw new InvalidDescriptorException(sprintf('Slot "%s": wrapIn "%s" is not a valid XML element name.', $target, $wrapIn));
+        }
+
+        $rule = SlotValidationRule::fromArray($data);
+        if (SlotFormat::Enum === $rule->format && [] === $rule->enums) {
+            throw new InvalidDescriptorException(sprintf('Slot "%s": format "enum" requires a non-empty "enums" list.', $target));
+        }
+
+        return new self($target, $node, $element, $parent, $wrapIn, $rule);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $out = ['target' => $this->target, 'node' => $this->node->value, 'element' => $this->element];
+        if (null !== $this->parent) {
+            $out['parent'] = $this->parent;
+        }
+        if (null !== $this->wrapIn) {
+            $out['wrapIn'] = $this->wrapIn;
+        }
+
+        return [...$out, ...$this->rule->toArray()];
+    }
+}

--- a/apps/api/src/Export/Feed/Domain/Descriptor/HtmlPolicy.php
+++ b/apps/api/src/Export/Feed/Domain/Descriptor/HtmlPolicy.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Domain\Descriptor;
+
+/**
+ * How HTML in a slot's value is handled when serialized (ADR-0023 §6.9,
+ * XMLF-P2-01). Never raw — the writer escapes, wraps in CDATA, or strips tags.
+ */
+enum HtmlPolicy: string
+{
+    case Escape = 'escape';
+    case Cdata = 'cdata';
+    case Strip = 'strip';
+}

--- a/apps/api/src/Export/Feed/Domain/Descriptor/InvalidDescriptorException.php
+++ b/apps/api/src/Export/Feed/Domain/Descriptor/InvalidDescriptorException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Domain\Descriptor;
+
+use InvalidArgumentException;
+
+/**
+ * Thrown when a feed descriptor JSONB payload is structurally invalid
+ * (unknown node kind, illegal XML name, attribute without a parent, an
+ * `enum` format without values, a `requiredOneOf` referencing a missing slot).
+ * The canonical shape guard (XMLF-P2-01).
+ */
+final class InvalidDescriptorException extends InvalidArgumentException
+{
+}

--- a/apps/api/src/Export/Feed/Domain/Descriptor/SlotFormat.php
+++ b/apps/api/src/Export/Feed/Domain/Descriptor/SlotFormat.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Domain\Descriptor;
+
+/**
+ * Expected value format of a slot (ADR-0023 §6.3/§6.5, XMLF-P2-01). Drives
+ * per-product validation (XMLF-P2-04) and the mapper type-mismatch hints
+ * (XMLF-P3-01). Mirrors the `fmt` values in the design's TEMPLATE_SLOTS.
+ */
+enum SlotFormat: string
+{
+    case Text = 'text';
+    case Html = 'html';
+    case Url = 'url';
+    case Price = 'price';
+    case Number = 'number';
+    case Date = 'date';
+    case Enum = 'enum';
+    case Category = 'category';
+}

--- a/apps/api/src/Export/Feed/Domain/Descriptor/SlotNodeKind.php
+++ b/apps/api/src/Export/Feed/Domain/Descriptor/SlotNodeKind.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Domain\Descriptor;
+
+/**
+ * How a slot renders into XML (ADR-0023 §6.3, XMLF-P2-01):
+ *   - Element: `<name>value</name>`;
+ *   - Attribute: `name="value"` on a parent element (Ceneo `<o price="…">`);
+ *   - Repeatable: many sibling elements (a gallery → many `<i>`);
+ *   - Keyvalue: PIM attributes as a `<a name="…">value</a>` list (Ceneo `<attrs>`).
+ */
+enum SlotNodeKind: string
+{
+    case Element = 'element';
+    case Attribute = 'attribute';
+    case Repeatable = 'repeatable';
+    case Keyvalue = 'keyvalue';
+}

--- a/apps/api/src/Export/Feed/Domain/Descriptor/SlotValidationRule.php
+++ b/apps/api/src/Export/Feed/Domain/Descriptor/SlotValidationRule.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Domain\Descriptor;
+
+/**
+ * Per-slot validation rules (ADR-0023 §6.5, XMLF-P2-01). Immutable value
+ * object consumed by the generator's feed-health check (XMLF-P2-04) and the
+ * mapper coverage/type hints (XMLF-P3-01).
+ */
+final class SlotValidationRule
+{
+    /**
+     * @param list<string> $requiredOneOf slot targets in this "at least one of" group
+     * @param list<string> $enums         allowed values when $format is Enum
+     */
+    public function __construct(
+        public readonly bool $required = false,
+        public readonly array $requiredOneOf = [],
+        public readonly ?int $maxLength = null,
+        public readonly HtmlPolicy $html = HtmlPolicy::Escape,
+        public readonly SlotFormat $format = SlotFormat::Text,
+        public readonly array $enums = [],
+    ) {
+    }
+
+    /**
+     * @param array<mixed, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $requiredOneOf = [];
+        if (isset($data['requiredOneOf']) && \is_array($data['requiredOneOf'])) {
+            foreach ($data['requiredOneOf'] as $target) {
+                if (\is_string($target)) {
+                    $requiredOneOf[] = $target;
+                }
+            }
+        }
+
+        $enums = [];
+        if (isset($data['enums']) && \is_array($data['enums'])) {
+            foreach ($data['enums'] as $value) {
+                if (\is_string($value)) {
+                    $enums[] = $value;
+                }
+            }
+        }
+
+        $format = SlotFormat::tryFrom(\is_string($data['fmt'] ?? null) ? $data['fmt'] : 'text') ?? SlotFormat::Text;
+        $html = HtmlPolicy::tryFrom(\is_string($data['html'] ?? null) ? $data['html'] : 'escape') ?? HtmlPolicy::Escape;
+        $maxLength = isset($data['maxLength']) && \is_int($data['maxLength']) ? $data['maxLength'] : null;
+
+        return new self(
+            required: true === ($data['required'] ?? false),
+            requiredOneOf: $requiredOneOf,
+            maxLength: $maxLength,
+            html: $html,
+            format: $format,
+            enums: $enums,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $out = ['fmt' => $this->format->value];
+        if ($this->required) {
+            $out['required'] = true;
+        }
+        if ([] !== $this->requiredOneOf) {
+            $out['requiredOneOf'] = $this->requiredOneOf;
+        }
+        if (null !== $this->maxLength) {
+            $out['maxLength'] = $this->maxLength;
+        }
+        if (HtmlPolicy::Escape !== $this->html) {
+            $out['html'] = $this->html->value;
+        }
+        if ([] !== $this->enums) {
+            $out['enums'] = $this->enums;
+        }
+
+        return $out;
+    }
+}

--- a/apps/api/tests/Unit/Export/Feed/FeedDescriptorTest.php
+++ b/apps/api/tests/Unit/Export/Feed/FeedDescriptorTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export\Feed;
+
+use App\Export\Feed\Domain\Descriptor\FeedDescriptor;
+use App\Export\Feed\Domain\Descriptor\InvalidDescriptorException;
+use App\Export\Feed\Domain\Descriptor\SlotNodeKind;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * XMLF-P2-01 — FeedDescriptor is the canonical, validated descriptor shape:
+ * round-trips the RSS-like (Google) and flat (Ceneo) forms and rejects
+ * structurally invalid payloads.
+ */
+final class FeedDescriptorTest extends TestCase
+{
+    /** @return list<array<string, mixed>> */
+    private function googleSlots(): array
+    {
+        return [
+            ['slot' => 'g:id', 'node' => 'element', 'required' => true, 'maxLength' => 50, 'fmt' => 'text'],
+            ['slot' => 'g:gtin', 'node' => 'element', 'requiredOneOf' => ['g:gtin', 'g:mpn'], 'fmt' => 'text'],
+            ['slot' => 'g:mpn', 'node' => 'element', 'requiredOneOf' => ['g:gtin', 'g:mpn'], 'fmt' => 'text'],
+            ['slot' => 'g:availability', 'node' => 'element', 'fmt' => 'enum', 'enums' => ['in_stock', 'out_of_stock']],
+        ];
+    }
+
+    /**
+     * @param list<array<string, mixed>> $slots
+     *
+     * @return array<string, mixed>
+     */
+    private function google(array $slots): array
+    {
+        return [
+            'root' => [
+                'element' => 'rss',
+                'attributes' => ['version' => '2.0'],
+                'namespaces' => ['g' => 'http://base.google.com/ns/1.0'],
+            ],
+            'channel' => [
+                'element' => 'channel',
+                'header' => [['element' => 'title', 'source' => ['kind' => 'static', 'value' => '{feed_name}']]],
+                'item' => ['element' => 'item', 'slots' => $slots],
+            ],
+        ];
+    }
+
+    /**
+     * @param list<array<string, mixed>> $slots
+     *
+     * @return array<string, mixed>
+     */
+    private function ceneo(array $slots): array
+    {
+        return [
+            'root' => ['element' => 'offers', 'attributes' => ['version' => '1']],
+            'item' => ['element' => 'o', 'slots' => $slots],
+        ];
+    }
+
+    /** @return list<array<string, mixed>> */
+    private function ceneoSlots(): array
+    {
+        return [
+            ['target' => 'id', 'node' => 'attribute', 'parent' => 'o', 'required' => true, 'fmt' => 'text'],
+            ['target' => 'name', 'node' => 'element', 'element' => 'name', 'required' => true, 'fmt' => 'text'],
+            ['target' => 'ceneo_image', 'node' => 'repeatable', 'element' => 'i', 'wrapIn' => 'imgs', 'fmt' => 'url'],
+            ['target' => 'attr', 'node' => 'keyvalue', 'element' => 'a', 'wrapIn' => 'attrs', 'fmt' => 'text'],
+        ];
+    }
+
+    #[Test]
+    public function parsesAndRoundTripsGoogleShape(): void
+    {
+        $descriptor = FeedDescriptor::fromArray($this->google($this->googleSlots()));
+
+        self::assertSame('rss', $descriptor->rootElement);
+        self::assertSame('channel', $descriptor->channelElement);
+        self::assertSame('item', $descriptor->itemElement);
+        self::assertSame('http://base.google.com/ns/1.0', $descriptor->namespaces['g']);
+        self::assertCount(4, $descriptor->slots);
+
+        $reparsed = FeedDescriptor::fromArray($descriptor->toArray());
+        self::assertSame($descriptor->toArray(), $reparsed->toArray());
+    }
+
+    #[Test]
+    public function parsesFlatCeneoShapeWithAttributeAndWrapNodes(): void
+    {
+        $descriptor = FeedDescriptor::fromArray($this->ceneo($this->ceneoSlots()));
+
+        self::assertSame('offers', $descriptor->rootElement);
+        self::assertNull($descriptor->channelElement);
+        self::assertSame('o', $descriptor->itemElement);
+
+        $id = $descriptor->findSlot('id');
+        self::assertNotNull($id);
+        self::assertSame(SlotNodeKind::Attribute, $id->node);
+        self::assertSame('o', $id->parent);
+
+        $image = $descriptor->findSlot('ceneo_image');
+        self::assertNotNull($image);
+        self::assertSame('imgs', $image->wrapIn);
+        self::assertSame('i', $image->element);
+    }
+
+    #[Test]
+    public function rejectsIllegalElementName(): void
+    {
+        $slots = [...$this->googleSlots(), ['slot' => 'description.pl', 'node' => 'element', 'fmt' => 'text']];
+
+        $this->expectException(InvalidDescriptorException::class);
+        FeedDescriptor::fromArray($this->google($slots));
+    }
+
+    #[Test]
+    public function rejectsAttributeWithoutParent(): void
+    {
+        $slots = [['target' => 'id', 'node' => 'attribute', 'fmt' => 'text']]; // no parent
+
+        $this->expectException(InvalidDescriptorException::class);
+        FeedDescriptor::fromArray($this->ceneo($slots));
+    }
+
+    #[Test]
+    public function rejectsEnumFormatWithoutValues(): void
+    {
+        $slots = [...$this->googleSlots(), ['slot' => 'g:condition', 'node' => 'element', 'fmt' => 'enum']];
+
+        $this->expectException(InvalidDescriptorException::class);
+        FeedDescriptor::fromArray($this->google($slots));
+    }
+
+    #[Test]
+    public function rejectsRequiredOneOfReferencingUnknownSlot(): void
+    {
+        $slots = [...$this->googleSlots(), ['slot' => 'g:brand', 'node' => 'element', 'requiredOneOf' => ['g:nope'], 'fmt' => 'text']];
+
+        $this->expectException(InvalidDescriptorException::class);
+        FeedDescriptor::fromArray($this->google($slots));
+    }
+
+    #[Test]
+    public function rejectsDuplicateSlotTarget(): void
+    {
+        $slots = [...$this->googleSlots(), ['slot' => 'g:id', 'node' => 'element', 'fmt' => 'text']];
+
+        $this->expectException(InvalidDescriptorException::class);
+        FeedDescriptor::fromArray($this->google($slots));
+    }
+
+    #[Test]
+    public function rejectsMissingItem(): void
+    {
+        $this->expectException(InvalidDescriptorException::class);
+        FeedDescriptor::fromArray(['root' => ['element' => 'rss']]);
+    }
+}


### PR DESCRIPTION
## XMLF-P2-01 — FeedDescriptor (kanoniczny kształt descriptora)

Serce deklaratywnego konfiguratora XML: jedno źródło prawdy kształtu descriptora, na którym stają guard zapisu (P1-04), seedy szablonów (P2-02), writer (P2-05) i generator (P2-04).

### Zakres (`src/Export/Feed/Domain/Descriptor/`)
- `FeedDescriptor` VO — parsuje/serializuje descriptor JSONB dla obu kształtów: RSS-like (root `rss`→`channel`→`item`, Google/Meta) i flat (root `offers`→`o`, Ceneo).
- `FeedSlot` — target (klucz logiczny) + node (element/attribute/repeatable/keyvalue) + element (NCName) + parent + wrapIn + reguły.
- `SlotValidationRule` (required/requiredOneOf/maxLength/html/format/enums) + enumy `SlotNodeKind`/`SlotFormat`/`HtmlPolicy` + `InvalidDescriptorException`.
- **Walidacja odrzuca**: nielegalne nazwy XML (`description.pl` jako element), attribute bez parent, `enum` bez enums, duplikaty targetów, `requiredOneOf` do nieistniejącego slotu, brak item.

### Walidacja lokalna
- ✅ CS-Fixer · PHPStan max **0** · PHPUnit **8/8 (21 assertions)** — round-trip Google+Ceneo + 6 przypadków odrzucenia · Deptrac **0**.

Refs #1912