### PR TITLE
feat(export): feed URL token lifecycle + delivery config (XMLF-P3-04)

### DIFF
--- a/apps/api/src/Export/Feed/Application/Delivery/FeedDeliveryConfig.php
+++ b/apps/api/src/Export/Feed/Application/Delivery/FeedDeliveryConfig.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Application\Delivery;
+
+use App\Shared\Application\Crypto\EncryptedSecret;
+use App\Shared\Application\Crypto\EncryptionServiceInterface;
+use InvalidArgumentException;
+
+/**
+ * Builds / reads a feed's delivery config JSONB (ADR-0023 §6.9, XMLF-P3-04):
+ * gzip toggle + optional HTTP Basic auth. The Basic password is encrypted with
+ * the shared AES-256-GCM service (reversible — it must be compared with the
+ * incoming credential), never stored or returned in plaintext.
+ */
+final class FeedDeliveryConfig
+{
+    public function __construct(private readonly EncryptionServiceInterface $encryption)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function build(bool $gzip, string $authType, ?string $username = null, ?string $password = null): array
+    {
+        if ('basic' === $authType) {
+            if (null === $username || '' === $username || null === $password || '' === $password) {
+                throw new InvalidArgumentException('HTTP Basic auth requires a username and password.');
+            }
+            $secret = $this->encryption->encrypt($password);
+
+            return [
+                'gzip' => $gzip,
+                'auth' => [
+                    'type' => 'basic',
+                    'username' => $username,
+                    'encrypted_password' => $secret->ciphertext,
+                    'encryption_version' => $secret->version,
+                ],
+            ];
+        }
+
+        return ['gzip' => $gzip, 'auth' => ['type' => 'none']];
+    }
+
+    public function gzipEnabled(mixed $delivery): bool
+    {
+        return \is_array($delivery) && true === ($delivery['gzip'] ?? false);
+    }
+
+    /**
+     * Decrypt the stored Basic credentials for comparison at serve time
+     * (XMLF-P3-05). Returns null when the feed is not Basic-protected.
+     *
+     * @return array{username: string, password: string}|null
+     */
+    public function basicCredentials(mixed $delivery): ?array
+    {
+        if (!\is_array($delivery) || !\is_array($delivery['auth'] ?? null)) {
+            return null;
+        }
+        $auth = $delivery['auth'];
+        if ('basic' !== ($auth['type'] ?? null)) {
+            return null;
+        }
+        $username = \is_string($auth['username'] ?? null) ? $auth['username'] : '';
+        $ciphertext = \is_string($auth['encrypted_password'] ?? null) ? $auth['encrypted_password'] : '';
+        $version = \is_int($auth['encryption_version'] ?? null) ? $auth['encryption_version'] : 0;
+        if ('' === $ciphertext) {
+            return null;
+        }
+
+        return ['username' => $username, 'password' => $this->encryption->decrypt(new EncryptedSecret($ciphertext, $version))];
+    }
+}

--- a/apps/api/src/Export/Feed/Application/Delivery/FeedTokenService.php
+++ b/apps/api/src/Export/Feed/Application/Delivery/FeedTokenService.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Application\Delivery;
+
+use App\Export\Feed\Domain\Entity\FeedProfile;
+
+/**
+ * Feed URL token lifecycle (ADR-0023 §6.9, XMLF-P3-04). Each feed's public URL
+ * carries an unguessable token (>=128-bit); we persist only its keyed HMAC on
+ * the profile (never the plaintext), so the public endpoint (XMLF-P3-05) can
+ * resolve the feed by a single indexed lookup on the hash. The token is shown
+ * once at mint/rotate; it is NOT the tenant API key (separate lifecycle,
+ * read-only, revocable per feed).
+ */
+final class FeedTokenService
+{
+    /** 24 random bytes → 32-char base64url token (192-bit, > the 128-bit floor). */
+    private const int TOKEN_BYTES = 24;
+
+    public function __construct(private readonly string $secret)
+    {
+    }
+
+    /**
+     * Mint a new token, store its HMAC on the feed, and return the plaintext
+     * (shown to the user once).
+     */
+    public function mint(FeedProfile $feed): string
+    {
+        $token = rtrim(strtr(base64_encode(random_bytes(self::TOKEN_BYTES)), '+/', '-_'), '=');
+        $feed->setTokenHash($this->hash($token));
+
+        return $token;
+    }
+
+    public function rotate(FeedProfile $feed): string
+    {
+        return $this->mint($feed);
+    }
+
+    public function revoke(FeedProfile $feed): void
+    {
+        $feed->setTokenHash(null);
+    }
+
+    /**
+     * Deterministic keyed hash used both to store the token and to resolve a
+     * feed from an incoming URL token.
+     */
+    public function hash(string $token): string
+    {
+        return hash_hmac('sha256', $token, $this->secret);
+    }
+
+    public function matches(FeedProfile $feed, string $token): bool
+    {
+        $stored = $feed->getTokenHash();
+
+        return null !== $stored && hash_equals($stored, $this->hash($token));
+    }
+}

--- a/apps/api/tests/Unit/Export/Feed/FeedTokenAndDeliveryTest.php
+++ b/apps/api/tests/Unit/Export/Feed/FeedTokenAndDeliveryTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export\Feed;
+
+use App\Export\Feed\Application\Delivery\FeedDeliveryConfig;
+use App\Export\Feed\Application\Delivery\FeedTokenService;
+use App\Export\Feed\Domain\Entity\FeedProfile;
+use App\Export\Feed\Domain\Enum\FeedTemplateKind;
+use App\Shared\Application\Crypto\EncryptedSecret;
+use App\Shared\Application\Crypto\EncryptionServiceInterface;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * XMLF-P3-04 — feed URL token lifecycle + delivery config (gzip + encrypted
+ * HTTP Basic).
+ */
+final class FeedTokenAndDeliveryTest extends TestCase
+{
+    private function feed(): FeedProfile
+    {
+        return new FeedProfile('c', 'n', FeedTemplateKind::Custom, Uuid::v7(), ['root' => ['element' => 'p'], 'item' => ['element' => 'i', 'slots' => []]]);
+    }
+
+    private function encryption(): EncryptionServiceInterface
+    {
+        return new class implements EncryptionServiceInterface {
+            public function encrypt(string $plaintext): EncryptedSecret
+            {
+                return new EncryptedSecret(base64_encode($plaintext), 1);
+            }
+
+            public function decrypt(EncryptedSecret $secret): string
+            {
+                return (string) base64_decode($secret->ciphertext, true);
+            }
+
+            public function needsRotation(EncryptedSecret $secret): bool
+            {
+                return false;
+            }
+        };
+    }
+
+    #[Test]
+    public function mintStoresHmacAndMatchesOnlyTheRightToken(): void
+    {
+        $service = new FeedTokenService('server-secret');
+        $feed = $this->feed();
+
+        $token = $service->mint($feed);
+        self::assertGreaterThanOrEqual(32, \strlen($token));
+        self::assertNotSame($token, $feed->getTokenHash()); // stored value is the HMAC, not the token
+        self::assertTrue($service->matches($feed, $token));
+        self::assertFalse($service->matches($feed, $token.'x'));
+    }
+
+    #[Test]
+    public function rotateChangesTheHashAndRevokeClearsIt(): void
+    {
+        $service = new FeedTokenService('server-secret');
+        $feed = $this->feed();
+
+        $first = $service->mint($feed);
+        $hash1 = $feed->getTokenHash();
+        $service->rotate($feed);
+        self::assertNotSame($hash1, $feed->getTokenHash());
+        self::assertFalse($service->matches($feed, $first));
+
+        $service->revoke($feed);
+        self::assertNull($feed->getTokenHash());
+    }
+
+    #[Test]
+    public function deliveryEncryptsBasicPasswordAndDecryptsBack(): void
+    {
+        $config = new FeedDeliveryConfig($this->encryption());
+
+        $delivery = $config->build(gzip: true, authType: 'basic', username: 'crawler', password: 's3cret');
+        self::assertTrue($config->gzipEnabled($delivery));
+        $auth = $delivery['auth'];
+        self::assertIsArray($auth);
+        self::assertSame('crawler', $auth['username']);
+        self::assertArrayHasKey('encrypted_password', $auth);
+        self::assertNotContains('s3cret', $auth);
+
+        $creds = $config->basicCredentials($delivery);
+        self::assertNotNull($creds);
+        self::assertSame('crawler', $creds['username']);
+        self::assertSame('s3cret', $creds['password']);
+    }
+
+    #[Test]
+    public function noneAuthHasNoCredentials(): void
+    {
+        $config = new FeedDeliveryConfig($this->encryption());
+        $delivery = $config->build(gzip: false, authType: 'none');
+
+        self::assertFalse($config->gzipEnabled($delivery));
+        self::assertNull($config->basicCredentials($delivery));
+    }
+
+    #[Test]
+    public function basicWithoutCredentialsIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new FeedDeliveryConfig($this->encryption())->build(gzip: true, authType: 'basic');
+    }
+}


### PR DESCRIPTION
## XMLF-P3-04 — token URL feedu + delivery [SEC][PM]

- `FeedTokenService`: mint token ≥128-bit (base64url), przechowuje tylko **HMAC** (nie plaintext, pokazany raz), verify/rotate/revoke. Token ≠ klucz tenanta (per-feed, read-only, rewokowalny).
- `FeedDeliveryConfig`: delivery JSONB (gzip + opcjonalny HTTP Basic), hasło Basic szyfrowane **AES-256-GCM**, deszyfrowane tylko do porównania przy serwowaniu.

### Świadome odejście
Wiring endpointów (mint/rotate/revoke) jedzie z CRUD-em (P1-03); lookup token→feed z bypassem RLS to publiczny endpoint (P3-05).

### Walidacja
- ✅ PHPStan max **0** · PHPUnit **5/5 (19 assertions)** (HMAC match, rotate, revoke, Basic encrypt/decrypt round-trip) · Deptrac **0**.

Refs #1922