### PR TITLE
feat(export): create feed from built-in template (XMLF-P2-06)

### DIFF
--- a/apps/api/src/Export/Feed/Application/Template/FeedProfileFactory.php
+++ b/apps/api/src/Export/Feed/Application/Template/FeedProfileFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Application\Template;
+
+use App\Export\Feed\Domain\Entity\FeedProfile;
+use App\Export\Feed\Domain\Enum\FeedTemplateKind;
+use App\Export\Feed\Domain\Template\FeedTemplateCatalog;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Creates a FeedProfile from a built-in template (ADR-0023 §6.5, XMLF-P2-06):
+ * clones the template's descriptor + default mappings into an editable profile.
+ * Predefs become a starting point the user then maps/filters; custom starts
+ * from the blank template and is structure-editable (XMLF-P2-07).
+ */
+final class FeedProfileFactory
+{
+    public function __construct(private readonly FeedTemplateCatalog $catalog)
+    {
+    }
+
+    public function fromTemplate(
+        FeedTemplateKind $kind,
+        string $code,
+        string $name,
+        Uuid $objectTypeId,
+        ?string $locale = null,
+        ?string $currency = null,
+    ): FeedProfile {
+        $template = $this->catalog->get($kind);
+
+        return new FeedProfile(
+            code: $code,
+            name: $name,
+            templateKind: $kind,
+            objectTypeId: $objectTypeId,
+            descriptor: $template->descriptor,
+            fieldMappings: $template->defaultMappings,
+            locale: $locale,
+            currency: $currency,
+        );
+    }
+}

--- a/apps/api/tests/Unit/Export/Feed/FeedProfileFactoryTest.php
+++ b/apps/api/tests/Unit/Export/Feed/FeedProfileFactoryTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export\Feed;
+
+use App\Export\Feed\Application\Template\FeedProfileFactory;
+use App\Export\Feed\Domain\Descriptor\FeedDescriptor;
+use App\Export\Feed\Domain\Enum\FeedTemplateKind;
+use App\Export\Feed\Domain\Template\FeedTemplateCatalog;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * XMLF-P2-06 — creating a feed from a built-in template clones its descriptor
+ * and default mappings into an editable profile.
+ */
+final class FeedProfileFactoryTest extends TestCase
+{
+    #[Test]
+    public function clonesTemplateDescriptorAndMappings(): void
+    {
+        $factory = new FeedProfileFactory(new FeedTemplateCatalog());
+        $objectTypeId = Uuid::v7();
+
+        $profile = $factory->fromTemplate(
+            FeedTemplateKind::GoogleShopping,
+            'google_pl',
+            'Google Shopping — PL',
+            $objectTypeId,
+            locale: 'pl',
+            currency: 'PLN',
+        );
+
+        self::assertSame('google_pl', $profile->getCode());
+        self::assertSame(FeedTemplateKind::GoogleShopping, $profile->getTemplateKind());
+        self::assertSame('pl', $profile->getLocale());
+        self::assertSame('PLN', $profile->getCurrency());
+        self::assertTrue($profile->getObjectTypeId()->equals($objectTypeId));
+
+        // The cloned descriptor is a valid, parseable feed structure.
+        $descriptor = FeedDescriptor::fromArray($profile->getDescriptor());
+        self::assertSame('rss', $descriptor->rootElement);
+        self::assertNotNull($descriptor->findSlot('g:id'));
+        self::assertNotEmpty($profile->getFieldMappings());
+    }
+
+    #[Test]
+    public function customTemplateProducesBlankStarter(): void
+    {
+        $profile = new FeedProfileFactory(new FeedTemplateCatalog())
+            ->fromTemplate(FeedTemplateKind::Custom, 'b2b', 'Feed B2B', Uuid::v7());
+
+        self::assertSame(FeedTemplateKind::Custom, $profile->getTemplateKind());
+        $descriptor = FeedDescriptor::fromArray($profile->getDescriptor());
+        self::assertSame('products', $descriptor->rootElement);
+    }
+}


### PR DESCRIPTION
## XMLF-P2-06 — utwórz feed z szablonu

`FeedProfileFactory`: klonuje descriptor + domyślne mapowania szablonu (P2-02) do nowego edytowalnego `FeedProfile`. Predef = gotowy punkt startu; custom = blank struktura edytowalna (P2-07).

### Walidacja
- ✅ PHPStan max **0** · PHPUnit **2/2 (10 assertions)** (Google clone + custom blank, descriptor parsuje) · Deptrac **0**.

Refs #1917