### PR TITLE
feat(export): add feed preview endpoint (draft + saved, N samples)

### DIFF
--- a/apps/api/src/Export/Feed/Application/Preview/FeedPreviewService.php
+++ b/apps/api/src/Export/Feed/Application/Preview/FeedPreviewService.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Application\Preview;
+
+use App\Export\Contracts\FeedProductScope;
+use App\Export\Contracts\FeedProductValues;
+use App\Export\Feed\Domain\Descriptor\FeedDescriptor;
+use App\Export\Feed\Domain\Generator\FeedRequiredValidator;
+use App\Export\Feed\Domain\Mapping\FeedFieldMapping;
+use App\Export\Feed\Domain\Mapping\FeedItemMapper;
+use App\Export\Feed\Infrastructure\Writer\XmlFeedWriter;
+use App\Export\Infrastructure\Writer\XmlWriterCore;
+
+/**
+ * Feed preview (ADR-0023 §6.8, XMLF-P4-04) — renders the first N products
+ * through the exact map → validate → serialize pipeline the generator uses
+ * (XMLF-P2-04), but in-memory: no FeedRun, no cache upload, no persistence.
+ *
+ * It powers the wizard's "Podgląd" step for both a draft (unsaved descriptor +
+ * mappings) and a saved feed, returning the sample XML plus a health report so
+ * the operator sees exactly what the feed will emit — including which required
+ * slots are missing — before committing to a full regeneration.
+ */
+final class FeedPreviewService
+{
+    public const int DEFAULT_LIMIT = 5;
+    private const int MAX_LIMIT = 25;
+
+    public function __construct(
+        private readonly FeedProductValues $values,
+        private readonly FeedItemMapper $mapper,
+        private readonly FeedRequiredValidator $validator,
+    ) {
+    }
+
+    /**
+     * @param list<FeedFieldMapping> $mappings
+     * @param array<string, string>  $context
+     *
+     * @return array{sample_count: int, xml: string, health: list<array{sku: string|null, slot: string, level: string, message: string}>}
+     */
+    public function preview(FeedDescriptor $descriptor, array $mappings, FeedProductScope $scope, array $context, int $limit = self::DEFAULT_LIMIT): array
+    {
+        $limit = max(1, min($limit, self::MAX_LIMIT));
+
+        $xml = XmlWriterCore::toMemory();
+        $writer = new XmlFeedWriter($xml, $descriptor, $context);
+        $writer->begin();
+
+        $health = [];
+        $count = 0;
+        foreach ($this->values->forScope($scope) as $attributes) {
+            if ($count >= $limit) {
+                break;
+            }
+            $item = $this->mapper->map($mappings, $attributes, $context);
+            $sku = \is_string($attributes['sku'] ?? null) ? $attributes['sku'] : null;
+            foreach ($this->validator->check($descriptor, $item) as $violation) {
+                $health[] = [
+                    'sku' => $sku,
+                    'slot' => $violation['slot'],
+                    'level' => 'warning',
+                    'message' => $violation['message'],
+                ];
+            }
+            // The preview shows what WOULD be emitted (warnings flagged
+            // separately), so invalid samples are still written.
+            $writer->writeItem($item);
+            ++$count;
+        }
+        $writer->finish();
+
+        return [
+            'sample_count' => $count,
+            'xml' => $xml->outputMemory(),
+            'health' => $health,
+        ];
+    }
+}

--- a/apps/api/src/Export/Feed/Presentation/Controller/FeedPreviewController.php
+++ b/apps/api/src/Export/Feed/Presentation/Controller/FeedPreviewController.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Presentation\Controller;
+
+use App\Export\Contracts\FeedProductScope;
+use App\Export\Feed\Application\Descriptor\FeedDescriptorGuard;
+use App\Export\Feed\Application\Preview\FeedPreviewService;
+use App\Export\Feed\Domain\Descriptor\FeedDescriptor;
+use App\Export\Feed\Domain\Descriptor\InvalidDescriptorException;
+use App\Export\Feed\Domain\Entity\FeedProfile;
+use App\Export\Feed\Domain\Mapping\FeedFieldMapping;
+use App\Export\Feed\Domain\Repository\FeedProfileRepositoryInterface;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\TenantContext;
+use App\Shared\Application\UserIdentityAware;
+use App\Shared\Domain\Tenant;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Feed preview API (ADR-0023 §6.8, XMLF-P4-04) — backs the wizard "Podgląd"
+ * step. `POST /api/feeds/preview` renders a draft (descriptor + mappings from
+ * the request body, before the feed is saved); `GET /api/feeds/{id}/preview`
+ * renders a saved feed. Both return the first N sample products as XML plus a
+ * health report, in-memory (no FeedRun, no cache). Auto-registered into OpenAPI
+ * by CustomRouteOpenApiFactory (ADR-0020).
+ */
+final class FeedPreviewController
+{
+    public function __construct(
+        private readonly FeedProfileRepositoryInterface $feeds,
+        private readonly FeedPreviewService $preview,
+        private readonly FeedDescriptorGuard $guard,
+        private readonly TenantContext $tenantContext,
+        private readonly Security $security,
+    ) {
+    }
+
+    #[Route(path: '/api/feeds/preview', name: 'pim_feeds_preview_draft', methods: ['POST'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'exports', action: 'view_all')]
+    public function draft(Request $request): JsonResponse
+    {
+        $this->resolveTenant();
+        $payload = $this->decodeJson($request);
+
+        $descriptorRaw = \is_array($payload['descriptor'] ?? null) ? $payload['descriptor'] : [];
+        $this->assertDescriptor($descriptorRaw);
+        $descriptor = FeedDescriptor::fromArray($descriptorRaw);
+
+        $mappings = FeedFieldMapping::listFromArray(
+            \is_array($payload['field_mappings'] ?? null)
+                ? array_values(array_filter($payload['field_mappings'], \is_array(...)))
+                : [],
+        );
+
+        $objectTypeId = $this->parseUuid($payload, 'object_type_id');
+        $locale = $this->optionalString($payload, 'locale');
+        $channel = $this->optionalString($payload, 'channel');
+        $filter = \is_array($payload['filter'] ?? null) ? $payload['filter'] : null;
+
+        $scope = new FeedProductScope($objectTypeId, $this->attributeCodes($mappings), $locale, $channel, $filter);
+        $context = [
+            'currency' => $this->optionalString($payload, 'currency') ?? '',
+            'store_url' => $this->optionalString($payload, 'store_url') ?? '',
+            'feed_name' => $this->optionalString($payload, 'name') ?? '',
+        ];
+
+        return new JsonResponse($this->preview->preview($descriptor, $mappings, $scope, $context, $this->limit($payload)));
+    }
+
+    #[Route(path: '/api/feeds/{id}/preview', name: 'pim_feeds_preview_saved', methods: ['GET'], requirements: ['id' => '[0-9a-fA-F-]{36}'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'exports', action: 'view_all')]
+    public function saved(string $id, Request $request): JsonResponse
+    {
+        $this->resolveTenant();
+        $feed = $this->loadOrFail($id);
+
+        $descriptor = FeedDescriptor::fromArray($feed->getDescriptor());
+        $mappings = FeedFieldMapping::listFromArray($feed->getFieldMappings());
+        $scope = new FeedProductScope(
+            $feed->getObjectTypeId(),
+            $this->attributeCodes($mappings),
+            $feed->getLocale(),
+            $feed->getPublicationChannel(),
+            $feed->getFilter(),
+        );
+        $delivery = $feed->getDelivery();
+        $context = [
+            'currency' => $feed->getCurrency() ?? '',
+            'store_url' => \is_string($delivery['store_url'] ?? null) ? $delivery['store_url'] : '',
+            'feed_name' => $feed->getName(),
+        ];
+
+        $limit = $request->query->getInt('limit', FeedPreviewService::DEFAULT_LIMIT);
+
+        return new JsonResponse($this->preview->preview($descriptor, $mappings, $scope, $context, $limit));
+    }
+
+    /**
+     * @param list<FeedFieldMapping> $mappings
+     *
+     * @return list<string>
+     */
+    private function attributeCodes(array $mappings): array
+    {
+        $codes = ['sku' => true]; // always needed for the health-report object_sku
+        foreach ($mappings as $mapping) {
+            if ('attribute' === $mapping->sourceKind && null !== $mapping->sourceRef) {
+                $codes[$mapping->sourceRef] = true;
+            }
+        }
+
+        return array_keys($codes);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function limit(array $payload): int
+    {
+        return \is_int($payload['limit'] ?? null) ? $payload['limit'] : FeedPreviewService::DEFAULT_LIMIT;
+    }
+
+    /**
+     * @param array<mixed, mixed> $descriptor
+     */
+    private function assertDescriptor(array $descriptor): void
+    {
+        try {
+            $this->guard->assertValid($descriptor);
+        } catch (InvalidDescriptorException $error) {
+            throw new BadRequestHttpException('Invalid feed descriptor: '.$error->getMessage(), $error);
+        }
+    }
+
+    private function resolveTenant(): Tenant
+    {
+        if (!$this->security->getUser() instanceof UserIdentityAware) {
+            throw new AccessDeniedHttpException('Authenticated user identity required.');
+        }
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new AccessDeniedHttpException('Tenant context required.');
+        }
+
+        return $tenant;
+    }
+
+    private function loadOrFail(string $id): FeedProfile
+    {
+        $feed = $this->feeds->findById(Uuid::fromString($id));
+        if (null === $feed) {
+            throw new NotFoundHttpException(sprintf('Feed "%s" was not found.', $id));
+        }
+
+        return $feed;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function parseUuid(array $payload, string $key): Uuid
+    {
+        $value = $payload[$key] ?? null;
+        if (!\is_string($value) || !Uuid::isValid($value)) {
+            throw new BadRequestHttpException(sprintf('%s is required (UUID).', $key));
+        }
+
+        return Uuid::fromString($value);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function optionalString(array $payload, string $key): ?string
+    {
+        $value = $payload[$key] ?? null;
+
+        return \is_string($value) && '' !== $value ? $value : null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(Request $request): array
+    {
+        $body = $request->getContent();
+        if ('' === $body) {
+            return [];
+        }
+        $decoded = json_decode($body, true);
+        if (!\is_array($decoded)) {
+            throw new BadRequestHttpException('Request body must be a JSON object.');
+        }
+        $payload = [];
+        foreach ($decoded as $key => $value) {
+            if (!\is_string($key)) {
+                throw new BadRequestHttpException('Request body must be a JSON object (string keys).');
+            }
+            $payload[$key] = $value;
+        }
+
+        return $payload;
+    }
+}

--- a/apps/api/tests/Unit/Export/Feed/FeedPreviewServiceTest.php
+++ b/apps/api/tests/Unit/Export/Feed/FeedPreviewServiceTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export\Feed;
+
+use App\Export\Contracts\FeedProductScope;
+use App\Export\Contracts\FeedProductValues;
+use App\Export\Feed\Application\Preview\FeedPreviewService;
+use App\Export\Feed\Domain\Descriptor\FeedDescriptor;
+use App\Export\Feed\Domain\Generator\FeedRequiredValidator;
+use App\Export\Feed\Domain\Mapping\FeedFieldMapping;
+use App\Export\Feed\Domain\Mapping\FeedItemMapper;
+use App\Export\Feed\Domain\Mapping\FeedTransformApplier;
+use DOMDocument;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * XMLF-P4-04 — preview: first N samples rendered in-memory with a health report.
+ */
+final class FeedPreviewServiceTest extends TestCase
+{
+    private function descriptor(): FeedDescriptor
+    {
+        return FeedDescriptor::fromArray([
+            'root' => ['element' => 'products'],
+            'item' => [
+                'element' => 'product',
+                'slots' => [
+                    ['slot' => 'sku', 'node' => 'element', 'required' => true, 'fmt' => 'text'],
+                    ['slot' => 'name', 'node' => 'element', 'fmt' => 'text'],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @return list<FeedFieldMapping>
+     */
+    private function mappings(): array
+    {
+        return FeedFieldMapping::listFromArray([
+            ['slot' => 'sku', 'source' => ['kind' => 'attribute', 'ref' => 'sku']],
+            ['slot' => 'name', 'source' => ['kind' => 'attribute', 'ref' => 'name']],
+        ]);
+    }
+
+    private function service(FeedProductValues $source): FeedPreviewService
+    {
+        return new FeedPreviewService($source, new FeedItemMapper(new FeedTransformApplier()), new FeedRequiredValidator());
+    }
+
+    private function scope(): FeedProductScope
+    {
+        return new FeedProductScope(Uuid::v7(), ['sku', 'name'], null, null, null);
+    }
+
+    #[Test]
+    public function previewCapsSamplesAndReportsHealth(): void
+    {
+        $source = new class implements FeedProductValues {
+            public function forScope(FeedProductScope $scope): iterable
+            {
+                yield ['sku' => 'A-1', 'name' => 'Alpha'];
+                yield ['sku' => 'A-2', 'name' => 'Beta'];
+                yield ['name' => 'No SKU']; // missing required sku → health warning
+                yield ['sku' => 'A-4', 'name' => 'Delta'];
+                yield ['sku' => 'A-5', 'name' => 'Echo'];
+                yield ['sku' => 'A-6', 'name' => 'Should not appear']; // beyond limit 5
+            }
+        };
+
+        $result = $this->service($source)->preview($this->descriptor(), $this->mappings(), $this->scope(), [], 5);
+
+        self::assertSame(5, $result['sample_count']);
+
+        $dom = new DOMDocument();
+        self::assertTrue($dom->loadXML($result['xml']));
+        self::assertSame(5, $dom->getElementsByTagName('product')->length);
+        self::assertStringNotContainsString('Should not appear', $result['xml']);
+
+        // The SKU-less sample raises exactly one health warning for the sku slot.
+        $skuWarnings = array_filter($result['health'], static fn (array $h): bool => 'sku' === $h['slot']);
+        self::assertCount(1, $skuWarnings);
+        self::assertSame('warning', array_values($skuWarnings)[0]['level']);
+    }
+
+    #[Test]
+    public function previewClampsLimitToAtLeastOne(): void
+    {
+        $source = new class implements FeedProductValues {
+            public function forScope(FeedProductScope $scope): iterable
+            {
+                yield ['sku' => 'A-1', 'name' => 'Alpha'];
+                yield ['sku' => 'A-2', 'name' => 'Beta'];
+            }
+        };
+
+        $result = $this->service($source)->preview($this->descriptor(), $this->mappings(), $this->scope(), [], 0);
+
+        self::assertSame(1, $result['sample_count']);
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -13047,6 +13047,32 @@
                 "x-cortex-permission": "integration.admin"
             }
         },
+        "/api/feeds/preview": {
+            "post": {
+                "operationId": "api_feeds_preview_post",
+                "tags": [
+                    "feeds"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api feeds preview",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "exports.view_all"
+            }
+        },
         "/api/feeds/{id}": {
             "get": {
                 "operationId": "api_feeds_id_get",
@@ -13197,6 +13223,45 @@
                 ],
                 "x-pim-source": "custom-route",
                 "x-cortex-permission": "integration.admin"
+            }
+        },
+        "/api/feeds/{id}/preview": {
+            "get": {
+                "operationId": "api_feeds_id_preview_get",
+                "tags": [
+                    "feeds"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api feeds id preview",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "exports.view_all"
             }
         },
         "/api/feeds/{id}/resume": {


### PR DESCRIPTION
## Cel (XMLF-P4-04, #1928)
Backend kroku "Podgląd" w kreatorze: renderuje pierwsze N produktów przez dokładnie ten sam pipeline map → validate → serialize co generator (XMLF-P2-04), ale **in-memory** — bez FeedRun, bez cache, bez persystencji.

## Zakres
- `FeedPreviewService.preview(descriptor, mappings, scope, context, limit)` → `{sample_count, xml, health[]}`. Limit clamp [1,25]. Reuse `FeedItemMapper` + `FeedRequiredValidator` + `XmlFeedWriter`.
- `POST /api/feeds/preview` — draft (descriptor+mappings+object_type_id z body, przed zapisem feedu).
- `GET /api/feeds/{id}/preview?limit=N` — zapisany feed.
- Health report: per-sample ostrzeżenia (missing required slot itd.) z SKU.

## Live smoke (pim.localhost, realny feed Google) ✅
```
GET /api/feeds/{id}/preview?limit=3 → 200
sample_count: 3 · health: 3 wpisy · xml 1724 B, well-formed (Google RSS <rss>/<item>)
```

## Bramki
PHPStan 0 · Deptrac 0 · PHP-CS-Fixer clean · PHPUnit 2/2 (7 assertions) · OpenAPI v0.json zregenerowany (obie trasy preview) · **manual smoke 200**

Refs #1928