### PR TITLE
feat(export): FeedRun + FeedRunLog entities (XMLF-P1-02)

### DIFF
--- a/apps/api/migrations/Version20260701130000.php
+++ b/apps/api/migrations/Version20260701130000.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * XMLF-P1-02 (#1909) — `feed_runs` + `feed_run_logs`: audit of feed
+ * regenerations and their per-product/slot health log (ADR-0023 §6.2).
+ *
+ * Both tenant-scoped with Postgres RLS (defence in depth on top of the
+ * Doctrine TenantFilter). feed_run_logs carries its own tenant_id like
+ * import_logs (IMP2-2.5), plus a CASCADE FK to feed_runs.
+ */
+final class Version20260701130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'XMLF-P1-02: feed_runs + feed_run_logs tables + tenant RLS policies';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE feed_runs (
+                id UUID NOT NULL,
+                tenant_id UUID NOT NULL,
+                feed_profile_id UUID NOT NULL,
+                trigger VARCHAR(16) NOT NULL,
+                status VARCHAR(16) NOT NULL,
+                item_count INT DEFAULT 0 NOT NULL,
+                skipped_count INT DEFAULT 0 NOT NULL,
+                warning_count INT DEFAULT 0 NOT NULL,
+                file_path TEXT DEFAULT NULL,
+                file_size_bytes BIGINT DEFAULT NULL,
+                duration_ms INT DEFAULT NULL,
+                error_message TEXT DEFAULT NULL,
+                started_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                completed_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+                PRIMARY KEY(id)
+            )
+            SQL);
+        $this->addSql('CREATE INDEX feed_runs_profile_idx ON feed_runs (feed_profile_id, started_at)');
+        $this->addSql(
+            'ALTER TABLE feed_runs ADD CONSTRAINT fk_feed_runs_tenant '
+            .'FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE RESTRICT NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+        $this->addSql(
+            'ALTER TABLE feed_runs ADD CONSTRAINT fk_feed_runs_profile '
+            .'FOREIGN KEY (feed_profile_id) REFERENCES feed_profiles (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE feed_run_logs (
+                id UUID NOT NULL,
+                tenant_id UUID NOT NULL,
+                feed_run_id UUID NOT NULL,
+                level VARCHAR(8) NOT NULL,
+                object_sku VARCHAR(255) DEFAULT NULL,
+                slot VARCHAR(64) DEFAULT NULL,
+                message TEXT NOT NULL,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY(id)
+            )
+            SQL);
+        $this->addSql('CREATE INDEX feed_run_logs_run_idx ON feed_run_logs (feed_run_id)');
+        $this->addSql(
+            'ALTER TABLE feed_run_logs ADD CONSTRAINT fk_feed_run_logs_tenant '
+            .'FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE RESTRICT NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+        $this->addSql(
+            'ALTER TABLE feed_run_logs ADD CONSTRAINT fk_feed_run_logs_run '
+            .'FOREIGN KEY (feed_run_id) REFERENCES feed_runs (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+
+        foreach (['feed_runs', 'feed_run_logs'] as $table) {
+            $this->addSql(sprintf('ALTER TABLE %s ENABLE ROW LEVEL SECURITY', $table));
+            $this->addSql(sprintf(
+                "CREATE POLICY tenant_isolation_%s ON %s USING (tenant_id = current_setting('app.current_tenant', true)::uuid)",
+                $table,
+                $table,
+            ));
+            $this->addSql(sprintf(
+                "CREATE POLICY super_admin_bypass_%s ON %s USING (current_setting('app.is_super_admin', true) = 'true')",
+                $table,
+                $table,
+            ));
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP POLICY IF EXISTS super_admin_bypass_feed_run_logs ON feed_run_logs');
+        $this->addSql('DROP POLICY IF EXISTS tenant_isolation_feed_run_logs ON feed_run_logs');
+        $this->addSql('DROP POLICY IF EXISTS super_admin_bypass_feed_runs ON feed_runs');
+        $this->addSql('DROP POLICY IF EXISTS tenant_isolation_feed_runs ON feed_runs');
+        $this->addSql('DROP TABLE feed_run_logs');
+        $this->addSql('DROP TABLE feed_runs');
+    }
+}

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -156,6 +156,8 @@ parameters:
               - src/Export/Domain/Entity/ExportSession.php
               - src/Export/Domain/Entity/ExportProfile.php
               - src/Export/Feed/Domain/Entity/FeedProfile.php
+              - src/Export/Feed/Domain/Entity/FeedRun.php
+              - src/Export/Feed/Domain/Entity/FeedRunLog.php
               - src/Backup/Domain/Entity/Backup.php
               - src/Channel/Domain/Entity/TenantLocale.php
               - src/Channel/Domain/Entity/ChannelPublicationProfile.php

--- a/apps/api/src/Export/Feed/Domain/Entity/FeedRun.php
+++ b/apps/api/src/Export/Feed/Domain/Entity/FeedRun.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Domain\Entity;
+
+use App\Export\Feed\Domain\Enum\FeedRunStatus;
+use App\Export\Feed\Domain\Enum\FeedRunTrigger;
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\AggregateRoot;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Audit of a single feed regeneration (ADR-0023 §6.2, XMLF-P1-02) — the
+ * feed-world analogue of {@see \App\Export\Domain\Entity\ExportSession}. On
+ * success its file becomes the cached artifact the public URL serves
+ * (XMLF-P3-05). Tenant-scoped with Postgres RLS.
+ */
+class FeedRun extends AggregateRoot implements TenantScoped
+{
+    private Uuid $id;
+
+    private ?Tenant $tenant = null;
+
+    /** Bare uuid → {@see FeedProfile} (DB-level FK, ON DELETE CASCADE). */
+    private Uuid $feedProfileId;
+
+    private string $trigger;
+
+    private string $status;
+
+    private int $itemCount = 0;
+
+    private int $skippedCount = 0;
+
+    private int $warningCount = 0;
+
+    private ?string $filePath = null;
+
+    private ?int $fileSizeBytes = null;
+
+    private ?int $durationMs = null;
+
+    private ?string $errorMessage = null;
+
+    private DateTimeImmutable $startedAt;
+
+    private ?DateTimeImmutable $completedAt = null;
+
+    public function __construct(
+        Uuid $feedProfileId,
+        FeedRunTrigger $trigger,
+        FeedRunStatus $status = FeedRunStatus::Pending,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->feedProfileId = $feedProfileId;
+        $this->trigger = $trigger->value;
+        $this->status = $status->value;
+        $this->startedAt = new DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant is already assigned and cannot be reassigned.');
+        }
+        $this->tenant = $tenant;
+    }
+
+    public function getFeedProfileId(): Uuid
+    {
+        return $this->feedProfileId;
+    }
+
+    public function getTrigger(): FeedRunTrigger
+    {
+        return FeedRunTrigger::from($this->trigger);
+    }
+
+    public function getStatus(): FeedRunStatus
+    {
+        return FeedRunStatus::from($this->status);
+    }
+
+    public function markRunning(): void
+    {
+        $this->status = FeedRunStatus::Running->value;
+    }
+
+    public function markDone(int $itemCount, int $skippedCount, int $warningCount, string $filePath, int $fileSizeBytes, int $durationMs): void
+    {
+        $this->status = FeedRunStatus::Done->value;
+        $this->itemCount = $itemCount;
+        $this->skippedCount = $skippedCount;
+        $this->warningCount = $warningCount;
+        $this->filePath = $filePath;
+        $this->fileSizeBytes = $fileSizeBytes;
+        $this->durationMs = $durationMs;
+        $this->completedAt = new DateTimeImmutable();
+    }
+
+    public function markError(string $message): void
+    {
+        $this->status = FeedRunStatus::Error->value;
+        $this->errorMessage = $message;
+        $this->completedAt = new DateTimeImmutable();
+    }
+
+    public function markCancelled(): void
+    {
+        $this->status = FeedRunStatus::Cancelled->value;
+        $this->completedAt = new DateTimeImmutable();
+    }
+
+    public function getItemCount(): int
+    {
+        return $this->itemCount;
+    }
+
+    public function getSkippedCount(): int
+    {
+        return $this->skippedCount;
+    }
+
+    public function getWarningCount(): int
+    {
+        return $this->warningCount;
+    }
+
+    public function getFilePath(): ?string
+    {
+        return $this->filePath;
+    }
+
+    public function getFileSizeBytes(): ?int
+    {
+        return $this->fileSizeBytes;
+    }
+
+    public function getDurationMs(): ?int
+    {
+        return $this->durationMs;
+    }
+
+    public function getErrorMessage(): ?string
+    {
+        return $this->errorMessage;
+    }
+
+    public function getStartedAt(): DateTimeImmutable
+    {
+        return $this->startedAt;
+    }
+
+    public function getCompletedAt(): ?DateTimeImmutable
+    {
+        return $this->completedAt;
+    }
+}

--- a/apps/api/src/Export/Feed/Domain/Entity/FeedRunLog.php
+++ b/apps/api/src/Export/Feed/Domain/Entity/FeedRunLog.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Domain\Entity;
+
+use App\Export\Feed\Domain\Enum\FeedRunLogLevel;
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * One per-product / per-slot line of a feed run (ADR-0023 §6.2, XMLF-P1-02) —
+ * the "feed health" trail (e.g. "SKU-123: missing g:gtin — skipped"). Carries
+ * its own `tenant_id` for RLS defence in depth (the import_logs precedent,
+ * IMP2-2.5), on top of the FeedRun cascade.
+ */
+class FeedRunLog implements TenantScoped
+{
+    private Uuid $id;
+
+    private ?Tenant $tenant = null;
+
+    /** Bare uuid → {@see FeedRun} (DB-level FK, ON DELETE CASCADE). */
+    private Uuid $feedRunId;
+
+    private string $level;
+
+    private ?string $objectSku;
+
+    private ?string $slot;
+
+    private string $message;
+
+    private DateTimeImmutable $createdAt;
+
+    public function __construct(
+        Uuid $feedRunId,
+        FeedRunLogLevel $level,
+        string $message,
+        ?string $objectSku = null,
+        ?string $slot = null,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->feedRunId = $feedRunId;
+        $this->level = $level->value;
+        $this->message = $message;
+        $this->objectSku = $objectSku;
+        $this->slot = $slot;
+        $this->createdAt = new DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant is already assigned and cannot be reassigned.');
+        }
+        $this->tenant = $tenant;
+    }
+
+    public function getFeedRunId(): Uuid
+    {
+        return $this->feedRunId;
+    }
+
+    public function getLevel(): FeedRunLogLevel
+    {
+        return FeedRunLogLevel::from($this->level);
+    }
+
+    public function getObjectSku(): ?string
+    {
+        return $this->objectSku;
+    }
+
+    public function getSlot(): ?string
+    {
+        return $this->slot;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/apps/api/src/Export/Feed/Domain/Enum/FeedRunLogLevel.php
+++ b/apps/api/src/Export/Feed/Domain/Enum/FeedRunLogLevel.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Domain\Enum;
+
+/**
+ * Severity of a per-product / per-slot feed-run log line (ADR-0023 §6.2,
+ * XMLF-P1-02). Drives the "feed health" report (XMLF-P4-03).
+ */
+enum FeedRunLogLevel: string
+{
+    case Info = 'info';
+    case Warning = 'warning';
+    case Error = 'error';
+}

--- a/apps/api/src/Export/Feed/Domain/Enum/FeedRunStatus.php
+++ b/apps/api/src/Export/Feed/Domain/Enum/FeedRunStatus.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Domain\Enum;
+
+/**
+ * Lifecycle of a single feed regeneration run (ADR-0023 §6.2, XMLF-P1-02).
+ */
+enum FeedRunStatus: string
+{
+    case Pending = 'pending';
+    case Running = 'running';
+    case Done = 'done';
+    case Error = 'error';
+    case Cancelled = 'cancelled';
+}

--- a/apps/api/src/Export/Feed/Domain/Enum/FeedRunTrigger.php
+++ b/apps/api/src/Export/Feed/Domain/Enum/FeedRunTrigger.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Domain\Enum;
+
+/**
+ * What started a feed regeneration (ADR-0023 §6.2, XMLF-P1-02): the cron
+ * scheduler, a manual "Regenerate now", or the first publish on create.
+ */
+enum FeedRunTrigger: string
+{
+    case Schedule = 'schedule';
+    case Manual = 'manual';
+    case FirstPublish = 'first_publish';
+}

--- a/apps/api/src/Export/Feed/Domain/Repository/FeedRunLogRepositoryInterface.php
+++ b/apps/api/src/Export/Feed/Domain/Repository/FeedRunLogRepositoryInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Domain\Repository;
+
+use App\Export\Feed\Domain\Entity\FeedRunLog;
+use Symfony\Component\Uid\Uuid;
+
+interface FeedRunLogRepositoryInterface
+{
+    public function save(FeedRunLog $log): void;
+
+    /**
+     * @return list<FeedRunLog>
+     */
+    public function findByRun(Uuid $feedRunId): array;
+}

--- a/apps/api/src/Export/Feed/Domain/Repository/FeedRunRepositoryInterface.php
+++ b/apps/api/src/Export/Feed/Domain/Repository/FeedRunRepositoryInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Domain\Repository;
+
+use App\Export\Feed\Domain\Entity\FeedRun;
+use Symfony\Component\Uid\Uuid;
+
+interface FeedRunRepositoryInterface
+{
+    public function save(FeedRun $run): void;
+
+    public function findById(Uuid $id): ?FeedRun;
+
+    /**
+     * Most recent runs of a feed, newest first.
+     *
+     * @return list<FeedRun>
+     */
+    public function findByFeedProfile(Uuid $feedProfileId, int $limit = 50): array;
+}

--- a/apps/api/src/Export/Feed/Infrastructure/Doctrine/Orm/Mapping/FeedRun.orm.xml
+++ b/apps/api/src/Export/Feed/Infrastructure/Doctrine/Orm/Mapping/FeedRun.orm.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Export\Feed\Domain\Entity\FeedRun"
+            table="feed_runs"
+            repository-class="App\Export\Feed\Infrastructure\Doctrine\Repository\DoctrineFeedRunRepository">
+
+        <indexes>
+            <index name="feed_runs_profile_idx" columns="feed_profile_id,started_at"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <field name="feedProfileId" type="uuid" column="feed_profile_id"/>
+        <field name="trigger" type="string" length="16"/>
+        <field name="status" type="string" length="16"/>
+
+        <field name="itemCount" type="integer" column="item_count"><options><option name="default">0</option></options></field>
+        <field name="skippedCount" type="integer" column="skipped_count"><options><option name="default">0</option></options></field>
+        <field name="warningCount" type="integer" column="warning_count"><options><option name="default">0</option></options></field>
+
+        <field name="filePath" type="text" column="file_path" nullable="true"/>
+        <field name="fileSizeBytes" type="bigint" column="file_size_bytes" nullable="true"/>
+        <field name="durationMs" type="integer" column="duration_ms" nullable="true"/>
+        <field name="errorMessage" type="text" column="error_message" nullable="true"/>
+
+        <field name="startedAt" type="datetime_immutable" column="started_at"/>
+        <field name="completedAt" type="datetime_immutable" column="completed_at" nullable="true"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Export/Feed/Infrastructure/Doctrine/Orm/Mapping/FeedRunLog.orm.xml
+++ b/apps/api/src/Export/Feed/Infrastructure/Doctrine/Orm/Mapping/FeedRunLog.orm.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Export\Feed\Domain\Entity\FeedRunLog"
+            table="feed_run_logs"
+            repository-class="App\Export\Feed\Infrastructure\Doctrine\Repository\DoctrineFeedRunLogRepository">
+
+        <indexes>
+            <index name="feed_run_logs_run_idx" columns="feed_run_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <field name="feedRunId" type="uuid" column="feed_run_id"/>
+        <field name="level" type="string" length="8"/>
+        <field name="objectSku" type="string" length="255" column="object_sku" nullable="true"/>
+        <field name="slot" type="string" length="64" nullable="true"/>
+        <field name="message" type="text"/>
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Export/Feed/Infrastructure/Doctrine/Repository/DoctrineFeedRunLogRepository.php
+++ b/apps/api/src/Export/Feed/Infrastructure/Doctrine/Repository/DoctrineFeedRunLogRepository.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Infrastructure\Doctrine\Repository;
+
+use App\Export\Feed\Domain\Entity\FeedRunLog;
+use App\Export\Feed\Domain\Repository\FeedRunLogRepositoryInterface;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<FeedRunLog>
+ */
+class DoctrineFeedRunLogRepository extends ServiceEntityRepository implements FeedRunLogRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, FeedRunLog::class);
+    }
+
+    public function save(FeedRunLog $log): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($log);
+        $em->flush();
+    }
+
+    /**
+     * @return list<FeedRunLog>
+     */
+    public function findByRun(Uuid $feedRunId): array
+    {
+        $qb = $this->createQueryBuilder('l')
+            ->where('l.feedRunId = :rid')
+            ->orderBy('l.createdAt', 'ASC')
+            ->setParameter('rid', $feedRunId->toRfc4122());
+
+        /** @var list<FeedRunLog> $result */
+        $result = $qb->getQuery()->getResult();
+
+        return $result;
+    }
+}

--- a/apps/api/src/Export/Feed/Infrastructure/Doctrine/Repository/DoctrineFeedRunRepository.php
+++ b/apps/api/src/Export/Feed/Infrastructure/Doctrine/Repository/DoctrineFeedRunRepository.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Infrastructure\Doctrine\Repository;
+
+use App\Export\Feed\Domain\Entity\FeedRun;
+use App\Export\Feed\Domain\Repository\FeedRunRepositoryInterface;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<FeedRun>
+ */
+class DoctrineFeedRunRepository extends ServiceEntityRepository implements FeedRunRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, FeedRun::class);
+    }
+
+    public function save(FeedRun $run): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($run);
+        $em->flush();
+    }
+
+    public function findById(Uuid $id): ?FeedRun
+    {
+        return parent::find($id->toRfc4122());
+    }
+
+    /**
+     * @return list<FeedRun>
+     */
+    public function findByFeedProfile(Uuid $feedProfileId, int $limit = 50): array
+    {
+        $qb = $this->createQueryBuilder('r')
+            ->where('r.feedProfileId = :fid')
+            ->orderBy('r.startedAt', 'DESC')
+            ->setMaxResults($limit)
+            ->setParameter('fid', $feedProfileId->toRfc4122());
+
+        /** @var list<FeedRun> $result */
+        $result = $qb->getQuery()->getResult();
+
+        return $result;
+    }
+}

--- a/apps/api/tests/Unit/Export/Feed/FeedRunTest.php
+++ b/apps/api/tests/Unit/Export/Feed/FeedRunTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export\Feed;
+
+use App\Export\Feed\Domain\Entity\FeedRun;
+use App\Export\Feed\Domain\Entity\FeedRunLog;
+use App\Export\Feed\Domain\Enum\FeedRunLogLevel;
+use App\Export\Feed\Domain\Enum\FeedRunStatus;
+use App\Export\Feed\Domain\Enum\FeedRunTrigger;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * XMLF-P1-02 — FeedRun / FeedRunLog domain behaviour.
+ */
+final class FeedRunTest extends TestCase
+{
+    #[Test]
+    public function newRunIsPendingWithZeroCounters(): void
+    {
+        $run = new FeedRun(Uuid::v7(), FeedRunTrigger::Manual);
+
+        self::assertSame(FeedRunStatus::Pending, $run->getStatus());
+        self::assertSame(FeedRunTrigger::Manual, $run->getTrigger());
+        self::assertSame(0, $run->getItemCount());
+        self::assertSame(0, $run->getSkippedCount());
+        self::assertNull($run->getCompletedAt());
+    }
+
+    #[Test]
+    public function markDoneStoresCountersFileAndCompletion(): void
+    {
+        $run = new FeedRun(Uuid::v7(), FeedRunTrigger::Schedule);
+        $run->markRunning();
+        self::assertSame(FeedRunStatus::Running, $run->getStatus());
+
+        $run->markDone(12_408, 34, 34, 'feeds/t/google_pl.xml', 18_700_000, 22_000);
+
+        self::assertSame(FeedRunStatus::Done, $run->getStatus());
+        self::assertSame(12_408, $run->getItemCount());
+        self::assertSame(34, $run->getSkippedCount());
+        self::assertSame('feeds/t/google_pl.xml', $run->getFilePath());
+        self::assertSame(18_700_000, $run->getFileSizeBytes());
+        self::assertSame(22_000, $run->getDurationMs());
+        self::assertNotNull($run->getCompletedAt());
+    }
+
+    #[Test]
+    public function markErrorRecordsMessage(): void
+    {
+        $run = new FeedRun(Uuid::v7(), FeedRunTrigger::Schedule);
+        $run->markError('missing required <price>');
+
+        self::assertSame(FeedRunStatus::Error, $run->getStatus());
+        self::assertSame('missing required <price>', $run->getErrorMessage());
+        self::assertNotNull($run->getCompletedAt());
+    }
+
+    #[Test]
+    public function logCarriesLevelSkuSlotAndMessage(): void
+    {
+        $runId = Uuid::v7();
+        $log = new FeedRunLog($runId, FeedRunLogLevel::Warning, 'missing g:gtin — skipped', 'KL-PT-80240', 'g:gtin');
+
+        self::assertTrue($log->getFeedRunId()->equals($runId));
+        self::assertSame(FeedRunLogLevel::Warning, $log->getLevel());
+        self::assertSame('KL-PT-80240', $log->getObjectSku());
+        self::assertSame('g:gtin', $log->getSlot());
+        self::assertSame('missing g:gtin — skipped', $log->getMessage());
+    }
+}


### PR DESCRIPTION
## XMLF-P1-02 — audyt regeneracji feedu

`FeedRun` (audyt jednej generacji) + `FeedRunLog` (linia health per produkt/slot), na których stoi monitor (P4-03) i generator (P2-04).

### Zakres (`src/Export/Feed/`)
- `FeedRun` (TenantScoped): trigger (schedule/manual/first_publish) + status (pending/running/done/error/cancelled) + item/skipped/warning counts + file/size/duration + markRunning/markDone/markError/markCancelled.
- `FeedRunLog` (TenantScoped, defence in depth jak import_logs): level/object_sku/slot/message.
- Enumy, ORM mappings, repozytoria, migracja `feed_runs` + `feed_run_logs` + **RLS na obu** + CASCADE FK (feed_runs→feed_profiles, feed_run_logs→feed_runs).

### Walidacja lokalna
- ✅ CS-Fixer · PHPStan max **0** · PHPUnit **4/4 (21 assertions)** · Deptrac **0** · migrate OK (tabele + RLS). schema:validate drift na bare-uuid FK jest oczekiwany (wzorzec ADR-0015, CI nie gate'uje).

Refs #1909