### PR TITLE
feat(export): feed run history, monitor and health KPI API

### DIFF
--- a/apps/api/src/Export/Feed/Domain/Repository/FeedRunLogRepositoryInterface.php
+++ b/apps/api/src/Export/Feed/Domain/Repository/FeedRunLogRepositoryInterface.php
@@ -22,4 +22,14 @@ interface FeedRunLogRepositoryInterface
      * @return list<FeedRunLog>
      */
     public function findByRun(Uuid $feedRunId): array;
+
+    /**
+     * Keyset page of one run's log lines for the drill-down (XMLF-P4-03),
+     * oldest first (the order they were emitted). Log ids are UUIDv7, so the
+     * cursor is the last-seen log id. `$level` filters info|warning|error;
+     * null = all lines.
+     *
+     * @return list<FeedRunLog>
+     */
+    public function findPageByRun(Uuid $feedRunId, ?string $level, ?Uuid $cursor, int $limit): array;
 }

--- a/apps/api/src/Export/Feed/Domain/Repository/FeedRunRepositoryInterface.php
+++ b/apps/api/src/Export/Feed/Domain/Repository/FeedRunRepositoryInterface.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Export\Feed\Domain\Repository;
 
 use App\Export\Feed\Domain\Entity\FeedRun;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
 use Symfony\Component\Uid\Uuid;
 
 interface FeedRunRepositoryInterface
@@ -19,4 +21,22 @@ interface FeedRunRepositoryInterface
      * @return list<FeedRun>
      */
     public function findByFeedProfile(Uuid $feedProfileId, int $limit = 50): array;
+
+    /**
+     * Keyset page of runs, newest first (XMLF-P4-03 monitor). FeedRun ids are
+     * UUIDv7, so ordering by id IS ordering by started_at — the cursor is the
+     * last-seen run id. `$health` filters the DISPLAY status: success (done,
+     * no warnings), warning (done with warnings), error; null = everything.
+     *
+     * @return list<FeedRun>
+     */
+    public function findPage(?Uuid $feedProfileId, ?string $health, ?Uuid $cursor, int $limit): array;
+
+    /**
+     * Tenant-wide 24h health KPI for the monitor tiles (XMLF-P4-03):
+     * regeneration count, skipped sum, error count + the most recent error.
+     *
+     * @return array{regenerations_24h: int, skipped_24h: int, errors_24h: int, last_error: array{run_id: string, feed_id: string, message: string|null}|null}
+     */
+    public function kpi24h(Tenant $tenant, DateTimeImmutable $now): array;
 }

--- a/apps/api/src/Export/Feed/Infrastructure/Doctrine/Repository/DoctrineFeedRunLogRepository.php
+++ b/apps/api/src/Export/Feed/Infrastructure/Doctrine/Repository/DoctrineFeedRunLogRepository.php
@@ -54,4 +54,31 @@ class DoctrineFeedRunLogRepository extends ServiceEntityRepository implements Fe
 
         return $result;
     }
+
+    /**
+     * @return list<FeedRunLog>
+     */
+    public function findPageByRun(Uuid $feedRunId, ?string $level, ?Uuid $cursor, int $limit): array
+    {
+        // UUIDv7 ids are time-ordered — id ASC == emission order, and the
+        // keyset cursor (id > last seen) stays stable across pages even
+        // while a running regeneration keeps appending lines.
+        $qb = $this->createQueryBuilder('l')
+            ->where('l.feedRunId = :rid')
+            ->orderBy('l.id', 'ASC')
+            ->setMaxResults($limit)
+            ->setParameter('rid', $feedRunId->toRfc4122());
+
+        if (null !== $level) {
+            $qb->andWhere('l.level = :level')->setParameter('level', $level);
+        }
+        if (null !== $cursor) {
+            $qb->andWhere('l.id > :cursor')->setParameter('cursor', $cursor->toRfc4122());
+        }
+
+        /** @var list<FeedRunLog> $result */
+        $result = $qb->getQuery()->getResult();
+
+        return $result;
+    }
 }

--- a/apps/api/src/Export/Feed/Infrastructure/Doctrine/Repository/DoctrineFeedRunRepository.php
+++ b/apps/api/src/Export/Feed/Infrastructure/Doctrine/Repository/DoctrineFeedRunRepository.php
@@ -5,7 +5,11 @@ declare(strict_types=1);
 namespace App\Export\Feed\Infrastructure\Doctrine\Repository;
 
 use App\Export\Feed\Domain\Entity\FeedRun;
+use App\Export\Feed\Domain\Enum\FeedRunStatus;
 use App\Export\Feed\Domain\Repository\FeedRunRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use DateTimeZone;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Uid\Uuid;
@@ -47,5 +51,93 @@ class DoctrineFeedRunRepository extends ServiceEntityRepository implements FeedR
         $result = $qb->getQuery()->getResult();
 
         return $result;
+    }
+
+    /**
+     * @return list<FeedRun>
+     */
+    public function findPage(?Uuid $feedProfileId, ?string $health, ?Uuid $cursor, int $limit): array
+    {
+        // UUIDv7 ids are time-ordered, so id DESC == started_at DESC and the
+        // keyset cursor is a plain id comparison (stable under concurrent
+        // inserts, unlike OFFSET).
+        $qb = $this->createQueryBuilder('r')
+            ->orderBy('r.id', 'DESC')
+            ->setMaxResults($limit);
+
+        if (null !== $feedProfileId) {
+            $qb->andWhere('r.feedProfileId = :fid')
+                ->setParameter('fid', $feedProfileId->toRfc4122());
+        }
+        if (null !== $cursor) {
+            $qb->andWhere('r.id < :cursor')
+                ->setParameter('cursor', $cursor->toRfc4122());
+        }
+
+        // Display-status filter: `success`/`warning` split `done` by warning
+        // count (the monitor's chips); `error` is the raw error status.
+        match ($health) {
+            'success' => $qb->andWhere('r.status = :st')->andWhere('r.warningCount = 0')
+                ->setParameter('st', FeedRunStatus::Done->value),
+            'warning' => $qb->andWhere('r.status = :st')->andWhere('r.warningCount > 0')
+                ->setParameter('st', FeedRunStatus::Done->value),
+            'error' => $qb->andWhere('r.status = :st')
+                ->setParameter('st', FeedRunStatus::Error->value),
+            default => null,
+        };
+
+        /** @var list<FeedRun> $result */
+        $result = $qb->getQuery()->getResult();
+
+        return $result;
+    }
+
+    public function kpi24h(Tenant $tenant, DateTimeImmutable $now): array
+    {
+        $since = $now->setTimezone(new DateTimeZone('UTC'))->modify('-24 hours')->format('Y-m-d H:i:s');
+        $params = ['tenant' => $tenant->getId()->toRfc4122(), 'since' => $since];
+
+        // tenant-safe: explicit tenant_id filter (monitor KPI scoped to the authenticated tenant; RLS GUC active as defence in depth)
+        $row = $this->getEntityManager()->getConnection()->executeQuery(
+            'SELECT COUNT(*) AS regenerations,'
+            .' COALESCE(SUM(skipped_count), 0) AS skipped,'
+            ." COUNT(*) FILTER (WHERE status = 'error') AS errors"
+            .' FROM feed_runs WHERE tenant_id = :tenant AND started_at >= :since',
+            $params,
+        )->fetchAssociative();
+
+        // tenant-safe: explicit tenant_id filter (single most-recent error row for the monitor tile)
+        $lastError = $this->getEntityManager()->getConnection()->executeQuery(
+            'SELECT id, feed_profile_id, error_message FROM feed_runs'
+            ." WHERE tenant_id = :tenant AND status = 'error' AND started_at >= :since"
+            .' ORDER BY id DESC LIMIT 1',
+            $params,
+        )->fetchAssociative();
+
+        $counters = \is_array($row) ? $row : [];
+
+        $lastErrorOut = null;
+        if (\is_array($lastError)
+            && \is_string($lastError['id'] ?? null)
+            && \is_string($lastError['feed_profile_id'] ?? null)
+        ) {
+            $lastErrorOut = [
+                'run_id' => $lastError['id'],
+                'feed_id' => $lastError['feed_profile_id'],
+                'message' => \is_string($lastError['error_message'] ?? null) ? $lastError['error_message'] : null,
+            ];
+        }
+
+        return [
+            'regenerations_24h' => self::toInt($counters['regenerations'] ?? 0),
+            'skipped_24h' => self::toInt($counters['skipped'] ?? 0),
+            'errors_24h' => self::toInt($counters['errors'] ?? 0),
+            'last_error' => $lastErrorOut,
+        ];
+    }
+
+    private static function toInt(mixed $value): int
+    {
+        return is_numeric($value) ? (int) $value : 0;
     }
 }

--- a/apps/api/src/Export/Feed/Presentation/Controller/FeedRunHistoryController.php
+++ b/apps/api/src/Export/Feed/Presentation/Controller/FeedRunHistoryController.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Presentation\Controller;
+
+use App\Export\Feed\Domain\Descriptor\FeedDescriptor;
+use App\Export\Feed\Domain\Descriptor\InvalidDescriptorException;
+use App\Export\Feed\Domain\Entity\FeedProfile;
+use App\Export\Feed\Domain\Entity\FeedRun;
+use App\Export\Feed\Domain\Entity\FeedRunLog;
+use App\Export\Feed\Domain\Repository\FeedProfileRepositoryInterface;
+use App\Export\Feed\Domain\Repository\FeedRunLogRepositoryInterface;
+use App\Export\Feed\Domain\Repository\FeedRunRepositoryInterface;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\TenantContext;
+use App\Shared\Application\UserIdentityAware;
+use DateTimeInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Per-feed run history + drill-down + health (XMLF-P4-03, ADR-0023 §6.5) —
+ * the read side behind FeedDetail and FeedRunDrilldown: run list, one run's
+ * tiles, its per-product FeedRunLog lines ("SKU-123: missing g:gtin —
+ * skipped") and the feed health card (syndication counters + mapping
+ * coverage). Read-only projections; auto-registered into OpenAPI (ADR-0020).
+ */
+final class FeedRunHistoryController
+{
+    private const int DEFAULT_LIMIT = 25;
+    private const int MAX_LIMIT = 100;
+
+    public function __construct(
+        private readonly FeedProfileRepositoryInterface $feeds,
+        private readonly FeedRunRepositoryInterface $runs,
+        private readonly FeedRunLogRepositoryInterface $logs,
+        private readonly TenantContext $tenantContext,
+        private readonly Security $security,
+    ) {
+    }
+
+    #[Route(path: '/api/feeds/{id}/runs', name: 'pim_feeds_runs_list', methods: ['GET'], requirements: ['id' => '[0-9a-fA-F-]{36}'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'exports', action: 'view_all')]
+    public function list(string $id, Request $request): JsonResponse
+    {
+        $this->assertTenantUser();
+        $feed = $this->loadFeedOrFail($id);
+
+        $status = $request->query->get('status');
+        $health = \in_array($status, ['success', 'warning', 'error'], true) ? $status : null;
+        $cursor = $this->readCursor($request);
+        $limit = max(1, min(self::MAX_LIMIT, $request->query->getInt('limit', self::DEFAULT_LIMIT)));
+
+        $page = $this->runs->findPage($feed->getId(), $health, $cursor, $limit);
+
+        return new JsonResponse([
+            'items' => array_map($this->serializeRun(...), $page),
+            'next_cursor' => [] !== $page && \count($page) === $limit
+                ? $page[\count($page) - 1]->getId()->toRfc4122()
+                : null,
+        ]);
+    }
+
+    #[Route(path: '/api/feeds/{id}/runs/{runId}', name: 'pim_feeds_run_detail', methods: ['GET'], requirements: ['id' => '[0-9a-fA-F-]{36}', 'runId' => '[0-9a-fA-F-]{36}'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'exports', action: 'view_all')]
+    public function detail(string $id, string $runId): JsonResponse
+    {
+        $this->assertTenantUser();
+        $feed = $this->loadFeedOrFail($id);
+        $run = $this->loadRunOrFail($feed, $runId);
+
+        return new JsonResponse($this->serializeRun($run));
+    }
+
+    #[Route(path: '/api/feeds/{id}/runs/{runId}/logs', name: 'pim_feeds_run_logs', methods: ['GET'], requirements: ['id' => '[0-9a-fA-F-]{36}', 'runId' => '[0-9a-fA-F-]{36}'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'exports', action: 'view_all')]
+    public function logs(string $id, string $runId, Request $request): JsonResponse
+    {
+        $this->assertTenantUser();
+        $feed = $this->loadFeedOrFail($id);
+        $run = $this->loadRunOrFail($feed, $runId);
+
+        $levelRaw = $request->query->get('level');
+        $level = \in_array($levelRaw, ['info', 'warning', 'error'], true) ? $levelRaw : null;
+        $cursor = $this->readCursor($request);
+        $limit = max(1, min(self::MAX_LIMIT, $request->query->getInt('limit', self::DEFAULT_LIMIT)));
+
+        $page = $this->logs->findPageByRun($run->getId(), $level, $cursor, $limit);
+
+        return new JsonResponse([
+            'items' => array_map(static fn (FeedRunLog $log): array => [
+                'id' => $log->getId()->toRfc4122(),
+                'level' => $log->getLevel()->value,
+                'object_sku' => $log->getObjectSku(),
+                'slot' => $log->getSlot(),
+                'message' => $log->getMessage(),
+                'created_at' => $log->getCreatedAt()->format(DateTimeInterface::ATOM),
+            ], $page),
+            'next_cursor' => [] !== $page && \count($page) === $limit
+                ? $page[\count($page) - 1]->getId()->toRfc4122()
+                : null,
+        ]);
+    }
+
+    #[Route(path: '/api/feeds/{id}/health', name: 'pim_feeds_health', methods: ['GET'], requirements: ['id' => '[0-9a-fA-F-]{36}'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'exports', action: 'view_all')]
+    public function health(string $id): JsonResponse
+    {
+        $this->assertTenantUser();
+        $feed = $this->loadFeedOrFail($id);
+
+        $lastRun = $this->runs->findByFeedProfile($feed->getId(), 1)[0] ?? null;
+
+        return new JsonResponse([
+            'feed_id' => $feed->getId()->toRfc4122(),
+            'status' => $feed->getStatus()->value,
+            'items_syndicated' => $feed->getCachedItemCount(),
+            'file_size_bytes' => $feed->getCachedFileSize(),
+            'cached_at' => $feed->getCachedAt()?->format(DateTimeInterface::ATOM),
+            'last_pulled_at' => $feed->getLastPulledAt()?->format(DateTimeInterface::ATOM),
+            'schedule_cron' => $feed->getScheduleCron(),
+            // The cron scheduler engine is a P4-01 leftover delivered with the
+            // worker daemon ticket — until it lands there is no computed
+            // next-run timestamp to report.
+            'next_run' => null,
+            'coverage' => $this->coverage($feed),
+            'last_run' => null !== $lastRun ? $this->serializeRun($lastRun) : null,
+        ]);
+    }
+
+    /**
+     * Mapping coverage: how many of the descriptor's item slots have a
+     * mapping (the design's "coverage mapped/total" card). Parsed through the
+     * FeedDescriptor VO — the authoritative reader for both the flat custom
+     * shape and the channel-nested marketplace shapes (Google RSS).
+     *
+     * @return array{mapped: int, total: int}
+     */
+    private function coverage(FeedProfile $feed): array
+    {
+        try {
+            $descriptor = FeedDescriptor::fromArray($feed->getDescriptor());
+        } catch (InvalidDescriptorException) {
+            // Write-time guarded (XMLF-P1-04); an unparsable legacy descriptor
+            // degrades the card to 0/0 instead of failing the health read.
+            return ['mapped' => 0, 'total' => 0];
+        }
+
+        $slots = [];
+        foreach ($descriptor->slots as $slot) {
+            $slots[$slot->target] = false;
+        }
+        foreach ($feed->getFieldMappings() as $mapping) {
+            $key = \is_string($mapping['slot'] ?? null) ? $mapping['slot'] : null;
+            if (null !== $key && \array_key_exists($key, $slots)) {
+                $slots[$key] = true;
+            }
+        }
+
+        return [
+            'mapped' => \count(array_filter($slots)),
+            'total' => \count($slots),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializeRun(FeedRun $run): array
+    {
+        return [
+            'id' => $run->getId()->toRfc4122(),
+            'feed_id' => $run->getFeedProfileId()->toRfc4122(),
+            'trigger' => $run->getTrigger()->value,
+            'status' => $run->getStatus()->value,
+            'health' => FeedRunMonitorController::health($run),
+            'item_count' => $run->getItemCount(),
+            'skipped_count' => $run->getSkippedCount(),
+            'warning_count' => $run->getWarningCount(),
+            'file_size_bytes' => $run->getFileSizeBytes(),
+            'duration_ms' => $run->getDurationMs(),
+            'error_message' => $run->getErrorMessage(),
+            'started_at' => $run->getStartedAt()->format(DateTimeInterface::ATOM),
+            'completed_at' => $run->getCompletedAt()?->format(DateTimeInterface::ATOM),
+        ];
+    }
+
+    private function readCursor(Request $request): ?Uuid
+    {
+        $raw = $request->query->get('cursor');
+
+        // An invalid cursor serves the first page — stale URLs never 500.
+        return (\is_string($raw) && Uuid::isValid($raw)) ? Uuid::fromString($raw) : null;
+    }
+
+    private function loadFeedOrFail(string $id): FeedProfile
+    {
+        $feed = $this->feeds->findById(Uuid::fromString($id));
+        if (null === $feed) {
+            // Tenant isolation via RLS/TenantFilter; a miss is a 404 either way.
+            throw new NotFoundHttpException(sprintf('Feed "%s" was not found.', $id));
+        }
+
+        return $feed;
+    }
+
+    private function loadRunOrFail(FeedProfile $feed, string $runId): FeedRun
+    {
+        $run = $this->runs->findById(Uuid::fromString($runId));
+        // A run of another feed is a flat 404 — ids are not interchangeable.
+        if (!$run instanceof FeedRun || !$run->getFeedProfileId()->equals($feed->getId())) {
+            throw new NotFoundHttpException(sprintf('Feed run "%s" was not found.', $runId));
+        }
+
+        return $run;
+    }
+
+    private function assertTenantUser(): void
+    {
+        if (!$this->security->getUser() instanceof UserIdentityAware) {
+            throw new AccessDeniedHttpException('Authenticated user identity required.');
+        }
+        if (null === $this->tenantContext->get()) {
+            throw new AccessDeniedHttpException('Tenant context required.');
+        }
+    }
+}

--- a/apps/api/src/Export/Feed/Presentation/Controller/FeedRunMonitorController.php
+++ b/apps/api/src/Export/Feed/Presentation/Controller/FeedRunMonitorController.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Presentation\Controller;
+
+use App\Export\Feed\Domain\Entity\FeedProfile;
+use App\Export\Feed\Domain\Entity\FeedRun;
+use App\Export\Feed\Domain\Enum\FeedRunStatus;
+use App\Export\Feed\Domain\Enum\FeedStatus;
+use App\Export\Feed\Domain\Repository\FeedProfileRepositoryInterface;
+use App\Export\Feed\Domain\Repository\FeedRunRepositoryInterface;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\TenantContext;
+use App\Shared\Application\UserIdentityAware;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Global feed monitor (XMLF-P4-03, ADR-0023 §6.5) — the read side behind the
+ * FeedMonitor screen: the tenant-wide run history (RunsTable) and the health
+ * KPI tiles (Regeneracje 24h / Produkty syndykowane / Pominięte 24h /
+ * Błędy 24h). Read-only projections; auto-registered into OpenAPI (ADR-0020).
+ *
+ * Runs are keyset-paginated over the UUIDv7 id (== started_at order); the
+ * `cursor` query param round-trips the last item's id. `status` filters the
+ * DISPLAY health: success (done, 0 warnings) | warning (done, >0) | error.
+ */
+final class FeedRunMonitorController
+{
+    private const int DEFAULT_LIMIT = 25;
+    private const int MAX_LIMIT = 100;
+
+    public function __construct(
+        private readonly FeedRunRepositoryInterface $runs,
+        private readonly FeedProfileRepositoryInterface $feeds,
+        private readonly TenantContext $tenantContext,
+        private readonly Security $security,
+    ) {
+    }
+
+    #[Route(path: '/api/feed-runs', name: 'pim_feed_runs_list', methods: ['GET'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'exports', action: 'view_all')]
+    public function list(Request $request): JsonResponse
+    {
+        $tenant = $this->resolveTenant();
+        [$health, $cursor, $limit] = $this->readListParams($request);
+
+        $page = $this->runs->findPage(null, $health, $cursor, $limit);
+
+        // Names for the global table — one indexed load for the whole page
+        // (a tenant has dozens of feeds, not thousands).
+        $profiles = [];
+        foreach ($this->feeds->findByTenant($tenant) as $profile) {
+            $profiles[$profile->getId()->toRfc4122()] = $profile;
+        }
+
+        $items = array_map(
+            fn (FeedRun $run): array => $this->serializeRun($run, $profiles[$run->getFeedProfileId()->toRfc4122()] ?? null),
+            $page,
+        );
+
+        return new JsonResponse([
+            'items' => $items,
+            'next_cursor' => [] !== $page && \count($page) === $limit
+                ? $page[\count($page) - 1]->getId()->toRfc4122()
+                : null,
+        ]);
+    }
+
+    #[Route(path: '/api/feed-runs/kpi', name: 'pim_feed_runs_kpi', methods: ['GET'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'exports', action: 'view_all')]
+    public function kpi(): JsonResponse
+    {
+        $tenant = $this->resolveTenant();
+
+        $kpi = $this->runs->kpi24h($tenant, new DateTimeImmutable());
+
+        // Current syndication snapshot: what the public URLs serve right now
+        // (design tile "Produkty syndykowane" — inventory, not a 24h flow).
+        $itemsSyndicated = 0;
+        $lastRegeneratedAt = null;
+        $statusCounts = ['active' => 0, 'paused' => 0, 'error' => 0];
+        foreach ($this->feeds->findByTenant($tenant) as $profile) {
+            $itemsSyndicated += $profile->getCachedItemCount() ?? 0;
+            $cachedAt = $profile->getCachedAt();
+            if (null !== $cachedAt && (null === $lastRegeneratedAt || $cachedAt > $lastRegeneratedAt)) {
+                $lastRegeneratedAt = $cachedAt;
+            }
+            $key = match ($profile->getStatus()) {
+                FeedStatus::Active => 'active',
+                FeedStatus::Paused => 'paused',
+                FeedStatus::Error => 'error',
+            };
+            ++$statusCounts[$key];
+        }
+
+        return new JsonResponse([
+            ...$kpi,
+            'items_syndicated' => $itemsSyndicated,
+            'last_regenerated_at' => $lastRegeneratedAt?->format(DateTimeInterface::ATOM),
+            'feeds' => $statusCounts,
+        ]);
+    }
+
+    /**
+     * @return array{0: string|null, 1: Uuid|null, 2: int}
+     */
+    private function readListParams(Request $request): array
+    {
+        $status = $request->query->get('status');
+        $health = \in_array($status, ['success', 'warning', 'error'], true) ? $status : null;
+
+        $cursorRaw = $request->query->get('cursor');
+        // An invalid cursor serves the first page — stale URLs never 500.
+        $cursor = (\is_string($cursorRaw) && Uuid::isValid($cursorRaw)) ? Uuid::fromString($cursorRaw) : null;
+
+        $limit = max(1, min(self::MAX_LIMIT, $request->query->getInt('limit', self::DEFAULT_LIMIT)));
+
+        return [$health, $cursor, $limit];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializeRun(FeedRun $run, ?FeedProfile $profile): array
+    {
+        return [
+            'id' => $run->getId()->toRfc4122(),
+            'feed_id' => $run->getFeedProfileId()->toRfc4122(),
+            'feed_name' => $profile?->getName(),
+            'feed_code' => $profile?->getCode(),
+            'template_kind' => $profile?->getTemplateKind()->value,
+            'trigger' => $run->getTrigger()->value,
+            'status' => $run->getStatus()->value,
+            'health' => self::health($run),
+            'item_count' => $run->getItemCount(),
+            'skipped_count' => $run->getSkippedCount(),
+            'warning_count' => $run->getWarningCount(),
+            'file_size_bytes' => $run->getFileSizeBytes(),
+            'duration_ms' => $run->getDurationMs(),
+            'error_message' => $run->getErrorMessage(),
+            'started_at' => $run->getStartedAt()->format(DateTimeInterface::ATOM),
+            'completed_at' => $run->getCompletedAt()?->format(DateTimeInterface::ATOM),
+        ];
+    }
+
+    /**
+     * Display status for the monitor chips — `done` splits by warnings.
+     */
+    public static function health(FeedRun $run): string
+    {
+        return match ($run->getStatus()) {
+            FeedRunStatus::Done => $run->getWarningCount() > 0 ? 'warning' : 'success',
+            FeedRunStatus::Error => 'error',
+            FeedRunStatus::Pending => 'pending',
+            FeedRunStatus::Running => 'running',
+            FeedRunStatus::Cancelled => 'cancelled',
+        };
+    }
+
+    private function resolveTenant(): Tenant
+    {
+        if (!$this->security->getUser() instanceof UserIdentityAware) {
+            throw new AccessDeniedHttpException('Authenticated user identity required.');
+        }
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new AccessDeniedHttpException('Tenant context required.');
+        }
+
+        return $tenant;
+    }
+}

--- a/apps/api/tests/Api/Export/FeedRunMonitorApiTest.php
+++ b/apps/api/tests/Api/Export/FeedRunMonitorApiTest.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Export;
+
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Catalog\Domain\ObjectKind;
+use App\Export\Feed\Domain\Entity\FeedRun;
+use App\Export\Feed\Domain\Entity\FeedRunLog;
+use App\Export\Feed\Domain\Enum\FeedRunLogLevel;
+use App\Export\Feed\Domain\Enum\FeedRunTrigger;
+use App\Export\Feed\Domain\Repository\FeedRunLogRepositoryInterface;
+use App\Export\Feed\Domain\Repository\FeedRunRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * XMLF-P4-03 — monitor read side: global run history (sort/filter/cursor),
+ * per-feed scoping, log drill-down, 24h KPI window and the health card.
+ */
+final class FeedRunMonitorApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function globalRunListSortsFiltersAndPaginates(): void
+    {
+        $admin = $this->authenticatedClient();
+        $feedA = $this->createFeed($admin, 'feed_a');
+        $feedB = $this->createFeed($admin, 'feed_b');
+
+        $success = $this->seedRun($feedA, 'done', warnings: 0);
+        $warning = $this->seedRun($feedA, 'done', warnings: 3);
+        $error = $this->seedRun($feedA, 'error', errorMessage: 'missing required <price> slot');
+        $other = $this->seedRun($feedB, 'done', warnings: 0);
+
+        $list = $admin->request('GET', '/api/feed-runs')->toArray(false);
+        $ids = self::idsOf($list['items']);
+        self::assertCount(4, $ids);
+        // Newest first (UUIDv7 keyset order == started_at order).
+        self::assertSame($other->getId()->toRfc4122(), $ids[0]);
+        self::assertSame('feed_a', self::row($list['items'], 3)['feed_code'], 'global list carries the feed identity');
+
+        $warnings = $admin->request('GET', '/api/feed-runs?status=warning')->toArray(false)['items'];
+        self::assertSame([$warning->getId()->toRfc4122()], self::idsOf($warnings));
+        self::assertSame('warning', self::row($warnings, 0)['health']);
+
+        $errors = $admin->request('GET', '/api/feed-runs?status=error')->toArray(false)['items'];
+        self::assertSame([$error->getId()->toRfc4122()], self::idsOf($errors));
+
+        // Cursor walk: 2 + 2, no overlap, terminates.
+        $first = $admin->request('GET', '/api/feed-runs?limit=2')->toArray(false);
+        $firstIds = self::idsOf($first['items']);
+        self::assertCount(2, $firstIds);
+        $cursor = $first['next_cursor'];
+        self::assertIsString($cursor);
+        $second = $admin->request('GET', '/api/feed-runs?limit=2&cursor='.$cursor)->toArray(false);
+        $secondIds = self::idsOf($second['items']);
+        self::assertCount(2, $secondIds);
+        $walked = array_merge($firstIds, $secondIds);
+        self::assertCount(4, array_unique($walked));
+        self::assertContains($success->getId()->toRfc4122(), $walked);
+    }
+
+    #[Test]
+    public function perFeedHistoryIsScopedAndCrossFeedRunIs404(): void
+    {
+        $admin = $this->authenticatedClient();
+        $feedA = $this->createFeed($admin, 'scoped_a');
+        $feedB = $this->createFeed($admin, 'scoped_b');
+
+        $runA = $this->seedRun($feedA, 'done');
+        $runB = $this->seedRun($feedB, 'done');
+
+        $items = $admin->request('GET', '/api/feeds/'.$feedA.'/runs')->toArray(false)['items'];
+        self::assertSame([$runA->getId()->toRfc4122()], self::idsOf($items));
+
+        self::assertSame(200, $admin->request('GET', '/api/feeds/'.$feedA.'/runs/'.$runA->getId()->toRfc4122())->getStatusCode());
+        // The other feed's run must not resolve through this feed's path.
+        self::assertSame(404, $admin->request('GET', '/api/feeds/'.$feedA.'/runs/'.$runB->getId()->toRfc4122())->getStatusCode());
+        self::assertSame(404, $admin->request('GET', '/api/feeds/'.Uuid::v7()->toRfc4122().'/runs')->getStatusCode());
+    }
+
+    #[Test]
+    public function logDrilldownFiltersByLevelAndPaginates(): void
+    {
+        $admin = $this->authenticatedClient();
+        $feedId = $this->createFeed($admin, 'logs_feed');
+        $run = $this->seedRun($feedId, 'done', warnings: 2);
+        $this->seedLogs($run, [
+            [FeedRunLogLevel::Warning, 'KL-1', 'g:gtin', 'missing required g:gtin — skipped'],
+            [FeedRunLogLevel::Warning, 'KL-2', 'g:image_link', 'empty g:image_link — skipped'],
+            [FeedRunLogLevel::Info, 'KL-3', 'g:title', 'g:title truncated to 150 chars'],
+        ]);
+
+        $url = '/api/feeds/'.$feedId.'/runs/'.$run->getId()->toRfc4122().'/logs';
+
+        $all = $admin->request('GET', $url)->toArray(false)['items'];
+        self::assertIsArray($all);
+        self::assertCount(3, $all);
+        self::assertSame('KL-1', self::row($all, 0)['object_sku'], 'oldest first — emission order');
+        self::assertSame('g:gtin', self::row($all, 0)['slot']);
+
+        $warningsOnly = $admin->request('GET', $url.'?level=warning')->toArray(false)['items'];
+        self::assertIsArray($warningsOnly);
+        self::assertCount(2, $warningsOnly);
+
+        $first = $admin->request('GET', $url.'?limit=2')->toArray(false);
+        $cursor = $first['next_cursor'];
+        self::assertIsString($cursor);
+        $rest = $admin->request('GET', $url.'?limit=2&cursor='.$cursor)->toArray(false);
+        self::assertIsArray($rest['items']);
+        self::assertCount(1, $rest['items']);
+        self::assertSame('KL-3', self::row($rest['items'], 0)['object_sku']);
+    }
+
+    #[Test]
+    public function kpiCountsOnlyTheLast24Hours(): void
+    {
+        $admin = $this->authenticatedClient();
+        $feedId = $this->createFeed($admin, 'kpi_feed');
+
+        $this->seedRun($feedId, 'done', skipped: 5);
+        $inWindowError = $this->seedRun($feedId, 'error', errorMessage: 'feed B2B — missing <price>');
+        $oldError = $this->seedRun($feedId, 'error', errorMessage: 'ancient failure');
+        $this->backdate($oldError, hours: 25);
+
+        $kpi = $admin->request('GET', '/api/feed-runs/kpi')->toArray(false);
+
+        self::assertSame(2, $kpi['regenerations_24h'], 'the 25h-old run is out of the window');
+        self::assertSame(5, $kpi['skipped_24h']);
+        self::assertSame(1, $kpi['errors_24h']);
+        $lastError = $kpi['last_error'];
+        self::assertIsArray($lastError);
+        self::assertSame($inWindowError->getId()->toRfc4122(), $lastError['run_id']);
+        self::assertSame('feed B2B — missing <price>', $lastError['message']);
+        self::assertSame(0, $kpi['items_syndicated'], 'no cached artifact yet');
+        self::assertIsArray($kpi['feeds']);
+        self::assertSame(1, $kpi['feeds']['active']);
+    }
+
+    #[Test]
+    public function healthExposesCoverageAndTheLastRun(): void
+    {
+        $admin = $this->authenticatedClient();
+        $feedId = $this->createFeed($admin, 'health_feed');
+        $run = $this->seedRun($feedId, 'done', warnings: 1);
+
+        $health = $admin->request('GET', '/api/feeds/'.$feedId.'/health')->toArray(false);
+
+        self::assertSame($feedId, $health['feed_id']);
+        self::assertSame(['mapped' => 1, 'total' => 1], $health['coverage'], 'the sku slot is mapped');
+        self::assertNull($health['items_syndicated'], 'never regenerated — nothing syndicated');
+        self::assertNull($health['next_run'], 'scheduler engine is a documented follow-up');
+        $lastRun = $health['last_run'];
+        self::assertIsArray($lastRun);
+        self::assertSame($run->getId()->toRfc4122(), $lastRun['id']);
+        self::assertSame('warning', $lastRun['health']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function row(mixed $items, int $index): array
+    {
+        self::assertIsArray($items);
+        $row = $items[$index] ?? null;
+        self::assertIsArray($row);
+        /** @var array<string, mixed> $typed */
+        $typed = $row;
+
+        return $typed;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function idsOf(mixed $items): array
+    {
+        self::assertIsArray($items);
+        $ids = [];
+        foreach ($items as $row) {
+            self::assertIsArray($row);
+            $id = $row['id'] ?? null;
+            self::assertIsString($id);
+            $ids[] = $id;
+        }
+
+        return $ids;
+    }
+
+    private function seedRun(
+        string $feedId,
+        string $terminal,
+        int $warnings = 0,
+        int $skipped = 0,
+        ?string $errorMessage = null,
+    ): FeedRun {
+        self::getContainer()->get(TenantContext::class)->set($this->tenant());
+        $run = new FeedRun(Uuid::fromString($feedId), FeedRunTrigger::Manual);
+        $run->markRunning();
+        if ('error' === $terminal) {
+            $run->markError($errorMessage ?? 'boom');
+        } else {
+            $run->markDone(itemCount: 10, skippedCount: $skipped, warningCount: $warnings, filePath: '/tmp/feed.xml', fileSizeBytes: 1024, durationMs: 42);
+        }
+
+        $runs = self::getContainer()->get(FeedRunRepositoryInterface::class);
+        $runs->save($run);
+
+        return $run;
+    }
+
+    /**
+     * @param list<array{0: FeedRunLogLevel, 1: string, 2: string, 3: string}> $lines
+     */
+    private function seedLogs(FeedRun $run, array $lines): void
+    {
+        self::getContainer()->get(TenantContext::class)->set($this->tenant());
+        $logs = [];
+        foreach ($lines as [$level, $sku, $slot, $message]) {
+            $logs[] = new FeedRunLog($run->getId(), $level, $message, $sku, $slot);
+        }
+        self::getContainer()->get(FeedRunLogRepositoryInterface::class)->saveMany($logs);
+    }
+
+    private function backdate(FeedRun $run, int $hours): void
+    {
+        $connection = self::getContainer()->get(Connection::class);
+        $connection->executeStatement(
+            'UPDATE feed_runs SET started_at = started_at - make_interval(hours => :h) WHERE id = :id',
+            ['h' => $hours, 'id' => $run->getId()->toRfc4122()],
+        );
+    }
+
+    private function tenant(): Tenant
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        return $tenant;
+    }
+
+    private function createFeed(Client $client, string $code): string
+    {
+        $created = $client->request('POST', '/api/feeds', ['json' => [
+            'template_kind' => 'custom',
+            'code' => $code,
+            'name' => 'Monitor feed '.$code,
+            'object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+            'descriptor' => [
+                'root' => ['element' => 'products'],
+                'item' => [
+                    'element' => 'product',
+                    'slots' => [['slot' => 'sku', 'node' => 'element', 'required' => true, 'fmt' => 'text']],
+                ],
+            ],
+            'field_mappings' => [['slot' => 'sku', 'source' => ['kind' => 'attribute', 'ref' => 'sku']]],
+            'locale' => 'pl',
+        ]]);
+        self::assertSame(201, $created->getStatusCode());
+
+        $id = $created->toArray(false)['id'];
+        self::assertIsString($id);
+
+        return $id;
+    }
+}

--- a/apps/api/tests/Unit/Export/Feed/FeedGeneratorTest.php
+++ b/apps/api/tests/Unit/Export/Feed/FeedGeneratorTest.php
@@ -19,6 +19,7 @@ use App\Export\Feed\Domain\Mapping\FeedItemMapper;
 use App\Export\Feed\Domain\Mapping\FeedTransformApplier;
 use App\Export\Feed\Domain\Repository\FeedRunLogRepositoryInterface;
 use App\Export\Feed\Domain\Repository\FeedRunRepositoryInterface;
+use DateTimeImmutable;
 use DOMDocument;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -83,6 +84,16 @@ final class FeedGeneratorTest extends TestCase
             {
                 return [];
             }
+
+            public function findPage(?Uuid $feedProfileId, ?string $health, ?Uuid $cursor, int $limit): array
+            {
+                return [];
+            }
+
+            public function kpi24h(\App\Shared\Domain\Tenant $tenant, DateTimeImmutable $now): array
+            {
+                return ['regenerations_24h' => 0, 'skipped_24h' => 0, 'errors_24h' => 0, 'last_error' => null];
+            }
         };
 
         $logRepo = new class implements FeedRunLogRepositoryInterface {
@@ -99,6 +110,11 @@ final class FeedGeneratorTest extends TestCase
             }
 
             public function findByRun(Uuid $feedRunId): array
+            {
+                return [];
+            }
+
+            public function findPageByRun(Uuid $feedRunId, ?string $level, ?Uuid $cursor, int $limit): array
             {
                 return [];
             }
@@ -161,6 +177,16 @@ final class FeedGeneratorTest extends TestCase
             {
                 return [];
             }
+
+            public function findPage(?Uuid $feedProfileId, ?string $health, ?Uuid $cursor, int $limit): array
+            {
+                return [];
+            }
+
+            public function kpi24h(\App\Shared\Domain\Tenant $tenant, DateTimeImmutable $now): array
+            {
+                return ['regenerations_24h' => 0, 'skipped_24h' => 0, 'errors_24h' => 0, 'last_error' => null];
+            }
         };
 
         $logRepo = new class implements FeedRunLogRepositoryInterface {
@@ -173,6 +199,11 @@ final class FeedGeneratorTest extends TestCase
             }
 
             public function findByRun(Uuid $feedRunId): array
+            {
+                return [];
+            }
+
+            public function findPageByRun(Uuid $feedRunId, ?string $level, ?Uuid $cursor, int $limit): array
             {
                 return [];
             }

--- a/apps/api/tests/Unit/Export/Feed/FeedRegeneratorTest.php
+++ b/apps/api/tests/Unit/Export/Feed/FeedRegeneratorTest.php
@@ -23,6 +23,7 @@ use App\Export\Feed\Domain\Repository\FeedRunLogRepositoryInterface;
 use App\Export\Feed\Domain\Repository\FeedRunRepositoryInterface;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
 use DOMDocument;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -75,6 +76,16 @@ final class FeedRegeneratorTest extends TestCase
             {
                 return [];
             }
+
+            public function findPage(?Uuid $feedProfileId, ?string $health, ?Uuid $cursor, int $limit): array
+            {
+                return [];
+            }
+
+            public function kpi24h(Tenant $tenant, DateTimeImmutable $now): array
+            {
+                return ['regenerations_24h' => 0, 'skipped_24h' => 0, 'errors_24h' => 0, 'last_error' => null];
+            }
         };
         $logRepo = new class implements FeedRunLogRepositoryInterface {
             public function save(FeedRunLog $log): void
@@ -86,6 +97,11 @@ final class FeedRegeneratorTest extends TestCase
             }
 
             public function findByRun(Uuid $feedRunId): array
+            {
+                return [];
+            }
+
+            public function findPageByRun(Uuid $feedRunId, ?string $level, ?Uuid $cursor, int $limit): array
             {
                 return [];
             }

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -12997,6 +12997,58 @@
                 "x-cortex-permission": "exports.view_all"
             }
         },
+        "/api/feed-runs": {
+            "get": {
+                "operationId": "api_feed_runs_get",
+                "tags": [
+                    "feed-runs"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api feed runs",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "exports.view_all"
+            }
+        },
+        "/api/feed-runs/kpi": {
+            "get": {
+                "operationId": "api_feed_runs_kpi_get",
+                "tags": [
+                    "feed-runs"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api feed runs kpi",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "exports.view_all"
+            }
+        },
         "/api/feeds": {
             "get": {
                 "operationId": "api_feeds_get",
@@ -13261,6 +13313,45 @@
                 ],
                 "x-pim-source": "custom-route",
                 "x-cortex-permission": "integration.admin"
+            }
+        },
+        "/api/feeds/{id}/health": {
+            "get": {
+                "operationId": "api_feeds_id_health_get",
+                "tags": [
+                    "feeds"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api feeds id health",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "exports.view_all"
             }
         },
         "/api/feeds/{id}/mapping": {
@@ -13534,6 +13625,96 @@
                 "x-cortex-permission": "integration.admin"
             }
         },
+        "/api/feeds/{id}/runs": {
+            "get": {
+                "operationId": "api_feeds_id_runs_get",
+                "tags": [
+                    "feeds"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api feeds id runs",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "exports.view_all"
+            }
+        },
+        "/api/feeds/{id}/runs/{runId}": {
+            "get": {
+                "operationId": "api_feeds_id_runs_runid_get",
+                "tags": [
+                    "feeds"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api feeds id runs runId",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    },
+                    {
+                        "name": "runId",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "exports.view_all"
+            }
+        },
         "/api/feeds/{id}/runs/{runId}/cancel": {
             "post": {
                 "operationId": "api_feeds_id_runs_runid_cancel_post",
@@ -13583,6 +13764,57 @@
                 ],
                 "x-pim-source": "custom-route",
                 "x-cortex-permission": "integration.admin"
+            }
+        },
+        "/api/feeds/{id}/runs/{runId}/logs": {
+            "get": {
+                "operationId": "api_feeds_id_runs_runid_logs_get",
+                "tags": [
+                    "feeds"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api feeds id runs runId logs",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    },
+                    {
+                        "name": "runId",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "exports.view_all"
             }
         },
         "/api/feeds/{id}/token": {


### PR DESCRIPTION
## Cel (XMLF-P4-03, #1927)
Operator musi widzieć czy feedy są zdrowe: bez tego nie wie, że 146 produktów wypadło z feedu Google przez brak GTIN. Ten PR dostarcza całą warstwę odczytu pod ekrany FeedMonitor / FeedDetail / FeedRunDrilldown (M5): historię runów, drill-down do logu per-produkt/slot i kafelki KPI.

## Endpointy (wszystkie read-only, tenant-scoped, RFC 7807 na 404)
- `GET /api/feed-runs` — globalna historia runów (sort newest-first, filtr `status=success|warning|error`, keyset cursor).
- `GET /api/feed-runs/kpi` — kafelki: `regenerations_24h`, `skipped_24h`, `errors_24h` + `last_error{run_id,feed_id,message}` (DBAL agregat z markerami tenant-safe) oraz snapshot syndykacji: `items_syndicated` (suma cached_item_count — stan bieżący, nie flow), `last_regenerated_at`, `feeds{active,paused,error}`.
- `GET /api/feeds/{id}/runs` — historia per feed (ten sam kształt + cursor).
- `GET /api/feeds/{id}/runs/{runId}` — kafelki drill-downu (items/skipped/warnings/rozmiar/czas/error).
- `GET /api/feeds/{id}/runs/{runId}/logs` — linie FeedRunLog (`object_sku/slot/message/level`), filtr `level`, cursor.
- `GET /api/feeds/{id}/health` — syndykacja + coverage mapowań + last_run; `next_run=null` dopóki silnik crona (leftover P4-01, idzie z ticketem worker-daemona) nie wyląduje — udokumentowane w kodzie.

## Decyzje
- **Cursor = UUIDv7 id** (id-order == started_at-order): keyset stabilny przy równoległych insertach, bez OFFSET; zepsuty cursor → pierwsza strona, nigdy 500. Cursor logów rośnie (id ASC = kolejność emisji) — strona jest stabilna nawet gdy run w toku dopisuje linie.
- **`health` = status wyświetlany**: `done` dzielone na success/warning po warning_count (chips z designu); surowy `status` też w payloadzie.
- **Coverage przez FeedDescriptor VO** — autorytatywny parser łapie też zagnieżdżone kształty marketplace (Google RSS `channel.item.slots`); pierwsza wersja ręcznie czytała `descriptor.item.slots` i pokazywała 0/13 na feedzie Google (wyłapane w live smoke).
- Nazwy feedów w globalnej liście: jeden odczyt `findByTenant` na stronę (dziesiątki feedów, nie tysiące).

## Live smoke (pim.localhost, dane z runów P4-02) ✅
```
GET /api/feed-runs?limit=3 → 200: [warning done 67 items | cancelled | warning done 67] + next_cursor
GET /api/feed-runs/kpi     → {"regenerations_24h":6,"skipped_24h":112,"errors_24h":0,
                              "items_syndicated":67,"feeds":{"active":1,...}}
GET /api/feeds/{id}/runs/{runId} → health:warning, items 67, skipped 28, 35291 B, 96 ms
GET .../logs?level=warning&limit=3 → linie: g:image_link / g:price / g:gtin|g:mpn (+cursor)
GET /api/feeds/{id}/health → coverage {mapped:12,total:13}, last_pulled_at, last_run.health
GET cross-run z obcym runId → 404
```

## Testy
- **Api (CI):** FeedRunMonitorApiTest 5 — sort+filtry+cursor-walk bez nakładek; per-feed scoping + cross-feed 404; logs level-filter + paginacja; KPI liczy tylko okno 24h (run backdatowany o 25h wycięty); health coverage + last_run.
- Fake'i interfejsów repo uzupełnione o nowe metody (FeedGeneratorTest / FeedRegeneratorTest — znany gotcha).

## Bramki
PHPStan max 0 · Deptrac 0 · CS-Fixer clean · lint:container OK · PHPUnit unit+architecture 1397 · raw-SQL markery (agregaty KPI) · OpenAPI v0.json +6 tras (drift green)

Refs #1927