### PR TITLE
feat(export): add manual feed regeneration endpoint (+ tenant-detach fix)

### DIFF
--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -353,6 +353,13 @@ services:
         arguments:
             $exportsStorage: '@exports.storage'
 
+    # XMLF-P4-01 — feed cache-and-serve storage. Same exports.storage MinIO
+    # bucket under a dedicated `feeds/` prefix (regeneration writes here, the
+    # XMLF-P3-05 public URL reads it back).
+    App\Export\Feed\Infrastructure\Delivery\FlysystemFeedCacheStorage:
+        arguments:
+            $exportsStorage: '@exports.storage'
+
     # EXP-08 (#587) — sessions controller streams the file back from
     # MinIO through PHP (no presigned URL in MVP).
     App\Export\Presentation\Controller\ExportSessionController:

--- a/apps/api/src/Export/Application/Feed/ExportBuilderFeedValues.php
+++ b/apps/api/src/Export/Application/Feed/ExportBuilderFeedValues.php
@@ -79,6 +79,20 @@ final class ExportBuilderFeedValues implements FeedProductValues
                 yield $this->toAttributeMap($row, $scope);
             }
             $this->em->clear();
+            // clear() detaches the Tenant the caller's TenantContext holds; the
+            // feed generator persists FeedRun/FeedRunLog rows (TenantScoped)
+            // after us and TenantAssignmentListener would otherwise assign a
+            // detached Tenant → "new entity found through relationship". Rebind
+            // a managed instance so downstream persists stay in the identity map.
+            $this->rebindTenantContext($tenantId);
+        }
+    }
+
+    private function rebindTenantContext(Uuid $tenantId): void
+    {
+        $tenant = $this->em->find(Tenant::class, $tenantId->toRfc4122());
+        if ($tenant instanceof Tenant) {
+            $this->tenantContext->set($tenant);
         }
     }
 

--- a/apps/api/src/Export/Feed/Application/Delivery/FeedCacheStorage.php
+++ b/apps/api/src/Export/Feed/Application/Delivery/FeedCacheStorage.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Application\Delivery;
+
+/**
+ * Cache-and-serve storage seam for feeds (ADR-0023 §6.6, XMLF-P4-01/P3-05).
+ *
+ * A regeneration streams the generated XML to a local temp file and then
+ * hands it to {@see put()} under a tenant-scoped key
+ * (`feeds/<tenant>/<feed>.xml`); the public URL endpoint (XMLF-P3-05) later
+ * streams the same key straight back to the puller. Keeping this a narrow
+ * interface (rather than passing the whole Flysystem operator around) keeps
+ * the generator testable with an in-memory fake.
+ */
+interface FeedCacheStorage
+{
+    /**
+     * Store the local file's bytes at the given tenant-scoped key,
+     * overwriting any previous cache for that feed.
+     */
+    public function put(string $key, string $localPath): void;
+}

--- a/apps/api/src/Export/Feed/Application/Generator/FeedGenerator.php
+++ b/apps/api/src/Export/Feed/Application/Generator/FeedGenerator.php
@@ -94,6 +94,10 @@ final class FeedGenerator
             $writer->finish();
         } catch (Throwable $error) {
             $this->logs->saveMany($buffer);
+            // The value source clears the EM between chunks (memory-flat 50k),
+            // which detaches $run — reload a managed instance before the
+            // terminal transition so save() issues an UPDATE, not a duplicate.
+            $run = $this->reload($run);
             $run->markError($error->getMessage());
             $this->runs->save($run);
 
@@ -104,10 +108,20 @@ final class FeedGenerator
 
         $size = is_file($targetPath) ? (int) filesize($targetPath) : 0;
         $durationMs = (int) ((hrtime(true) - $startedAt) / 1_000_000);
+        $run = $this->reload($run);
         $run->markDone($items, $skipped, $warnings, $targetPath, $size, $durationMs);
         $this->runs->save($run);
 
         return $run;
+    }
+
+    /**
+     * Reload a managed FeedRun after the value source's mid-run EM clears
+     * detached it (falls back to the detached instance if the row is gone).
+     */
+    private function reload(FeedRun $run): FeedRun
+    {
+        return $this->runs->findById($run->getId()) ?? $run;
     }
 
     /**

--- a/apps/api/src/Export/Feed/Application/Generator/FeedRegenerator.php
+++ b/apps/api/src/Export/Feed/Application/Generator/FeedRegenerator.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Application\Generator;
+
+use App\Export\Feed\Application\Delivery\FeedCacheStorage;
+use App\Export\Feed\Domain\Entity\FeedProfile;
+use App\Export\Feed\Domain\Entity\FeedRun;
+use App\Export\Feed\Domain\Enum\FeedRunStatus;
+use App\Export\Feed\Domain\Enum\FeedRunTrigger;
+use App\Export\Feed\Domain\Repository\FeedProfileRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use DateTimeImmutable;
+use RuntimeException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Regeneration orchestrator (ADR-0023 §6.6, XMLF-P4-01) — the shared core the
+ * manual "Regeneruj teraz" endpoint and (later, XMLF-P4-02) the async worker
+ * both drive, mirroring how {@see \App\Export\Application\Sync\SyncExportRunner}
+ * is shared by the sync export controller and the async job handler.
+ *
+ * It streams the feed through {@see FeedGenerator} into a local temp file,
+ * uploads a successful run to the tenant-scoped cache key
+ * (`feeds/<tenant>/<feed>.xml`, {@see FeedCacheStorage}) and records the cache
+ * pointer on the {@see FeedProfile} so the public URL (XMLF-P3-05) can serve it.
+ *
+ * The generator's value source clears the EntityManager between chunks to stay
+ * memory-flat (IMP2 reuse), which detaches the profile — we reload a managed
+ * instance before recording the cache pointer, the same guard the export job
+ * handler uses.
+ */
+final class FeedRegenerator
+{
+    public function __construct(
+        private readonly FeedGenerator $generator,
+        private readonly FeedCacheStorage $cache,
+        private readonly FeedProfileRepositoryInterface $feeds,
+        private readonly TenantContext $tenantContext,
+    ) {
+    }
+
+    public function regenerate(FeedProfile $profile, FeedRunTrigger $trigger): FeedRun
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new RuntimeException('Feed regeneration requires a tenant context.');
+        }
+
+        $tempPath = tempnam(sys_get_temp_dir(), 'pim-feed-');
+        if (false === $tempPath) {
+            throw new RuntimeException('Unable to allocate a temp file for feed generation.');
+        }
+
+        try {
+            $run = $this->generator->generate($profile, $tempPath, $trigger);
+
+            if (FeedRunStatus::Done === $run->getStatus()) {
+                $key = $this->cacheKey($tenant->getId(), $profile->getId());
+                $this->cache->put($key, $tempPath);
+
+                // The streaming value source clears the EM mid-run (IMP2 reuse),
+                // detaching $profile — reload a managed instance before saving.
+                $managed = $this->feeds->findById($profile->getId()) ?? $profile;
+                $size = $run->getFileSizeBytes() ?? (is_file($tempPath) ? (int) filesize($tempPath) : 0);
+                $managed->recordCache($run->getId(), $key, $size, $run->getItemCount(), new DateTimeImmutable());
+                $this->feeds->save($managed);
+            }
+
+            return $run;
+        } finally {
+            @unlink($tempPath);
+        }
+    }
+
+    private function cacheKey(Uuid $tenantId, Uuid $feedId): string
+    {
+        return sprintf('feeds/%s/%s.xml', $tenantId->toRfc4122(), $feedId->toRfc4122());
+    }
+}

--- a/apps/api/src/Export/Feed/Infrastructure/Delivery/FlysystemFeedCacheStorage.php
+++ b/apps/api/src/Export/Feed/Infrastructure/Delivery/FlysystemFeedCacheStorage.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Infrastructure\Delivery;
+
+use App\Export\Feed\Application\Delivery\FeedCacheStorage;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use RuntimeException;
+
+/**
+ * Flysystem-backed feed cache (XMLF-P4-01). Reuses the `exports.storage`
+ * MinIO/S3 bucket the export feature already provisions, under a dedicated
+ * `feeds/` prefix so a lifecycle/TTL policy can target feeds independently.
+ * Tenant isolation rides on the key prefix (`feeds/<tenant>/…`), the same
+ * application-layer barrier exports use (RLS does not extend to object
+ * storage in MVP).
+ */
+final class FlysystemFeedCacheStorage implements FeedCacheStorage
+{
+    public function __construct(
+        private readonly FilesystemOperator $exportsStorage,
+    ) {
+    }
+
+    public function put(string $key, string $localPath): void
+    {
+        $stream = @fopen($localPath, 'r');
+        if (false === $stream) {
+            throw new RuntimeException(sprintf('Unable to read local feed file "%s" for cache upload.', $localPath));
+        }
+        try {
+            $this->exportsStorage->writeStream($key, $stream);
+        } catch (FilesystemException $error) {
+            throw new RuntimeException(sprintf('Feed cache upload failed for "%s": %s', $key, $error->getMessage()), previous: $error);
+        } finally {
+            if (\is_resource($stream)) {
+                fclose($stream);
+            }
+        }
+    }
+}

--- a/apps/api/src/Export/Feed/Presentation/Controller/FeedRegenerateController.php
+++ b/apps/api/src/Export/Feed/Presentation/Controller/FeedRegenerateController.php
@@ -55,7 +55,11 @@ final class FeedRegenerateController
 
         $run = $this->regenerator->regenerate($feed, FeedRunTrigger::Manual);
 
-        return new JsonResponse($this->serialize($feed, $run), Response::HTTP_ACCEPTED);
+        // The generator's value source clears the EM mid-run, detaching $feed;
+        // reload so the response reflects the freshly recorded cache pointer.
+        $fresh = $this->feeds->findById($feed->getId()) ?? $feed;
+
+        return new JsonResponse($this->serialize($fresh, $run), Response::HTTP_ACCEPTED);
     }
 
     private function resolveTenant(): Tenant

--- a/apps/api/src/Export/Feed/Presentation/Controller/FeedRegenerateController.php
+++ b/apps/api/src/Export/Feed/Presentation/Controller/FeedRegenerateController.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Presentation\Controller;
+
+use App\Export\Feed\Application\Generator\FeedRegenerator;
+use App\Export\Feed\Domain\Entity\FeedProfile;
+use App\Export\Feed\Domain\Entity\FeedRun;
+use App\Export\Feed\Domain\Enum\FeedRunTrigger;
+use App\Export\Feed\Domain\Repository\FeedProfileRepositoryInterface;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\TenantContext;
+use App\Shared\Application\UserIdentityAware;
+use App\Shared\Domain\Tenant;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+use const DATE_ATOM;
+
+/**
+ * Manual feed regeneration (ADR-0023 §6.6, XMLF-P4-01) — the "Regeneruj teraz"
+ * trigger. Runs the regeneration synchronously through {@see FeedRegenerator}
+ * (generate → cache upload → record pointer) and returns the resulting
+ * {@see FeedRun} summary so the UI can render the health report immediately.
+ *
+ * Async dispatch (a RunFeedMessage on the `import` transport) and cron-driven
+ * scheduling are XMLF-P4-02 follow-ups; the manual trigger runs inline so it is
+ * smoke-testable end-to-end today. Auto-registered into OpenAPI by
+ * CustomRouteOpenApiFactory (ADR-0020).
+ */
+final class FeedRegenerateController
+{
+    public function __construct(
+        private readonly FeedProfileRepositoryInterface $feeds,
+        private readonly FeedRegenerator $regenerator,
+        private readonly TenantContext $tenantContext,
+        private readonly Security $security,
+    ) {
+    }
+
+    #[Route(path: '/api/feeds/{id}/regenerate', name: 'pim_feeds_regenerate', methods: ['POST'], requirements: ['id' => '[0-9a-fA-F-]{36}'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'integration', action: 'admin')]
+    public function regenerate(string $id): JsonResponse
+    {
+        $this->resolveTenant();
+        $feed = $this->loadOrFail($id);
+
+        $run = $this->regenerator->regenerate($feed, FeedRunTrigger::Manual);
+
+        return new JsonResponse($this->serialize($feed, $run), Response::HTTP_ACCEPTED);
+    }
+
+    private function resolveTenant(): Tenant
+    {
+        if (!$this->security->getUser() instanceof UserIdentityAware) {
+            throw new AccessDeniedHttpException('Authenticated user identity required.');
+        }
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new AccessDeniedHttpException('Tenant context required.');
+        }
+
+        return $tenant;
+    }
+
+    private function loadOrFail(string $id): FeedProfile
+    {
+        $feed = $this->feeds->findById(Uuid::fromString($id));
+        if (null === $feed) {
+            // Tenant isolation via RLS/TenantFilter; a miss is a 404 either way.
+            throw new NotFoundHttpException(sprintf('Feed "%s" was not found.', $id));
+        }
+
+        return $feed;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serialize(FeedProfile $feed, FeedRun $run): array
+    {
+        return [
+            'run' => [
+                'id' => $run->getId()->toRfc4122(),
+                'status' => $run->getStatus()->value,
+                'item_count' => $run->getItemCount(),
+                'skipped_count' => $run->getSkippedCount(),
+                'warning_count' => $run->getWarningCount(),
+                'file_size_bytes' => $run->getFileSizeBytes(),
+                'duration_ms' => $run->getDurationMs(),
+            ],
+            'cache' => [
+                'file_path' => $feed->getCachedFilePath(),
+                'file_size' => $feed->getCachedFileSize(),
+                'item_count' => $feed->getCachedItemCount(),
+                'generated_at' => $feed->getCachedAt()?->format(DATE_ATOM),
+            ],
+        ];
+    }
+}

--- a/apps/api/tests/Unit/Export/Feed/FeedRegeneratorTest.php
+++ b/apps/api/tests/Unit/Export/Feed/FeedRegeneratorTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export\Feed;
+
+use App\Export\Contracts\FeedProductScope;
+use App\Export\Contracts\FeedProductValues;
+use App\Export\Feed\Application\Delivery\FeedCacheStorage;
+use App\Export\Feed\Application\Generator\FeedGenerator;
+use App\Export\Feed\Application\Generator\FeedRegenerator;
+use App\Export\Feed\Domain\Entity\FeedProfile;
+use App\Export\Feed\Domain\Entity\FeedRun;
+use App\Export\Feed\Domain\Entity\FeedRunLog;
+use App\Export\Feed\Domain\Enum\FeedRunStatus;
+use App\Export\Feed\Domain\Enum\FeedRunTrigger;
+use App\Export\Feed\Domain\Enum\FeedTemplateKind;
+use App\Export\Feed\Domain\Generator\FeedRequiredValidator;
+use App\Export\Feed\Domain\Mapping\FeedItemMapper;
+use App\Export\Feed\Domain\Mapping\FeedTransformApplier;
+use App\Export\Feed\Domain\Repository\FeedProfileRepositoryInterface;
+use App\Export\Feed\Domain\Repository\FeedRunLogRepositoryInterface;
+use App\Export\Feed\Domain\Repository\FeedRunRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use DOMDocument;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * XMLF-P4-01 — regeneration orchestrator: generate → cache upload → record
+ * cache pointer on the profile.
+ */
+final class FeedRegeneratorTest extends TestCase
+{
+    private function profile(): FeedProfile
+    {
+        return new FeedProfile(
+            code: 'google_pl',
+            name: 'Google PL',
+            templateKind: FeedTemplateKind::Custom,
+            objectTypeId: Uuid::v7(),
+            descriptor: [
+                'root' => ['element' => 'products'],
+                'item' => [
+                    'element' => 'product',
+                    'slots' => [
+                        ['slot' => 'sku', 'node' => 'element', 'required' => true, 'fmt' => 'text'],
+                        ['slot' => 'name', 'node' => 'element', 'fmt' => 'text'],
+                    ],
+                ],
+            ],
+            fieldMappings: [
+                ['slot' => 'sku', 'source' => ['kind' => 'attribute', 'ref' => 'sku']],
+                ['slot' => 'name', 'source' => ['kind' => 'attribute', 'ref' => 'name']],
+            ],
+        );
+    }
+
+    private function generator(FeedProductValues $source): FeedGenerator
+    {
+        $runRepo = new class implements FeedRunRepositoryInterface {
+            public function save(FeedRun $run): void
+            {
+            }
+
+            public function findById(Uuid $id): ?FeedRun
+            {
+                return null;
+            }
+
+            public function findByFeedProfile(Uuid $feedProfileId, int $limit = 50): array
+            {
+                return [];
+            }
+        };
+        $logRepo = new class implements FeedRunLogRepositoryInterface {
+            public function save(FeedRunLog $log): void
+            {
+            }
+
+            public function saveMany(array $logs): void
+            {
+            }
+
+            public function findByRun(Uuid $feedRunId): array
+            {
+                return [];
+            }
+        };
+
+        return new FeedGenerator($source, new FeedItemMapper(new FeedTransformApplier()), new FeedRequiredValidator(), $runRepo, $logRepo);
+    }
+
+    private function repo(FeedProfile $profile): FeedProfileRepositoryInterface
+    {
+        return new class($profile) implements FeedProfileRepositoryInterface {
+            public function __construct(private ?FeedProfile $known)
+            {
+            }
+
+            public function save(FeedProfile $profile): void
+            {
+            }
+
+            public function remove(FeedProfile $profile): void
+            {
+            }
+
+            public function findById(Uuid $id): ?FeedProfile
+            {
+                return $this->known;
+            }
+
+            public function findByTenantAndCode(Tenant $tenant, string $code): ?FeedProfile
+            {
+                return null;
+            }
+
+            public function findByTenant(Tenant $tenant): array
+            {
+                return [];
+            }
+        };
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        $context = new TenantContext();
+        $context->set(new Tenant('demo', 'Demo'));
+
+        return $context;
+    }
+
+    #[Test]
+    public function regenerateUploadsCacheAndRecordsPointer(): void
+    {
+        $source = new class implements FeedProductValues {
+            public function forScope(FeedProductScope $scope): iterable
+            {
+                yield ['sku' => 'KL-1', 'name' => 'Wkręt'];
+                yield ['sku' => 'KL-2', 'name' => 'Kątownik'];
+            }
+        };
+
+        $cache = new class implements FeedCacheStorage {
+            /** @var list<string> */
+            public array $keys = [];
+            public string $content = '';
+
+            public function put(string $key, string $localPath): void
+            {
+                $this->keys[] = $key;
+                $this->content = (string) file_get_contents($localPath);
+            }
+        };
+
+        $profile = $this->profile();
+        $repo = $this->repo($profile);
+
+        $run = new FeedRegenerator($this->generator($source), $cache, $repo, $this->tenantContext())
+            ->regenerate($profile, FeedRunTrigger::Manual);
+
+        self::assertSame(FeedRunStatus::Done, $run->getStatus());
+        self::assertSame(2, $run->getItemCount());
+
+        self::assertCount(1, $cache->keys);
+        self::assertStringStartsWith('feeds/', $cache->keys[0]);
+        self::assertStringEndsWith($profile->getId()->toRfc4122().'.xml', $cache->keys[0]);
+
+        self::assertSame($cache->keys[0], $profile->getCachedFilePath());
+        self::assertSame(2, $profile->getCachedItemCount());
+        self::assertNotNull($profile->getCachedAt());
+
+        $dom = new DOMDocument();
+        self::assertNotFalse($dom->loadXML($cache->content));
+        self::assertSame(2, $dom->getElementsByTagName('product')->length);
+    }
+
+    #[Test]
+    public function regenerateRequiresTenantContext(): void
+    {
+        $source = new class implements FeedProductValues {
+            public function forScope(FeedProductScope $scope): iterable
+            {
+                yield ['sku' => 'X', 'name' => 'Y'];
+            }
+        };
+        $cache = new class implements FeedCacheStorage {
+            public function put(string $key, string $localPath): void
+            {
+            }
+        };
+        $profile = $this->profile();
+        $repo = $this->repo($profile);
+
+        $this->expectException(RuntimeException::class);
+        new FeedRegenerator($this->generator($source), $cache, $repo, new TenantContext())
+            ->regenerate($profile, FeedRunTrigger::Manual);
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -13199,6 +13199,45 @@
                 "x-cortex-permission": "integration.admin"
             }
         },
+        "/api/feeds/{id}/regenerate": {
+            "post": {
+                "operationId": "api_feeds_id_regenerate_post",
+                "tags": [
+                    "feeds"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api feeds id regenerate",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "integration.admin"
+            }
+        },
         "/api/feeds/{id}/resume": {
             "post": {
                 "operationId": "api_feeds_id_resume_post",


### PR DESCRIPTION
## Cel (XMLF-P4-01, #1927)
Manualny trigger "Regeneruj teraz" — `POST /api/feeds/{id}/regenerate`. Uruchamia feed synchronicznie, streamuje XML do MinIO cache i zapisuje wskaźnik cache na profilu, który serwuje publiczny URL (XMLF-P3-05).

## Zakres
- `FeedRegenerator` — współdzielony rdzeń (generate → temp → upload `feeds/<tenant>/<feed>.xml` → `recordCache`), wzorzec jak `SyncExportRunner` współdzielony przez sync+async export.
- `FeedCacheStorage` seam + `FlysystemFeedCacheStorage` (reuse bucket `exports.storage`, prefix `feeds/`).
- `POST /api/feeds/{id}/regenerate` → 202 + podsumowanie `FeedRun` + wskaźnik cache.
- **fix(export): tenant managed across value-source EM clears** — live regeneracja odsłoniła latentny bug w adapterze P3-02: `em->clear()` między chunkami detachował Tenant z TenantContext → `FeedRunLog#tenant` "new entity found through relationship". Fix: adapter re-binduje managed Tenant po clear; generator reloaduje FeedRun przed markDone/markError; kontroler reloaduje profil do response.

## Live smoke (pim.localhost, realne dane) ✅
```
POST /api/feeds/{id}/regenerate → 202
run: { status: done, item_count: 67, skipped_count: 28, warning_count: 30, file_size_bytes: 35291, duration_ms: 308 }
cache: { file_path: "feeds/<tenant>/<feed>.xml", file_size: 35291, item_count: 67, generated_at: 2026-07-01T20:02:43+00:00 }
```
67 realnych produktów wygenerowanych do well-formed XML + zapisanych w MinIO. **To także domyka odłożony live-smoke P3-02** (adapter ExportBuilder generuje realne wartości).

## Świadome odejście
Async dispatch (RunFeedMessage na transport `import`) + cron scheduling = XMLF-P4-02. Manual trigger biegnie inline (smoke-testowalny dziś).

## Bramki (kontener + live)
PHPStan 0 · Deptrac 0 · PHP-CS-Fixer clean · PHPUnit Feed 50/50 (247 assertions; +FeedRegeneratorTest 2/2) · container lint OK · OpenAPI `v0.json` zregenerowany (trasa regenerate) · **manual smoke 202 na żywym backendzie**

Refs #1927