### PR TITLE
feat(export): descriptor-driven XmlFeedWriter (XMLF-P2-05)

### DIFF
--- a/apps/api/src/Export/Feed/Infrastructure/Writer/XmlFeedWriter.php
+++ b/apps/api/src/Export/Feed/Infrastructure/Writer/XmlFeedWriter.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Infrastructure\Writer;
+
+use App\Export\Contracts\ItemWriter;
+use App\Export\Feed\Domain\Descriptor\FeedDescriptor;
+use App\Export\Feed\Domain\Descriptor\FeedSlot;
+use App\Export\Feed\Domain\Descriptor\HtmlPolicy;
+use App\Export\Feed\Domain\Descriptor\SlotNodeKind;
+use App\Export\Infrastructure\Writer\XmlWriterCore;
+
+/**
+ * Descriptor-driven feed serializer (ADR-0023 §6.3, XMLF-P2-05). Implements the
+ * associative {@see ItemWriter} contract: for each item it walks the
+ * {@see FeedDescriptor} slots and assembles the XML through {@see XmlWriterCore}
+ * (the only class touching XMLWriter — escaping, CDATA, control-char sanitising,
+ * always well-formed). The generator (XMLF-P2-04) feeds it an item map keyed by
+ * slot target, already transformed and validated.
+ *
+ * Node kinds: attribute nodes are written first (XMLWriter requires attributes
+ * right after the element opens); element / repeatable / keyvalue nodes follow,
+ * grouped under an optional `wrapIn` element (Ceneo `<imgs>` around `<i>`).
+ */
+final class XmlFeedWriter implements ItemWriter
+{
+    private const string MULTI_GLUE = '|';
+
+    /**
+     * @param array<string, string> $context feed-level tokens for header/static interpolation
+     *                                       (e.g. feed_name, store_url)
+     */
+    public function __construct(
+        private readonly XmlWriterCore $xml,
+        private readonly FeedDescriptor $descriptor,
+        private readonly array $context = [],
+    ) {
+    }
+
+    public function begin(): void
+    {
+        $this->xml->startDocument()->startElement($this->descriptor->rootElement);
+        foreach ($this->descriptor->rootAttributes as $name => $value) {
+            $this->xml->attribute($name, $value);
+        }
+        foreach ($this->descriptor->namespaces as $prefix => $uri) {
+            $this->xml->namespaceAttribute($prefix, $uri);
+        }
+
+        if (null !== $this->descriptor->channelElement) {
+            $this->xml->startElement($this->descriptor->channelElement);
+            foreach ($this->descriptor->header as $node) {
+                $element = \is_string($node['element'] ?? null) ? $node['element'] : null;
+                if (null === $element) {
+                    continue;
+                }
+                $this->xml->element($element, $this->headerValue($node));
+            }
+        }
+    }
+
+    public function writeItem(array $item): void
+    {
+        $this->xml->startElement($this->descriptor->itemElement);
+
+        // 1) Attribute nodes on the item element — must precede any children.
+        foreach ($this->descriptor->slots as $slot) {
+            if (SlotNodeKind::Attribute === $slot->node) {
+                $this->xml->attribute($slot->element, $item[$slot->target] ?? '');
+            }
+        }
+
+        // 2) Element / repeatable / keyvalue children, grouped by wrapIn.
+        $openWrap = null;
+        foreach ($this->descriptor->slots as $slot) {
+            if (SlotNodeKind::Attribute === $slot->node) {
+                continue;
+            }
+            if ($slot->wrapIn !== $openWrap) {
+                if (null !== $openWrap) {
+                    $this->xml->endElement();
+                }
+                $openWrap = $slot->wrapIn;
+                if (null !== $openWrap) {
+                    $this->xml->startElement($openWrap);
+                }
+            }
+            $this->writeSlot($slot, $item[$slot->target] ?? '');
+        }
+        if (null !== $openWrap) {
+            $this->xml->endElement();
+        }
+
+        $this->xml->endElement();
+    }
+
+    public function finish(): void
+    {
+        if (null !== $this->descriptor->channelElement) {
+            $this->xml->endElement();
+        }
+        $this->xml->endElement()->endDocument();
+    }
+
+    private function writeSlot(FeedSlot $slot, string $value): void
+    {
+        if (SlotNodeKind::Repeatable === $slot->node) {
+            if ('' === $value) {
+                return;
+            }
+            foreach (explode(self::MULTI_GLUE, $value) as $single) {
+                $this->writeValueElement($slot, $single);
+            }
+
+            return;
+        }
+
+        $this->writeValueElement($slot, $value);
+    }
+
+    private function writeValueElement(FeedSlot $slot, string $value): void
+    {
+        $this->xml->startElement($slot->element);
+        match ($slot->rule->html) {
+            HtmlPolicy::Cdata => $this->xml->cdata($value),
+            HtmlPolicy::Strip => $this->xml->text(strip_tags($value)),
+            HtmlPolicy::Escape => $this->xml->text($value),
+        };
+        $this->xml->endElement();
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function headerValue(array $node): string
+    {
+        $source = $node['source'] ?? null;
+        if (!\is_array($source)) {
+            return '';
+        }
+        $value = \is_string($source['value'] ?? null) ? $source['value'] : '';
+
+        return $this->interpolate($value);
+    }
+
+    private function interpolate(string $template): string
+    {
+        return preg_replace_callback(
+            '/\{([a-z_]+)\}/',
+            fn (array $m): string => $this->context[$m[1]] ?? $m[0],
+            $template,
+        ) ?? $template;
+    }
+}

--- a/apps/api/tests/Unit/Export/Feed/XmlFeedWriterTest.php
+++ b/apps/api/tests/Unit/Export/Feed/XmlFeedWriterTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export\Feed;
+
+use App\Export\Feed\Domain\Descriptor\FeedDescriptor;
+use App\Export\Feed\Infrastructure\Writer\XmlFeedWriter;
+use App\Export\Infrastructure\Writer\XmlWriterCore;
+use DOMDocument;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * XMLF-P2-05 — XmlFeedWriter assembles descriptor-driven feed XML: element /
+ * attribute / repeatable / wrapIn nodes, namespaces, header and CDATA, always
+ * well-formed via XmlWriterCore.
+ */
+final class XmlFeedWriterTest extends TestCase
+{
+    private static function dom(string $xml): DOMDocument
+    {
+        $dom = new DOMDocument();
+        self::assertNotFalse($dom->loadXML($xml), 'feed must be well-formed');
+
+        return $dom;
+    }
+
+    #[Test]
+    public function writesRssShapeWithNamespaceHeaderAndCdata(): void
+    {
+        $descriptor = FeedDescriptor::fromArray([
+            'root' => ['element' => 'rss', 'attributes' => ['version' => '2.0'], 'namespaces' => ['g' => 'http://base.google.com/ns/1.0']],
+            'channel' => [
+                'element' => 'channel',
+                'header' => [['element' => 'title', 'source' => ['kind' => 'static', 'value' => '{feed_name}']]],
+                'item' => [
+                    'element' => 'item',
+                    'slots' => [
+                        ['slot' => 'g:id', 'node' => 'element', 'fmt' => 'text'],
+                        ['slot' => 'g:price', 'node' => 'element', 'fmt' => 'price'],
+                        ['slot' => 'g:description', 'node' => 'element', 'html' => 'cdata', 'fmt' => 'html'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $xml = XmlWriterCore::toMemory();
+        $writer = new XmlFeedWriter($xml, $descriptor, ['feed_name' => 'Klimas Feed']);
+        $writer->begin();
+        $writer->writeItem(['g:id' => 'KL-CB-4838', 'g:price' => '19.90 PLN', 'g:description' => '<p>opis & więcej</p>']);
+        $writer->finish();
+        $out = $xml->outputMemory();
+
+        $dom = self::dom($out);
+        self::assertStringContainsString('xmlns:g="http://base.google.com/ns/1.0"', $out);
+        self::assertStringContainsString('<title>Klimas Feed</title>', $out);
+        self::assertStringContainsString('<![CDATA[<p>opis & więcej</p>]]>', $out);
+
+        $ids = $dom->getElementsByTagName('id'); // local name of g:id
+        self::assertSame('KL-CB-4838', $ids->item(0)?->textContent);
+    }
+
+    #[Test]
+    public function writesFlatShapeWithAttributesAndRepeatableWrap(): void
+    {
+        $descriptor = FeedDescriptor::fromArray([
+            'root' => ['element' => 'offers', 'attributes' => ['version' => '1']],
+            'item' => [
+                'element' => 'o',
+                'slots' => [
+                    ['target' => 'id', 'node' => 'attribute', 'parent' => 'o', 'element' => 'id', 'fmt' => 'text'],
+                    ['target' => 'price', 'node' => 'attribute', 'parent' => 'o', 'element' => 'price', 'fmt' => 'number'],
+                    ['target' => 'name', 'node' => 'element', 'element' => 'name', 'fmt' => 'text'],
+                    ['target' => 'img', 'node' => 'repeatable', 'element' => 'i', 'wrapIn' => 'imgs', 'fmt' => 'url'],
+                ],
+            ],
+        ]);
+
+        $xml = XmlWriterCore::toMemory();
+        $writer = new XmlFeedWriter($xml, $descriptor);
+        $writer->begin();
+        $writer->writeItem([
+            'id' => 'KL-1',
+            'price' => '19.90',
+            'name' => 'Wkręt',
+            'img' => 'https://cdn/a.jpg|https://cdn/b.jpg',
+        ]);
+        $writer->finish();
+        $out = $xml->outputMemory();
+
+        $dom = self::dom($out);
+        $o = $dom->getElementsByTagName('o')->item(0);
+        self::assertNotNull($o);
+        self::assertSame('KL-1', $o->getAttribute('id'));
+        self::assertSame('19.90', $o->getAttribute('price'));
+        self::assertSame('Wkręt', $dom->getElementsByTagName('name')->item(0)?->textContent);
+
+        $imgs = $dom->getElementsByTagName('imgs')->item(0);
+        self::assertNotNull($imgs);
+        self::assertSame(2, $dom->getElementsByTagName('i')->length);
+    }
+}


### PR DESCRIPTION
## XMLF-P2-05 — XmlFeedWriter

Serializer feedu sterowany descriptorem, implementuje `ItemWriter` (P0-04). Chodzi po slotach `FeedDescriptor` (P2-01) i składa XML przez `XmlWriterCore` (always well-formed).

### Zakres
- Węzły: **attribute** (najpierw, Ceneo `<o price>`), **element**/**repeatable**/**keyvalue** (grupowane pod `wrapIn`, np. `<imgs><i>`), polityka HTML per slot (escape/cdata/strip), namespaces + interpolowany header (`{feed_name}`).
- Feedowy odpowiednik `GenericXmlWriter`; generator (P2-04) poda mu zmapowany item.

### Walidacja
- ✅ PHPStan max **0** · PHPUnit **2/2 (12 assertions)** — RSS (ns/header/CDATA) + flat Ceneo (atrybuty/wrapIn/repeatable), DOM weryfikuje strukturę · Deptrac **0**.

Refs #1916