### PR TITLE
feat(export): custom feed descriptor structure editor (XMLF-P2-07)

### DIFF
--- a/apps/api/src/Export/Feed/Application/Descriptor/FeedDescriptorEditor.php
+++ b/apps/api/src/Export/Feed/Application/Descriptor/FeedDescriptorEditor.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Application\Descriptor;
+
+use App\Export\Feed\Domain\Descriptor\FeedDescriptor;
+use App\Export\Feed\Domain\Descriptor\FeedSlot;
+use App\Export\Feed\Domain\Descriptor\InvalidDescriptorException;
+
+/**
+ * Structure-editing operations for a custom feed descriptor (ADR-0023 §7,
+ * XMLF-P2-07): define the root / namespaces and add / rename / remove slots,
+ * so a client can build a custom feed "from scratch" (not just clone a predef).
+ *
+ * Each operation parses the input through {@see FeedDescriptor} (rejecting a
+ * bad starting point), rebuilds the descriptor with the edited slot list and
+ * re-validates the result — so the editor can never persist a broken structure.
+ * Only `custom` feeds are structure-editable; the CRUD (XMLF-P1-03) enforces
+ * that predefs stay immutable.
+ */
+final class FeedDescriptorEditor
+{
+    /**
+     * @param array<mixed, mixed>   $descriptor
+     * @param array<string, string> $attributes
+     * @param array<string, string> $namespaces prefix => URI
+     *
+     * @return array<string, mixed>
+     */
+    public function setRoot(array $descriptor, string $rootElement, array $attributes = [], array $namespaces = []): array
+    {
+        $current = FeedDescriptor::fromArray($descriptor);
+
+        return $this->build(
+            $rootElement,
+            $attributes,
+            $namespaces,
+            $current->channelElement,
+            $current->header,
+            $current->itemElement,
+            $this->slotList($current),
+        );
+    }
+
+    /**
+     * @param array<mixed, mixed> $descriptor
+     * @param array<mixed, mixed> $slot
+     *
+     * @return array<string, mixed>
+     */
+    public function addSlot(array $descriptor, array $slot): array
+    {
+        $current = FeedDescriptor::fromArray($descriptor);
+        $slots = $this->slotList($current);
+        $slots[] = FeedSlot::fromArray($slot)->toArray();
+
+        return $this->rebuild($current, $slots);
+    }
+
+    /**
+     * @param array<mixed, mixed> $descriptor
+     *
+     * @return array<string, mixed>
+     */
+    public function removeSlot(array $descriptor, string $target): array
+    {
+        $current = FeedDescriptor::fromArray($descriptor);
+        if (null === $current->findSlot($target)) {
+            throw new InvalidDescriptorException(sprintf('Cannot remove unknown slot "%s".', $target));
+        }
+
+        $slots = array_values(array_filter(
+            $this->slotList($current),
+            static fn (array $slot): bool => ($slot['target'] ?? null) !== $target,
+        ));
+
+        return $this->rebuild($current, $slots);
+    }
+
+    /**
+     * @param array<mixed, mixed> $descriptor
+     *
+     * @return array<string, mixed>
+     */
+    public function renameSlot(array $descriptor, string $from, string $to): array
+    {
+        $current = FeedDescriptor::fromArray($descriptor);
+        if (null === $current->findSlot($from)) {
+            throw new InvalidDescriptorException(sprintf('Cannot rename unknown slot "%s".', $from));
+        }
+
+        $slots = array_map(
+            static function (array $slot) use ($from, $to): array {
+                if (($slot['target'] ?? null) === $from) {
+                    $slot['target'] = $to;
+                }
+                if (isset($slot['requiredOneOf']) && \is_array($slot['requiredOneOf'])) {
+                    $slot['requiredOneOf'] = array_map(
+                        static fn (mixed $ref): mixed => $ref === $from ? $to : $ref,
+                        $slot['requiredOneOf'],
+                    );
+                }
+
+                return $slot;
+            },
+            $this->slotList($current),
+        );
+
+        return $this->rebuild($current, $slots);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function slotList(FeedDescriptor $descriptor): array
+    {
+        return array_map(static fn (FeedSlot $slot): array => $slot->toArray(), $descriptor->slots);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $slots
+     *
+     * @return array<string, mixed>
+     */
+    private function rebuild(FeedDescriptor $current, array $slots): array
+    {
+        return $this->build(
+            $current->rootElement,
+            $current->rootAttributes,
+            $current->namespaces,
+            $current->channelElement,
+            $current->header,
+            $current->itemElement,
+            $slots,
+        );
+    }
+
+    /**
+     * @param array<string, string>      $attributes
+     * @param array<string, string>      $namespaces
+     * @param list<array<string, mixed>> $header
+     * @param list<array<string, mixed>> $slots
+     *
+     * @return array<string, mixed>
+     */
+    private function build(
+        string $rootElement,
+        array $attributes,
+        array $namespaces,
+        ?string $channelElement,
+        array $header,
+        string $itemElement,
+        array $slots,
+    ): array {
+        $root = ['element' => $rootElement];
+        if ([] !== $attributes) {
+            $root['attributes'] = $attributes;
+        }
+        if ([] !== $namespaces) {
+            $root['namespaces'] = $namespaces;
+        }
+
+        $item = ['element' => $itemElement, 'slots' => $slots];
+
+        $descriptor = null === $channelElement
+            ? ['root' => $root, 'item' => $item]
+            : ['root' => $root, 'channel' => ['element' => $channelElement, 'header' => $header, 'item' => $item]];
+
+        // Re-validate — never return a structurally broken descriptor.
+        FeedDescriptor::fromArray($descriptor);
+
+        return $descriptor;
+    }
+}

--- a/apps/api/tests/Unit/Export/Feed/FeedDescriptorEditorTest.php
+++ b/apps/api/tests/Unit/Export/Feed/FeedDescriptorEditorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export\Feed;
+
+use App\Export\Feed\Application\Descriptor\FeedDescriptorEditor;
+use App\Export\Feed\Domain\Descriptor\FeedDescriptor;
+use App\Export\Feed\Domain\Descriptor\InvalidDescriptorException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * XMLF-P2-07 — custom descriptor structure editing (add/rename/remove slots,
+ * set root/namespaces), always leaving a valid descriptor.
+ */
+final class FeedDescriptorEditorTest extends TestCase
+{
+    /** @return array<string, mixed> */
+    private function blank(): array
+    {
+        return [
+            'root' => ['element' => 'products'],
+            'item' => [
+                'element' => 'product',
+                'slots' => [['slot' => 'sku', 'node' => 'element', 'fmt' => 'text']],
+            ],
+        ];
+    }
+
+    #[Test]
+    public function addsRenamesAndRemovesSlots(): void
+    {
+        $editor = new FeedDescriptorEditor();
+
+        $d = $editor->addSlot($this->blank(), ['slot' => 'name', 'node' => 'element', 'fmt' => 'text']);
+        self::assertNotNull(FeedDescriptor::fromArray($d)->findSlot('name'));
+
+        $d = $editor->renameSlot($d, 'name', 'title');
+        $parsed = FeedDescriptor::fromArray($d);
+        self::assertNull($parsed->findSlot('name'));
+        self::assertNotNull($parsed->findSlot('title'));
+
+        $d = $editor->removeSlot($d, 'title');
+        self::assertNull(FeedDescriptor::fromArray($d)->findSlot('title'));
+        self::assertNotNull(FeedDescriptor::fromArray($d)->findSlot('sku'));
+    }
+
+    #[Test]
+    public function setRootUpdatesElementAndNamespaces(): void
+    {
+        $d = new FeedDescriptorEditor()->setRoot($this->blank(), 'rss', ['version' => '2.0'], ['g' => 'http://x']);
+
+        $parsed = FeedDescriptor::fromArray($d);
+        self::assertSame('rss', $parsed->rootElement);
+        self::assertSame('2.0', $parsed->rootAttributes['version']);
+        self::assertSame('http://x', $parsed->namespaces['g']);
+    }
+
+    #[Test]
+    public function rejectsAddingSlotWithIllegalName(): void
+    {
+        $this->expectException(InvalidDescriptorException::class);
+        new FeedDescriptorEditor()->addSlot($this->blank(), ['slot' => 'bad.name', 'node' => 'element', 'fmt' => 'text']);
+    }
+
+    #[Test]
+    public function rejectsRemovingUnknownSlot(): void
+    {
+        $this->expectException(InvalidDescriptorException::class);
+        new FeedDescriptorEditor()->removeSlot($this->blank(), 'nope');
+    }
+}


### PR DESCRIPTION
## XMLF-P2-07 — edytor struktury custom descriptora

`FeedDescriptorEditor`: set root/namespaces + add/rename/remove slotów → custom feed „od zera" (nie tylko klon predefa). Każda operacja parsuje wejście, przebudowuje z edytowaną listą slotów i **re-waliduje przez FeedDescriptor VO** — edytor nigdy nie zwróci zepsutej struktury; rename przepisuje też referencje `requiredOneOf`. Tylko custom (predef immutable — egzekwuje CRUD P1-03).

### Walidacja
- ✅ PHPStan max **0** · PHPUnit **4/4 (10 assertions)** · Deptrac **0**.

Refs #1918