### PR TITLE
feat(export): add feed mapper API (slots, attribute catalog, coverage)

### DIFF
--- a/apps/api/src/Export/Feed/Application/Mapping/FeedMappingService.php
+++ b/apps/api/src/Export/Feed/Application/Mapping/FeedMappingService.php
@@ -1,0 +1,322 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Application\Mapping;
+
+use App\Catalog\Contracts\Query\AttributeSummary;
+use App\Export\Feed\Domain\Descriptor\FeedDescriptor;
+use App\Export\Feed\Domain\Descriptor\FeedSlot;
+use App\Export\Feed\Domain\Entity\FeedProfile;
+use App\Export\Feed\Domain\Mapping\FeedFieldMapping;
+
+/**
+ * Mapper read model + write validator (ADR-0023 §6.4, XMLF-P3-01).
+ *
+ * The mapper is where the operator wires each descriptor slot to a PIM
+ * attribute (or a static/template source) and an optional transform. This
+ * service projects the mapper state the UI (XMLF-P5-03) renders — slots with
+ * their current mapping, the tenant attribute catalog, coverage counters and
+ * advisory type warnings — and validates a PUT payload before it is persisted
+ * onto {@see FeedProfile::updateFieldMappings()}.
+ *
+ * The attribute catalog is read through the cross-BC
+ * {@see \App\Catalog\Contracts\Service\AttributeCatalogReader} seam (the
+ * caller passes the already-fetched list), so the Feed sub-area never reaches
+ * into Catalog internals.
+ */
+final class FeedMappingService
+{
+    /**
+     * Transform kinds recognised by {@see \App\Export\Feed\Domain\Mapping\FeedTransformApplier}.
+     */
+    public const array TRANSFORMS = [
+        'default',
+        'price',
+        'number',
+        'date',
+        'enum_map',
+        'template',
+        'strip_html',
+        'truncate',
+    ];
+
+    private const array SOURCE_KINDS = ['attribute', 'static', 'template'];
+
+    public function __construct(
+        private readonly SlotFormatCompatibility $compatibility = new SlotFormatCompatibility(),
+    ) {
+    }
+
+    /**
+     * @param list<AttributeSummary> $attributes
+     *
+     * @return array<string, mixed>
+     */
+    public function view(FeedProfile $feed, array $attributes): array
+    {
+        $descriptor = FeedDescriptor::fromArray($feed->getDescriptor());
+        $mappings = $this->indexMappings(FeedFieldMapping::listFromArray($feed->getFieldMappings()));
+        $typeByCode = $this->attributeTypes($attributes);
+
+        $slots = [];
+        $requiredTotal = 0;
+        $requiredMapped = 0;
+        $missingRequired = [];
+        $mappedCount = 0;
+
+        foreach ($descriptor->slots as $slot) {
+            $mapping = $mappings[$slot->target] ?? null;
+            $mapped = null !== $mapping && $this->hasSource($mapping);
+            if ($mapped) {
+                ++$mappedCount;
+            }
+            if ($slot->rule->required) {
+                ++$requiredTotal;
+                if ($mapped) {
+                    ++$requiredMapped;
+                } else {
+                    $missingRequired[] = $slot->target;
+                }
+            }
+
+            $slots[] = [
+                'target' => $slot->target,
+                'element' => $slot->element,
+                'node' => $slot->node->value,
+                'required' => $slot->rule->required,
+                'required_one_of' => $slot->rule->requiredOneOf,
+                'format' => $slot->rule->format->value,
+                'max_length' => $slot->rule->maxLength,
+                'enums' => $slot->rule->enums,
+                'mapping' => null === $mapping ? null : $this->serializeMapping($mapping),
+                'mapped' => $mapped,
+                'type_warning' => $this->typeWarning($slot, $mapping, $typeByCode),
+            ];
+        }
+
+        return [
+            'feed_id' => $feed->getId()->toRfc4122(),
+            'object_type_id' => $feed->getObjectTypeId()->toRfc4122(),
+            'slots' => $slots,
+            'attributes' => array_map($this->serializeAttribute(...), $attributes),
+            'coverage' => [
+                'slots_total' => \count($descriptor->slots),
+                'slots_mapped' => $mappedCount,
+                'required_total' => $requiredTotal,
+                'required_mapped' => $requiredMapped,
+                'missing_required' => $missingRequired,
+                'one_of_groups' => $this->oneOfGroups($descriptor->slots, $mappings),
+            ],
+            'transforms' => self::TRANSFORMS,
+        ];
+    }
+
+    /**
+     * Validate a PUT payload and write the normalised mappings onto the feed.
+     * The caller persists the feed afterwards.
+     *
+     * @param array<string, mixed>   $payload    {mappings: list<{slot, source, transform?}>}
+     * @param list<AttributeSummary> $attributes tenant attribute catalog
+     *
+     * @throws InvalidMappingException
+     */
+    public function applyUpdate(FeedProfile $feed, array $payload, array $attributes): void
+    {
+        $raw = $payload['mappings'] ?? null;
+        if (!\is_array($raw)) {
+            throw new InvalidMappingException('Pole "mappings" jest wymagane (lista mapowań).');
+        }
+
+        $descriptor = FeedDescriptor::fromArray($feed->getDescriptor());
+        $slotTargets = [];
+        foreach ($descriptor->slots as $slot) {
+            $slotTargets[$slot->target] = true;
+        }
+        $attributeCodes = [];
+        foreach ($attributes as $attribute) {
+            $attributeCodes[$attribute->code] = true;
+        }
+
+        $normalised = [];
+        $seenSlots = [];
+        foreach ($raw as $entry) {
+            if (!\is_array($entry)) {
+                throw new InvalidMappingException('Każde mapowanie musi być obiektem.');
+            }
+            $normalised[] = $this->normaliseEntry($entry, $slotTargets, $attributeCodes, $seenSlots);
+        }
+
+        $feed->updateFieldMappings($normalised);
+    }
+
+    /**
+     * @param array<mixed, mixed> $entry
+     * @param array<string, true> $slotTargets
+     * @param array<string, true> $attributeCodes
+     * @param array<string, true> $seenSlots
+     *
+     * @return array<string, mixed>
+     */
+    private function normaliseEntry(array $entry, array $slotTargets, array $attributeCodes, array &$seenSlots): array
+    {
+        $slot = $entry['slot'] ?? null;
+        if (!\is_string($slot) || !isset($slotTargets[$slot])) {
+            throw new InvalidMappingException(sprintf('Nieznany slot "%s" (brak w deskryptorze feedu).', \is_string($slot) ? $slot : ''));
+        }
+        if (isset($seenSlots[$slot])) {
+            throw new InvalidMappingException(sprintf('Slot "%s" zmapowany więcej niż raz.', $slot));
+        }
+        $seenSlots[$slot] = true;
+
+        $source = \is_array($entry['source'] ?? null) ? $entry['source'] : [];
+        $kind = \is_string($source['kind'] ?? null) ? $source['kind'] : null;
+        if (null === $kind || !\in_array($kind, self::SOURCE_KINDS, true)) {
+            throw new InvalidMappingException(sprintf('Slot "%s": nieznany typ źródła (attribute|static|template).', $slot));
+        }
+
+        $normalisedSource = ['kind' => $kind];
+        if ('attribute' === $kind) {
+            $ref = \is_string($source['ref'] ?? null) ? $source['ref'] : '';
+            if ('' === $ref || !isset($attributeCodes[$ref])) {
+                throw new InvalidMappingException(sprintf('Slot "%s": atrybut "%s" nie istnieje w katalogu.', $slot, $ref));
+            }
+            $normalisedSource['ref'] = $ref;
+        } else {
+            $value = \is_string($source['value'] ?? null) ? $source['value'] : '';
+            if ('' === $value) {
+                throw new InvalidMappingException(sprintf('Slot "%s": źródło "%s" wymaga wartości.', $slot, $kind));
+            }
+            $normalisedSource['value'] = $value;
+        }
+
+        $out = ['slot' => $slot, 'source' => $normalisedSource];
+
+        $transform = $entry['transform'] ?? null;
+        if (\is_array($transform)) {
+            $transformKind = \is_string($transform['kind'] ?? null) ? $transform['kind'] : null;
+            if (null === $transformKind || !\in_array($transformKind, self::TRANSFORMS, true)) {
+                throw new InvalidMappingException(sprintf('Slot "%s": nieznana transformacja "%s".', $slot, $transformKind ?? ''));
+            }
+            $out['transform'] = $transform;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param list<FeedFieldMapping> $mappings
+     *
+     * @return array<string, FeedFieldMapping>
+     */
+    private function indexMappings(array $mappings): array
+    {
+        $byTarget = [];
+        foreach ($mappings as $mapping) {
+            $byTarget[$mapping->slot] = $mapping;
+        }
+
+        return $byTarget;
+    }
+
+    private function hasSource(FeedFieldMapping $mapping): bool
+    {
+        return ('attribute' === $mapping->sourceKind && null !== $mapping->sourceRef && '' !== $mapping->sourceRef)
+            || (\in_array($mapping->sourceKind, ['static', 'template'], true) && null !== $mapping->sourceValue && '' !== $mapping->sourceValue);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function serializeMapping(FeedFieldMapping $mapping): array
+    {
+        return array_filter([
+            'source_kind' => $mapping->sourceKind ?? '',
+            'source_ref' => $mapping->sourceRef ?? '',
+            'source_value' => $mapping->sourceValue ?? '',
+            'transform' => \is_array($mapping->transform) && \is_string($mapping->transform['kind'] ?? null)
+                ? $mapping->transform['kind']
+                : '',
+        ], static fn (string $v): bool => '' !== $v);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializeAttribute(AttributeSummary $attribute): array
+    {
+        return [
+            'id' => $attribute->id->toRfc4122(),
+            'code' => $attribute->code,
+            'label' => $attribute->label,
+            'type' => $attribute->type,
+            'localizable' => $attribute->isLocalizable,
+            'group_code' => $attribute->groupCode,
+            'group_label' => $attribute->groupLabel,
+        ];
+    }
+
+    /**
+     * @param array<string, string> $typeByCode
+     */
+    private function typeWarning(FeedSlot $slot, ?FeedFieldMapping $mapping, array $typeByCode): ?string
+    {
+        if (null === $mapping || 'attribute' !== $mapping->sourceKind || null === $mapping->sourceRef) {
+            return null;
+        }
+        $type = $typeByCode[$mapping->sourceRef] ?? null;
+        if (null === $type) {
+            return sprintf('Atrybut "%s" nie istnieje w katalogu.', $mapping->sourceRef);
+        }
+
+        return $this->compatibility->warn($slot->rule->format, $type);
+    }
+
+    /**
+     * @param list<AttributeSummary> $attributes
+     *
+     * @return array<string, string>
+     */
+    private function attributeTypes(array $attributes): array
+    {
+        $types = [];
+        foreach ($attributes as $attribute) {
+            $types[$attribute->code] = $attribute->type;
+        }
+
+        return $types;
+    }
+
+    /**
+     * @param list<FeedSlot>                  $slots
+     * @param array<string, FeedFieldMapping> $mappings
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function oneOfGroups(array $slots, array $mappings): array
+    {
+        $groups = [];
+        foreach ($slots as $slot) {
+            $targets = $slot->rule->requiredOneOf;
+            if ([] === $targets) {
+                continue;
+            }
+            sort($targets);
+            $groups[implode('|', $targets)] = $targets;
+        }
+
+        $out = [];
+        foreach ($groups as $targets) {
+            $satisfied = false;
+            foreach ($targets as $target) {
+                if (isset($mappings[$target]) && $this->hasSource($mappings[$target])) {
+                    $satisfied = true;
+                    break;
+                }
+            }
+            $out[] = ['targets' => $targets, 'satisfied' => $satisfied];
+        }
+
+        return $out;
+    }
+}

--- a/apps/api/src/Export/Feed/Application/Mapping/InvalidMappingException.php
+++ b/apps/api/src/Export/Feed/Application/Mapping/InvalidMappingException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Application\Mapping;
+
+use RuntimeException;
+
+/**
+ * Raised by {@see FeedMappingService::applyUpdate()} when a PUT mapping payload
+ * is malformed (unknown slot, unknown source kind, unknown attribute code…).
+ * The controller (XMLF-P3-01) translates it to an RFC 7807 400.
+ */
+final class InvalidMappingException extends RuntimeException
+{
+}

--- a/apps/api/src/Export/Feed/Application/Mapping/SlotFormatCompatibility.php
+++ b/apps/api/src/Export/Feed/Application/Mapping/SlotFormatCompatibility.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Application\Mapping;
+
+use App\Export\Feed\Domain\Descriptor\SlotFormat;
+
+/**
+ * Soft type-compatibility hints for the mapper (ADR-0023 §6.4, XMLF-P3-01).
+ *
+ * When an operator maps a PIM attribute onto a descriptor slot, the slot's
+ * declared {@see SlotFormat} implies a value shape (a price node wants a
+ * numeric attribute, a date node wants a date attribute…). This helper returns
+ * a human-readable warning when the attribute type is unlikely to satisfy the
+ * slot format. It is advisory only — the mapper never blocks the mapping, it
+ * paints a badge so the operator can override deliberately.
+ *
+ * Attribute type vocabulary mirrors {@see \App\Catalog\Domain\AttributeType};
+ * we key on the string tag carried by the cross-BC
+ * {@see \App\Catalog\Contracts\Query\AttributeSummary} to avoid coupling the
+ * Feed sub-area to the Catalog domain enum.
+ */
+final class SlotFormatCompatibility
+{
+    /**
+     * Attribute type tags that satisfy each slot format. `text` accepts any
+     * scalar attribute (everything renders to a string), so it is never warned.
+     *
+     * @var array<string, list<string>>
+     */
+    private const array COMPATIBLE = [
+        'html' => ['wysiwyg', 'textarea', 'text'],
+        'url' => ['text', 'textarea', 'identifier', 'asset', 'reference', 'relation', 'email'],
+        'price' => ['price', 'number', 'metric'],
+        'number' => ['number', 'metric', 'price', 'identifier'],
+        'date' => ['date', 'datetime'],
+        'enum' => ['select', 'multiselect', 'boolean', 'text'],
+        'category' => ['reference', 'relation', 'select', 'text', 'identifier'],
+    ];
+
+    /**
+     * @return string|null a warning message, or null when the pairing is fine
+     */
+    public function warn(SlotFormat $format, string $attributeType): ?string
+    {
+        // Text/free-form slots accept any attribute — no warning.
+        $allowed = self::COMPATIBLE[$format->value] ?? null;
+        if (null === $allowed) {
+            return null;
+        }
+
+        if (\in_array($attributeType, $allowed, true)) {
+            return null;
+        }
+
+        return sprintf(
+            'Atrybut typu "%s" może nie pasować do slotu w formacie "%s".',
+            $attributeType,
+            $format->value,
+        );
+    }
+}

--- a/apps/api/src/Export/Feed/Presentation/Controller/FeedMappingController.php
+++ b/apps/api/src/Export/Feed/Presentation/Controller/FeedMappingController.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Presentation\Controller;
+
+use App\Catalog\Contracts\Service\AttributeCatalogReader;
+use App\Export\Feed\Application\Mapping\FeedMappingService;
+use App\Export\Feed\Application\Mapping\InvalidMappingException;
+use App\Export\Feed\Domain\Entity\FeedProfile;
+use App\Export\Feed\Domain\Repository\FeedProfileRepositoryInterface;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\TenantContext;
+use App\Shared\Application\UserIdentityAware;
+use App\Shared\Domain\Tenant;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Feed mapper API (ADR-0023 §6.4, XMLF-P3-01) — the backend for the mapper
+ * step (XMLF-P5-03). `GET` projects the mapper state (descriptor slots + their
+ * current mapping, the tenant PIM attribute catalog, coverage counters and
+ * advisory type warnings); `PUT` validates and persists a new mapping set.
+ *
+ * The attribute catalog is read through the cross-BC
+ * {@see AttributeCatalogReader} seam; feeds never reach Catalog internals.
+ * Auto-registered into OpenAPI by CustomRouteOpenApiFactory (ADR-0020).
+ *
+ * The channel `column_aliases` pre-fill (ADR-0018) is a deliberate follow-up:
+ * it needs a Channel contracts-layer publication-alias reader (a second bounded
+ * context / Plan Mode change) and the built-in templates already seed sensible
+ * default mappings (XMLF-P2-02), so the mapper ships without it.
+ */
+final class FeedMappingController
+{
+    public function __construct(
+        private readonly FeedProfileRepositoryInterface $feeds,
+        private readonly AttributeCatalogReader $attributes,
+        private readonly FeedMappingService $mapper,
+        private readonly TenantContext $tenantContext,
+        private readonly Security $security,
+    ) {
+    }
+
+    #[Route(path: '/api/feeds/{id}/mapping', name: 'pim_feeds_mapping_get', methods: ['GET'], requirements: ['id' => '[0-9a-fA-F-]{36}'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'exports', action: 'view_all')]
+    public function get(string $id): JsonResponse
+    {
+        $tenant = $this->resolveTenant();
+        $feed = $this->loadOrFail($id);
+
+        return new JsonResponse($this->mapper->view($feed, $this->attributes->findAllByTenant($tenant->getId())));
+    }
+
+    #[Route(path: '/api/feeds/{id}/mapping', name: 'pim_feeds_mapping_put', methods: ['PUT'], requirements: ['id' => '[0-9a-fA-F-]{36}'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'integration', action: 'admin')]
+    public function put(string $id, Request $request): JsonResponse
+    {
+        $tenant = $this->resolveTenant();
+        $feed = $this->loadOrFail($id);
+        $catalog = $this->attributes->findAllByTenant($tenant->getId());
+
+        try {
+            $this->mapper->applyUpdate($feed, $this->decodeJson($request), $catalog);
+        } catch (InvalidMappingException $error) {
+            throw new BadRequestHttpException($error->getMessage(), $error);
+        }
+        $this->feeds->save($feed);
+
+        return new JsonResponse($this->mapper->view($feed, $catalog));
+    }
+
+    private function resolveTenant(): Tenant
+    {
+        if (!$this->security->getUser() instanceof UserIdentityAware) {
+            throw new AccessDeniedHttpException('Authenticated user identity required.');
+        }
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new AccessDeniedHttpException('Tenant context required.');
+        }
+
+        return $tenant;
+    }
+
+    private function loadOrFail(string $id): FeedProfile
+    {
+        $feed = $this->feeds->findById(Uuid::fromString($id));
+        if (null === $feed) {
+            // Tenant isolation via RLS/TenantFilter; a miss is a 404 either way.
+            throw new NotFoundHttpException(sprintf('Feed "%s" was not found.', $id));
+        }
+
+        return $feed;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(Request $request): array
+    {
+        $body = $request->getContent();
+        if ('' === $body) {
+            return [];
+        }
+        $decoded = json_decode($body, true);
+        if (!\is_array($decoded)) {
+            throw new BadRequestHttpException('Request body must be a JSON object.');
+        }
+        $payload = [];
+        foreach ($decoded as $key => $value) {
+            if (!\is_string($key)) {
+                throw new BadRequestHttpException('Request body must be a JSON object (string keys).');
+            }
+            $payload[$key] = $value;
+        }
+
+        return $payload;
+    }
+}

--- a/apps/api/tests/Unit/Export/Feed/FeedMappingServiceTest.php
+++ b/apps/api/tests/Unit/Export/Feed/FeedMappingServiceTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export\Feed;
+
+use App\Catalog\Contracts\Query\AttributeSummary;
+use App\Export\Feed\Application\Mapping\FeedMappingService;
+use App\Export\Feed\Application\Mapping\InvalidMappingException;
+use App\Export\Feed\Application\Mapping\SlotFormatCompatibility;
+use App\Export\Feed\Domain\Descriptor\SlotFormat;
+use App\Export\Feed\Domain\Entity\FeedProfile;
+use App\Export\Feed\Domain\Enum\FeedTemplateKind;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * XMLF-P3-01 — mapper read model + write validator.
+ */
+final class FeedMappingServiceTest extends TestCase
+{
+    private function profile(): FeedProfile
+    {
+        return new FeedProfile(
+            code: 'google_pl',
+            name: 'Google PL',
+            templateKind: FeedTemplateKind::GoogleShopping,
+            objectTypeId: Uuid::v7(),
+            descriptor: [
+                'root' => ['element' => 'products'],
+                'item' => [
+                    'element' => 'product',
+                    'slots' => [
+                        ['slot' => 'id', 'node' => 'element', 'required' => true, 'fmt' => 'text'],
+                        ['slot' => 'price', 'node' => 'element', 'required' => true, 'fmt' => 'price'],
+                        ['slot' => 'gtin', 'node' => 'element', 'fmt' => 'text', 'requiredOneOf' => ['gtin', 'mpn']],
+                        ['slot' => 'mpn', 'node' => 'element', 'fmt' => 'text', 'requiredOneOf' => ['gtin', 'mpn']],
+                    ],
+                ],
+            ],
+            fieldMappings: [
+                ['slot' => 'id', 'source' => ['kind' => 'attribute', 'ref' => 'sku']],
+                ['slot' => 'price', 'source' => ['kind' => 'attribute', 'ref' => 'title']], // text→price = warning
+            ],
+        );
+    }
+
+    /**
+     * @return list<AttributeSummary>
+     */
+    private function catalog(): array
+    {
+        $tenant = Uuid::v7();
+
+        return [
+            new AttributeSummary(Uuid::v7(), $tenant, 'sku', ['pl' => 'SKU'], 'identifier', false, true, true, null, 'general', ['pl' => 'Ogólne'], 0),
+            new AttributeSummary(Uuid::v7(), $tenant, 'title', ['pl' => 'Nazwa'], 'text', true, true, false, null, 'general', ['pl' => 'Ogólne'], 1),
+            new AttributeSummary(Uuid::v7(), $tenant, 'price', ['pl' => 'Cena'], 'price', false, false, false, null, 'general', ['pl' => 'Ogólne'], 2),
+            new AttributeSummary(Uuid::v7(), $tenant, 'gtin', ['pl' => 'GTIN'], 'text', false, false, false, null, 'general', ['pl' => 'Ogólne'], 3),
+        ];
+    }
+
+    #[Test]
+    public function compatibilityWarnsOnMismatchButNotOnTextSlot(): void
+    {
+        $compat = new SlotFormatCompatibility();
+
+        self::assertNotNull($compat->warn(SlotFormat::Price, 'text'));
+        self::assertNull($compat->warn(SlotFormat::Price, 'number'));
+        self::assertNull($compat->warn(SlotFormat::Text, 'boolean')); // text slot accepts anything
+        self::assertNull($compat->warn(SlotFormat::Date, 'datetime'));
+        self::assertNotNull($compat->warn(SlotFormat::Date, 'text'));
+    }
+
+    #[Test]
+    public function viewProjectsSlotsCoverageAndTypeWarning(): void
+    {
+        $view = new FeedMappingService()->view($this->profile(), $this->catalog());
+
+        $coverage = $view['coverage'];
+        self::assertIsArray($coverage);
+        self::assertSame(4, $coverage['slots_total']);
+        self::assertSame(2, $coverage['slots_mapped']);
+        self::assertSame(2, $coverage['required_total']);
+        self::assertSame(2, $coverage['required_mapped']);
+        self::assertSame([], $coverage['missing_required']);
+        self::assertSame([['targets' => ['gtin', 'mpn'], 'satisfied' => false]], $coverage['one_of_groups']);
+
+        $transforms = $view['transforms'];
+        self::assertIsArray($transforms);
+        self::assertContains('truncate', $transforms);
+
+        $attributes = $view['attributes'];
+        self::assertIsArray($attributes);
+        self::assertCount(4, $attributes);
+
+        $byTarget = $this->slotsByTarget($view);
+        self::assertNull($byTarget['id']['type_warning']);          // text slot, no warning
+        self::assertNotNull($byTarget['price']['type_warning']);    // title(text) → price slot
+        self::assertFalse($byTarget['gtin']['mapped']);
+    }
+
+    #[Test]
+    public function applyUpdatePersistsNormalisedMappings(): void
+    {
+        $feed = $this->profile();
+        $service = new FeedMappingService();
+
+        $service->applyUpdate($feed, ['mappings' => [
+            ['slot' => 'id', 'source' => ['kind' => 'attribute', 'ref' => 'sku']],
+            ['slot' => 'price', 'source' => ['kind' => 'attribute', 'ref' => 'price'], 'transform' => ['kind' => 'price']],
+            ['slot' => 'gtin', 'source' => ['kind' => 'attribute', 'ref' => 'gtin']],
+        ]], $this->catalog());
+
+        self::assertCount(3, $feed->getFieldMappings());
+
+        $view = $service->view($feed, $this->catalog());
+        $byTarget = $this->slotsByTarget($view);
+        self::assertNull($byTarget['price']['type_warning']); // price(price attr) now clean
+
+        $coverage = $view['coverage'];
+        self::assertIsArray($coverage);
+        self::assertSame([['targets' => ['gtin', 'mpn'], 'satisfied' => true]], $coverage['one_of_groups']);
+    }
+
+    /**
+     * @param array<string, mixed> $view
+     *
+     * @return array<string, array<mixed, mixed>>
+     */
+    private function slotsByTarget(array $view): array
+    {
+        $slots = $view['slots'];
+        self::assertIsArray($slots);
+
+        $byTarget = [];
+        foreach ($slots as $slot) {
+            self::assertIsArray($slot);
+            $target = $slot['target'];
+            self::assertIsString($target);
+            $byTarget[$target] = $slot;
+        }
+
+        return $byTarget;
+    }
+
+    #[Test]
+    public function applyUpdateRejectsUnknownSlot(): void
+    {
+        $this->expectException(InvalidMappingException::class);
+        new FeedMappingService()->applyUpdate($this->profile(), ['mappings' => [
+            ['slot' => 'nope', 'source' => ['kind' => 'attribute', 'ref' => 'sku']],
+        ]], $this->catalog());
+    }
+
+    #[Test]
+    public function applyUpdateRejectsUnknownAttribute(): void
+    {
+        $this->expectException(InvalidMappingException::class);
+        new FeedMappingService()->applyUpdate($this->profile(), ['mappings' => [
+            ['slot' => 'id', 'source' => ['kind' => 'attribute', 'ref' => 'ghost']],
+        ]], $this->catalog());
+    }
+
+    #[Test]
+    public function applyUpdateRejectsUnknownTransform(): void
+    {
+        $this->expectException(InvalidMappingException::class);
+        new FeedMappingService()->applyUpdate($this->profile(), ['mappings' => [
+            ['slot' => 'id', 'source' => ['kind' => 'attribute', 'ref' => 'sku'], 'transform' => ['kind' => 'bogus']],
+        ]], $this->catalog());
+    }
+
+    #[Test]
+    public function applyUpdateRejectsStaticWithoutValue(): void
+    {
+        $this->expectException(InvalidMappingException::class);
+        new FeedMappingService()->applyUpdate($this->profile(), ['mappings' => [
+            ['slot' => 'id', 'source' => ['kind' => 'static']],
+        ]], $this->catalog());
+    }
+
+    #[Test]
+    public function applyUpdateRejectsDuplicateSlot(): void
+    {
+        $this->expectException(InvalidMappingException::class);
+        new FeedMappingService()->applyUpdate($this->profile(), ['mappings' => [
+            ['slot' => 'id', 'source' => ['kind' => 'attribute', 'ref' => 'sku']],
+            ['slot' => 'id', 'source' => ['kind' => 'attribute', 'ref' => 'title']],
+        ]], $this->catalog());
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -13160,6 +13160,82 @@
                 "x-cortex-permission": "integration.admin"
             }
         },
+        "/api/feeds/{id}/mapping": {
+            "get": {
+                "operationId": "api_feeds_id_mapping_get",
+                "tags": [
+                    "feeds"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api feeds id mapping",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "exports.view_all"
+            },
+            "put": {
+                "operationId": "api_feeds_id_mapping_put",
+                "tags": [
+                    "feeds"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api feeds id mapping",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "integration.admin"
+            }
+        },
         "/api/feeds/{id}/pause": {
             "post": {
                 "operationId": "api_feeds_id_pause_post",


### PR DESCRIPTION
## Cel (XMLF-P3-01, #1919)
Backend mappera feedu — kroku, w którym operator wiąże sloty deskryptora z atrybutami PIM. Zasila wizard mapping step (XMLF-P5-03).

## Zakres
- `GET /api/feeds/{id}/mapping` — projekcja stanu mappera: sloty deskryptora z bieżącym mapowaniem, katalog atrybutów PIM tenanta, liczniki pokrycia (`slots_mapped`/`required_mapped`/`missing_required`/`one_of_groups`), doradcze ostrzeżenia typu (atrybut vs `SlotFormat`).
- `PUT /api/feeds/{id}/mapping` — walidacja + zapis nowego zestawu mapowań (slot musi istnieć w deskryptorze; `kind` ∈ attribute|static|template; atrybut musi istnieć w katalogu; transformacja z zamkniętej listy; brak duplikatów slotów).
- `SlotFormatCompatibility` — czysta mapa zgodności typ atrybutu ↔ format slotu (advisory; nigdy nie blokuje).
- Katalog atrybutów czytany przez cross-BC `AttributeCatalogReader` (Catalog_Contracts) — feed nie sięga do Catalog internals (Deptrac 0).

## Świadome odejście
**Kanałowy `column_aliases` pre-fill (ADR-0018) odłożony** — wymaga Channel contracts-layer publication-alias readera (drugi bounded context → Plan Mode), a wbudowane szablony (XMLF-P2-02) już seedują sensowne `defaultMappings`. Mapper działa bez tego; pre-fill = follow-up.

## Bramki (lokalnie w kontenerze)
- PHPStan max: **0**
- Deptrac: **0** (Export_Feed_Internals → Catalog_Contracts dozwolone)
- PHP-CS-Fixer: clean
- PHPUnit: **8/8** (44 assertions) — compatibility, view/coverage/type-warning, applyUpdate happy path + 5 ścieżek walidacji
- OpenAPI `v0.json`: zregenerowany (trasy `/api/feeds/{id}/mapping`)

## Poza zakresem
Kanałowy seed (wyżej), UI mappera (P5-03), preview live-sample (P4-04).

Refs #1919