### PR TITLE
feat(export): FeedGenerator orchestrator (XMLF-P2-04)

### DIFF
--- a/apps/api/src/Export/Feed/Application/Generator/FeedGenerator.php
+++ b/apps/api/src/Export/Feed/Application/Generator/FeedGenerator.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Application\Generator;
+
+use App\Export\Feed\Domain\Descriptor\FeedDescriptor;
+use App\Export\Feed\Domain\Entity\FeedProfile;
+use App\Export\Feed\Domain\Entity\FeedRun;
+use App\Export\Feed\Domain\Entity\FeedRunLog;
+use App\Export\Feed\Domain\Enum\FeedRunLogLevel;
+use App\Export\Feed\Domain\Enum\FeedRunTrigger;
+use App\Export\Feed\Domain\Enum\FeedValidationPolicy;
+use App\Export\Feed\Domain\Generator\FeedProductValues;
+use App\Export\Feed\Domain\Generator\FeedRequiredValidator;
+use App\Export\Feed\Domain\Mapping\FeedFieldMapping;
+use App\Export\Feed\Domain\Mapping\FeedItemMapper;
+use App\Export\Feed\Domain\Repository\FeedRunLogRepositoryInterface;
+use App\Export\Feed\Domain\Repository\FeedRunRepositoryInterface;
+use App\Export\Feed\Infrastructure\Writer\XmlFeedWriter;
+use App\Export\Infrastructure\Writer\XmlWriterCore;
+use Throwable;
+
+/**
+ * Orchestrates one feed regeneration (ADR-0023 §6.3, XMLF-P2-04): streams the
+ * product value maps ({@see FeedProductValues}, memory-bounded), applies the
+ * feed's mappings + transforms ({@see FeedItemMapper}), validates required
+ * fields ({@see FeedRequiredValidator}) under the feed's skip policy, serializes
+ * through the descriptor-driven {@see XmlFeedWriter} to $targetPath, and records
+ * the {@see FeedRun} + per-product {@see FeedRunLog} health trail.
+ *
+ * Delivery (MinIO cache + public URL) is XMLF-P3-05; scope/filter wiring of the
+ * value source is XMLF-P3-02.
+ */
+final class FeedGenerator
+{
+    private const int LOG_FLUSH_EVERY = 500;
+
+    public function __construct(
+        private readonly FeedProductValues $values,
+        private readonly FeedItemMapper $mapper,
+        private readonly FeedRequiredValidator $validator,
+        private readonly FeedRunRepositoryInterface $runs,
+        private readonly FeedRunLogRepositoryInterface $logs,
+    ) {
+    }
+
+    public function generate(FeedProfile $profile, string $targetPath, FeedRunTrigger $trigger): FeedRun
+    {
+        $run = new FeedRun($profile->getId(), $trigger);
+        $run->markRunning();
+        $this->runs->save($run);
+
+        $descriptor = FeedDescriptor::fromArray($profile->getDescriptor());
+        $mappings = FeedFieldMapping::listFromArray($profile->getFieldMappings());
+        $context = $this->context($profile);
+        $skip = FeedValidationPolicy::SkipInvalid === $profile->getValidationPolicy();
+
+        $xml = XmlWriterCore::toUri($targetPath);
+        $writer = new XmlFeedWriter($xml, $descriptor, $context);
+        $writer->begin();
+
+        $items = 0;
+        $skipped = 0;
+        $warnings = 0;
+        /** @var list<FeedRunLog> $buffer */
+        $buffer = [];
+        $startedAt = hrtime(true);
+
+        try {
+            foreach ($this->values->forProfile($profile) as $attributes) {
+                $item = $this->mapper->map($mappings, $attributes, $context);
+                $violations = $this->validator->check($descriptor, $item);
+                $sku = $attributes['sku'] ?? null;
+
+                if ([] !== $violations) {
+                    foreach ($violations as $violation) {
+                        $buffer[] = new FeedRunLog($run->getId(), FeedRunLogLevel::Warning, $violation['message'], $sku, $violation['slot']);
+                    }
+                    $warnings += \count($violations);
+                    if ($skip) {
+                        ++$skipped;
+                        $buffer = $this->maybeFlush($buffer);
+                        continue;
+                    }
+                }
+
+                $writer->writeItem($item);
+                ++$items;
+                $buffer = $this->maybeFlush($buffer);
+            }
+            $writer->finish();
+        } catch (Throwable $error) {
+            $this->logs->saveMany($buffer);
+            $run->markError($error->getMessage());
+            $this->runs->save($run);
+
+            throw $error;
+        }
+
+        $this->logs->saveMany($buffer);
+
+        $size = is_file($targetPath) ? (int) filesize($targetPath) : 0;
+        $durationMs = (int) ((hrtime(true) - $startedAt) / 1_000_000);
+        $run->markDone($items, $skipped, $warnings, $targetPath, $size, $durationMs);
+        $this->runs->save($run);
+
+        return $run;
+    }
+
+    /**
+     * @param list<FeedRunLog> $buffer
+     *
+     * @return list<FeedRunLog>
+     */
+    private function maybeFlush(array $buffer): array
+    {
+        if (\count($buffer) >= self::LOG_FLUSH_EVERY) {
+            $this->logs->saveMany($buffer);
+
+            return [];
+        }
+
+        return $buffer;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function context(FeedProfile $profile): array
+    {
+        $delivery = $profile->getDelivery();
+        $storeUrl = \is_string($delivery['store_url'] ?? null) ? $delivery['store_url'] : '';
+
+        return [
+            'currency' => $profile->getCurrency() ?? '',
+            'store_url' => $storeUrl,
+            'feed_name' => $profile->getName(),
+        ];
+    }
+}

--- a/apps/api/src/Export/Feed/Domain/Generator/FeedProductValues.php
+++ b/apps/api/src/Export/Feed/Domain/Generator/FeedProductValues.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Domain\Generator;
+
+use App\Export\Feed\Domain\Entity\FeedProfile;
+
+/**
+ * Seam over the product value source a feed projects (ADR-0023 §6.3, XMLF-P2-04).
+ * Yields one attribute-code-keyed map per product, memory-bounded (the
+ * implementation owns chunking + EntityManager::clear()). The ExportBuilder-backed
+ * adapter — which resolves the feed's scope (locale/channel/filter) into an
+ * ExportSession — lands with XMLF-P3-02, so the generator core here stays
+ * unit-testable against a fake source.
+ */
+interface FeedProductValues
+{
+    /**
+     * @return iterable<array<string, string>> attribute code => serialized value, per product
+     */
+    public function forProfile(FeedProfile $profile): iterable;
+}

--- a/apps/api/src/Export/Feed/Domain/Generator/FeedRequiredValidator.php
+++ b/apps/api/src/Export/Feed/Domain/Generator/FeedRequiredValidator.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Domain\Generator;
+
+use App\Export\Feed\Domain\Descriptor\FeedDescriptor;
+
+/**
+ * Per-product feed-health validation (ADR-0023 §6.5, XMLF-P2-04): checks an
+ * item map against the descriptor's required / requiredOneOf / maxLength rules.
+ * Returns one violation per broken rule (slot + message) for the FeedRunLog.
+ */
+final class FeedRequiredValidator
+{
+    /**
+     * @param array<string, string> $item slot target => rendered value
+     *
+     * @return list<array{slot: string, message: string}>
+     */
+    public function check(FeedDescriptor $descriptor, array $item): array
+    {
+        $violations = [];
+        $oneOf = [];
+
+        foreach ($descriptor->slots as $slot) {
+            $value = $item[$slot->target] ?? '';
+
+            if ($slot->rule->required && '' === $value) {
+                $violations[] = ['slot' => $slot->target, 'message' => sprintf('missing required %s', $slot->target)];
+            }
+
+            if ([] !== $slot->rule->requiredOneOf) {
+                $key = implode('|', $slot->rule->requiredOneOf);
+                $oneOf[$key] = ($oneOf[$key] ?? false) || '' !== $value;
+            }
+
+            if (null !== $slot->rule->maxLength && mb_strlen($value) > $slot->rule->maxLength) {
+                $violations[] = ['slot' => $slot->target, 'message' => sprintf('%s exceeds max length %d', $slot->target, $slot->rule->maxLength)];
+            }
+        }
+
+        foreach ($oneOf as $key => $satisfied) {
+            if (!$satisfied) {
+                $violations[] = ['slot' => $key, 'message' => sprintf('none of required-one-of [%s] is set', $key)];
+            }
+        }
+
+        return $violations;
+    }
+}

--- a/apps/api/src/Export/Feed/Domain/Repository/FeedRunLogRepositoryInterface.php
+++ b/apps/api/src/Export/Feed/Domain/Repository/FeedRunLogRepositoryInterface.php
@@ -12,6 +12,13 @@ interface FeedRunLogRepositoryInterface
     public function save(FeedRunLog $log): void;
 
     /**
+     * Persist many log lines in one flush (feed-health during generation).
+     *
+     * @param list<FeedRunLog> $logs
+     */
+    public function saveMany(array $logs): void;
+
+    /**
      * @return list<FeedRunLog>
      */
     public function findByRun(Uuid $feedRunId): array;

--- a/apps/api/src/Export/Feed/Infrastructure/Doctrine/Repository/DoctrineFeedRunLogRepository.php
+++ b/apps/api/src/Export/Feed/Infrastructure/Doctrine/Repository/DoctrineFeedRunLogRepository.php
@@ -27,6 +27,18 @@ class DoctrineFeedRunLogRepository extends ServiceEntityRepository implements Fe
         $em->flush();
     }
 
+    public function saveMany(array $logs): void
+    {
+        if ([] === $logs) {
+            return;
+        }
+        $em = $this->getEntityManager();
+        foreach ($logs as $log) {
+            $em->persist($log);
+        }
+        $em->flush();
+    }
+
     /**
      * @return list<FeedRunLog>
      */

--- a/apps/api/tests/Unit/Export/Feed/FeedGeneratorTest.php
+++ b/apps/api/tests/Unit/Export/Feed/FeedGeneratorTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export\Feed;
+
+use App\Export\Feed\Application\Generator\FeedGenerator;
+use App\Export\Feed\Domain\Entity\FeedProfile;
+use App\Export\Feed\Domain\Entity\FeedRun;
+use App\Export\Feed\Domain\Entity\FeedRunLog;
+use App\Export\Feed\Domain\Enum\FeedRunStatus;
+use App\Export\Feed\Domain\Enum\FeedRunTrigger;
+use App\Export\Feed\Domain\Enum\FeedTemplateKind;
+use App\Export\Feed\Domain\Generator\FeedProductValues;
+use App\Export\Feed\Domain\Generator\FeedRequiredValidator;
+use App\Export\Feed\Domain\Mapping\FeedItemMapper;
+use App\Export\Feed\Domain\Mapping\FeedTransformApplier;
+use App\Export\Feed\Domain\Repository\FeedRunLogRepositoryInterface;
+use App\Export\Feed\Domain\Repository\FeedRunRepositoryInterface;
+use DOMDocument;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * XMLF-P2-04 — FeedGenerator orchestration: maps + validates + serializes each
+ * product, applies the skip policy, and records the FeedRun counters + logs.
+ */
+final class FeedGeneratorTest extends TestCase
+{
+    private function profile(): FeedProfile
+    {
+        return new FeedProfile(
+            code: 'custom_pl',
+            name: 'Custom Feed',
+            templateKind: FeedTemplateKind::Custom,
+            objectTypeId: Uuid::v7(),
+            descriptor: [
+                'root' => ['element' => 'products'],
+                'item' => [
+                    'element' => 'product',
+                    'slots' => [
+                        ['slot' => 'sku', 'node' => 'element', 'required' => true, 'fmt' => 'text'],
+                        ['slot' => 'name', 'node' => 'element', 'fmt' => 'text'],
+                    ],
+                ],
+            ],
+            fieldMappings: [
+                ['slot' => 'sku', 'source' => ['kind' => 'attribute', 'ref' => 'sku']],
+                ['slot' => 'name', 'source' => ['kind' => 'attribute', 'ref' => 'name']],
+            ],
+        );
+    }
+
+    #[Test]
+    public function generatesFeedApplyingSkipPolicyAndCounters(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'pim-feed-');
+        self::assertIsString($path);
+
+        $source = new class implements FeedProductValues {
+            public function forProfile(FeedProfile $profile): iterable
+            {
+                yield ['sku' => 'KL-1', 'name' => 'Wkręt'];
+                yield ['sku' => 'KL-2', 'name' => 'Kątownik'];
+                yield ['name' => 'Bez SKU']; // missing required sku → skipped
+            }
+        };
+
+        $runRepo = new class implements FeedRunRepositoryInterface {
+            public function save(FeedRun $run): void
+            {
+            }
+
+            public function findById(Uuid $id): ?FeedRun
+            {
+                return null;
+            }
+
+            public function findByFeedProfile(Uuid $feedProfileId, int $limit = 50): array
+            {
+                return [];
+            }
+        };
+
+        $logRepo = new class implements FeedRunLogRepositoryInterface {
+            public int $saved = 0;
+
+            public function save(FeedRunLog $log): void
+            {
+                ++$this->saved;
+            }
+
+            public function saveMany(array $logs): void
+            {
+                $this->saved += \count($logs);
+            }
+
+            public function findByRun(Uuid $feedRunId): array
+            {
+                return [];
+            }
+        };
+
+        try {
+            $generator = new FeedGenerator($source, new FeedItemMapper(new FeedTransformApplier()), new FeedRequiredValidator(), $runRepo, $logRepo);
+            $run = $generator->generate($this->profile(), $path, FeedRunTrigger::Manual);
+
+            self::assertSame(FeedRunStatus::Done, $run->getStatus());
+            self::assertSame(2, $run->getItemCount());
+            self::assertSame(1, $run->getSkippedCount());
+            self::assertGreaterThanOrEqual(1, $run->getWarningCount());
+            self::assertGreaterThanOrEqual(1, $logRepo->saved);
+
+            $dom = new DOMDocument();
+            self::assertNotFalse($dom->loadXML((string) file_get_contents($path)));
+            self::assertSame(2, $dom->getElementsByTagName('product')->length);
+            self::assertSame('KL-1', $dom->getElementsByTagName('sku')->item(0)?->textContent);
+        } finally {
+            @unlink($path);
+        }
+    }
+}


### PR DESCRIPTION
## XMLF-P2-04 — FeedGenerator [PM]

Orkiestrator regeneracji: streamuje mapy wartości produktów przez memory-bounded seam `FeedProductValues` → mapowania+transformacje (`FeedItemMapper`) → walidacja required/requiredOneOf/maxLength (`FeedRequiredValidator`) wg polityki skip_invalid/include_with_warning → serializacja przez `XmlFeedWriter` → `FeedRun` + batchowany `FeedRunLog`.

### Świadome odejście (udokumentowane)
Adapter źródła oparty na **ExportBuilder** (scope/locale/channel/filter → ExportSession) ląduje z **P3-02** (scope/filtr konfigurują dokładnie to, czego adapter potrzebuje); MinIO delivery z **P3-05**. Rdzeń orkiestracji tutaj jest w pełni unit-testowany przeciw fake source — reuse ExportBuilder to czysty seam, nie duplikacja.

### Walidacja
- ✅ PHPStan max **0** · PHPUnit **1/1 (11 assertions)** — 3 produkty (2 valid + 1 bez required sku → skipped), well-formed XML, counters item=2/skipped=1/warnings≥1 · Deptrac **0**.

Refs #1915