### PR TITLE
feat(export): feed field mappings + closed-list transforms (XMLF-P2-03)

### DIFF
--- a/apps/api/src/Export/Feed/Domain/Mapping/FeedFieldMapping.php
+++ b/apps/api/src/Export/Feed/Domain/Mapping/FeedFieldMapping.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Domain\Mapping;
+
+/**
+ * One slot mapping (ADR-0023 §6.4, XMLF-P2-03): which source feeds a descriptor
+ * slot and the optional transform. Source kinds: `attribute` (a PIM attribute
+ * code), `static` (a fixed value), `template` (interpolation of other fields).
+ */
+final class FeedFieldMapping
+{
+    /**
+     * @param array<mixed, mixed>|null $transform {kind, …params}
+     */
+    public function __construct(
+        public readonly string $slot,
+        public readonly ?string $sourceKind,
+        public readonly ?string $sourceRef,
+        public readonly ?string $sourceValue,
+        public readonly ?array $transform,
+    ) {
+    }
+
+    /**
+     * @param array<mixed, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $slot = \is_string($data['slot'] ?? null) ? $data['slot'] : '';
+
+        $source = \is_array($data['source'] ?? null) ? $data['source'] : [];
+        $kind = \is_string($source['kind'] ?? null) ? $source['kind'] : null;
+        $ref = \is_string($source['ref'] ?? null) ? $source['ref'] : null;
+        $value = \is_string($source['value'] ?? null) ? $source['value'] : null;
+
+        $transform = \is_array($data['transform'] ?? null) ? $data['transform'] : null;
+
+        return new self($slot, $kind, $ref, $value, $transform);
+    }
+
+    /**
+     * Parse a persisted `field_mappings` list.
+     *
+     * @param array<mixed, mixed> $raw
+     *
+     * @return list<self>
+     */
+    public static function listFromArray(array $raw): array
+    {
+        $out = [];
+        foreach ($raw as $entry) {
+            if (\is_array($entry)) {
+                $out[] = self::fromArray($entry);
+            }
+        }
+
+        return $out;
+    }
+}

--- a/apps/api/src/Export/Feed/Domain/Mapping/FeedItemMapper.php
+++ b/apps/api/src/Export/Feed/Domain/Mapping/FeedItemMapper.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Domain\Mapping;
+
+/**
+ * Builds the descriptor item map (slot target => value) from a product's raw
+ * attribute values (ADR-0023 §6.4, XMLF-P2-03). For each mapping it resolves the
+ * source (attribute / static / template) then applies the optional transform.
+ * The generator (XMLF-P2-04) feeds the result to {@see \App\Export\Feed\Infrastructure\Writer\XmlFeedWriter}.
+ */
+final class FeedItemMapper
+{
+    public function __construct(private readonly FeedTransformApplier $transforms)
+    {
+    }
+
+    /**
+     * @param list<FeedFieldMapping> $mappings
+     * @param array<string, string>  $attributes raw attribute values keyed by attribute code
+     * @param array<string, string>  $context    feed tokens (currency, store_url, …)
+     *
+     * @return array<string, string> slot target => rendered value
+     */
+    public function map(array $mappings, array $attributes, array $context = []): array
+    {
+        $item = [];
+        foreach ($mappings as $mapping) {
+            $raw = $this->resolveSource($mapping, $attributes, $context);
+            $item[$mapping->slot] = null !== $mapping->transform
+                ? $this->transforms->apply($mapping->transform, $raw, $attributes + $context)
+                : $raw;
+        }
+
+        return $item;
+    }
+
+    /**
+     * @param array<string, string> $attributes
+     * @param array<string, string> $context
+     */
+    private function resolveSource(FeedFieldMapping $mapping, array $attributes, array $context): string
+    {
+        return match ($mapping->sourceKind) {
+            'attribute' => $attributes[$mapping->sourceRef ?? ''] ?? '',
+            'static' => $mapping->sourceValue ?? '',
+            'template' => $this->interpolate($mapping->sourceValue ?? '', $attributes + $context),
+            default => '',
+        };
+    }
+
+    /**
+     * @param array<string, string> $vars
+     */
+    private function interpolate(string $template, array $vars): string
+    {
+        return preg_replace_callback(
+            '/\{([a-z0-9_.]+)\}/i',
+            static fn (array $m): string => $vars[$m[1]] ?? $m[0],
+            $template,
+        ) ?? $template;
+    }
+}

--- a/apps/api/src/Export/Feed/Domain/Mapping/FeedTransformApplier.php
+++ b/apps/api/src/Export/Feed/Domain/Mapping/FeedTransformApplier.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Domain\Mapping;
+
+use DateTimeImmutable;
+
+/**
+ * Applies the closed list of feed transforms (ADR-0023 §6.4, XMLF-P2-03) over a
+ * value already serialized to a string by the export ValueSerializer. Deliberate
+ * departure from the APIC 1:1 rule — feeds need `price` "123.45 PLN",
+ * `availability` enums, etc. Anything beyond this list is a hook (§7).
+ *
+ * Transforms: default/fallback, price, number, date, enum_map, template/concat,
+ * strip_html, truncate.
+ */
+final class FeedTransformApplier
+{
+    /**
+     * @param array<mixed, mixed>   $transform {kind, …params}
+     * @param array<string, string> $context   feed tokens (currency) + sibling field values (template)
+     */
+    public function apply(array $transform, string $value, array $context = []): string
+    {
+        $kind = \is_string($transform['kind'] ?? null) ? $transform['kind'] : 'none';
+
+        return match ($kind) {
+            'default', 'fallback' => '' === $value ? $this->stringParam($transform, 'value') : $value,
+            'price' => $this->price($value, $context),
+            'number' => $this->number($value, $transform),
+            'date' => $this->date($value, $transform),
+            'enum_map' => $this->enumMap($value, $transform),
+            'template', 'concat' => $this->interpolate($this->stringParam($transform, 'value'), $context, $value),
+            'strip_html' => trim(strip_tags($value)),
+            'truncate' => $this->truncate($value, $transform),
+            default => $value,
+        };
+    }
+
+    /**
+     * @param array<string, string> $context
+     */
+    private function price(string $value, array $context): string
+    {
+        $amount = $this->toFloat($value);
+        if (null === $amount) {
+            return $value;
+        }
+        $currency = \is_string($context['currency'] ?? null) ? $context['currency'] : '';
+
+        return trim(sprintf('%.2f %s', $amount, $currency));
+    }
+
+    /**
+     * @param array<mixed, mixed> $transform
+     */
+    private function number(string $value, array $transform): string
+    {
+        $amount = $this->toFloat($value);
+        if (null === $amount) {
+            return $value;
+        }
+        $precision = \is_int($transform['precision'] ?? null) ? $transform['precision'] : 2;
+
+        return number_format($amount, max(0, $precision), '.', '');
+    }
+
+    /**
+     * @param array<mixed, mixed> $transform
+     */
+    private function date(string $value, array $transform): string
+    {
+        if ('' === $value) {
+            return '';
+        }
+        $ts = strtotime($value);
+        if (false === $ts) {
+            return $value;
+        }
+        $format = \is_string($transform['format'] ?? null) ? $transform['format'] : DateTimeImmutable::ATOM;
+
+        return date($format, $ts);
+    }
+
+    /**
+     * enum_map: a `rule` shortcut (stock qty → in/out of stock) or an explicit
+     * `map` of value => output with an optional `default`.
+     *
+     * @param array<mixed, mixed> $transform
+     */
+    private function enumMap(string $value, array $transform): string
+    {
+        $rule = \is_string($transform['rule'] ?? null) ? $transform['rule'] : null;
+        if (null !== $rule) {
+            $qty = $this->toFloat($value);
+
+            return match ($rule) {
+                'stock' => (null !== $qty && $qty > 0) ? 'in_stock' : 'out_of_stock',
+                'meta_stock' => (null !== $qty && $qty > 0) ? 'in stock' : 'out of stock',
+                'ceneo_avail' => (null !== $qty && $qty > 0) ? '1' : '0',
+                default => $value,
+            };
+        }
+
+        $map = \is_array($transform['map'] ?? null) ? $transform['map'] : [];
+        if (\array_key_exists($value, $map) && \is_scalar($map[$value])) {
+            return (string) $map[$value];
+        }
+
+        $default = $this->stringParam($transform, 'default');
+
+        return '' !== $default ? $default : $value;
+    }
+
+    /**
+     * @param array<mixed, mixed> $transform
+     */
+    private function truncate(string $value, array $transform): string
+    {
+        $to = \is_int($transform['to'] ?? null) ? $transform['to'] : 0;
+        if ($to <= 0 || mb_strlen($value) <= $to) {
+            return $value;
+        }
+        $cut = mb_substr($value, 0, $to);
+        $lastSpace = mb_strrpos($cut, ' ');
+
+        return rtrim(false !== $lastSpace && $lastSpace > 0 ? mb_substr($cut, 0, $lastSpace) : $cut);
+    }
+
+    /**
+     * @param array<string, string> $context
+     */
+    private function interpolate(string $template, array $context, string $self): string
+    {
+        $ctx = $context + ['value' => $self, 'self' => $self];
+
+        return preg_replace_callback(
+            '/\{([a-z0-9_.]+)\}/i',
+            static fn (array $m): string => $ctx[$m[1]] ?? $m[0],
+            $template,
+        ) ?? $template;
+    }
+
+    /**
+     * @param array<mixed, mixed> $transform
+     */
+    private function stringParam(array $transform, string $key): string
+    {
+        return \is_string($transform[$key] ?? null) ? $transform[$key] : '';
+    }
+
+    private function toFloat(string $value): ?float
+    {
+        $normalized = str_replace([' ', ','], ['', '.'], trim($value));
+        if ('' === $normalized || !is_numeric($normalized)) {
+            return null;
+        }
+
+        return (float) $normalized;
+    }
+}

--- a/apps/api/tests/Unit/Export/Feed/FeedTransformTest.php
+++ b/apps/api/tests/Unit/Export/Feed/FeedTransformTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export\Feed;
+
+use App\Export\Feed\Domain\Mapping\FeedFieldMapping;
+use App\Export\Feed\Domain\Mapping\FeedItemMapper;
+use App\Export\Feed\Domain\Mapping\FeedTransformApplier;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * XMLF-P2-03 — the closed transform list + item mapper.
+ */
+final class FeedTransformTest extends TestCase
+{
+    private FeedTransformApplier $t;
+
+    protected function setUp(): void
+    {
+        $this->t = new FeedTransformApplier();
+    }
+
+    #[Test]
+    public function priceFormatsWithCurrency(): void
+    {
+        self::assertSame('19.90 PLN', $this->t->apply(['kind' => 'price'], '19.9', ['currency' => 'PLN']));
+        self::assertSame('1234.50 EUR', $this->t->apply(['kind' => 'price'], '1 234,5', ['currency' => 'EUR']));
+    }
+
+    #[Test]
+    public function numberFormatsPrecision(): void
+    {
+        self::assertSame('1234.50', $this->t->apply(['kind' => 'number', 'precision' => 2], '1234.5'));
+        self::assertSame('7', $this->t->apply(['kind' => 'number', 'precision' => 0], '7.4'));
+    }
+
+    #[Test]
+    public function defaultFillsEmptyOnly(): void
+    {
+        self::assertSame('Unbranded', $this->t->apply(['kind' => 'default', 'value' => 'Unbranded'], ''));
+        self::assertSame('Klimas', $this->t->apply(['kind' => 'default', 'value' => 'Unbranded'], 'Klimas'));
+    }
+
+    #[Test]
+    public function enumMapStockRule(): void
+    {
+        self::assertSame('in_stock', $this->t->apply(['kind' => 'enum_map', 'rule' => 'stock'], '15'));
+        self::assertSame('out_of_stock', $this->t->apply(['kind' => 'enum_map', 'rule' => 'stock'], '0'));
+        self::assertSame('in stock', $this->t->apply(['kind' => 'enum_map', 'rule' => 'meta_stock'], '3'));
+    }
+
+    #[Test]
+    public function stripHtmlAndTruncate(): void
+    {
+        self::assertSame('opis produktu', $this->t->apply(['kind' => 'strip_html'], '<p>opis <b>produktu</b></p>'));
+        self::assertSame('Wkręt ciesielski', $this->t->apply(['kind' => 'truncate', 'to' => 17], 'Wkręt ciesielski do drewna'));
+    }
+
+    #[Test]
+    public function templateInterpolatesSiblingFields(): void
+    {
+        $out = $this->t->apply(['kind' => 'template', 'value' => '{name} {brand}'], '', ['name' => 'Wkręt', 'brand' => 'Klimas']);
+        self::assertSame('Wkręt Klimas', $out);
+    }
+
+    #[Test]
+    public function mapperResolvesSourcesAndTransforms(): void
+    {
+        $mapper = new FeedItemMapper($this->t);
+        $mappings = FeedFieldMapping::listFromArray([
+            ['slot' => 'g:id', 'source' => ['kind' => 'attribute', 'ref' => 'sku']],
+            ['slot' => 'g:price', 'source' => ['kind' => 'attribute', 'ref' => 'price_gross'], 'transform' => ['kind' => 'price']],
+            ['slot' => 'g:condition', 'source' => ['kind' => 'static', 'value' => 'new']],
+            ['slot' => 'g:link', 'source' => ['kind' => 'template', 'value' => '{store_url}/p/{url_slug}']],
+        ]);
+
+        $item = $mapper->map(
+            $mappings,
+            ['sku' => 'KL-1', 'price_gross' => '19.9', 'url_slug' => 'wkret'],
+            ['currency' => 'PLN', 'store_url' => 'https://shop.pl'],
+        );
+
+        self::assertSame('KL-1', $item['g:id']);
+        self::assertSame('19.90 PLN', $item['g:price']);
+        self::assertSame('new', $item['g:condition']);
+        self::assertSame('https://shop.pl/p/wkret', $item['g:link']);
+    }
+}


### PR DESCRIPTION
## XMLF-P2-03 — mapowania + transformacje

- `FeedFieldMapping` VO (slot ← attribute/static/template + transform?).
- `FeedTransformApplier` — zamknięta lista: default/price/number/date/enum_map/template/strip_html/truncate nad wyjściem `ValueSerializer`.
- `FeedItemMapper` — resolwuje mapowania → item map dla `XmlFeedWriter`.
- Świadome odejście od 1:1 APIC (feed wymaga `price` „19.90 PLN", `availability` enum); reszta = hook §7.

### Walidacja
- ✅ PHPStan max **0** · PHPUnit **7/7 (16 assertions)** (price/number/default/enum_map/strip/truncate/template + mapper) · Deptrac **0**.

Refs #1914