### PR TITLE
feat(admin): feed wizard shell — template + scope steps (+ GET /api/feeds/templates)

### DIFF
--- a/apps/admin/e2e/1929-feeds-hub.spec.ts
+++ b/apps/admin/e2e/1929-feeds-hub.spec.ts
@@ -109,7 +109,9 @@ test('XMLF-P5-01 — feeds hub: tab, KPI, cards, filtering, a11y', async ({ page
   // NewFeedCard CTA routes to the wizard placeholder.
   await page.getByRole('button', { name: /Nowy feed|New feed/ }).click();
   await expect(page).toHaveURL(/\/integrations\/api-configurator\/feeds\/new$/);
-  await page.getByRole('link', { name: /Wróć do feedów|Back to feeds/ }).click();
+  // The target is the full wizard since P5-02 — return via its back control.
+  await expect(page.getByRole('heading', { name: /Nowy feed|New feed/ })).toBeVisible();
+  await page.getByRole('button', { name: /Wróć do feedów|Back to feeds/ }).click();
   await expect(page).toHaveURL(/\/integrations\/api-configurator\/feeds$/);
 
   // a11y — no serious/critical violations on the hub.

--- a/apps/admin/e2e/1930-feed-wizard.spec.ts
+++ b/apps/admin/e2e/1930-feed-wizard.spec.ts
@@ -1,0 +1,120 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * XMLF-P5-02 (#1930) — the 5-step feed wizard shell with template + scope:
+ * template cards from GET /api/feeds/templates seed name/code + mappings,
+ * step gating (Dalej disabled until kind && name), the scope step reuses the
+ * shared AdvancedFilterPanel with a live preflight count, and leaving scope
+ * persists the draft (POST /api/feeds). All endpoints are mocked.
+ */
+
+const TEMPLATES = {
+  items: [
+    {
+      kind: 'google_shopping',
+      built_in: true,
+      root_element: 'rss',
+      namespaces: ['g'],
+      descriptor: { root: { element: 'rss' } },
+      default_mappings: [{ slot: 'g:id', source: { kind: 'attribute', ref: 'sku' } }],
+    },
+    {
+      kind: 'custom',
+      built_in: false,
+      root_element: 'products',
+      namespaces: [],
+      descriptor: { root: { element: 'products' } },
+      default_mappings: [],
+    },
+  ],
+};
+
+test('XMLF-P5-02 — wizard: template choice, gating, scope + draft save', async ({ page }) => {
+  await loginAsAdmin(page);
+
+  // Registered before the more specific routes — Playwright matches LIFO,
+  // so `/api/feeds/templates` (below) wins over this id-wildcard.
+  await page.route('**/api/feeds/*', (route) => {
+    if (route.request().method() === 'PATCH') {
+      return route.fulfill({ json: route.request().postDataJSON() as Record<string, unknown> });
+    }
+    return route.fulfill({ json: {} });
+  });
+  await page.route('**/api/feeds/templates', (route) => route.fulfill({ json: TEMPLATES }));
+  await page.route('**/api/object_types*', (route) =>
+    route.fulfill({
+      json: {
+        member: [{ id: '019f0000-0000-7000-8000-000000000001', kind: 'product' }],
+        totalItems: 1,
+      },
+    }),
+  );
+  await page.route('**/api/tenant-locales', (route) =>
+    route.fulfill({
+      json: {
+        items: [
+          { code: 'pl', label: 'Polski', isActive: true },
+          { code: 'en', label: 'English', isActive: true },
+        ],
+      },
+    }),
+  );
+  await page.route('**/api/channels*', (route) =>
+    route.fulfill({ json: { member: [], totalItems: 0 } }),
+  );
+  await page.route('**/api/exports/preflight', (route) =>
+    route.fulfill({
+      json: { count: 12408, mode: 'async', threshold: 500, soft_cap: 100000, exceeds_cap: false },
+    }),
+  );
+  let createdPayload: Record<string, unknown> | null = null;
+  await page.route('**/api/feeds', (route) => {
+    if (route.request().method() === 'POST') {
+      createdPayload = route.request().postDataJSON() as Record<string, unknown>;
+      return route.fulfill({
+        status: 201,
+        json: { ...createdPayload, id: '019f0000-0000-7000-8000-00000000aaaa' },
+      });
+    }
+    return route.fulfill({ json: { items: [] } });
+  });
+
+  await page.goto('/integrations/api-configurator/feeds/new');
+
+  // Step 1: Next is gated until a template is chosen (name auto-fills).
+  const nextButton = page.getByRole('button', { name: /Dalej|^Next$/ });
+  await expect(nextButton).toBeDisabled();
+  await page.getByRole('button', { name: /Google Shopping/ }).click();
+
+  const nameInput = page.getByPlaceholder(/Google Shopping/);
+  await expect(nameInput).not.toHaveValue('');
+  const codeInput = page.getByPlaceholder('google_pl');
+  await expect(codeInput).toHaveValue(/google_shopping/);
+  await expect(nextButton).toBeEnabled();
+  await nextButton.click();
+
+  // Step 2: scope + shared filter panel + live count from the preflight.
+  await expect(page.getByText(/12\s?408/).first()).toBeVisible();
+  await expect(page.getByRole('combobox').first()).toBeVisible();
+
+  // Leaving scope persists the draft.
+  await nextButton.click();
+  await expect(page.getByText(/XMLF-P5-03/)).toBeVisible();
+  expect(createdPayload).not.toBeNull();
+  expect(createdPayload?.template_kind).toBe('google_shopping');
+  expect(createdPayload?.locale).toBe('pl');
+
+  // Stepper: done steps stay clickable, pending ones do not.
+  await expect(page.getByRole('button', { name: /Szablon|Template/ })).toBeEnabled();
+  await expect(page.getByRole('button', { name: /Podgląd|Preview/ })).toBeDisabled();
+
+  // a11y — no serious/critical violations on the scope/mapping shell.
+  const axe = await new AxeBuilder({ page }).analyze();
+  const blocking = axe.violations.filter(
+    (violation) => violation.impact === 'serious' || violation.impact === 'critical',
+  );
+  expect(blocking).toEqual([]);
+});

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -697,6 +697,10 @@ function App() {
                       element={<FeedWizardPage />}
                     />
                     <Route
+                      path="/integrations/api-configurator/feeds/:id/edit"
+                      element={<FeedWizardPage />}
+                    />
+                    <Route
                       path="/integrations/api-configurator/feeds/:id"
                       element={<FeedDetailPage />}
                     />

--- a/apps/admin/src/features/api-configurator/feeds/__tests__/wizard-state.test.ts
+++ b/apps/admin/src/features/api-configurator/feeds/__tests__/wizard-state.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FeedRow } from '../api/feeds';
+import { canLeaveStep, draftFromFeed, emptyDraft, slugifyCode } from '../wizard/wizard-state';
+
+/**
+ * XMLF-P5-02 — pure wizard logic: the code auto-slug, step gating and the
+ * edit-mode prefill mapping.
+ */
+
+describe('slugifyCode', () => {
+  it('slugs a Polish display name into a mono code', () => {
+    expect(slugifyCode('Google Shopping — Polska')).toBe('google_shopping_polska');
+    expect(slugifyCode('Łóżka & Materace 2024')).toBe('lozka_materace_2024');
+    expect(slugifyCode('  __x__  ')).toBe('x');
+  });
+});
+
+describe('canLeaveStep', () => {
+  it('gates step 0 on template and name', () => {
+    const draft = emptyDraft();
+    expect(canLeaveStep(0, draft)).toBe(false);
+    draft.kind = 'ceneo';
+    expect(canLeaveStep(0, draft)).toBe(false);
+    draft.name = 'Ceneo PL';
+    expect(canLeaveStep(0, draft)).toBe(true);
+  });
+
+  it('gates step 1 on a locale and lets later steps pass', () => {
+    const draft = { ...emptyDraft(), kind: 'ceneo' as const, name: 'x', locale: '' };
+    expect(canLeaveStep(1, draft)).toBe(false);
+    draft.locale = 'pl';
+    expect(canLeaveStep(1, draft)).toBe(true);
+    expect(canLeaveStep(2, draft)).toBe(true);
+  });
+});
+
+describe('draftFromFeed', () => {
+  it('prefills every step-1/2 field from the API row', () => {
+    const feed = {
+      id: 'f-1',
+      code: 'google_pl',
+      name: 'Google — PL',
+      template_kind: 'google_shopping',
+      status: 'active',
+      locale: 'pl',
+      currency: 'PLN',
+      channel_id: 'ch-1',
+      publication_channel: null,
+      schedule_cron: null,
+      descriptor: {},
+      field_mappings: [{ slot: 'g:id' }],
+      filter: { field: 'status', operator: 'eq', value: 'active' },
+      cached_item_count: null,
+      cached_at: null,
+      last_pulled_at: null,
+      has_token: false,
+    } as unknown as FeedRow;
+
+    const draft = draftFromFeed(feed);
+    expect(draft.id).toBe('f-1');
+    expect(draft.kind).toBe('google_shopping');
+    expect(draft.codeTouched).toBe(true);
+    expect(draft.channelId).toBe('ch-1');
+    expect(draft.mappings).toHaveLength(1);
+    expect(draft.filterDsl).not.toBeNull();
+  });
+});

--- a/apps/admin/src/features/api-configurator/feeds/api/feeds.ts
+++ b/apps/admin/src/features/api-configurator/feeds/api/feeds.ts
@@ -57,6 +57,19 @@ interface PullStatsResponse {
 
 export const FEEDS_QUERY_KEY = ['xmlf', 'feeds'] as const;
 
+export async function fetchFeed(id: string): Promise<FeedRow> {
+  return jsonFetch<FeedRow>(`/api/feeds/${id}`);
+}
+
+/** Command helpers for the wizard (POST create / PATCH update). */
+export async function createFeed(payload: Record<string, unknown>): Promise<FeedRow> {
+  return jsonFetch<FeedRow>('/api/feeds', { method: 'POST', body: payload });
+}
+
+export async function patchFeed(id: string, payload: Record<string, unknown>): Promise<FeedRow> {
+  return jsonFetch<FeedRow>(`/api/feeds/${id}`, { method: 'PATCH', body: payload });
+}
+
 export function useFeeds() {
   return useQuery({
     queryKey: FEEDS_QUERY_KEY,

--- a/apps/admin/src/features/api-configurator/feeds/api/feeds.ts
+++ b/apps/admin/src/features/api-configurator/feeds/api/feeds.ts
@@ -25,6 +25,7 @@ export interface FeedRow {
   schedule_cron: string | null;
   descriptor: Record<string, unknown>;
   field_mappings: Array<Record<string, unknown>>;
+  filter?: unknown;
   cached_item_count: number | null;
   cached_at: string | null;
   last_pulled_at: string | null;

--- a/apps/admin/src/features/api-configurator/feeds/api/templates.ts
+++ b/apps/admin/src/features/api-configurator/feeds/api/templates.ts
@@ -1,0 +1,76 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { jsonFetch } from '@/lib/http';
+
+import type { FeedTemplateKind } from './feeds';
+
+/**
+ * XMLF-P5-02 — the wizard's template catalog (GET /api/feeds/templates):
+ * the same in-code catalog the backend seeds descriptors from, plus the
+ * default mappings the wizard copies into its draft on choice.
+ */
+export interface FeedTemplateInfo {
+  kind: FeedTemplateKind;
+  built_in: boolean;
+  root_element: string | null;
+  namespaces: string[];
+  descriptor: Record<string, unknown>;
+  default_mappings: Array<Record<string, unknown>>;
+}
+
+interface TemplatesResponse {
+  items: FeedTemplateInfo[];
+}
+
+export function useFeedTemplates() {
+  return useQuery({
+    queryKey: ['xmlf', 'feed-templates'],
+    queryFn: async () => (await jsonFetch<TemplatesResponse>('/api/feeds/templates')).items,
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+interface ObjectTypeRow {
+  id: string;
+  kind: string;
+}
+
+/**
+ * The wizard's ObjectType is locked to Product (MVP), but the create endpoint
+ * still requires the tenant's concrete type id — resolve it once.
+ */
+export function useProductObjectTypeId() {
+  return useQuery({
+    queryKey: ['xmlf', 'product-object-type'],
+    queryFn: async () => {
+      // API Platform shape depends on the negotiated format: LD+JSON wraps
+      // the collection in `member`, plain JSON returns a bare array.
+      const response = await jsonFetch<unknown>('/api/object_types?itemsPerPage=50');
+      const rows = Array.isArray(response)
+        ? (response as ObjectTypeRow[])
+        : ((response as { member?: ObjectTypeRow[] }).member ?? []);
+      return rows.find((row) => row.kind === 'product')?.id ?? null;
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export interface TenantLocaleRow {
+  code: string;
+  label: string;
+  isActive: boolean;
+}
+
+/** Active tenant locales for the scope step's locale select. */
+export function useTenantLocales() {
+  return useQuery({
+    queryKey: ['xmlf', 'tenant-locales'],
+    queryFn: async () => {
+      const response = await jsonFetch<{ items: TenantLocaleRow[] }>('/api/tenant-locales', {
+        accept: 'application/json',
+      });
+      return response.items.filter((row) => row.isActive);
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/apps/admin/src/features/api-configurator/feeds/wizard/FeedWizardPage.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/wizard/FeedWizardPage.tsx
@@ -1,27 +1,339 @@
+import { ArrowLeft, ArrowRight, Check, ChevronRight, Rss } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router';
+import { useNavigate, useParams } from 'react-router';
+
+import { useToast } from '@/components/ui/toast';
+import { useExportPreflight } from '@/features/exports/wizard/use-export-preflight';
+import { dslToFlatConditions, type FilterDsl } from '@/lib/filters/filter-dsl';
+import { useFilterDslState } from '@/lib/filters/use-filter-dsl-state';
+import { httpErrorDetail, jsonFetch } from '@/lib/http';
+import { cn } from '@/lib/utils';
+
+import type { FeedRow } from '../api/feeds';
+import { type FeedTemplateInfo, useFeedTemplates, useProductObjectTypeId } from '../api/templates';
+import { TemplateBadge } from '../components/primitives';
+import { StepScope } from './steps/StepScope';
+import { StepTemplate } from './steps/StepTemplate';
+import {
+  canLeaveStep,
+  createPayload,
+  draftFromFeed,
+  emptyDraft,
+  type FeedDraft,
+  patchPayload,
+  slugifyCode,
+  WIZARD_STEP_IDS,
+} from './wizard-state';
+
+const HUB_PATH = '/integrations/api-configurator/feeds';
 
 /**
- * XMLF-P5-01 — route placeholder for the 5-step feed wizard (XMLF-P5-02..04).
- * The hub's "New feed" CTA needs a stable target today; the wizard shell,
- * mapper and delivery steps replace this screen in their own tickets.
+ * XMLF-P5-02 — the 5-step full-page feed wizard shell with steps 1 (template
+ * + identity) and 2 (scope + assortment filter with a live preflight count).
+ * Steps 3-5 render in-shell placeholders until P5-03 (mapper) and P5-04
+ * (delivery + preview) replace them. Leaving step 2 persists the draft
+ * (POST on first pass, PATCH afterwards) so the mapper steps always operate
+ * on a saved FeedProfile.
  */
 export function FeedWizardPage() {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const toast = useToast();
+  const { id: editId } = useParams();
+  const templates = useFeedTemplates();
+  const productTypeId = useProductObjectTypeId();
+
+  const [step, setStep] = useState(0);
+  const [draft, setDraft] = useState<FeedDraft>(emptyDraft);
+  const [saving, setSaving] = useState(false);
+  const [loadedForEdit, setLoadedForEdit] = useState(false);
+  const filterState = useFilterDslState(draft.filterDsl);
+  const setFilterConditions = filterState.setConditions;
+
+  useEffect(() => {
+    if (editId === undefined || loadedForEdit) {
+      return;
+    }
+    let cancelled = false;
+    void jsonFetch<FeedRow>(`/api/feeds/${editId}`).then((feed) => {
+      if (!cancelled) {
+        setDraft(draftFromFeed(feed));
+        // The filter state hook only reads its initial value on mount —
+        // push the loaded DSL into it explicitly for the edit flow.
+        setFilterConditions(dslToFlatConditions((feed.filter as FilterDsl | null) ?? null) ?? []);
+        setLoadedForEdit(true);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [editId, loadedForEdit, setFilterConditions]);
+
+  const preflight = useExportPreflight({
+    entityType: 'product',
+    objectTypeId: null,
+    targetScope: filterState.dsl === null ? 'all' : 'filter',
+    filterDsl: filterState.dsl,
+    selectedIds: null,
+    enabled: step === 1,
+  });
+  const resultCount = preflight.result?.count ?? null;
+
+  const editing = draft.id !== null;
+  const currentDraft = useMemo(
+    () => ({ ...draft, filterDsl: filterState.dsl }),
+    [draft, filterState.dsl],
+  );
+
+  function chooseTemplate(template: FeedTemplateInfo): void {
+    setDraft((prev) => {
+      const nextName =
+        prev.name.trim() === ''
+          ? `${t(`api_configurator.feeds.template.${template.kind}`)} — PL`
+          : prev.name;
+      return {
+        ...prev,
+        kind: template.kind,
+        mappings: template.default_mappings.map((mapping) => ({ ...mapping })),
+        name: nextName,
+        code: prev.codeTouched ? prev.code : slugifyCode(nextName),
+      };
+    });
+  }
+
+  async function persistDraft(): Promise<boolean> {
+    setSaving(true);
+    try {
+      let feedId = currentDraft.id;
+      if (feedId === null) {
+        const typeId = productTypeId.data;
+        if (typeId === null || typeId === undefined) {
+          toast.error(t('api_configurator.feeds.wizard.save_error'));
+          return false;
+        }
+        const created = await jsonFetch<FeedRow>('/api/feeds', {
+          method: 'POST',
+          body: createPayload(currentDraft, typeId),
+        });
+        feedId = created.id;
+        setDraft((prev) => ({ ...prev, id: created.id }));
+      }
+      // The create endpoint owns identity + template seed; the assortment
+      // filter (and later renames) go through PATCH — one follow-up call
+      // covers both the fresh-draft and the edit flow.
+      await jsonFetch<FeedRow>(`/api/feeds/${feedId}`, {
+        method: 'PATCH',
+        body: patchPayload(currentDraft),
+      });
+      return true;
+    } catch (error) {
+      toast.error(httpErrorDetail(error) ?? t('api_configurator.feeds.wizard.save_error'));
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function next(): Promise<void> {
+    if (!canLeaveStep(step, currentDraft)) {
+      return;
+    }
+    // The mapper (P5-03) needs a persisted FeedProfile — save when leaving scope.
+    if (step === 1 && !(await persistDraft())) {
+      return;
+    }
+    setStep((value) => Math.min(value + 1, WIZARD_STEP_IDS.length - 1));
+  }
+
+  const last = WIZARD_STEP_IDS.length - 1;
+  // Leaving scope needs the resolved product ObjectType id for the create
+  // payload — hold the button until the lookup lands (fresh drafts only).
+  const waitingForTypeId =
+    step === 1 && currentDraft.id === null && productTypeId.data === undefined;
+  const stepAllowed = canLeaveStep(step, currentDraft) && !waitingForTypeId;
+
   return (
-    <div className="rounded-3xl bg-white p-10 text-center soft-shadow">
-      <h1 className="font-display text-[18px] font-semibold tracking-tight">
-        {t('api_configurator.feeds.wizard.placeholder_title')}
-      </h1>
-      <p className="mt-2 text-[13px] text-zinc-500">
-        {t('api_configurator.feeds.wizard.placeholder_hint')}
-      </p>
-      <Link
-        to="/integrations/api-configurator/feeds"
-        className="mt-6 inline-flex h-9 items-center rounded-lg bg-zinc-900 px-4 text-[13px] font-medium text-white hover:bg-zinc-800"
-      >
-        {t('api_configurator.feeds.wizard.back_to_hub')}
-      </Link>
+    <div className="max-w-[1180px] space-y-5">
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => void navigate(HUB_PATH)}
+          aria-label={t('api_configurator.feeds.wizard.back_to_hub')}
+          className="grid h-9 w-9 shrink-0 place-items-center rounded-xl bg-white text-zinc-500 soft-shadow hover:text-zinc-900"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden />
+        </button>
+        <div className="min-w-0 flex-1">
+          <h1 className="font-display text-[22px] font-semibold tracking-tight">
+            {t(
+              editing
+                ? 'api_configurator.feeds.wizard.title_edit'
+                : 'api_configurator.feeds.wizard.title_new',
+            )}
+          </h1>
+          <p className="text-[12.5px] text-zinc-500">
+            {t('api_configurator.feeds.wizard.subtitle')}
+          </p>
+        </div>
+        {draft.kind !== null && <TemplateBadge kind={draft.kind} />}
+      </div>
+
+      <nav aria-label={t('api_configurator.feeds.wizard.steps_aria')}>
+        <ol className="flex items-stretch gap-2 rounded-3xl bg-white p-3 soft-shadow">
+          {WIZARD_STEP_IDS.map((stepId, index) => {
+            const state = index < step ? 'done' : index === step ? 'active' : 'pending';
+            const clickable = index <= step;
+            return (
+              <li key={stepId} className="flex min-w-0 flex-1 items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => clickable && setStep(index)}
+                  aria-current={state === 'active' ? 'step' : undefined}
+                  disabled={!clickable}
+                  className={cn(
+                    'min-w-0 flex-1 rounded-xl border px-3 py-2 text-left transition',
+                    state === 'done' && 'border-emerald-200/70 bg-emerald-50/60',
+                    state === 'active' && 'border-zinc-900/15 bg-white shadow-sm',
+                    state === 'pending' && 'cursor-default border-zinc-100 bg-zinc-50/60',
+                  )}
+                >
+                  <div className="flex items-center gap-1.5">
+                    <span
+                      className={cn(
+                        'grid h-5 w-5 place-items-center rounded-full text-[10px] font-semibold',
+                        state === 'done' && 'bg-emerald-500 text-white',
+                        state === 'active' && 'bg-zinc-900 text-white',
+                        state === 'pending' && 'bg-zinc-200 text-zinc-500',
+                      )}
+                    >
+                      {state === 'done' ? <Check className="h-3 w-3" aria-hidden /> : index + 1}
+                    </span>
+                    <span
+                      className={cn(
+                        'truncate text-[12.5px] font-semibold tracking-tight',
+                        state === 'active' && 'text-zinc-900',
+                        state === 'done' && 'text-emerald-800',
+                        state === 'pending' && 'text-zinc-500',
+                      )}
+                    >
+                      {t(`api_configurator.feeds.wizard.step.${stepId}`)}
+                    </span>
+                  </div>
+                  <div
+                    className={cn(
+                      'mt-0.5 truncate font-mono text-[10.5px]',
+                      state === 'pending' ? 'text-zinc-400' : 'text-zinc-500',
+                    )}
+                  >
+                    {t(`api_configurator.feeds.wizard.step_note.${stepId}`)}
+                  </div>
+                </button>
+                {index < last && (
+                  <ChevronRight className="h-3 w-3 shrink-0 text-zinc-300" aria-hidden />
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+
+      <div key={step}>
+        {step === 0 && (
+          <StepTemplate
+            templates={templates.data ?? []}
+            kind={draft.kind}
+            onChoose={chooseTemplate}
+            name={draft.name}
+            onName={(value) =>
+              setDraft((prev) => ({
+                ...prev,
+                name: value,
+                code: prev.codeTouched ? prev.code : slugifyCode(value),
+              }))
+            }
+            code={draft.code}
+            onCode={(value) => setDraft((prev) => ({ ...prev, code: value, codeTouched: true }))}
+          />
+        )}
+        {step === 1 && (
+          <StepScope
+            locale={draft.locale}
+            onLocale={(value) => setDraft((prev) => ({ ...prev, locale: value }))}
+            currency={draft.currency}
+            onCurrency={(value) => setDraft((prev) => ({ ...prev, currency: value }))}
+            channelId={draft.channelId}
+            onChannelId={(value) => setDraft((prev) => ({ ...prev, channelId: value }))}
+            filterState={filterState}
+            resultCount={resultCount}
+            countLoading={preflight.isLoading}
+          />
+        )}
+        {step >= 2 && (
+          <div className="rounded-3xl bg-white p-10 text-center soft-shadow">
+            <h2 className="font-display text-[16px] font-semibold tracking-tight">
+              {t(`api_configurator.feeds.wizard.placeholder.${WIZARD_STEP_IDS[step]}_title`)}
+            </h2>
+            <p className="mt-2 text-[13px] text-zinc-500">
+              {t(`api_configurator.feeds.wizard.placeholder.${WIZARD_STEP_IDS[step]}_hint`)}
+            </p>
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3 pt-1">
+        <button
+          type="button"
+          onClick={() => (step === 0 ? void navigate(HUB_PATH) : setStep(step - 1))}
+          className="h-10 rounded-xl border border-zinc-200 bg-white px-4 text-[13px] font-medium text-zinc-700 hover:bg-zinc-50"
+        >
+          {t(
+            step === 0
+              ? 'api_configurator.feeds.wizard.cancel'
+              : 'api_configurator.feeds.wizard.back',
+          )}
+        </button>
+        <div className="flex-1" />
+        <div className="hidden text-[12px] text-zinc-500 sm:block">
+          {t('api_configurator.feeds.wizard.progress', {
+            current: step + 1,
+            total: WIZARD_STEP_IDS.length,
+          })}
+        </div>
+        {step < last ? (
+          <button
+            type="button"
+            onClick={() => void next()}
+            disabled={!stepAllowed || saving}
+            className={cn(
+              'flex h-10 items-center gap-1.5 rounded-xl px-5 text-[13px] font-bold soft-shadow',
+              stepAllowed && !saving
+                ? 'bg-orange-500 text-zinc-900 hover:bg-orange-600'
+                : 'cursor-not-allowed bg-zinc-200 text-zinc-500',
+            )}
+          >
+            {t('api_configurator.feeds.wizard.next')}
+            <ArrowRight className="h-4 w-4" aria-hidden />
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => {
+              void persistDraft().then((ok) => {
+                if (ok) {
+                  toast.success(t('api_configurator.feeds.wizard.saved'));
+                  void navigate(HUB_PATH);
+                }
+              });
+            }}
+            disabled={saving}
+            className="flex h-10 items-center gap-1.5 rounded-xl bg-zinc-900 px-5 text-[13px] font-bold text-white soft-shadow hover:bg-zinc-800 disabled:opacity-50"
+          >
+            <Rss className="h-4 w-4" aria-hidden />
+            {t('api_configurator.feeds.wizard.save_and_generate')}
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/admin/src/features/api-configurator/feeds/wizard/FeedWizardPage.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/wizard/FeedWizardPage.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from '@tanstack/react-query';
 import { ArrowLeft, ArrowRight, Check, ChevronRight, Rss } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -7,10 +8,10 @@ import { useToast } from '@/components/ui/toast';
 import { useExportPreflight } from '@/features/exports/wizard/use-export-preflight';
 import { dslToFlatConditions, type FilterDsl } from '@/lib/filters/filter-dsl';
 import { useFilterDslState } from '@/lib/filters/use-filter-dsl-state';
-import { httpErrorDetail, jsonFetch } from '@/lib/http';
+import { httpErrorDetail } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
-import type { FeedRow } from '../api/feeds';
+import { createFeed, fetchFeed, patchFeed } from '../api/feeds';
 import { type FeedTemplateInfo, useFeedTemplates, useProductObjectTypeId } from '../api/templates';
 import { TemplateBadge } from '../components/primitives';
 import { StepScope } from './steps/StepScope';
@@ -51,24 +52,25 @@ export function FeedWizardPage() {
   const filterState = useFilterDslState(draft.filterDsl);
   const setFilterConditions = filterState.setConditions;
 
+  // Edit mode loads through useQuery (ADR-0021 — an effect-driven raw read
+  // would be invisible to the query cache); the effect below only copies
+  // the arrived row into the draft once.
+  const editFeed = useQuery({
+    queryKey: ['xmlf', 'feed', editId ?? 'none'],
+    enabled: editId !== undefined,
+    queryFn: async () => fetchFeed(editId ?? ''),
+  });
+  const editRow = editFeed.data;
   useEffect(() => {
-    if (editId === undefined || loadedForEdit) {
+    if (editRow === undefined || loadedForEdit) {
       return;
     }
-    let cancelled = false;
-    void jsonFetch<FeedRow>(`/api/feeds/${editId}`).then((feed) => {
-      if (!cancelled) {
-        setDraft(draftFromFeed(feed));
-        // The filter state hook only reads its initial value on mount —
-        // push the loaded DSL into it explicitly for the edit flow.
-        setFilterConditions(dslToFlatConditions((feed.filter as FilterDsl | null) ?? null) ?? []);
-        setLoadedForEdit(true);
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [editId, loadedForEdit, setFilterConditions]);
+    setDraft(draftFromFeed(editRow));
+    // The filter state hook only reads its initial value on mount —
+    // push the loaded DSL into it explicitly for the edit flow.
+    setFilterConditions(dslToFlatConditions((editRow.filter as FilterDsl | null) ?? null) ?? []);
+    setLoadedForEdit(true);
+  }, [editRow, loadedForEdit, setFilterConditions]);
 
   const preflight = useExportPreflight({
     entityType: 'product',
@@ -112,20 +114,14 @@ export function FeedWizardPage() {
           toast.error(t('api_configurator.feeds.wizard.save_error'));
           return false;
         }
-        const created = await jsonFetch<FeedRow>('/api/feeds', {
-          method: 'POST',
-          body: createPayload(currentDraft, typeId),
-        });
+        const created = await createFeed(createPayload(currentDraft, typeId));
         feedId = created.id;
         setDraft((prev) => ({ ...prev, id: created.id }));
       }
       // The create endpoint owns identity + template seed; the assortment
       // filter (and later renames) go through PATCH — one follow-up call
       // covers both the fresh-draft and the edit flow.
-      await jsonFetch<FeedRow>(`/api/feeds/${feedId}`, {
-        method: 'PATCH',
-        body: patchPayload(currentDraft),
-      });
+      await patchFeed(feedId, patchPayload(currentDraft));
       return true;
     } catch (error) {
       toast.error(httpErrorDetail(error) ?? t('api_configurator.feeds.wizard.save_error'));

--- a/apps/admin/src/features/api-configurator/feeds/wizard/steps/StepScope.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/wizard/steps/StepScope.tsx
@@ -1,0 +1,197 @@
+import { useList } from '@refinedev/core';
+import { Box, Filter, Globe, Info, Lock } from 'lucide-react';
+import { lazy, Suspense } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { FilterDslState } from '@/lib/filters/use-filter-dsl-state';
+
+import { useTenantLocales } from '../../api/templates';
+
+const AdvancedFilterPanel = lazy(() =>
+  import('@/components/catalog/advanced-filter-panel').then((m) => ({
+    default: m.AdvancedFilterPanel,
+  })),
+);
+
+interface ChannelRow {
+  id: string;
+  code: string;
+  name: string;
+}
+
+const CURRENCIES = ['PLN', 'EUR', 'USD', 'GBP', 'CZK'] as const;
+
+/**
+ * XMLF-P5-02 — wizard step 2 (design feed-wizard.jsx StepScope): the value
+ * scope card (locked ObjectType, locale, currency, channel overlay + the
+ * flat-variants note) and the assortment filter reusing the shared
+ * AdvancedFilterPanel with a live preflight count. The publication-profile
+ * select from the design is deliberately absent: the backend does not expose
+ * ChannelPublicationProfile over the API yet — the select lands with that
+ * endpoint (ADR-0018 follow-up).
+ */
+export function StepScope({
+  locale,
+  onLocale,
+  currency,
+  onCurrency,
+  channelId,
+  onChannelId,
+  filterState,
+  resultCount,
+  countLoading,
+}: {
+  locale: string;
+  onLocale: (value: string) => void;
+  currency: string | null;
+  onCurrency: (value: string | null) => void;
+  channelId: string | null;
+  onChannelId: (value: string | null) => void;
+  filterState: FilterDslState;
+  resultCount: number | null;
+  countLoading: boolean;
+}) {
+  const { t } = useTranslation();
+  const locales = useTenantLocales();
+  const channels = useList<ChannelRow>({ resource: 'channels', pagination: { mode: 'off' } });
+
+  const selectClass =
+    'mt-1.5 h-10 w-full rounded-xl border border-zinc-200 bg-white px-3 text-[13px] outline-none focus:border-zinc-400';
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-3xl bg-white p-6 soft-shadow">
+        <div className="flex items-center gap-2.5">
+          <span className="grid h-7 w-7 place-items-center rounded-xl bg-zinc-100 text-zinc-700">
+            <Globe className="h-4 w-4" aria-hidden />
+          </span>
+          <div className="text-[14.5px] font-semibold tracking-tight">
+            {t('api_configurator.feeds.wizard.scope.title')}
+          </div>
+          <span className="text-[11.5px] text-zinc-500">
+            {t('api_configurator.feeds.wizard.scope.one_locale')}
+          </span>
+        </div>
+
+        <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div>
+            <span className="text-[12px] font-medium text-zinc-700">
+              {t('api_configurator.feeds.wizard.scope.object_type')}
+            </span>
+            <div className="mt-1.5 flex h-10 items-center gap-2 rounded-xl border border-zinc-200 bg-zinc-50/60 px-3 text-[13px] text-zinc-600">
+              <Box className="h-4 w-4 text-zinc-500" aria-hidden />
+              {t('api_configurator.feeds.wizard.scope.product')}
+              <Lock
+                className="ml-auto h-3.5 w-3.5 text-zinc-400"
+                aria-label={t('api_configurator.feeds.wizard.scope.locked')}
+              />
+            </div>
+          </div>
+          <label className="block">
+            <span className="text-[12px] font-medium text-zinc-700">
+              {t('api_configurator.feeds.wizard.scope.locale')}
+              <span className="ml-0.5 text-rose-600">*</span>
+            </span>
+            <select
+              value={locale}
+              onChange={(event) => onLocale(event.target.value)}
+              className={selectClass}
+            >
+              {(locales.data ?? []).map((row) => (
+                <option key={row.code} value={row.code}>
+                  {row.label} · {row.code}
+                </option>
+              ))}
+              {locales.data?.some((row) => row.code === locale) !== true && (
+                <option value={locale}>{locale}</option>
+              )}
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-[12px] font-medium text-zinc-700">
+              {t('api_configurator.feeds.wizard.scope.currency')}
+            </span>
+            <select
+              value={currency ?? ''}
+              onChange={(event) =>
+                onCurrency(event.target.value === '' ? null : event.target.value)
+              }
+              className={selectClass}
+            >
+              <option value="">{t('api_configurator.feeds.wizard.scope.none')}</option>
+              {CURRENCIES.map((value) => (
+                <option key={value} value={value}>
+                  {value}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-[12px] font-medium text-zinc-700">
+              {t('api_configurator.feeds.wizard.scope.channel')}
+              <span className="ml-1.5 text-[11px] font-normal text-zinc-500">
+                {t('api_configurator.feeds.wizard.scope.channel_hint')}
+              </span>
+            </span>
+            <select
+              value={channelId ?? ''}
+              onChange={(event) =>
+                onChannelId(event.target.value === '' ? null : event.target.value)
+              }
+              className={selectClass}
+            >
+              <option value="">{t('api_configurator.feeds.wizard.scope.none')}</option>
+              {(channels.result?.data ?? []).map((channel) => (
+                <option key={channel.id} value={channel.id}>
+                  {channel.name} · {channel.code}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className="mt-4 flex items-start gap-2 rounded-xl border border-zinc-200 bg-zinc-50/60 px-3 py-2 text-[12px] leading-relaxed text-zinc-600">
+          <Info className="mt-0.5 h-4 w-4 shrink-0 text-zinc-500" aria-hidden />
+          <span>{t('api_configurator.feeds.wizard.scope.variants_note')}</span>
+        </div>
+      </div>
+
+      <div className="rounded-3xl bg-white p-6 soft-shadow">
+        <div className="flex flex-wrap items-center gap-2.5">
+          <span className="grid h-7 w-7 place-items-center rounded-xl bg-zinc-100 text-zinc-700">
+            <Filter className="h-4 w-4" aria-hidden />
+          </span>
+          <div className="text-[14.5px] font-semibold tracking-tight">
+            {t('api_configurator.feeds.wizard.scope.assortment')}
+          </div>
+          <div className="ml-auto inline-flex h-8 items-center gap-2 rounded-full bg-emerald-50 px-3 text-[12px] font-medium text-emerald-800">
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden />
+            {countLoading
+              ? t('api_configurator.feeds.wizard.scope.counting')
+              : t('api_configurator.feeds.wizard.scope.in_feed', {
+                  count: resultCount ?? 0,
+                })}
+          </div>
+        </div>
+        <div className="mt-1 text-[12px] text-zinc-500">
+          {t('api_configurator.feeds.wizard.scope.filter_hint')}
+        </div>
+        <div className="mt-4">
+          <Suspense fallback={<div className="h-24 animate-pulse rounded-xl bg-zinc-100" />}>
+            <AdvancedFilterPanel
+              open
+              conditions={filterState.conditions}
+              setConditions={filterState.setConditions}
+              matchOperator={filterState.matchOperator}
+              setMatchOperator={filterState.setMatchOperator}
+              onApply={() => {}}
+              onClose={() => {}}
+              onClear={() => filterState.clear()}
+              resultCount={resultCount ?? undefined}
+            />
+          </Suspense>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/api-configurator/feeds/wizard/steps/StepTemplate.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/wizard/steps/StepTemplate.tsx
@@ -1,0 +1,149 @@
+import { Rss } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { cn } from '@/lib/utils';
+
+import type { FeedTemplateKind } from '../../api/feeds';
+import type { FeedTemplateInfo } from '../../api/templates';
+
+const TONES: Record<string, string> = {
+  google_shopping: 'bg-sky-50 text-sky-600',
+  ceneo: 'bg-emerald-50 text-emerald-600',
+  meta: 'bg-violet-50 text-violet-600',
+  custom: 'bg-zinc-100 text-zinc-600',
+};
+
+/**
+ * XMLF-P5-02 — wizard step 1 (design feed-wizard.jsx StepTemplate): the
+ * SelectableCard grid over GET /api/feeds/templates plus the name/code
+ * identity card (code auto-slugs from the name until touched).
+ */
+export function StepTemplate({
+  templates,
+  kind,
+  onChoose,
+  name,
+  onName,
+  code,
+  onCode,
+}: {
+  templates: FeedTemplateInfo[];
+  kind: FeedTemplateKind | null;
+  onChoose: (template: FeedTemplateInfo) => void;
+  name: string;
+  onName: (value: string) => void;
+  code: string;
+  onCode: (value: string) => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-3xl bg-white p-6 soft-shadow">
+        <div className="text-[15px] font-semibold tracking-tight">
+          {t('api_configurator.feeds.wizard.template.title')}
+        </div>
+        <div className="mt-0.5 text-[12.5px] text-zinc-500">
+          {t('api_configurator.feeds.wizard.template.subtitle')}
+        </div>
+        <div className="mt-5 grid grid-cols-1 gap-3 md:grid-cols-2">
+          {templates.map((template) => {
+            const active = kind === template.kind;
+            return (
+              <button
+                key={template.kind}
+                type="button"
+                onClick={() => onChoose(template)}
+                aria-pressed={active}
+                className={cn(
+                  'rounded-2xl border bg-white p-4 text-left transition',
+                  active
+                    ? 'border-zinc-900 ring-1 ring-zinc-900 soft-shadow'
+                    : 'border-zinc-200 hover:border-zinc-400',
+                  template.kind === 'custom' && !active && 'border-dashed',
+                )}
+              >
+                <div className="flex items-center gap-3">
+                  <div
+                    className={cn(
+                      'grid h-11 w-11 shrink-0 place-items-center rounded-2xl',
+                      active ? 'bg-zinc-900 text-white' : (TONES[template.kind] ?? TONES.custom),
+                    )}
+                  >
+                    <Rss className="h-5 w-5" aria-hidden />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <div className="text-[14.5px] font-semibold tracking-tight">
+                        {t(`api_configurator.feeds.template.${template.kind}`)}
+                      </div>
+                      <span
+                        className={cn(
+                          'rounded px-1.5 py-0.5 text-[9.5px] font-semibold uppercase tracking-wider',
+                          template.built_in
+                            ? 'bg-zinc-100 text-zinc-500'
+                            : 'bg-violet-100/70 text-violet-700',
+                        )}
+                      >
+                        {t(
+                          template.built_in
+                            ? 'api_configurator.feeds.wizard.template.predef'
+                            : 'api_configurator.feeds.wizard.template.custom',
+                        )}
+                      </span>
+                      {active && (
+                        <span className="rounded bg-orange-500 px-1.5 py-0.5 text-[9.5px] font-semibold uppercase tracking-wider text-zinc-900">
+                          {t('api_configurator.feeds.wizard.template.chosen')}
+                        </span>
+                      )}
+                    </div>
+                    <div className="mt-0.5 font-mono text-[10.5px] text-zinc-500">
+                      root: {template.root_element ?? '—'} · ns:{' '}
+                      {template.namespaces.length > 0 ? template.namespaces.join(', ') : '—'}
+                    </div>
+                  </div>
+                </div>
+                <div className="mt-3 text-[12px] leading-relaxed text-zinc-500">
+                  {t(`api_configurator.feeds.wizard.template.desc.${template.kind}`)}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {kind !== null && (
+        <div className="rounded-3xl bg-white p-6 soft-shadow">
+          <div className="grid grid-cols-1 gap-x-8 gap-y-5 sm:grid-cols-2">
+            <label className="block">
+              <span className="text-[12px] font-medium text-zinc-700">
+                {t('api_configurator.feeds.wizard.template.name_label')}
+                <span className="ml-0.5 text-rose-600">*</span>
+              </span>
+              <input
+                value={name}
+                onChange={(event) => onName(event.target.value)}
+                placeholder={t('api_configurator.feeds.wizard.template.name_placeholder')}
+                className="mt-1.5 h-10 w-full rounded-xl border border-zinc-200 bg-white px-3 text-[13px] outline-none focus:border-zinc-400"
+              />
+            </label>
+            <label className="block">
+              <span className="text-[12px] font-medium text-zinc-700">
+                {t('api_configurator.feeds.wizard.template.code_label')}
+                <span className="ml-1.5 text-[11px] font-normal text-zinc-500">
+                  {t('api_configurator.feeds.wizard.template.code_hint')}
+                </span>
+              </span>
+              <input
+                value={code}
+                onChange={(event) => onCode(event.target.value)}
+                placeholder="google_pl"
+                className="mt-1.5 h-10 w-full rounded-xl border border-zinc-200 bg-white px-3 font-mono text-[13px] outline-none focus:border-zinc-400"
+              />
+            </label>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/features/api-configurator/feeds/wizard/wizard-state.ts
+++ b/apps/admin/src/features/api-configurator/feeds/wizard/wizard-state.ts
@@ -1,0 +1,102 @@
+import type { FilterDsl } from '@/lib/filters/filter-dsl';
+
+import type { FeedRow, FeedTemplateKind } from '../api/feeds';
+
+/**
+ * XMLF-P5-02 — the wizard's draft state (design feed-wizard.jsx FeedWizard):
+ * steps 1-2 own template/identity/scope/filter; mapping (P5-03) and
+ * delivery/preview (P5-04) extend the same draft in their tickets.
+ */
+export interface FeedDraft {
+  id: string | null;
+  kind: FeedTemplateKind | null;
+  name: string;
+  code: string;
+  codeTouched: boolean;
+  locale: string;
+  currency: string | null;
+  channelId: string | null;
+  mappings: Array<Record<string, unknown>>;
+  filterDsl: FilterDsl | null;
+}
+
+export const WIZARD_STEP_IDS = ['template', 'scope', 'mapping', 'delivery', 'preview'] as const;
+export type WizardStepId = (typeof WIZARD_STEP_IDS)[number];
+
+export function emptyDraft(): FeedDraft {
+  return {
+    id: null,
+    kind: null,
+    name: '',
+    code: '',
+    codeTouched: false,
+    locale: 'pl',
+    currency: null,
+    channelId: null,
+    mappings: [],
+    filterDsl: null,
+  };
+}
+
+/** Edit mode — prefill from GET /api/feeds/:id. */
+export function draftFromFeed(feed: FeedRow): FeedDraft {
+  return {
+    id: feed.id,
+    kind: feed.template_kind,
+    name: feed.name,
+    code: feed.code,
+    codeTouched: true,
+    locale: feed.locale ?? 'pl',
+    currency: feed.currency,
+    channelId: feed.channel_id,
+    mappings: feed.field_mappings,
+    filterDsl: (feed.filter as FilterDsl | null) ?? null,
+  };
+}
+
+/** Auto-slug for the code field: `Google Shopping — PL` → `google_shopping_pl`. */
+export function slugifyCode(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/ł/g, 'l')
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+/** Step gating (design canNext): step 0 needs a template and a name. */
+export function canLeaveStep(step: number, draft: FeedDraft): boolean {
+  if (step === 0) {
+    return draft.kind !== null && draft.name.trim() !== '';
+  }
+  if (step === 1) {
+    return draft.locale.trim() !== '';
+  }
+  return true;
+}
+
+/** POST /api/feeds payload for a fresh draft. */
+export function createPayload(draft: FeedDraft, objectTypeId: string): Record<string, unknown> {
+  return {
+    template_kind: draft.kind,
+    name: draft.name.trim(),
+    code: draft.code.trim(),
+    object_type_id: objectTypeId,
+    locale: draft.locale,
+    currency: draft.currency,
+    channel_id: draft.channelId,
+    filter: draft.filterDsl,
+  };
+}
+
+/** PATCH /api/feeds/:id payload — scope + filter + identity rename. */
+export function patchPayload(draft: FeedDraft): Record<string, unknown> {
+  return {
+    name: draft.name.trim(),
+    locale: draft.locale,
+    currency: draft.currency,
+    channel_id: draft.channelId,
+    filter: draft.filterDsl,
+  };
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1776,8 +1776,73 @@
         "last_regen": "Last regen."
       },
       "wizard": {
-        "placeholder_title": "Feed wizard — coming in the next ticket",
-        "placeholder_hint": "The 5-step creator (template, scope, mapping, delivery, review) lands with XMLF-P5-02..04.",
+        "title_new": "New feed",
+        "title_edit": "Edit feed",
+        "subtitle": "An XML feed for a marketplace or partner — template, mapping, filter, preview and a stable URL. No developer needed.",
+        "steps_aria": "Wizard steps",
+        "step": {
+          "template": "Template",
+          "scope": "Scope",
+          "mapping": "Mapping",
+          "delivery": "Delivery",
+          "preview": "Preview"
+        },
+        "step_note": {
+          "template": "target channel",
+          "scope": "filter · scope",
+          "mapping": "slots ↔ attributes",
+          "delivery": "URL · schedule",
+          "preview": "XML · publish"
+        },
+        "cancel": "Cancel",
+        "back": "← Back",
+        "next": "Next",
+        "progress": "Step {{current}} of {{total}}",
+        "save_and_generate": "Save and generate",
+        "saved": "Feed saved.",
+        "save_error": "Saving the feed failed. Check the fields and try again.",
+        "template": {
+          "title": "Choose a feed template",
+          "subtitle": "A predefined channel ships ready slots and validation rules. Custom builds its own structure (or clones a predef).",
+          "predef": "predef",
+          "custom": "custom",
+          "chosen": "chosen",
+          "name_label": "Feed name",
+          "name_placeholder": "e.g. Google Shopping — Poland",
+          "code_label": "Code",
+          "code_hint": "auto from name",
+          "desc": {
+            "google_shopping": "Google Merchant Center product feed (RSS 2.0, g: namespace) — GTIN/MPN validation, variants via item_group_id.",
+            "ceneo": "Ceneo.pl offer feed — <o> items with attribute nodes, category as a CDATA path.",
+            "meta": "Meta (Facebook/Instagram) catalog feed — RSS with fb product fields.",
+            "custom": "Your own XML structure: root, item and slots defined slot-by-slot. Clone a predef or start empty."
+          }
+        },
+        "scope": {
+          "title": "Value scope",
+          "one_locale": "· one feed = one locale",
+          "object_type": "Object type",
+          "product": "Product",
+          "locked": "locked",
+          "locale": "Language (locale)",
+          "currency": "Currency",
+          "none": "—",
+          "channel": "Channel",
+          "channel_hint": "value overlay",
+          "variants_note": "Product variants enter the feed FLAT — every variant is its own <item> with its own id and a shared item_group_id = the master's SKU. Multiple languages = multiple feeds.",
+          "assortment": "Assortment in the feed",
+          "filter_hint": "The same filter (DSL) as the product list and the export — no second implementation.",
+          "in_feed": "In feed: {{count}} products",
+          "counting": "Counting…"
+        },
+        "placeholder": {
+          "mapping_title": "Mapping — next ticket",
+          "mapping_hint": "The slot ↔ attribute mapper lands with XMLF-P5-03.",
+          "delivery_title": "Delivery — next ticket",
+          "delivery_hint": "Schedule, gzip, URL auth and the token card land with XMLF-P5-04.",
+          "preview_title": "Preview — next ticket",
+          "preview_hint": "The live XML preview with the health report lands with XMLF-P5-04."
+        },
         "back_to_hub": "Back to feeds"
       },
       "detail": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1824,8 +1824,73 @@
         "last_regen": "Ost. regen."
       },
       "wizard": {
-        "placeholder_title": "Kreator feedu — w kolejnym tickecie",
-        "placeholder_hint": "5-krokowy kreator (szablon, zakres, mapowanie, delivery, przegląd) wchodzi z XMLF-P5-02..04.",
+        "title_new": "Nowy feed",
+        "title_edit": "Edytuj feed",
+        "subtitle": "Feed XML dla marketplace lub partnera — szablon, mapowanie, filtr, podgląd i stabilny URL. Bez developera.",
+        "steps_aria": "Kroki kreatora",
+        "step": {
+          "template": "Szablon",
+          "scope": "Zakres",
+          "mapping": "Mapowanie",
+          "delivery": "Dostarczanie",
+          "preview": "Podgląd"
+        },
+        "step_note": {
+          "template": "kanał docelowy",
+          "scope": "filtr · scope",
+          "mapping": "sloty ↔ atrybuty",
+          "delivery": "URL · harmonogram",
+          "preview": "XML · publikacja"
+        },
+        "cancel": "Anuluj",
+        "back": "← Wstecz",
+        "next": "Dalej",
+        "progress": "Krok {{current}} z {{total}}",
+        "save_and_generate": "Zapisz i wygeneruj",
+        "saved": "Feed zapisany.",
+        "save_error": "Zapis feedu nie powiódł się. Sprawdź pola i spróbuj ponownie.",
+        "template": {
+          "title": "Wybierz szablon feedu",
+          "subtitle": "Predefiniowany kanał ma gotowe sloty i reguły walidacji. Custom buduje własną strukturę od zera (lub klonuje predef).",
+          "predef": "predef",
+          "custom": "custom",
+          "chosen": "wybrany",
+          "name_label": "Nazwa feedu",
+          "name_placeholder": "np. Google Shopping — Polska",
+          "code_label": "Code",
+          "code_hint": "auto z nazwy",
+          "desc": {
+            "google_shopping": "Feed produktowy Google Merchant Center (RSS 2.0, namespace g:) — walidacja GTIN/MPN, warianty przez item_group_id.",
+            "ceneo": "Feed ofertowy Ceneo.pl — itemy <o> z atrybutami, kategoria jako ścieżka w CDATA.",
+            "meta": "Feed katalogu Meta (Facebook/Instagram) — RSS z polami produktowymi fb.",
+            "custom": "Własna struktura XML: root, item i sloty definiowane slot po slocie. Sklonuj predef albo zacznij od zera."
+          }
+        },
+        "scope": {
+          "title": "Scope wartości",
+          "one_locale": "· feed = jeden locale",
+          "object_type": "Typ obiektu",
+          "product": "Produkt",
+          "locked": "zablokowane",
+          "locale": "Język (locale)",
+          "currency": "Waluta",
+          "none": "—",
+          "channel": "Kanał",
+          "channel_hint": "overlay wartości",
+          "variants_note": "Warianty produktów trafiają do feedu PŁASKO — każdy wariant to osobny <item> z własnym id i wspólnym item_group_id = SKU mastera. Wiele języków = wiele feedów.",
+          "assortment": "Asortyment w feedzie",
+          "filter_hint": "Ten sam filtr (DSL) co lista produktów i eksport — bez drugiej implementacji.",
+          "in_feed": "W feedzie: {{count}} produktów",
+          "counting": "Liczenie…"
+        },
+        "placeholder": {
+          "mapping_title": "Mapowanie — kolejny ticket",
+          "mapping_hint": "Mapper slotów ↔ atrybutów wchodzi z XMLF-P5-03.",
+          "delivery_title": "Dostarczanie — kolejny ticket",
+          "delivery_hint": "Harmonogram, gzip, autoryzacja URL i karta tokenu wchodzą z XMLF-P5-04.",
+          "preview_title": "Podgląd — kolejny ticket",
+          "preview_hint": "Podgląd XML na żywo z raportem zdrowia wchodzi z XMLF-P5-04."
+        },
         "back_to_hub": "Wróć do feedów"
       },
       "detail": {

--- a/apps/api/src/Export/Feed/Presentation/Controller/FeedTemplatesController.php
+++ b/apps/api/src/Export/Feed/Presentation/Controller/FeedTemplatesController.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Feed\Presentation\Controller;
+
+use App\Export\Feed\Domain\Enum\FeedTemplateKind;
+use App\Export\Feed\Domain\Template\FeedTemplate;
+use App\Export\Feed\Domain\Template\FeedTemplateCatalog;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * XMLF-P5-02 — read-only catalog of feed templates for the wizard's step 1
+ * (SelectableCard grid). Serves the same in-code catalog the create endpoint
+ * seeds descriptors from (XMLF-P2-02), plus the default mappings the wizard
+ * copies into its state on template choice. Auto-registered into OpenAPI
+ * (ADR-0020).
+ */
+final class FeedTemplatesController
+{
+    public function __construct(
+        private readonly FeedTemplateCatalog $catalog,
+    ) {
+    }
+
+    #[Route(path: '/api/feeds/templates', name: 'pim_feeds_templates', methods: ['GET'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'exports', action: 'view_all')]
+    public function list(): JsonResponse
+    {
+        return new JsonResponse([
+            'items' => array_map($this->serialize(...), $this->catalog->all()),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serialize(FeedTemplate $template): array
+    {
+        $root = \is_array($template->descriptor['root'] ?? null) ? $template->descriptor['root'] : [];
+        $namespaces = \is_array($root['namespaces'] ?? null) ? $root['namespaces'] : [];
+
+        return [
+            'kind' => $template->kind->value,
+            'built_in' => FeedTemplateKind::Custom !== $template->kind,
+            'root_element' => \is_string($root['element'] ?? null) ? $root['element'] : null,
+            'namespaces' => array_keys($namespaces),
+            'descriptor' => $template->descriptor,
+            'default_mappings' => $template->defaultMappings,
+        ];
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -13202,6 +13202,32 @@
                 "x-cortex-permission": false
             }
         },
+        "/api/feeds/templates": {
+            "get": {
+                "operationId": "api_feeds_templates_get",
+                "tags": [
+                    "feeds"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api feeds templates",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "exports.view_all"
+            }
+        },
         "/api/feeds/{id}": {
             "get": {
                 "operationId": "api_feeds_id_get",


### PR DESCRIPTION
## Cel (XMLF-P5-02, #1930)
Serce flow „feed w 5 minut bez developera": pełnostronicowy kreator pod `/feeds/new` i `/feeds/:id/edit` — stepper 5 kroków, krok 1 (Szablon) i krok 2 (Zakres). Kroki 3–5 renderują placeholdery w shellu (P5-03/P5-04 je podmienią). Layout 1:1 z `feedy/feed-wizard.jsx`.

## Co jest w środku
- **BE (mały):** `GET /api/feeds/templates` — serializacja in-code katalogu (P2-02): kind, built_in, root/namespaces, descriptor + default_mappings (kreator kopiuje je do draftu przy wyborze). OpenAPI +1 trasa.
- **Stepper:** klikalne tylko kroki ≤ current (done/active/pending, `aria-current="step"`), nawigacja `<nav><ol>`.
- **Krok 1 Szablon:** SelectableCard-grid (predef|custom badge, root/ns mono, „wybrany"), wybór seeduje mappings + auto-fill name/code (slug do pierwszego ręcznego dotknięcia code).
- **Krok 2 Zakres:** locked ObjectType=Produkt, locale z `/api/tenant-locales` (tylko aktywne), waluta, kanał (overlay) z `/api/channels`, nota o wariantach flat; **AdvancedFilterPanel + use-filter-dsl-state w reuse** (zero drugiej implementacji filtra) + live-count z `POST /api/exports/preflight` (debounce 500 ms, wzorzec EXR).
- **Zapis draftu przy wyjściu z kroku 2:** `POST /api/feeds` (wymaga konkretnego `object_type_id` — rozwiązywany raz z `/api/object_types`; hydra vs plain-JSON obsłużone) → follow-up `PATCH` z filtrem (create świadomie nie przyjmuje `filter`). Edit mode prefilluje draft + wpycha zapisany DSL do stanu filtra explicitly (hook czyta initial tylko na mount). Przycisk „Dalej" trzymany do czasu rozwiązania typu (bez wyścigu).
- **Świadome odejście:** select „Profil publikacji" z designu NIE wchodzi — BE nie wystawia ChannelPublicationProfile przez API; wchodzi z tym endpointem (ADR-0018 follow-up, zalążek mapowania w P5-03).
- **Porządek:** spec huba przeniesiony na właściwy numer (`1929-feeds-hub.spec.ts`) + asercja CTA zaktualizowana pod realny wizard.

## Live smoke (pim.localhost, unmocked) ✅
```
/feeds/new → karta Google Shopping → name/code auto-fill → Dalej
Krok 2: „W feedzie: N produktów" (POST /api/exports/preflight 200, realny katalog)
Dalej → POST /api/feeds → 201 → PATCH /api/feeds/{id} → 200 → krok 3 (placeholder P5-03)
```

## Testy
- **Playwright `1930-feed-wizard.spec.ts`** (mocked): gating Dalej (disabled→enabled po wyborze szablonu), auto-fill code, live-count 12 408 z preflight, zapis draftu (asercja payloadu POST: template_kind+locale), stepper done-clickable/pending-disabled, **axe 0 serious/critical**.
- **Vitest 9/9:** slugifyCode (PL diakrytyki), canLeaveStep (gating kroków 0/1), draftFromFeed (prefill edit).
- tsc ✓ · Biome ✓ · vite build ✓ · PHPStan max 0 · PHPUnit 1398 · OpenAPI drift green.

Refs #1930