### PR TITLE
feat(export): persist-time feed descriptor guard (XMLF-P1-04)

### DIFF
--- a/apps/api/src/Export/Feed/Application/Descriptor/FeedDescriptorGuard.php
+++ b/apps/api/src/Export/Feed/Application/Descriptor/FeedDescriptorGuard.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Application\Descriptor;
+
+use App\Export\Feed\Domain\Descriptor\FeedDescriptor;
+use App\Export\Feed\Domain\Descriptor\InvalidDescriptorException;
+
+/**
+ * Persist-time guard for a feed descriptor (ADR-0023, XMLF-P1-04). Runs before
+ * a FeedProfile.descriptor JSONB is saved (XMLF-P1-03): checks the top-level
+ * shape and delegates the full structural validation to the canonical
+ * {@see FeedDescriptor} value object (XMLF-P2-01) — the single source of truth.
+ *
+ * A lightweight guard whose only job is to fail a bad save early with a clear
+ * message instead of persisting a descriptor the generator/writer cannot run.
+ */
+final class FeedDescriptorGuard
+{
+    /**
+     * @param array<mixed, mixed> $descriptor
+     *
+     * @throws InvalidDescriptorException when the descriptor is not persistable
+     */
+    public function assertValid(array $descriptor): FeedDescriptor
+    {
+        if ([] === $descriptor) {
+            throw new InvalidDescriptorException('Feed descriptor must not be empty.');
+        }
+        if (!\array_key_exists('root', $descriptor)) {
+            throw new InvalidDescriptorException('Feed descriptor is missing the "root" element.');
+        }
+        if (!\array_key_exists('channel', $descriptor) && !\array_key_exists('item', $descriptor)) {
+            throw new InvalidDescriptorException('Feed descriptor must define an "item" (directly or under "channel").');
+        }
+
+        // Full structural validation (node kinds, XML names, requiredOneOf refs,
+        // duplicate targets, …) is the value object's responsibility.
+        return FeedDescriptor::fromArray($descriptor);
+    }
+
+    /**
+     * @param array<mixed, mixed> $descriptor
+     */
+    public function isValid(array $descriptor): bool
+    {
+        try {
+            $this->assertValid($descriptor);
+
+            return true;
+        } catch (InvalidDescriptorException) {
+            return false;
+        }
+    }
+}

--- a/apps/api/tests/Unit/Export/Feed/FeedDescriptorGuardTest.php
+++ b/apps/api/tests/Unit/Export/Feed/FeedDescriptorGuardTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export\Feed;
+
+use App\Export\Feed\Application\Descriptor\FeedDescriptorGuard;
+use App\Export\Feed\Domain\Descriptor\InvalidDescriptorException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * XMLF-P1-04 — the persist-time descriptor guard accepts a well-formed
+ * descriptor and rejects structurally broken payloads early.
+ */
+final class FeedDescriptorGuardTest extends TestCase
+{
+    /** @return array<string, mixed> */
+    private function validDescriptor(): array
+    {
+        return [
+            'root' => ['element' => 'products'],
+            'item' => [
+                'element' => 'product',
+                'slots' => [
+                    ['slot' => 'sku', 'node' => 'element', 'required' => true, 'fmt' => 'text'],
+                    ['slot' => 'name', 'node' => 'element', 'fmt' => 'text'],
+                ],
+            ],
+        ];
+    }
+
+    #[Test]
+    public function acceptsWellFormedDescriptor(): void
+    {
+        $descriptor = new FeedDescriptorGuard()->assertValid($this->validDescriptor());
+
+        self::assertSame('products', $descriptor->rootElement);
+        self::assertCount(2, $descriptor->slots);
+        self::assertTrue(new FeedDescriptorGuard()->isValid($this->validDescriptor()));
+    }
+
+    #[Test]
+    public function rejectsEmptyDescriptor(): void
+    {
+        $this->expectException(InvalidDescriptorException::class);
+        new FeedDescriptorGuard()->assertValid([]);
+    }
+
+    #[Test]
+    public function rejectsDescriptorWithoutRoot(): void
+    {
+        $this->expectException(InvalidDescriptorException::class);
+        new FeedDescriptorGuard()->assertValid(['item' => ['element' => 'product', 'slots' => []]]);
+    }
+
+    #[Test]
+    public function rejectsDescriptorWithoutItem(): void
+    {
+        $this->expectException(InvalidDescriptorException::class);
+        new FeedDescriptorGuard()->assertValid(['root' => ['element' => 'rss']]);
+    }
+
+    #[Test]
+    public function delegatesDeepValidationToValueObject(): void
+    {
+        // Top-level shape is fine, but a slot has an illegal XML element name —
+        // only the value object catches that, proving the guard delegates.
+        $descriptor = [
+            'root' => ['element' => 'products'],
+            'item' => [
+                'element' => 'product',
+                'slots' => [['slot' => 'bad.name', 'node' => 'element', 'fmt' => 'text']],
+            ],
+        ];
+
+        $this->expectException(InvalidDescriptorException::class);
+        new FeedDescriptorGuard()->assertValid($descriptor);
+    }
+}


### PR DESCRIPTION
## XMLF-P1-04 — guard descriptora przy zapisie

`FeedDescriptorGuard`: sprawdza top-level shape (root + item/channel) i **deleguje pełną walidację strukturalną do `FeedDescriptor` VO** (P2-01, kanoniczne źródło prawdy). Zły descriptor pada przy zapisie z czytelnym błędem, nie łamie generatora później. Używany przez CRUD (P1-03).

### Walidacja
- ✅ PHPStan max **0** · PHPUnit **5/5** · Deptrac **0** (Application → Domain intra-BC).

Refs #1911