### PR TITLE
feat(admin): Feeds tab in Konfigurator shell + feeds hub

### DIFF
--- a/agent/lessons.md
+++ b/agent/lessons.md
@@ -2728,3 +2728,14 @@ M4 (P4-01..08) + M5 Hardening (P5-01..05) — wszystkie zmergowane. Epik APIC ko
 4. **fmt=category = trigger resolucji, mapping = override**: wartość z explicit mappingu (np. `category_path`) wygrywa nad external_code; required-empty idzie przez FeedRequiredValidator (skip+warning), optional-empty → unset slot + własna linia FeedRunLog.
 5. **`setScope()` był martwy w API** — create/PATCH nie przyjmowały `channel_id`/`publication_channel`; bez tego cała resolucja kategorii jest nieosiągalna dla klienta. Domknięte w P3-03 (create + PATCH scope-block + serializacja `channel_id`).
 6. **Built-in kolumny w feedach za darmo**: mapping `{kind:attribute, ref:'parent_sku'}` przepływa przez ColumnResolver.BUILT_INS bez zmian w mapperze — g:item_group_id to czysty default-mapping w szablonie. Uwaga: atrybut `sku` (lokalizowany) wygrywa nad built-in `sku` w toAttributeMap (preferencja locale) — SKU w feedzie to wartość atrybutu, nie code obiektu, jeśli tenant ma taki atrybut.
+
+## Lessons z XMLF P5-01 (2026-07-02 — hub feedów, FE)
+
+1. **pl-PL grouping zaczyna się od 5 cyfr** (CLDR `minimumGroupingDigits=2`): `(1284).toLocaleString('pl-PL')` = `"1284"` (bez separatora!), `12408` → `"12 408"` z NBSP. Asercje e2e na liczby: `/1\s?284/` (opcjonalny `\s` — łapie oba przypadki; `\s` w JS matchuje U+00A0).
+2. **Playwright renderuje admin po ANGIELSKU** (language detector bierze locale przeglądarki en-US, mimo `fallbackLng: 'pl'`) — lokatory tekstowe w e2e MUSZĄ być dwujęzyczne: `/Feedy|Feeds/`, `/wstrzymane|^paused$/i` (konwencja repo, np. `/silnik|engine/i` w 1096).
+3. **axe w Playwright LICZY kontrast** (jsdom nie — stary gotcha): `text-zinc-400` na białym = fail AA (serious) przy KAŻDYM tekście, nie tylko labelkach. Nowe featury od razu `text-zinc-500`; `text-zinc-400` zostaje tylko na ikonach `aria-hidden`.
+4. **`/api/feeds` (custom route, kształt `{items:[]}`)** nie przejdzie przez Refine dataProvider (getList czyta hydra `member`) — wzorzec: `useQuery` + `jsonFetch` (jak catalog channel-placements). KPI huba = merge dwóch read-modeli: `/api/feed-runs/kpi` (statusy+syndykacja) + `/api/feeds/pull-stats` (pulls24h+spark) — spec-owe `/api/feeds/stats` nigdy nie istniało.
+5. **URL feedu na karcie:** plaintext tokenu nie da się odtworzyć (HMAC w DB) — karta pokazuje maskowany hint + pełny URL tylko w sesji po rotate (response mint). `has_token` dodane do serializacji listy (rozróżnia copy „rotuj by wygenerować" vs „token ukryty").
+6. **Konsola admina zawsze ma 2×401 na twardym wejściu** (in-memory JWT + refresh-cookie bootstrap) — asercja `consoleErrors === []` w e2e jest zbyt ostra; filtrować 401-e z /api/auth.
+
+**Errata numeracji (2026-07-02):** P3-03 = **#1921**, nie #1922 (to P3-04) — instrukcja operatora miała zły numer; commit P3-03 w PR #2017 nosi błędny `Refs #1922`. Reguła bez wyjątku: `gh issue list --search "XMLF-PX-NN in:title"` przed KAŻDYM `Refs`/`Closes`/`gh issue close`, także gdy numer podał operator.

--- a/apps/admin/e2e/1930-feeds-hub.spec.ts
+++ b/apps/admin/e2e/1930-feeds-hub.spec.ts
@@ -1,0 +1,121 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * XMLF-P5-01 (#1930) — the feeds hub under the Konfigurator shell: fourth
+ * pill tab, KPI strip fed by /api/feed-runs/kpi + /api/feeds/pull-stats,
+ * feed cards with coverage, search + status filter, the NewFeedCard CTA and
+ * the ad-hoc XML note. All feed endpoints are mocked — deterministic and
+ * offline.
+ */
+
+const FEEDS = [
+  {
+    id: '019f0000-0000-7000-8000-000000000001',
+    code: 'google_pl',
+    name: 'Google Shopping — Polska',
+    template_kind: 'google_shopping',
+    status: 'active',
+    locale: 'pl',
+    currency: 'PLN',
+    channel_id: null,
+    publication_channel: 'google',
+    schedule_cron: '0 3 * * *',
+    descriptor: { item: { slots: [{ slot: 'g:id' }, { slot: 'g:title' }] } },
+    field_mappings: [{ slot: 'g:id' }],
+    cached_item_count: 12408,
+    cached_at: '2026-07-01T04:00:00+00:00',
+    last_pulled_at: '2026-07-01T21:00:00+00:00',
+    has_token: true,
+  },
+  {
+    id: '019f0000-0000-7000-8000-000000000002',
+    code: 'ceneo_elektro',
+    name: 'Ceneo — Elektronika',
+    template_kind: 'ceneo',
+    status: 'paused',
+    locale: 'pl',
+    currency: 'PLN',
+    channel_id: null,
+    publication_channel: null,
+    schedule_cron: null,
+    descriptor: { item: { slots: [{ slot: 'cat' }] } },
+    field_mappings: [],
+    cached_item_count: null,
+    cached_at: null,
+    last_pulled_at: null,
+    has_token: false,
+  },
+];
+
+test('XMLF-P5-01 — feeds hub: tab, KPI, cards, filtering, a11y', async ({ page }) => {
+  await loginAsAdmin(page);
+
+  await page.route('**/api/feeds', (route) => route.fulfill({ json: { items: FEEDS } }));
+  await page.route('**/api/feed-runs/kpi', (route) =>
+    route.fulfill({
+      json: {
+        regenerations_24h: 6,
+        skipped_24h: 112,
+        errors_24h: 0,
+        last_error: null,
+        items_syndicated: 12408,
+        last_regenerated_at: '2026-07-01T04:00:00+00:00',
+        feeds: { active: 1, paused: 1, error: 0 },
+      },
+    }),
+  );
+  await page.route('**/api/feeds/pull-stats', (route) =>
+    route.fulfill({
+      json: {
+        pulls_24h: 1284,
+        spark: [{ bucket: '2026-07-01T20:00:00+00:00', count: 640 }],
+      },
+    }),
+  );
+
+  await page.goto('/integrations/api-configurator/feeds');
+
+  // Shell: the fourth tab exists and is active for the /feeds prefix.
+  const feedsTab = page.getByRole('tab', { name: /Feedy|Feeds/ });
+  await expect(feedsTab).toBeVisible();
+  await expect(feedsTab).toHaveAttribute('aria-selected', 'true');
+
+  // KPI strip renders the merged aggregates. pl-PL grouping starts at five
+  // digits (CLDR minimumGroupingDigits=2), so 1284 renders bare and 12408 gets
+  // an NBSP separator; an optional whitespace matches both.
+  await expect(page.getByText(/1\s?284/)).toBeVisible();
+  await expect(page.getByText(/12\s?408/).first()).toBeVisible();
+
+  // Cards render with template badge + coverage.
+  await expect(page.getByText('Google Shopping — Polska')).toBeVisible();
+  await expect(page.getByText('Ceneo — Elektronika')).toBeVisible();
+  await expect(page.getByText('1/2')).toBeVisible();
+
+  // Status filter narrows the grid.
+  await page.getByRole('button', { name: /wstrzymane|^paused$/i }).click();
+  await expect(page.getByText('Ceneo — Elektronika')).toBeVisible();
+  await expect(page.getByText('Google Shopping — Polska')).not.toBeVisible();
+  await page.getByRole('button', { name: /wszystkie|^all$/i }).click();
+
+  // Search combines with the filter.
+  await page.getByRole('textbox', { name: /Szukaj feedów|Search feeds/ }).fill('google');
+  await expect(page.getByText('Google Shopping — Polska')).toBeVisible();
+  await expect(page.getByText('Ceneo — Elektronika')).not.toBeVisible();
+  await page.getByRole('textbox', { name: /Szukaj feedów|Search feeds/ }).fill('');
+
+  // NewFeedCard CTA routes to the wizard placeholder.
+  await page.getByRole('button', { name: /Nowy feed|New feed/ }).click();
+  await expect(page).toHaveURL(/\/integrations\/api-configurator\/feeds\/new$/);
+  await page.getByRole('link', { name: /Wróć do feedów|Back to feeds/ }).click();
+  await expect(page).toHaveURL(/\/integrations\/api-configurator\/feeds$/);
+
+  // a11y — no serious/critical violations on the hub.
+  const axe = await new AxeBuilder({ page }).analyze();
+  const blocking = axe.violations.filter(
+    (violation) => violation.impact === 'serious' || violation.impact === 'critical',
+  );
+  expect(blocking).toEqual([]);
+});

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -83,6 +83,18 @@ const SyncMonitorScreen = lazyPage(
   () => import('@/features/api-configurator/monitor/SyncMonitorScreen'),
   'SyncMonitorScreen',
 );
+const FeedsHubPage = lazyPage(
+  () => import('@/features/api-configurator/feeds/hub/FeedsHubPage'),
+  'FeedsHubPage',
+);
+const FeedWizardPage = lazyPage(
+  () => import('@/features/api-configurator/feeds/wizard/FeedWizardPage'),
+  'FeedWizardPage',
+);
+const FeedDetailPage = lazyPage(
+  () => import('@/features/api-configurator/feeds/detail/FeedDetailPage'),
+  'FeedDetailPage',
+);
 const AssetsListPage = lazyPage(() => import('@/features/asset/assets/list'), 'AssetsListPage');
 const AssetShowPage = lazyPage(() => import('@/features/asset/assets/show'), 'AssetShowPage');
 const AttributeGroupCreatePage = lazyPage(
@@ -675,6 +687,18 @@ function App() {
                     <Route
                       path="/integrations/api-configurator/monitor"
                       element={<SyncMonitorScreen />}
+                    />
+                    {/* XMLF-P5-01 — product XML feeds (hub / wizard / detail)
+                        under the same shell; wizard + detail are placeholder
+                        targets until P5-02..P5-05 replace them. */}
+                    <Route path="/integrations/api-configurator/feeds" element={<FeedsHubPage />} />
+                    <Route
+                      path="/integrations/api-configurator/feeds/new"
+                      element={<FeedWizardPage />}
+                    />
+                    <Route
+                      path="/integrations/api-configurator/feeds/:id"
+                      element={<FeedDetailPage />}
                     />
                     <Route
                       path="/integrations/api-configurator/:id/edit"

--- a/apps/admin/src/features/api-configurator/feeds/__tests__/feeds.test.ts
+++ b/apps/admin/src/features/api-configurator/feeds/__tests__/feeds.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeCoverage, type FeedRow, filterFeeds } from '../api/feeds';
+
+/**
+ * XMLF-P5-01 — pure hub logic: mapping coverage (both descriptor shapes) and
+ * the toolbar's combined search + status filtering.
+ */
+
+function feed(overrides: Partial<FeedRow>): FeedRow {
+  return {
+    id: 'f1',
+    code: 'google_pl',
+    name: 'Google Shopping — Polska',
+    template_kind: 'google_shopping',
+    status: 'active',
+    locale: 'pl',
+    currency: 'PLN',
+    channel_id: null,
+    publication_channel: null,
+    schedule_cron: null,
+    descriptor: {},
+    field_mappings: [],
+    cached_item_count: null,
+    cached_at: null,
+    last_pulled_at: null,
+    has_token: false,
+    ...overrides,
+  };
+}
+
+describe('computeCoverage', () => {
+  it('counts flat custom descriptors', () => {
+    const coverage = computeCoverage(
+      {
+        item: {
+          slots: [{ slot: 'sku' }, { slot: 'name' }, { slot: 'price' }],
+        },
+      },
+      [{ slot: 'sku' }, { slot: 'price' }, { slot: 'price' }],
+    );
+    expect(coverage).toEqual({ mapped: 2, total: 3 });
+  });
+
+  it('counts channel-nested marketplace descriptors (Google RSS)', () => {
+    const coverage = computeCoverage(
+      {
+        channel: {
+          item: { slots: [{ slot: 'g:id' }, { slot: 'g:title' }] },
+        },
+      },
+      [{ slot: 'g:id' }],
+    );
+    expect(coverage).toEqual({ mapped: 1, total: 2 });
+  });
+
+  it('ignores mappings pointing at unknown slots', () => {
+    const coverage = computeCoverage({ item: { slots: [{ slot: 'sku' }] } }, [{ slot: 'ghost' }]);
+    expect(coverage).toEqual({ mapped: 0, total: 1 });
+  });
+});
+
+describe('filterFeeds', () => {
+  const feeds = [
+    feed({ id: '1', code: 'google_pl', name: 'Google Shopping — Polska', status: 'active' }),
+    feed({ id: '2', code: 'ceneo_elektro', name: 'Ceneo — Elektronika', status: 'paused' }),
+    feed({ id: '3', code: 'b2b_stalko', name: 'Feed B2B — Stalko', status: 'error' }),
+  ];
+
+  it('searches name and code case-insensitively', () => {
+    expect(filterFeeds(feeds, 'CENEO', 'all').map((f) => f.id)).toEqual(['2']);
+    expect(filterFeeds(feeds, 'stalko', 'all').map((f) => f.id)).toEqual(['3']);
+  });
+
+  it('narrows by status and combines with search', () => {
+    expect(filterFeeds(feeds, '', 'paused').map((f) => f.id)).toEqual(['2']);
+    expect(filterFeeds(feeds, 'google', 'error')).toEqual([]);
+  });
+});

--- a/apps/admin/src/features/api-configurator/feeds/api/feeds.ts
+++ b/apps/admin/src/features/api-configurator/feeds/api/feeds.ts
@@ -1,0 +1,190 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { jsonFetch } from '@/lib/http';
+
+/**
+ * XMLF-P5-01 — data layer for the feeds hub. `/api/feeds` is a custom
+ * `#[Route]` surface (not an API Platform resource), so the Refine
+ * dataProvider's hydra parsing does not apply — plain jsonFetch + react-query,
+ * the established pattern for custom endpoints.
+ */
+
+export type FeedStatus = 'active' | 'paused' | 'error';
+export type FeedTemplateKind = 'google_shopping' | 'ceneo' | 'meta' | 'custom';
+
+export interface FeedRow {
+  id: string;
+  code: string;
+  name: string;
+  template_kind: FeedTemplateKind;
+  status: FeedStatus;
+  locale: string | null;
+  currency: string | null;
+  channel_id: string | null;
+  publication_channel: string | null;
+  schedule_cron: string | null;
+  descriptor: Record<string, unknown>;
+  field_mappings: Array<Record<string, unknown>>;
+  cached_item_count: number | null;
+  cached_at: string | null;
+  last_pulled_at: string | null;
+  has_token: boolean;
+}
+
+export interface FeedKpi {
+  active: number;
+  paused: number;
+  error: number;
+  itemsSyndicated: number;
+  pulls24h: number;
+  spark: Array<{ bucket: string; count: number }>;
+}
+
+interface FeedsResponse {
+  items: FeedRow[];
+}
+
+interface RunsKpiResponse {
+  items_syndicated: number;
+  feeds: { active: number; paused: number; error: number };
+}
+
+interface PullStatsResponse {
+  pulls_24h: number;
+  spark: Array<{ bucket: string; count: number }>;
+}
+
+export const FEEDS_QUERY_KEY = ['xmlf', 'feeds'] as const;
+
+export function useFeeds() {
+  return useQuery({
+    queryKey: FEEDS_QUERY_KEY,
+    queryFn: async () => (await jsonFetch<FeedsResponse>('/api/feeds')).items,
+  });
+}
+
+/**
+ * The design's FEED_KPI merges two read models: feed status counts + current
+ * syndication snapshot (`/api/feed-runs/kpi`, XMLF-P4-03) and the pull counter
+ * + sparkline (`/api/feeds/pull-stats`, XMLF-P3-06). The `/api/feeds/stats`
+ * endpoint sketched in the backlog never existed — these two cover it.
+ */
+export function useFeedKpi() {
+  return useQuery({
+    queryKey: ['xmlf', 'feed-kpi'],
+    queryFn: async (): Promise<FeedKpi> => {
+      const [kpi, pulls] = await Promise.all([
+        jsonFetch<RunsKpiResponse>('/api/feed-runs/kpi'),
+        jsonFetch<PullStatsResponse>('/api/feeds/pull-stats'),
+      ]);
+      return {
+        active: kpi.feeds.active,
+        paused: kpi.feeds.paused,
+        error: kpi.feeds.error,
+        itemsSyndicated: kpi.items_syndicated,
+        pulls24h: pulls.pulls_24h,
+        spark: pulls.spark,
+      };
+    },
+  });
+}
+
+function useFeedAction(path: (id: string) => string, method: 'POST' | 'DELETE' = 'POST') {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => jsonFetch<Record<string, unknown>>(path(id), { method }),
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: FEEDS_QUERY_KEY });
+      void queryClient.invalidateQueries({ queryKey: ['xmlf', 'feed-kpi'] });
+    },
+  });
+}
+
+export function useRegenerateFeed() {
+  return useFeedAction((id) => `/api/feeds/${id}/regenerate`);
+}
+
+export function usePauseFeed() {
+  return useFeedAction((id) => `/api/feeds/${id}/pause`);
+}
+
+export function useResumeFeed() {
+  return useFeedAction((id) => `/api/feeds/${id}/resume`);
+}
+
+export interface MintedToken {
+  token: string;
+  url: string;
+}
+
+/** Mint/rotate the URL token — the plaintext URL is shown once (P3-04/P3-05). */
+export function useRotateToken() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) =>
+      jsonFetch<MintedToken>(`/api/feeds/${id}/token`, { method: 'POST' }),
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: FEEDS_QUERY_KEY });
+    },
+  });
+}
+
+/**
+ * Mapping coverage for the card's CoverageBar — client-side mirror of the
+ * health endpoint's math: slots come from the descriptor (flat custom shape
+ * `item.slots` or the marketplace RSS shape `channel.item.slots`), mapped =
+ * slots with a mapping entry.
+ */
+export function computeCoverage(
+  descriptor: Record<string, unknown>,
+  mappings: Array<Record<string, unknown>>,
+): { mapped: number; total: number } {
+  const item = pickRecord(descriptor.item) ?? pickRecord(pickRecord(descriptor.channel)?.item);
+  const slots = Array.isArray(item?.slots) ? item.slots : [];
+  const targets = new Set<string>();
+  for (const slot of slots) {
+    const record = pickRecord(slot);
+    const target = record?.slot ?? record?.target;
+    if (typeof target === 'string' && target !== '') {
+      targets.add(target);
+    }
+  }
+  let mapped = 0;
+  const seen = new Set<string>();
+  for (const mapping of mappings) {
+    const slot = mapping.slot;
+    if (typeof slot === 'string' && targets.has(slot) && !seen.has(slot)) {
+      seen.add(slot);
+      mapped += 1;
+    }
+  }
+  return { mapped, total: targets.size };
+}
+
+function pickRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/** Search (name|code) + status filter — the hub toolbar semantics. */
+export function filterFeeds(
+  feeds: FeedRow[],
+  search: string,
+  status: 'all' | FeedStatus,
+): FeedRow[] {
+  const needle = search.trim().toLowerCase();
+  return feeds.filter((feed) => {
+    if (status !== 'all' && feed.status !== status) {
+      return false;
+    }
+    if (
+      needle !== '' &&
+      !feed.name.toLowerCase().includes(needle) &&
+      !feed.code.toLowerCase().includes(needle)
+    ) {
+      return false;
+    }
+    return true;
+  });
+}

--- a/apps/admin/src/features/api-configurator/feeds/components/primitives.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/components/primitives.tsx
@@ -1,0 +1,96 @@
+import { Check, Copy } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { cn } from '@/lib/utils';
+
+import type { FeedTemplateKind } from '../api/feeds';
+
+/**
+ * XMLF-P5-01 — feed-area primitives ported from the design's
+ * feed-primitives.jsx (TemplateBadge / CoverageBar / CopyButton) onto the
+ * project's shadcn/Tailwind conventions.
+ */
+
+const TEMPLATE_TONES: Record<FeedTemplateKind, string> = {
+  google_shopping: 'border-sky-300 text-sky-700',
+  ceneo: 'border-emerald-300 text-emerald-700',
+  meta: 'border-violet-300 text-violet-700',
+  custom: 'border-zinc-300 text-zinc-600',
+};
+
+export function TemplateBadge({ kind }: { kind: FeedTemplateKind }) {
+  const { t } = useTranslation();
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-md border border-dashed px-1.5 py-0.5 font-mono text-[10.5px]',
+        TEMPLATE_TONES[kind] ?? TEMPLATE_TONES.custom,
+      )}
+    >
+      {t(`api_configurator.feeds.template.${kind}`)}
+    </span>
+  );
+}
+
+export function CoverageBar({
+  mapped,
+  total,
+  width = 96,
+}: {
+  mapped: number;
+  total: number;
+  width?: number;
+}) {
+  const { t } = useTranslation();
+  const pct = total > 0 ? Math.round((mapped / total) * 100) : 0;
+  const tone = pct >= 90 ? 'bg-emerald-500' : pct >= 60 ? 'bg-amber-500' : 'bg-rose-500';
+  return (
+    <div className="flex items-center gap-2">
+      <div
+        role="progressbar"
+        aria-valuenow={mapped}
+        aria-valuemin={0}
+        aria-valuemax={total}
+        aria-label={t('api_configurator.feeds.card.coverage_aria', { mapped, total })}
+        className="h-1.5 overflow-hidden rounded-full bg-zinc-100"
+        style={{ width }}
+      >
+        <div className={cn('h-full rounded-full', tone)} style={{ width: `${pct}%` }} />
+      </div>
+      <span className="num text-[11.5px] text-zinc-600">
+        {mapped}/{total}
+      </span>
+    </div>
+  );
+}
+
+export function CopyButton({ value, disabled }: { value: string; disabled?: boolean }) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+
+  async function copy(): Promise<void> {
+    await navigator.clipboard.writeText(value);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+  }
+
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={() => void copy()}
+      aria-label={t('api_configurator.feeds.card.copy_url')}
+      className={cn(
+        'grid h-7 w-7 place-items-center rounded-lg border border-zinc-200 bg-white text-zinc-500 transition',
+        disabled ? 'cursor-not-allowed opacity-40' : 'hover:text-zinc-700',
+      )}
+    >
+      {copied ? (
+        <Check className="h-3.5 w-3.5 text-emerald-600" />
+      ) : (
+        <Copy className="h-3.5 w-3.5" />
+      )}
+    </button>
+  );
+}

--- a/apps/admin/src/features/api-configurator/feeds/detail/FeedDetailPage.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/detail/FeedDetailPage.tsx
@@ -1,0 +1,29 @@
+import { useTranslation } from 'react-i18next';
+import { Link, useParams } from 'react-router';
+
+/**
+ * XMLF-P5-01 — route placeholder for the feed detail / monitor screen
+ * (XMLF-P5-05). Cards deep-link here today; the pipeline view, run history
+ * and drill-down land in their own ticket.
+ */
+export function FeedDetailPage() {
+  const { t } = useTranslation();
+  const { id } = useParams();
+  return (
+    <div className="rounded-3xl bg-white p-10 text-center soft-shadow">
+      <h1 className="font-display text-[18px] font-semibold tracking-tight">
+        {t('api_configurator.feeds.detail.placeholder_title')}
+      </h1>
+      <p className="mt-2 font-mono text-[12px] text-zinc-500">{id}</p>
+      <p className="mt-2 text-[13px] text-zinc-500">
+        {t('api_configurator.feeds.detail.placeholder_hint')}
+      </p>
+      <Link
+        to="/integrations/api-configurator/feeds"
+        className="mt-6 inline-flex h-9 items-center rounded-lg bg-zinc-900 px-4 text-[13px] font-medium text-white hover:bg-zinc-800"
+      >
+        {t('api_configurator.feeds.wizard.back_to_hub')}
+      </Link>
+    </div>
+  );
+}

--- a/apps/admin/src/features/api-configurator/feeds/hub/FeedCard.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/hub/FeedCard.tsx
@@ -1,0 +1,244 @@
+import { Link2, Pause, Play, RefreshCw, Rss } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
+import { useToast } from '@/components/ui/toast';
+import { ConnStatusPill } from '@/features/api-configurator/components/primitives';
+import { httpErrorDetail } from '@/lib/http';
+import { cn } from '@/lib/utils';
+
+import {
+  computeCoverage,
+  type FeedRow,
+  usePauseFeed,
+  useRegenerateFeed,
+  useResumeFeed,
+  useRotateToken,
+} from '../api/feeds';
+import { CopyButton, CoverageBar, TemplateBadge } from '../components/primitives';
+
+const TEMPLATE_ICON_TONES: Record<string, string> = {
+  google_shopping: 'bg-sky-50 text-sky-600',
+  ceneo: 'bg-emerald-50 text-emerald-600',
+  meta: 'bg-violet-50 text-violet-600',
+  custom: 'bg-zinc-100 text-zinc-600',
+};
+
+/**
+ * XMLF-P5-01 — one configured feed (design feed-hub.jsx FeedCard): identity +
+ * template badge, the public URL row (the plaintext token URL exists only
+ * right after a mint/rotate — the backend stores a hash, so before rotation
+ * the row shows a masked hint), metric grid and the action footer.
+ */
+export function FeedCard({ feed }: { feed: FeedRow }) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const toast = useToast();
+  const regenerate = useRegenerateFeed();
+  const pause = usePauseFeed();
+  const resume = useResumeFeed();
+  const rotate = useRotateToken();
+  const [mintedUrl, setMintedUrl] = useState<string | null>(null);
+
+  const coverage = useMemo(
+    () => computeCoverage(feed.descriptor, feed.field_mappings),
+    [feed.descriptor, feed.field_mappings],
+  );
+
+  const url = mintedUrl !== null ? absoluteUrl(mintedUrl) : null;
+  const iconTone =
+    feed.status === 'error'
+      ? 'bg-rose-50 text-rose-600'
+      : feed.status === 'paused'
+        ? 'bg-zinc-100 text-zinc-500'
+        : (TEMPLATE_ICON_TONES[feed.template_kind] ?? TEMPLATE_ICON_TONES.custom);
+
+  function onRotate(): void {
+    rotate.mutate(feed.id, {
+      onSuccess: (minted) => {
+        setMintedUrl(minted.url);
+        toast.success(t('api_configurator.feeds.card.rotate_success'));
+      },
+      onError: (error) => {
+        toast.error(httpErrorDetail(error) ?? t('api_configurator.feeds.card.action_error'));
+      },
+    });
+  }
+
+  function onRegenerate(): void {
+    regenerate.mutate(feed.id, {
+      onSuccess: () => toast.success(t('api_configurator.feeds.card.regenerate_started')),
+      onError: (error) => {
+        toast.error(httpErrorDetail(error) ?? t('api_configurator.feeds.card.action_error'));
+      },
+    });
+  }
+
+  function onToggle(): void {
+    const action = feed.status === 'paused' ? resume : pause;
+    action.mutate(feed.id, {
+      onError: (error) => {
+        toast.error(httpErrorDetail(error) ?? t('api_configurator.feeds.card.action_error'));
+      },
+    });
+  }
+
+  return (
+    <div className="group rounded-3xl bg-white p-5 soft-shadow transition hover:soft-shadow-lg">
+      <div className="flex items-start gap-3">
+        <div className={cn('grid h-11 w-11 shrink-0 place-items-center rounded-xl', iconTone)}>
+          <Rss className="h-5 w-5" aria-hidden />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="text-[15px] font-semibold tracking-tight">{feed.name}</div>
+            <TemplateBadge kind={feed.template_kind} />
+          </div>
+          <div className="mt-1 flex items-center gap-1.5 text-[11.5px] text-zinc-500">
+            <span className="font-mono">{feed.code}</span>
+            {feed.locale !== null && (
+              <>
+                <span className="text-zinc-300">·</span>
+                <span className="font-mono uppercase">{feed.locale}</span>
+              </>
+            )}
+            {feed.publication_channel !== null && (
+              <>
+                <span className="text-zinc-300">·</span>
+                <span>{feed.publication_channel}</span>
+              </>
+            )}
+          </div>
+        </div>
+        <ConnStatusPill
+          status={feed.status}
+          label={t(`api_configurator.feeds.status.${feed.status}`)}
+        />
+      </div>
+
+      <div className="mt-4 flex items-center gap-2">
+        <Link2 className="h-4 w-4 shrink-0 text-zinc-500" aria-hidden />
+        <code className="min-w-0 flex-1 truncate rounded-lg border border-zinc-100 bg-zinc-50 px-2.5 py-1.5 font-mono text-[11.5px] text-zinc-600">
+          {url ??
+            t(
+              feed.has_token
+                ? 'api_configurator.feeds.card.url_masked'
+                : 'api_configurator.feeds.card.url_none',
+            )}
+        </code>
+        <CopyButton value={url ?? ''} disabled={url === null} />
+        <button
+          type="button"
+          onClick={onRotate}
+          disabled={rotate.isPending}
+          aria-label={t('api_configurator.feeds.card.rotate')}
+          title={t('api_configurator.feeds.card.rotate')}
+          className="grid h-7 w-7 place-items-center rounded-lg border border-zinc-200 bg-white text-zinc-500 transition hover:text-zinc-700 disabled:opacity-40"
+        >
+          <RefreshCw
+            className={cn('h-3.5 w-3.5', rotate.isPending && 'animate-spin')}
+            aria-hidden
+          />
+        </button>
+      </div>
+
+      <div className="mt-4 grid grid-cols-2 gap-x-5 gap-y-3 text-[12px]">
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-zinc-500">
+            {t('api_configurator.feeds.card.items')}
+          </div>
+          <div className="num mt-1 font-semibold text-zinc-900">
+            {feed.cached_item_count === null ? '—' : feed.cached_item_count.toLocaleString('pl-PL')}
+          </div>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-zinc-500">
+            {t('api_configurator.feeds.card.schedule')}
+          </div>
+          <div className="mt-1 font-mono text-[11px] text-zinc-700">
+            {feed.schedule_cron ?? t('api_configurator.feeds.card.schedule_manual')}
+          </div>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-zinc-500">
+            {t('api_configurator.feeds.card.coverage')}
+          </div>
+          <div className="mt-1.5">
+            <CoverageBar mapped={coverage.mapped} total={coverage.total} />
+          </div>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-zinc-500">
+            {t('api_configurator.feeds.card.last_pull')}
+          </div>
+          <div className="mt-1 text-zinc-700">
+            {feed.last_pulled_at !== null
+              ? new Date(feed.last_pulled_at).toLocaleString('pl-PL')
+              : '—'}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 flex items-center gap-3 border-t border-zinc-100 pt-3">
+        <div className="min-w-0 flex-1 text-[11.5px]">
+          <span className="mr-1 text-[10px] uppercase tracking-wider text-zinc-500">
+            {t('api_configurator.feeds.card.last_regen')}
+          </span>
+          <span className="text-zinc-700">
+            {feed.cached_at !== null ? new Date(feed.cached_at).toLocaleString('pl-PL') : '—'}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={onRegenerate}
+          disabled={regenerate.isPending}
+          className="flex h-8 items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-2.5 text-[12px] font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-40"
+        >
+          <RefreshCw
+            className={cn('h-3.5 w-3.5', regenerate.isPending && 'animate-spin')}
+            aria-hidden
+          />
+          {t('api_configurator.feeds.card.regenerate')}
+        </button>
+        <button
+          type="button"
+          onClick={onToggle}
+          disabled={pause.isPending || resume.isPending}
+          aria-label={t(
+            feed.status === 'paused'
+              ? 'api_configurator.feeds.card.resume'
+              : 'api_configurator.feeds.card.pause',
+          )}
+          title={t(
+            feed.status === 'paused'
+              ? 'api_configurator.feeds.card.resume'
+              : 'api_configurator.feeds.card.pause',
+          )}
+          className={cn(
+            'grid h-8 w-8 place-items-center rounded-lg border border-zinc-200 bg-white disabled:opacity-40',
+            feed.status === 'paused'
+              ? 'text-emerald-600 hover:bg-emerald-50'
+              : 'text-zinc-500 hover:bg-zinc-50',
+          )}
+        >
+          {feed.status === 'paused' ? (
+            <Play className="h-3.5 w-3.5" aria-hidden />
+          ) : (
+            <Pause className="h-3.5 w-3.5" aria-hidden />
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={() => void navigate(`/integrations/api-configurator/feeds/${feed.id}`)}
+          className="h-8 rounded-lg bg-zinc-900 px-3 text-[12px] font-medium text-white hover:bg-zinc-800"
+        >
+          {t('api_configurator.feeds.card.open')}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function absoluteUrl(path: string): string {
+  return path.startsWith('http') ? path : `${window.location.origin}${path}`;
+}

--- a/apps/admin/src/features/api-configurator/feeds/hub/FeedKpiStrip.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/hub/FeedKpiStrip.tsx
@@ -1,0 +1,78 @@
+import { Rss } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Sparkline } from '@/components/ui-v2/sparkline';
+
+import type { FeedKpi } from '../api/feeds';
+
+/**
+ * XMLF-P5-01 — the hub KPI strip (design feed-primitives.jsx FeedKpiStrip):
+ * feed status split, current syndication snapshot and the 24h pull counter
+ * with its sparkline (XMLF-P3-06 telemetry).
+ */
+export function FeedKpiStrip({ kpi }: { kpi: FeedKpi | undefined }) {
+  const { t } = useTranslation();
+  const total = kpi ? kpi.active + kpi.paused + kpi.error : 0;
+
+  return (
+    <div className="grid grid-cols-2 gap-3 lg:grid-cols-3">
+      <div className="rounded-2xl bg-white p-4 soft-shadow">
+        <div className="flex items-start justify-between">
+          <div>
+            <div className="text-[10.5px] font-medium uppercase tracking-wider text-zinc-500">
+              {t('api_configurator.feeds.kpi.feeds')}
+            </div>
+            <div className="num mt-1 font-display text-[28px] font-semibold tracking-tight">
+              {total}
+            </div>
+            <div className="mt-1.5 flex items-center gap-2 text-[11px]">
+              <span className="num flex items-center gap-1 font-medium text-emerald-700">
+                <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden />
+                {kpi?.active ?? 0}
+              </span>
+              <span className="num flex items-center gap-1 font-medium text-amber-700">
+                <span className="h-1.5 w-1.5 rounded-full bg-amber-500" aria-hidden />
+                {kpi?.paused ?? 0}
+              </span>
+              <span className="num flex items-center gap-1 font-medium text-rose-700">
+                <span className="h-1.5 w-1.5 rounded-full bg-rose-500" aria-hidden />
+                {kpi?.error ?? 0}
+              </span>
+            </div>
+          </div>
+          <div className="grid h-10 w-10 place-items-center rounded-xl bg-zinc-900 text-white">
+            <Rss className="h-4.5 w-4.5" aria-hidden />
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-2xl bg-white p-4 soft-shadow">
+        <div className="text-[10.5px] font-medium uppercase tracking-wider text-zinc-500">
+          {t('api_configurator.feeds.kpi.items')}
+        </div>
+        <div className="num mt-1 font-display text-[28px] font-semibold tracking-tight">
+          {(kpi?.itemsSyndicated ?? 0).toLocaleString('pl-PL')}
+        </div>
+        <div className="mt-1.5 text-[11px] text-zinc-500">
+          {t('api_configurator.feeds.kpi.items_hint')}
+        </div>
+      </div>
+
+      <div className="rounded-2xl bg-white p-4 soft-shadow">
+        <div className="text-[10.5px] font-medium uppercase tracking-wider text-zinc-500">
+          {t('api_configurator.feeds.kpi.pulls')}
+        </div>
+        <div className="num mt-1 font-display text-[28px] font-semibold tracking-tight">
+          {(kpi?.pulls24h ?? 0).toLocaleString('pl-PL')}
+        </div>
+        <div className="-ml-0.5 mt-1">
+          <Sparkline
+            data={(kpi?.spark ?? []).map((point) => point.count)}
+            width={130}
+            height={22}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/api-configurator/feeds/hub/FeedsHubPage.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/hub/FeedsHubPage.tsx
@@ -1,0 +1,116 @@
+import { ArrowRight, Download, Plus, Search } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link, useNavigate } from 'react-router';
+
+import { Segmented } from '@/features/api-configurator/components/primitives';
+
+import { type FeedStatus, filterFeeds, useFeedKpi, useFeeds } from '../api/feeds';
+import { FeedCard } from './FeedCard';
+import { FeedKpiStrip } from './FeedKpiStrip';
+
+type StatusFilter = 'all' | FeedStatus;
+
+/**
+ * XMLF-P5-01 — the feeds hub (design feed-hub.jsx FeedHub): KPI strip, search
+ * + status filter toolbar, the feed card grid with the NewFeedCard CTA and the
+ * ad-hoc XML note pointing at the export wizard (mode 2 — one-off dump).
+ */
+export function FeedsHubPage() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const feedsQuery = useFeeds();
+  const kpiQuery = useFeedKpi();
+  const [search, setSearch] = useState('');
+  const [status, setStatus] = useState<StatusFilter>('all');
+
+  const feeds = feedsQuery.data ?? [];
+  const filtered = useMemo(() => filterFeeds(feeds, search, status), [feeds, search, status]);
+
+  return (
+    <div className="space-y-6">
+      <FeedKpiStrip kpi={kpiQuery.data} />
+
+      <div className="flex flex-wrap items-center gap-3">
+        <h1 className="font-display text-[16px] font-semibold tracking-tight">
+          {t('api_configurator.feeds.hub.title')}
+        </h1>
+        <span className="text-[12px] text-zinc-500">
+          {t('api_configurator.feeds.hub.subtitle', { count: feeds.length })}
+        </span>
+        <div className="ml-auto flex items-center gap-2">
+          <div className="flex h-9 items-center gap-2 rounded-xl bg-white pl-3 pr-2 soft-shadow">
+            <Search className="h-4 w-4 text-zinc-500" aria-hidden />
+            <input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder={t('api_configurator.feeds.hub.search_placeholder')}
+              aria-label={t('api_configurator.feeds.hub.search_aria')}
+              className="w-48 bg-transparent text-[13px] outline-none placeholder:text-zinc-500"
+            />
+          </div>
+          <Segmented<StatusFilter>
+            value={status}
+            onChange={setStatus}
+            ariaLabel={t('api_configurator.feeds.hub.filter_aria')}
+            options={[
+              { value: 'all', label: t('api_configurator.feeds.hub.filter.all') },
+              { value: 'active', label: t('api_configurator.feeds.hub.filter.active') },
+              { value: 'paused', label: t('api_configurator.feeds.hub.filter.paused') },
+              { value: 'error', label: t('api_configurator.feeds.hub.filter.error') },
+            ]}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+        {filtered.map((feed) => (
+          <FeedCard key={feed.id} feed={feed} />
+        ))}
+        <button
+          type="button"
+          onClick={() => void navigate('/integrations/api-configurator/feeds/new')}
+          className="group flex min-h-[240px] flex-col items-center justify-center rounded-3xl border-2 border-dashed border-zinc-200 p-5 text-zinc-500 transition hover:border-zinc-400 hover:bg-zinc-50/50 hover:text-zinc-900"
+        >
+          <div className="grid h-12 w-12 place-items-center rounded-2xl bg-zinc-100 transition group-hover:bg-zinc-900 group-hover:text-white">
+            <Plus className="h-5 w-5" aria-hidden />
+          </div>
+          <div className="mt-3 text-[14px] font-medium">
+            {t('api_configurator.feeds.hub.new_feed')}
+          </div>
+          <div className="mt-1 max-w-[280px] text-center text-[12px] leading-relaxed text-zinc-500">
+            {t('api_configurator.feeds.hub.new_feed_hint')}
+          </div>
+        </button>
+      </div>
+
+      <Link
+        to="/exports"
+        className="group block rounded-2xl border border-zinc-200 bg-white px-5 py-4 transition hover:border-zinc-300 hover:bg-zinc-50/60"
+      >
+        <div className="flex items-center gap-4">
+          <div className="grid h-10 w-10 shrink-0 place-items-center rounded-xl bg-zinc-100 text-zinc-600">
+            <Download className="h-4.5 w-4.5" aria-hidden />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <div className="text-[13.5px] font-semibold tracking-tight">
+                {t('api_configurator.feeds.hub.adhoc_title')}
+              </div>
+              <span className="rounded-md border border-zinc-300 px-1.5 py-0.5 font-mono text-[10.5px] text-zinc-600">
+                XML
+              </span>
+            </div>
+            <div className="mt-0.5 text-[12px] leading-relaxed text-zinc-500">
+              {t('api_configurator.feeds.hub.adhoc_hint')}
+            </div>
+          </div>
+          <ArrowRight
+            className="h-4 w-4 shrink-0 text-zinc-300 transition group-hover:text-zinc-600"
+            aria-hidden
+          />
+        </div>
+      </Link>
+    </div>
+  );
+}

--- a/apps/admin/src/features/api-configurator/feeds/wizard/FeedWizardPage.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/wizard/FeedWizardPage.tsx
@@ -1,0 +1,27 @@
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+
+/**
+ * XMLF-P5-01 — route placeholder for the 5-step feed wizard (XMLF-P5-02..04).
+ * The hub's "New feed" CTA needs a stable target today; the wizard shell,
+ * mapper and delivery steps replace this screen in their own tickets.
+ */
+export function FeedWizardPage() {
+  const { t } = useTranslation();
+  return (
+    <div className="rounded-3xl bg-white p-10 text-center soft-shadow">
+      <h1 className="font-display text-[18px] font-semibold tracking-tight">
+        {t('api_configurator.feeds.wizard.placeholder_title')}
+      </h1>
+      <p className="mt-2 text-[13px] text-zinc-500">
+        {t('api_configurator.feeds.wizard.placeholder_hint')}
+      </p>
+      <Link
+        to="/integrations/api-configurator/feeds"
+        className="mt-6 inline-flex h-9 items-center rounded-lg bg-zinc-900 px-4 text-[13px] font-medium text-white hover:bg-zinc-800"
+      >
+        {t('api_configurator.feeds.wizard.back_to_hub')}
+      </Link>
+    </div>
+  );
+}

--- a/apps/admin/src/features/api-configurator/layout/KonfiguratorApiLayout.tsx
+++ b/apps/admin/src/features/api-configurator/layout/KonfiguratorApiLayout.tsx
@@ -5,17 +5,19 @@ import { PillTabs } from '@/components/ui-v2/pill-tabs';
 
 const BASE = '/integrations/api-configurator';
 
-type ShellTab = 'connections' | 'producer' | 'monitor';
+type ShellTab = 'connections' | 'producer' | 'feeds' | 'monitor';
 
 /**
- * APIC-P0-04 / P4-08 — shared shell unifying both faces of the Konfigurator API
- * area (ADR-0022, api-app.jsx prototype): a three-way pill-tab split over an
- * Outlet between the **consumer** side (Połączenia — hub/wizard/detail/mapping/
- * sync, P1-07/P2/P3-11/P3-12), the **producer** side (Moje API — the hub with
- * Profile/Keys/Webhooks tabs + the profile builder, P4-06/P4-07), and the sync
- * **Monitor** (P4-02). The active tab is derived from the path prefix so every
- * sub-route (connection detail, profile builder, monitor drill-down) keeps its
- * face highlighted; switching tabs deep-links to each face's landing.
+ * APIC-P0-04 / P4-08 — shared shell unifying the faces of the Konfigurator API
+ * area (ADR-0022, api-app.jsx prototype): a pill-tab split over an Outlet
+ * between the **consumer** side (Połączenia — hub/wizard/detail/mapping/sync,
+ * P1-07/P2/P3-11/P3-12), the **producer** side (Moje API — the hub with
+ * Profile/Keys/Webhooks tabs + the profile builder, P4-06/P4-07), the product
+ * XML **Feeds** hub (XMLF-P5-01 — the third citizen of the area, ADR-0023) and
+ * the sync **Monitor** (P4-02). The active tab is derived from the path prefix
+ * so every sub-route (connection detail, profile builder, feed detail, monitor
+ * drill-down) keeps its face highlighted; switching tabs deep-links to each
+ * face's landing.
  */
 export function KonfiguratorApiLayout() {
   const { t } = useTranslation();
@@ -24,9 +26,11 @@ export function KonfiguratorApiLayout() {
 
   const activeId: ShellTab = pathname.startsWith(`${BASE}/connections`)
     ? 'connections'
-    : pathname.startsWith(`${BASE}/monitor`)
-      ? 'monitor'
-      : 'producer';
+    : pathname.startsWith(`${BASE}/feeds`)
+      ? 'feeds'
+      : pathname.startsWith(`${BASE}/monitor`)
+        ? 'monitor'
+        : 'producer';
 
   return (
     <div className="space-y-5">
@@ -39,6 +43,7 @@ export function KonfiguratorApiLayout() {
         items={[
           { id: 'connections', label: t('api_configurator.shell.tabs.connections') },
           { id: 'producer', label: t('api_configurator.shell.tabs.producer') },
+          { id: 'feeds', label: t('api_configurator.shell.tabs.feeds') },
           { id: 'monitor', label: t('api_configurator.shell.tabs.monitor') },
         ]}
       />

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1720,11 +1720,77 @@
     }
   },
   "api_configurator": {
+    "feeds": {
+      "template": {
+        "google_shopping": "Google Shopping",
+        "ceneo": "Ceneo",
+        "meta": "Meta",
+        "custom": "Custom"
+      },
+      "status": {
+        "active": "Active",
+        "paused": "Paused",
+        "error": "Error"
+      },
+      "kpi": {
+        "feeds": "Feeds",
+        "items": "Products in feeds",
+        "items_hint": "syndicated to channels",
+        "pulls": "Feed pulls / 24h"
+      },
+      "hub": {
+        "title": "Product feeds",
+        "subtitle": "Static XML projections for channel crawlers · {{count}} configured",
+        "search_placeholder": "name or code…",
+        "search_aria": "Search feeds",
+        "filter_aria": "Filter feeds by status",
+        "filter": {
+          "all": "all",
+          "active": "active",
+          "paused": "paused",
+          "error": "error"
+        },
+        "new_feed": "New feed",
+        "new_feed_hint": "Pick a template (Google Shopping, Ceneo, Meta) or build your own. Mapping, filter, preview and a stable URL — no developer needed.",
+        "adhoc_title": "Need a one-off XML dump?",
+        "adhoc_hint": "The XML format is also available in the export wizard — next to XLSX/CSV. Generic wrapper, free column choice, one-time download. No template, mapping or schedule."
+      },
+      "card": {
+        "copy_url": "Copy feed URL",
+        "rotate": "Rotate token",
+        "rotate_success": "New token minted — the URL below is shown once, copy it now.",
+        "regenerate": "Regenerate",
+        "regenerate_started": "Regeneration queued.",
+        "pause": "Pause",
+        "resume": "Resume",
+        "open": "Open",
+        "action_error": "The action failed. Try again.",
+        "url_masked": "https://…/api/feeds/pull/… (token hidden — rotate to mint a new URL)",
+        "url_none": "no token yet — rotate to mint the feed URL",
+        "items": "Products in feed",
+        "schedule": "Schedule",
+        "schedule_manual": "manual only",
+        "coverage": "Mapping coverage",
+        "coverage_aria": "Mapping coverage: {{mapped}} of {{total}} slots",
+        "last_pull": "Last pull",
+        "last_regen": "Last regen."
+      },
+      "wizard": {
+        "placeholder_title": "Feed wizard — coming in the next ticket",
+        "placeholder_hint": "The 5-step creator (template, scope, mapping, delivery, review) lands with XMLF-P5-02..04.",
+        "back_to_hub": "Back to feeds"
+      },
+      "detail": {
+        "placeholder_title": "Feed detail — coming in the next ticket",
+        "placeholder_hint": "The pipeline view, run history and per-product log drill-down land with XMLF-P5-05."
+      }
+    },
     "shell": {
       "tabs_aria": "API Configurator sections",
       "tabs": {
         "connections": "Connections",
         "producer": "My API",
+        "feeds": "Feeds",
         "monitor": "Monitor"
       },
       "connections_soon_title": "Connections — coming soon",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1768,11 +1768,77 @@
     }
   },
   "api_configurator": {
+    "feeds": {
+      "template": {
+        "google_shopping": "Google Shopping",
+        "ceneo": "Ceneo",
+        "meta": "Meta",
+        "custom": "Własny"
+      },
+      "status": {
+        "active": "Aktywny",
+        "paused": "Wstrzymany",
+        "error": "Błąd"
+      },
+      "kpi": {
+        "feeds": "Feedy",
+        "items": "Produkty w feedach",
+        "items_hint": "syndykowane do kanałów",
+        "pulls": "Pobrania feedów · 24h"
+      },
+      "hub": {
+        "title": "Feedy produktowe",
+        "subtitle": "Statyczne projekcje XML pod crawler kanału · {{count}} skonfigurowanych",
+        "search_placeholder": "nazwa lub code…",
+        "search_aria": "Szukaj feedów",
+        "filter_aria": "Filtruj feedy po statusie",
+        "filter": {
+          "all": "wszystkie",
+          "active": "aktywne",
+          "paused": "wstrzymane",
+          "error": "błąd"
+        },
+        "new_feed": "Nowy feed",
+        "new_feed_hint": "Wybierz szablon (Google Shopping, Ceneo, Meta) albo zbuduj własny. Mapowanie, filtr, podgląd i stabilny URL — bez developera.",
+        "adhoc_title": "Potrzebujesz jednorazowego zrzutu XML?",
+        "adhoc_hint": "Format XML jest też dostępny w kreatorze eksportu — obok XLSX/CSV. Generyczny wrapper, wolny wybór kolumn, jednorazowy download. Bez szablonu, mapowania i harmonogramu."
+      },
+      "card": {
+        "copy_url": "Kopiuj URL feedu",
+        "rotate": "Rotuj token",
+        "rotate_success": "Nowy token wygenerowany — URL poniżej widoczny raz, skopiuj go teraz.",
+        "regenerate": "Regeneruj",
+        "regenerate_started": "Regeneracja zakolejkowana.",
+        "pause": "Wstrzymaj",
+        "resume": "Wznów",
+        "open": "Otwórz",
+        "action_error": "Akcja nie powiodła się. Spróbuj ponownie.",
+        "url_masked": "https://…/api/feeds/pull/… (token ukryty — rotuj, by wygenerować nowy URL)",
+        "url_none": "brak tokenu — rotuj, by wygenerować URL feedu",
+        "items": "Produkty w feedzie",
+        "schedule": "Harmonogram",
+        "schedule_manual": "tylko ręcznie",
+        "coverage": "Pokrycie mapowania",
+        "coverage_aria": "Pokrycie mapowania: {{mapped}} z {{total}} slotów",
+        "last_pull": "Ostatnie pobranie",
+        "last_regen": "Ost. regen."
+      },
+      "wizard": {
+        "placeholder_title": "Kreator feedu — w kolejnym tickecie",
+        "placeholder_hint": "5-krokowy kreator (szablon, zakres, mapowanie, delivery, przegląd) wchodzi z XMLF-P5-02..04.",
+        "back_to_hub": "Wróć do feedów"
+      },
+      "detail": {
+        "placeholder_title": "Detal feedu — w kolejnym tickecie",
+        "placeholder_hint": "Widok pipeline, historia runów i drill-down logu per produkt wchodzą z XMLF-P5-05."
+      }
+    },
     "shell": {
       "tabs_aria": "Sekcje Konfiguratora API",
       "tabs": {
         "connections": "Połączenia",
         "producer": "Moje API",
+        "feeds": "Feedy",
         "monitor": "Monitor"
       },
       "connections_soon_title": "Połączenia — wkrótce",

--- a/apps/api/src/Export/Feed/Presentation/Controller/FeedProfileController.php
+++ b/apps/api/src/Export/Feed/Presentation/Controller/FeedProfileController.php
@@ -379,6 +379,9 @@ final class FeedProfileController
             'cached_item_count' => $feed->getCachedItemCount(),
             'cached_at' => $feed->getCachedAt()?->format(DateTimeInterface::ATOM),
             'last_pulled_at' => $feed->getLastPulledAt()?->format(DateTimeInterface::ATOM),
+            // The plaintext token is never persisted (P3-04); the hub only
+            // needs to know whether a URL exists to offer rotate vs mint copy.
+            'has_token' => null !== $feed->getTokenHash(),
             'last_run_id' => $feed->getLastRunId()?->toRfc4122(),
             'created_at' => $feed->getCreatedAt()->format(DateTimeInterface::ATOM),
             'updated_at' => $feed->getUpdatedAt()->format(DateTimeInterface::ATOM),


### PR DESCRIPTION
## Cel (XMLF-P5-01, #1929)
Feed produktowy XML wchodzi do shella Konfiguratora jako trzeci obywatel (obok Połączeń i Mojego API): czwarta zakładka **Feedy** + hub — punkt wejścia do zarządzania feedami i kreatora. Layout 1:1 z designu `feedy/feed-hub.jsx`.

## Co jest w środku
- **Shell:** 4. pill-tab `Feedy` (activeId z prefixu `/feeds`); istniejące zakładki APIC bez regresji (Playwright przechodzi po staremu).
- **Hub:** `FeedKpiStrip` (feedy active/paused/error + produkty syndykowane + pobrania 24h ze sparkline) · toolbar search (name|code) + segmented filtr statusu (działają łącznie) · grid `FeedCard` + `NewFeedCard` CTA → `/feeds/new` · `AdHocXmlNote` → kreator eksportu (tryb 2).
- **FeedCard:** TemplateBadge (tone per szablon), ConnStatusPill, wiersz publicznego URL z CopyButton + „Rotuj token" (toast + URL widoczny raz w sesji), grid metryk (produkty, harmonogram cron, **CoverageBar** liczony client-side na obu kształtach descriptora — flat i `channel.item` Google RSS, ostatnie pobranie z telemetrii P3-06), footer: ost. regeneracja + Regeneruj / Wstrzymaj-Wznów / Otwórz.
- **Trasy:** `/feeds` hub + placeholdery `/feeds/new` (P5-02) i `/feeds/:id` (P5-05) — CTA mają stabilne cele.
- **Data layer:** `/api/feeds` to custom route (`{items:[]}`) — `jsonFetch` + react-query (hydra dataProvider nie pasuje). KPI = merge `/api/feed-runs/kpi` + `/api/feeds/pull-stats` (spec-owe `/api/feeds/stats` nigdy nie istniało — świadome odejście, udokumentowane w hooku).
- **BE (1 linia):** `has_token` w serializacji listy — model bezpieczeństwa tokenu (HMAC w DB, plaintext raz przy mint) uniemożliwia pokazanie URL na karcie po reloadzie; `has_token` rozróżnia copy maskowanego hinta („token ukryty — rotuj") od „brak tokenu". Świadome odejście od designu (tam URL zawsze widoczny) wymuszone security-modelem P3-04.
- **i18n:** komplet kluczy `api_configurator.feeds.*` w en+pl, zero literałów JSX.

## Testy + bramki
- **Vitest 5/5** — computeCoverage (oba kształty descriptora, dedup slotów) + filterFeeds (search∧status).
- **Playwright `1930-feeds-hub.spec.ts`** (mocked, deterministyczny): tab aria-selected, KPI z merge'a, karty+coverage, filtr, search, CTA→wizard→powrót, **axe 0 serious/critical** (poprawka kontrastu: text-zinc-500 zamiast 400 na tekstach).
- **Live smoke (unmocked, pim.localhost):** hub renderuje realne feedy (`smoke_p303`), Network: `/api/feeds` 200 + `/api/feed-runs/kpi` 200 + `/api/feeds/pull-stats` 200; konsola bez errorów poza standardowym 2×401 bootstrapem auth (in-memory JWT + refresh — każda strona).
- tsc ✓ · Biome ✓ · vite build ✓ · PHPStan max 0 (BE 1 linia).

## Gotchas utrwalone w lessons.md
pl-PL grupuje liczby dopiero od 5 cyfr (CLDR minimumGroupingDigits=2 — `1284` bez spacji, `12408` z NBSP); Playwright renderuje admin po EN (detector) → lokatory dwujęzyczne; axe w Playwright liczy kontrast (jsdom nie).

Refs #1929