### PR TITLE
feat(admin): feed wizard mapper step (slots ↔ PIM attributes)

### DIFF
--- a/agent/lessons.md
+++ b/agent/lessons.md
@@ -2739,3 +2739,13 @@ M4 (P4-01..08) + M5 Hardening (P5-01..05) — wszystkie zmergowane. Epik APIC ko
 6. **Konsola admina zawsze ma 2×401 na twardym wejściu** (in-memory JWT + refresh-cookie bootstrap) — asercja `consoleErrors === []` w e2e jest zbyt ostra; filtrować 401-e z /api/auth.
 
 **Errata numeracji (2026-07-02):** P3-03 = **#1921**, nie #1922 (to P3-04) — instrukcja operatora miała zły numer; commit P3-03 w PR #2017 nosi błędny `Refs #1922`. Reguła bez wyjątku: `gh issue list --search "XMLF-PX-NN in:title"` przed KAŻDYM `Refs`/`Closes`/`gh issue close`, także gdy numer podał operator.
+
+## Lessons z XMLF P5-02/P5-03 (2026-07-02 — kreator + mapper FE)
+
+1. **Guard `lint-jsonfetch-useeffect` liczy STRING co-occurrence** (`grep jsonFetch` × `grep 'useEffect('`) w pliku — nawet komentarz ze słowem jsonFetch flaguje plik. Ekrany z efektami trzymać BEZ transportu: read przez useQuery, komendy (POST/PATCH) jako funkcje w `api/*.ts`.
+2. **Playwright glob `*` nie matchuje `/`** — `**/api/feeds/*` NIE łapie `/api/feeds/{id}/mapping`; catch-all = `**`; route'y matchowane LIFO (szczegółowe rejestrować PO catch-allu).
+3. **`attribute.label` to JSONB `{pl,en}`** — render obiektu = React crash w ErrorBoundary („Objects are not valid as a React child"); zawsze helper `attributeLabel()`.
+4. **Default mappings szablonu to SUGESTIA**: BE waliduje istnienie atrybutów w katalogu tenanta (400 „nie istnieje w katalogu") — na load katalogu sanitize (unknown ref → source null), a PUT wysyła TYLKO zmapowane sloty (source null ≠ wpis mapowania → 400 „nieznany typ źródła").
+5. **API Platform format-dependent shape**: z `accept: application/json` kolekcja to goły ARRAY (bez `member`); default (LD+JSON) ma `member` — hooki odporne na oba.
+6. **Feed create wymaga `object_type_id`** mimo locked-Produkt w UI — rozwiązywać raz z `/api/object_types` i trzymać przycisk „Dalej" do czasu resolve (wyścig na szybkim kliku). `filter` przyjmuje tylko PATCH — flow: POST create → follow-up PATCH.
+7. **Kolumna „Wynik·próbka" mappera bez nowego BE**: POST /api/feeds/preview (limit=1) + DOMParser na XML writera (getElementsByTagNameNS('*', local) dla namespace'ów) — BE zostaje jedynym źródłem semantyki renderowania.

--- a/apps/admin/e2e/1930-feed-wizard.spec.ts
+++ b/apps/admin/e2e/1930-feed-wizard.spec.ts
@@ -37,12 +37,34 @@ test('XMLF-P5-02 — wizard: template choice, gating, scope + draft save', async
 
   // Registered before the more specific routes — Playwright matches LIFO,
   // so `/api/feeds/templates` (below) wins over this id-wildcard.
-  await page.route('**/api/feeds/*', (route) => {
+  await page.route('**/api/feeds/**', (route) => {
+    if (route.request().url().endsWith('/mapping')) {
+      return route.fulfill({
+        json: {
+          feed_id: '019f0000-0000-7000-8000-00000000aaaa',
+          object_type_id: '019f0000-0000-7000-8000-000000000001',
+          slots: [],
+          attributes: [],
+          coverage: {
+            slots_total: 0,
+            slots_mapped: 0,
+            required_total: 0,
+            required_mapped: 0,
+            missing_required: [],
+            one_of_groups: [],
+          },
+          transforms: ['none'],
+        },
+      });
+    }
     if (route.request().method() === 'PATCH') {
       return route.fulfill({ json: route.request().postDataJSON() as Record<string, unknown> });
     }
     return route.fulfill({ json: {} });
   });
+  await page.route('**/api/feeds/preview', (route) =>
+    route.fulfill({ json: { sample_count: 0, xml: '', health: [] } }),
+  );
   await page.route('**/api/feeds/templates', (route) => route.fulfill({ json: TEMPLATES }));
   await page.route('**/api/object_types*', (route) =>
     route.fulfill({
@@ -102,7 +124,8 @@ test('XMLF-P5-02 — wizard: template choice, gating, scope + draft save', async
 
   // Leaving scope persists the draft.
   await nextButton.click();
-  await expect(page.getByText(/XMLF-P5-03/)).toBeVisible();
+  // Step 3 is the live mapper since P5-03 — its header proves the transition.
+  await expect(page.getByText(/Mapowanie slot|Slot ↔ attribute/)).toBeVisible();
   expect(createdPayload).not.toBeNull();
   expect(createdPayload?.template_kind).toBe('google_shopping');
   expect(createdPayload?.locale).toBe('pl');

--- a/apps/admin/e2e/1931-feed-mapper.spec.ts
+++ b/apps/admin/e2e/1931-feed-mapper.spec.ts
@@ -1,0 +1,174 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * XMLF-P5-03 (#1931) — the mapper step over the P3-01 view model: slot table
+ * with required/node/fmt badges, unmapped-required error state, the source
+ * picker updating the draft, the live sample column resolved from the draft
+ * preview XML, and the PUT persisting only mapped slots when leaving the
+ * step. All endpoints mocked.
+ */
+
+const MAPPING_VIEW = {
+  feed_id: '019f0000-0000-7000-8000-00000000aaaa',
+  object_type_id: '019f0000-0000-7000-8000-000000000001',
+  slots: [
+    {
+      target: 'g:id',
+      element: 'g:id',
+      node: 'element',
+      required: true,
+      required_one_of: [],
+      format: 'text',
+      max_length: 50,
+      enums: [],
+      mapping: { slot: 'g:id', source: { kind: 'attribute', ref: 'sku' } },
+      mapped: true,
+      type_warning: null,
+    },
+    {
+      target: 'g:title',
+      element: 'g:title',
+      node: 'element',
+      required: true,
+      required_one_of: [],
+      format: 'text',
+      max_length: 150,
+      enums: [],
+      mapping: null,
+      mapped: false,
+      type_warning: null,
+    },
+  ],
+  attributes: [
+    { code: 'sku', label: { pl: 'SKU', en: 'SKU' }, type: 'text' },
+    { code: 'name', label: { pl: 'Nazwa', en: 'Name' }, type: 'text' },
+  ],
+  coverage: {
+    slots_total: 2,
+    slots_mapped: 1,
+    required_total: 2,
+    required_mapped: 1,
+    missing_required: ['g:title'],
+    one_of_groups: [],
+  },
+  transforms: [
+    'none',
+    'default',
+    'price',
+    'number',
+    'date',
+    'enum_map',
+    'template',
+    'strip_html',
+    'truncate',
+  ],
+};
+
+const PREVIEW = {
+  sample_count: 1,
+  xml: '<?xml version="1.0"?><rss xmlns:g="http://base.google.com/ns/1.0"><channel><item><g:id>KL-1</g:id></item></channel></rss>',
+  health: [],
+};
+
+test('XMLF-P5-03 — mapper: table, badges, source pick, sample, PUT on leave', async ({ page }) => {
+  await loginAsAdmin(page);
+
+  let putBody: { mappings?: Array<{ slot: string; source: unknown }> } | null = null;
+  await page.route('**/api/feeds/**', (route) => {
+    const url = route.request().url();
+    if (url.endsWith('/mapping')) {
+      if (route.request().method() === 'PUT') {
+        putBody = route.request().postDataJSON() as typeof putBody;
+        return route.fulfill({ json: MAPPING_VIEW });
+      }
+      return route.fulfill({ json: MAPPING_VIEW });
+    }
+    if (route.request().method() === 'PATCH') {
+      return route.fulfill({ json: route.request().postDataJSON() as Record<string, unknown> });
+    }
+    return route.fulfill({ json: {} });
+  });
+  await page.route('**/api/feeds/preview', (route) => route.fulfill({ json: PREVIEW }));
+  await page.route('**/api/feeds/templates', (route) =>
+    route.fulfill({
+      json: {
+        items: [
+          {
+            kind: 'google_shopping',
+            built_in: true,
+            root_element: 'rss',
+            namespaces: ['g'],
+            descriptor: { root: { element: 'rss' } },
+            default_mappings: [{ slot: 'g:id', source: { kind: 'attribute', ref: 'sku' } }],
+          },
+        ],
+      },
+    }),
+  );
+  await page.route('**/api/object_types*', (route) =>
+    route.fulfill({
+      json: {
+        member: [{ id: '019f0000-0000-7000-8000-000000000001', kind: 'product' }],
+        totalItems: 1,
+      },
+    }),
+  );
+  await page.route('**/api/tenant-locales', (route) =>
+    route.fulfill({ json: { items: [{ code: 'pl', label: 'Polski', isActive: true }] } }),
+  );
+  await page.route('**/api/channels*', (route) =>
+    route.fulfill({ json: { member: [], totalItems: 0 } }),
+  );
+  await page.route('**/api/exports/preflight', (route) =>
+    route.fulfill({
+      json: { count: 10, mode: 'sync', threshold: 500, soft_cap: 100000, exceeds_cap: false },
+    }),
+  );
+  await page.route('**/api/feeds', (route) => {
+    if (route.request().method() === 'POST') {
+      return route.fulfill({
+        status: 201,
+        json: {
+          ...(route.request().postDataJSON() as Record<string, unknown>),
+          id: '019f0000-0000-7000-8000-00000000aaaa',
+        },
+      });
+    }
+    return route.fulfill({ json: { items: [] } });
+  });
+
+  await page.goto('/integrations/api-configurator/feeds/new');
+  await page.getByRole('button', { name: /Google Shopping/ }).click();
+  await page.getByRole('button', { name: /Dalej|^Next$/ }).click();
+  await page.getByRole('button', { name: /Dalej|^Next$/ }).click();
+
+  // Slot table renders with badges + the unmapped-required error state.
+  await expect(page.getByText('g:id', { exact: true })).toBeVisible();
+  await expect(page.getByText(/wym\.|req\./).first()).toBeVisible();
+  await expect(page.getByText(/brak wartości|no value/)).toBeVisible();
+
+  // The live sample column shows the writer's output for the mapped slot.
+  await expect(page.getByText('KL-1')).toBeVisible();
+
+  // Coverage header reflects the backend counters.
+  await expect(page.getByText('1/2')).toBeVisible();
+
+  // Pick a source for the unmapped slot, then leave the step → PUT with
+  // ONLY mapped slots.
+  await page
+    .getByRole('combobox', { name: /g:title/ })
+    .first()
+    .selectOption('name');
+  await page.getByRole('button', { name: /Dalej|^Next$/ }).click();
+  await expect(page.getByText(/XMLF-P5-04/)).toBeVisible();
+  expect(putBody?.mappings?.every((m) => m.source !== null)).toBe(true);
+  expect(putBody?.mappings?.some((m) => m.slot === 'g:title')).toBe(true);
+
+  const axe = await new AxeBuilder({ page }).analyze();
+  expect(axe.violations.filter((v) => v.impact === 'serious' || v.impact === 'critical')).toEqual(
+    [],
+  );
+});

--- a/apps/admin/src/features/api-configurator/feeds/__tests__/wizard-state.test.ts
+++ b/apps/admin/src/features/api-configurator/feeds/__tests__/wizard-state.test.ts
@@ -66,3 +66,77 @@ describe('draftFromFeed', () => {
     expect(draft.filterDsl).not.toBeNull();
   });
 });
+
+describe('sampleValuesFromXml', () => {
+  it('resolves element and namespaced values from the first item', async () => {
+    const { sampleValuesFromXml } = await import('../api/mapping');
+    const xml = `<?xml version="1.0"?><rss xmlns:g="http://base.google.com/ns/1.0"><channel><item><g:id>KL-1</g:id><g:title>Wkręt</g:title></item></channel></rss>`;
+    const slots = [
+      {
+        target: 'g:id',
+        element: 'g:id',
+        node: 'element',
+        required: true,
+        required_one_of: [],
+        format: 'text',
+        max_length: null,
+        enums: [],
+        mapping: null,
+        mapped: true,
+        type_warning: null,
+      },
+      {
+        target: 'g:title',
+        element: 'g:title',
+        node: 'element',
+        required: true,
+        required_one_of: [],
+        format: 'text',
+        max_length: 150,
+        enums: [],
+        mapping: null,
+        mapped: true,
+        type_warning: null,
+      },
+      {
+        target: 'g:brand',
+        element: 'g:brand',
+        node: 'element',
+        required: false,
+        required_one_of: [],
+        format: 'text',
+        max_length: null,
+        enums: [],
+        mapping: null,
+        mapped: false,
+        type_warning: null,
+      },
+    ] as never[];
+    const values = sampleValuesFromXml(xml, slots);
+    expect(values.get('g:id')).toBe('KL-1');
+    expect(values.get('g:title')).toBe('Wkręt');
+    expect(values.has('g:brand')).toBe(false);
+  });
+
+  it('returns empty on malformed xml', async () => {
+    const { sampleValuesFromXml } = await import('../api/mapping');
+    expect(sampleValuesFromXml('<broken', []).size).toBe(0);
+  });
+});
+
+describe('sanitizeMappings', () => {
+  it('drops attribute refs the tenant does not have, keeps the rest', async () => {
+    const { sanitizeMappings } = await import('../api/mapping');
+    const cleaned = sanitizeMappings(
+      [
+        { slot: 'g:id', source: { kind: 'attribute', ref: 'sku' } },
+        { slot: 'g:availability', source: { kind: 'attribute', ref: 'stock_qty' } },
+        { slot: 'g:condition', source: { kind: 'static', value: 'new' } },
+      ],
+      [{ code: 'sku', label: 'SKU', type: 'text' }],
+    );
+    expect(cleaned[0]?.source).not.toBeNull();
+    expect(cleaned[1]?.source).toBeNull();
+    expect(cleaned[2]?.source?.kind).toBe('static');
+  });
+});

--- a/apps/admin/src/features/api-configurator/feeds/api/feeds.ts
+++ b/apps/admin/src/features/api-configurator/feeds/api/feeds.ts
@@ -26,6 +26,7 @@ export interface FeedRow {
   descriptor: Record<string, unknown>;
   field_mappings: Array<Record<string, unknown>>;
   filter?: unknown;
+  validation_policy?: 'skip_invalid' | 'include_with_warning';
   cached_item_count: number | null;
   cached_at: string | null;
   last_pulled_at: string | null;

--- a/apps/admin/src/features/api-configurator/feeds/api/mapping.ts
+++ b/apps/admin/src/features/api-configurator/feeds/api/mapping.ts
@@ -1,0 +1,177 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { jsonFetch } from '@/lib/http';
+
+/**
+ * XMLF-P5-03 — data layer for the mapper step, a thin consumer of the P3-01
+ * backend: GET/PUT /api/feeds/{id}/mapping serves the full view model (slots
+ * with required/one-of/format/max_length, the tenant attribute catalog, the
+ * coverage counters and the closed transform list); POST /api/feeds/preview
+ * renders a small sample whose first item feeds the live "Wynik" column.
+ */
+
+export interface MappingSource {
+  kind: 'attribute' | 'static' | 'template';
+  ref?: string | null;
+  value?: string | null;
+}
+
+export interface SlotMapping {
+  slot: string;
+  source: MappingSource | null;
+  transform?: Record<string, unknown> | null;
+}
+
+export interface MappingSlotView {
+  target: string;
+  element: string;
+  node: 'element' | 'attribute' | 'repeatable' | 'keyvalue';
+  required: boolean;
+  required_one_of: string[];
+  format: string;
+  max_length: number | null;
+  enums: string[];
+  mapping: SlotMapping | null;
+  mapped: boolean;
+  type_warning: string | null;
+}
+
+export interface AttributeOption {
+  code: string;
+  /** Multilingual JSONB label ({pl, en, …}) or a plain string. */
+  label: string | Record<string, string>;
+  type: string;
+}
+
+/** Pick a display label: current-locale-ish first, then any, then the code. */
+export function attributeLabel(attribute: AttributeOption): string {
+  if (typeof attribute.label === 'string') {
+    return attribute.label;
+  }
+  return (
+    attribute.label.pl ?? attribute.label.en ?? Object.values(attribute.label)[0] ?? attribute.code
+  );
+}
+
+export interface MappingView {
+  feed_id: string;
+  object_type_id: string;
+  slots: MappingSlotView[];
+  attributes: AttributeOption[];
+  coverage: {
+    slots_total: number;
+    slots_mapped: number;
+    required_total: number;
+    required_mapped: number;
+    missing_required: string[];
+    one_of_groups: Array<{ slots: string[]; satisfied: boolean }>;
+  };
+  transforms: string[];
+}
+
+/**
+ * Template default mappings are suggestions — refs pointing at attributes the
+ * tenant does not have would fail the backend's catalog validation on PUT.
+ * Drop those sources (the slot shows as unmapped and the operator picks one).
+ */
+export function sanitizeMappings(
+  mappings: SlotMapping[],
+  attributes: AttributeOption[],
+): SlotMapping[] {
+  const known = new Set(attributes.map((attribute) => attribute.code));
+  return mappings.map((mapping) => {
+    if (mapping.source?.kind === 'attribute' && !known.has(mapping.source.ref ?? '')) {
+      return { ...mapping, source: null };
+    }
+    return mapping;
+  });
+}
+
+export function mappingQueryKey(feedId: string) {
+  return ['xmlf', 'feed-mapping', feedId] as const;
+}
+
+export function useFeedMapping(feedId: string | null) {
+  return useQuery({
+    queryKey: mappingQueryKey(feedId ?? 'none'),
+    enabled: feedId !== null,
+    queryFn: async () => jsonFetch<MappingView>(`/api/feeds/${feedId}/mapping`),
+  });
+}
+
+export function useSaveFeedMapping(feedId: string | null) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (mappings: SlotMapping[]) =>
+      jsonFetch<MappingView>(`/api/feeds/${feedId}/mapping`, {
+        method: 'PUT',
+        body: { mappings },
+      }),
+    onSuccess: (view) => {
+      queryClient.setQueryData(mappingQueryKey(feedId ?? 'none'), view);
+    },
+  });
+}
+
+interface PreviewResponse {
+  sample_count: number;
+  xml: string;
+  health: Array<{ sku: string | null; slot: string; level: string; message: string }>;
+}
+
+/** One-sample draft preview for the live result column. */
+export async function fetchSamplePreview(input: {
+  descriptor: Record<string, unknown>;
+  mappings: SlotMapping[];
+  objectTypeId: string;
+  locale: string | null;
+  filter: unknown;
+}): Promise<PreviewResponse> {
+  return jsonFetch<PreviewResponse>('/api/feeds/preview', {
+    method: 'POST',
+    body: {
+      descriptor: input.descriptor,
+      field_mappings: input.mappings,
+      object_type_id: input.objectTypeId,
+      locale: input.locale,
+      filter: input.filter,
+      limit: 1,
+    },
+  });
+}
+
+/**
+ * Resolve the first sample item's value per slot target from the preview XML
+ * (client-side — the backend's writer is the single source of the rendering
+ * semantics, we only read its output back).
+ */
+export function sampleValuesFromXml(xml: string, slots: MappingSlotView[]): Map<string, string> {
+  const values = new Map<string, string>();
+  if (xml.trim() === '') {
+    return values;
+  }
+  const doc = new DOMParser().parseFromString(xml, 'application/xml');
+  if (doc.querySelector('parsererror') !== null) {
+    return values;
+  }
+  for (const slot of slots) {
+    const local = slot.element.includes(':')
+      ? (slot.element.split(':').pop() ?? slot.element)
+      : slot.element;
+    const nodes = doc.getElementsByTagName(slot.element);
+    const anyNs = nodes.length > 0 ? nodes : doc.getElementsByTagNameNS('*', local);
+    const first = anyNs.item(0);
+    if (first !== null && first.textContent !== null && first.textContent.trim() !== '') {
+      values.set(slot.target, first.textContent.trim());
+      continue;
+    }
+    if (slot.node === 'attribute') {
+      const owner = doc.querySelector(`[${CSS.escape(slot.element)}]`);
+      const attr = owner?.getAttribute(slot.element);
+      if (attr !== null && attr !== undefined && attr !== '') {
+        values.set(slot.target, attr);
+      }
+    }
+  }
+  return values;
+}

--- a/apps/admin/src/features/api-configurator/feeds/wizard/FeedWizardPage.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/wizard/FeedWizardPage.tsx
@@ -12,8 +12,15 @@ import { httpErrorDetail } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
 import { createFeed, fetchFeed, patchFeed } from '../api/feeds';
+import {
+  type SlotMapping,
+  sanitizeMappings,
+  useFeedMapping,
+  useSaveFeedMapping,
+} from '../api/mapping';
 import { type FeedTemplateInfo, useFeedTemplates, useProductObjectTypeId } from '../api/templates';
 import { TemplateBadge } from '../components/primitives';
+import { StepMapper } from './steps/StepMapper';
 import { StepScope } from './steps/StepScope';
 import { StepTemplate } from './steps/StepTemplate';
 import {
@@ -72,6 +79,23 @@ export function FeedWizardPage() {
     setLoadedForEdit(true);
   }, [editRow, loadedForEdit, setFilterConditions]);
 
+  const mappingView = useFeedMapping(step >= 2 ? draft.id : null);
+  const saveMapping = useSaveFeedMapping(draft.id);
+  const attributesKey = mappingView.data?.attributes.map((a) => a.code).join(',') ?? null;
+  // biome-ignore lint/correctness/useExhaustiveDependencies: catalog tracked via its code key
+  useEffect(() => {
+    if (attributesKey === null || mappingView.data === undefined) {
+      return;
+    }
+    const catalog = mappingView.data.attributes;
+    setDraft((prev) => {
+      const cleaned = sanitizeMappings(prev.mappings, catalog);
+      return JSON.stringify(cleaned) === JSON.stringify(prev.mappings)
+        ? prev
+        : { ...prev, mappings: cleaned };
+    });
+  }, [attributesKey]);
+
   const preflight = useExportPreflight({
     entityType: 'product',
     objectTypeId: null,
@@ -97,7 +121,10 @@ export function FeedWizardPage() {
       return {
         ...prev,
         kind: template.kind,
-        mappings: template.default_mappings.map((mapping) => ({ ...mapping })),
+        descriptor: template.descriptor,
+        mappings: template.default_mappings.map((mapping) => ({
+          ...mapping,
+        })) as unknown as SlotMapping[],
         name: nextName,
         code: prev.codeTouched ? prev.code : slugifyCode(nextName),
       };
@@ -138,6 +165,21 @@ export function FeedWizardPage() {
     // The mapper (P5-03) needs a persisted FeedProfile — save when leaving scope.
     if (step === 1 && !(await persistDraft())) {
       return;
+    }
+    // Leaving the mapper persists the slot mappings (PUT — the backend
+    // validates and returns the fresh view) + the skip policy via PATCH.
+    if (step === 2) {
+      try {
+        // Only mapped slots go to the backend — a null source means "unmapped"
+        // in the UI, not a mapping entry.
+        await saveMapping.mutateAsync(draft.mappings.filter((m) => m.source !== null));
+      } catch (error) {
+        toast.error(httpErrorDetail(error) ?? t('api_configurator.feeds.wizard.save_error'));
+        return;
+      }
+      if (!(await persistDraft())) {
+        return;
+      }
     }
     setStep((value) => Math.min(value + 1, WIZARD_STEP_IDS.length - 1));
   }
@@ -265,7 +307,20 @@ export function FeedWizardPage() {
             countLoading={preflight.isLoading}
           />
         )}
-        {step >= 2 && (
+        {step === 2 && mappingView.data !== undefined && productTypeId.data != null && (
+          <StepMapper
+            view={mappingView.data}
+            mappings={draft.mappings}
+            onMappings={(next) => setDraft((prev) => ({ ...prev, mappings: next }))}
+            skipPolicy={draft.skipPolicy}
+            onSkipPolicy={(policy) => setDraft((prev) => ({ ...prev, skipPolicy: policy }))}
+            descriptor={draft.descriptor}
+            objectTypeId={productTypeId.data}
+            locale={draft.locale}
+            filter={filterState.dsl}
+          />
+        )}
+        {step >= 3 && (
           <div className="rounded-3xl bg-white p-10 text-center soft-shadow">
             <h2 className="font-display text-[16px] font-semibold tracking-tight">
               {t(`api_configurator.feeds.wizard.placeholder.${WIZARD_STEP_IDS[step]}_title`)}

--- a/apps/admin/src/features/api-configurator/feeds/wizard/steps/StepMapper.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/wizard/steps/StepMapper.tsx
@@ -1,0 +1,359 @@
+import { AlertTriangle, CheckCircle2 } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Segmented } from '@/features/api-configurator/components/primitives';
+import { cn } from '@/lib/utils';
+
+import {
+  type AttributeOption,
+  attributeLabel,
+  fetchSamplePreview,
+  type MappingSlotView,
+  type MappingView,
+  type SlotMapping,
+  sampleValuesFromXml,
+} from '../../api/mapping';
+import { CoverageBar } from '../../components/primitives';
+
+const NODE_TONES: Record<string, string> = {
+  element: 'bg-zinc-100 text-zinc-600',
+  attribute: 'bg-sky-50 text-sky-700',
+  repeatable: 'bg-violet-50 text-violet-700',
+  keyvalue: 'bg-amber-50 text-amber-800',
+};
+
+export type SkipPolicy = 'skip_invalid' | 'include_with_warning';
+
+/**
+ * XMLF-P5-03 — the mapper (wizard step 3, design feed-mapper.jsx): the
+ * slot ↔ PIM-attribute table over the P3-01 view model. Each row shows the
+ * slot identity (node badge, required / one-of badges, fmt hint), a source
+ * picker (attribute | static | template), the closed transform list and the
+ * live sample column resolved from a one-item draft preview rendered by the
+ * backend writer. Rows with an unmapped required slot go rose; type
+ * mismatches surfaced by the backend go amber.
+ */
+export function StepMapper({
+  view,
+  mappings,
+  onMappings,
+  skipPolicy,
+  onSkipPolicy,
+  descriptor,
+  objectTypeId,
+  locale,
+  filter,
+}: {
+  view: MappingView;
+  mappings: SlotMapping[];
+  onMappings: (next: SlotMapping[]) => void;
+  skipPolicy: SkipPolicy;
+  onSkipPolicy: (policy: SkipPolicy) => void;
+  descriptor: Record<string, unknown>;
+  objectTypeId: string;
+  locale: string | null;
+  filter: unknown;
+}) {
+  const { t } = useTranslation();
+  const [sample, setSample] = useState<Map<string, string>>(new Map());
+  const seqRef = useRef(0);
+
+  const byndex = useMemo(() => {
+    const map = new Map<string, SlotMapping>();
+    for (const mapping of mappings) {
+      map.set(mapping.slot, mapping);
+    }
+    return map;
+  }, [mappings]);
+
+  const mappingsKey = JSON.stringify(mappings);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mappings tracked via its JSON key
+  useEffect(() => {
+    const seq = ++seqRef.current;
+    const timer = setTimeout(() => {
+      fetchSamplePreview({ descriptor, mappings, objectTypeId, locale, filter })
+        .then((preview) => {
+          if (seqRef.current === seq) {
+            setSample(sampleValuesFromXml(preview.xml, view.slots));
+          }
+        })
+        .catch(() => {
+          if (seqRef.current === seq) {
+            setSample(new Map());
+          }
+        });
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [mappingsKey, objectTypeId, locale]);
+
+  function setSlotMapping(target: string, patch: Partial<SlotMapping>): void {
+    const current = byndex.get(target) ?? { slot: target, source: null, transform: null };
+    const next = { ...current, ...patch };
+    const others = mappings.filter((mapping) => mapping.slot !== target);
+    onMappings([...others, next]);
+  }
+
+  const typeWarnings = view.slots.filter((slot) => slot.type_warning !== null).length;
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-3xl bg-white p-5 soft-shadow">
+        <div className="flex flex-wrap items-center gap-4">
+          <div>
+            <div className="text-[14.5px] font-semibold tracking-tight">
+              {t('api_configurator.feeds.mapper.title')}
+            </div>
+            <div className="mt-0.5 text-[12px] text-zinc-500">
+              {t('api_configurator.feeds.mapper.subtitle')}
+            </div>
+          </div>
+          <div className="ml-auto flex flex-wrap items-center gap-4">
+            <div className="text-right">
+              <div className="text-[10px] uppercase tracking-wider text-zinc-500">
+                {t('api_configurator.feeds.mapper.required_coverage')}
+              </div>
+              <div className="mt-1">
+                <CoverageBar
+                  mapped={view.coverage.required_mapped}
+                  total={view.coverage.required_total}
+                />
+              </div>
+            </div>
+            <div className="text-right">
+              <div className="text-[10px] uppercase tracking-wider text-zinc-500">
+                {t('api_configurator.feeds.mapper.type_warnings')}
+              </div>
+              <div
+                className={cn(
+                  'num mt-0.5 text-[15px] font-semibold',
+                  typeWarnings > 0 ? 'text-amber-700' : 'text-emerald-700',
+                )}
+              >
+                {typeWarnings}
+              </div>
+            </div>
+            <Segmented<SkipPolicy>
+              value={skipPolicy}
+              onChange={onSkipPolicy}
+              ariaLabel={t('api_configurator.feeds.mapper.skip_policy_aria')}
+              options={[
+                {
+                  value: 'skip_invalid',
+                  label: t('api_configurator.feeds.mapper.skip_invalid'),
+                },
+                {
+                  value: 'include_with_warning',
+                  label: t('api_configurator.feeds.mapper.include_with_warning'),
+                },
+              ]}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="overflow-hidden rounded-3xl bg-white soft-shadow">
+        <div className="grid grid-cols-[1.1fr_1.3fr_0.8fr_1fr] gap-3 border-b border-zinc-100 px-5 py-2.5 text-[10.5px] font-medium uppercase tracking-wider text-zinc-500">
+          <div>{t('api_configurator.feeds.mapper.col.slot')}</div>
+          <div>{t('api_configurator.feeds.mapper.col.source')}</div>
+          <div>{t('api_configurator.feeds.mapper.col.transform')}</div>
+          <div>{t('api_configurator.feeds.mapper.col.sample')}</div>
+        </div>
+        {view.slots.map((slot) => (
+          <SlotRow
+            key={slot.target}
+            slot={slot}
+            attributes={view.attributes}
+            transforms={view.transforms}
+            mapping={byndex.get(slot.target) ?? null}
+            sample={sample.get(slot.target) ?? null}
+            onChange={(patch) => setSlotMapping(slot.target, patch)}
+          />
+        ))}
+      </div>
+
+      <p className="text-[12px] leading-relaxed text-zinc-500">
+        {t('api_configurator.feeds.mapper.category_note')}
+      </p>
+    </div>
+  );
+}
+
+function SlotRow({
+  slot,
+  attributes,
+  transforms,
+  mapping,
+  sample,
+  onChange,
+}: {
+  slot: MappingSlotView;
+  attributes: AttributeOption[];
+  transforms: string[];
+  mapping: SlotMapping | null;
+  sample: string | null;
+  onChange: (patch: Partial<SlotMapping>) => void;
+}) {
+  const { t } = useTranslation();
+  const source = mapping?.source ?? null;
+  const sourceKind = source?.kind ?? 'none';
+  const transformKind =
+    typeof mapping?.transform?.kind === 'string' ? mapping.transform.kind : 'none';
+
+  const requiredMissing = slot.required && !slot.mapped;
+  const tooLong = slot.max_length !== null && sample !== null && sample.length > slot.max_length;
+
+  function pickSource(value: string): void {
+    if (value === 'none') {
+      onChange({ source: null });
+    } else if (value === 'static' || value === 'template') {
+      onChange({ source: { kind: value, value: source?.value ?? '' } });
+    } else {
+      onChange({ source: { kind: 'attribute', ref: value } });
+    }
+  }
+
+  function pickTransform(kind: string): void {
+    if (kind === 'none') {
+      onChange({ transform: null });
+    } else if (kind === 'truncate') {
+      onChange({ transform: { kind, to: slot.max_length ?? 100 } });
+    } else {
+      onChange({ transform: { kind } });
+    }
+  }
+
+  const selectClass =
+    'h-9 w-full rounded-lg border border-zinc-200 bg-white px-2 text-[12.5px] outline-none focus:border-zinc-400';
+
+  return (
+    <div
+      className={cn(
+        'grid grid-cols-[1.1fr_1.3fr_0.8fr_1fr] items-start gap-3 border-b border-zinc-50 px-5 py-3',
+        requiredMissing && 'border-l-2 border-l-rose-400 bg-rose-50/30',
+        !requiredMissing &&
+          slot.type_warning !== null &&
+          'border-l-2 border-l-amber-400 bg-amber-50/30',
+      )}
+    >
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="font-mono text-[12.5px] font-semibold text-zinc-800">{slot.target}</span>
+          {slot.required && (
+            <span className="rounded bg-rose-100 px-1 py-0.5 text-[9px] font-semibold uppercase text-rose-700">
+              {t('api_configurator.feeds.mapper.required')}
+            </span>
+          )}
+          {slot.required_one_of.length > 0 && (
+            <span
+              className="rounded bg-amber-100 px-1 py-0.5 text-[9px] font-semibold uppercase text-amber-800"
+              title={slot.required_one_of.join(' | ')}
+            >
+              {t('api_configurator.feeds.mapper.one_of', { count: slot.required_one_of.length })}
+            </span>
+          )}
+          <span
+            className={cn(
+              'rounded px-1 py-0.5 text-[9px] font-semibold uppercase',
+              NODE_TONES[slot.node] ?? NODE_TONES.element,
+            )}
+          >
+            {slot.node}
+          </span>
+        </div>
+        <div className="mt-1 font-mono text-[10.5px] text-zinc-500">
+          {slot.format}
+          {slot.max_length !== null && ` · ≤${slot.max_length}`}
+          {slot.enums.length > 0 && ` · enum(${slot.enums.length})`}
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <select
+          value={sourceKind === 'attribute' ? (source?.ref ?? 'none') : sourceKind}
+          onChange={(event) => pickSource(event.target.value)}
+          aria-label={t('api_configurator.feeds.mapper.source_aria', { slot: slot.target })}
+          className={selectClass}
+        >
+          <option value="none">{t('api_configurator.feeds.mapper.source_none')}</option>
+          <optgroup label={t('api_configurator.feeds.mapper.source_attribute')}>
+            {attributes.map((attribute) => (
+              <option key={attribute.code} value={attribute.code}>
+                {attributeLabel(attribute)} · {attribute.code} ({attribute.type})
+              </option>
+            ))}
+          </optgroup>
+          <optgroup label={t('api_configurator.feeds.mapper.source_other')}>
+            <option value="static">{t('api_configurator.feeds.mapper.source_static')}</option>
+            <option value="template">{t('api_configurator.feeds.mapper.source_template')}</option>
+          </optgroup>
+        </select>
+        {(sourceKind === 'static' || sourceKind === 'template') && (
+          <input
+            value={source?.value ?? ''}
+            onChange={(event) =>
+              onChange({ source: { kind: sourceKind, value: event.target.value } })
+            }
+            placeholder={
+              sourceKind === 'template'
+                ? '{store_url}/p/{url_slug}'
+                : t('api_configurator.feeds.mapper.static_placeholder')
+            }
+            aria-label={t('api_configurator.feeds.mapper.value_aria', { slot: slot.target })}
+            className="h-9 w-full rounded-lg border border-zinc-200 bg-white px-2 font-mono text-[12px] outline-none focus:border-zinc-400"
+          />
+        )}
+        {slot.type_warning !== null && (
+          <div className="flex items-start gap-1.5 text-[11px] text-amber-800">
+            <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
+            {slot.type_warning}
+          </div>
+        )}
+      </div>
+
+      <div>
+        <select
+          value={transformKind}
+          onChange={(event) => pickTransform(event.target.value)}
+          aria-label={t('api_configurator.feeds.mapper.transform_aria', { slot: slot.target })}
+          className={selectClass}
+        >
+          {transforms.map((kind) => (
+            <option key={kind} value={kind}>
+              {kind}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="min-w-0">
+        {sample !== null ? (
+          <div className="flex items-start gap-1.5">
+            <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-600" aria-hidden />
+            <code
+              className={cn(
+                'block truncate rounded-lg border border-zinc-100 bg-zinc-50 px-2 py-1 font-mono text-[11.5px]',
+                tooLong ? 'border-amber-300 text-amber-800' : 'text-zinc-700',
+              )}
+              title={sample}
+            >
+              {sample}
+            </code>
+          </div>
+        ) : requiredMissing ? (
+          <div className="flex items-center gap-1.5 text-[11.5px] font-medium text-rose-700">
+            <AlertTriangle className="h-3.5 w-3.5" aria-hidden />
+            {t('api_configurator.feeds.mapper.missing_value')}
+          </div>
+        ) : (
+          <span className="text-[11.5px] text-zinc-400">—</span>
+        )}
+        {tooLong && (
+          <div className="mt-1 text-[10.5px] text-amber-700">
+            {t('api_configurator.feeds.mapper.too_long', { max: slot.max_length })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/api-configurator/feeds/wizard/wizard-state.ts
+++ b/apps/admin/src/features/api-configurator/feeds/wizard/wizard-state.ts
@@ -1,6 +1,7 @@
 import type { FilterDsl } from '@/lib/filters/filter-dsl';
 
 import type { FeedRow, FeedTemplateKind } from '../api/feeds';
+import type { SlotMapping } from '../api/mapping';
 
 /**
  * XMLF-P5-02 — the wizard's draft state (design feed-wizard.jsx FeedWizard):
@@ -13,11 +14,13 @@ export interface FeedDraft {
   name: string;
   code: string;
   codeTouched: boolean;
+  descriptor: Record<string, unknown>;
   locale: string;
   currency: string | null;
   channelId: string | null;
-  mappings: Array<Record<string, unknown>>;
+  mappings: SlotMapping[];
   filterDsl: FilterDsl | null;
+  skipPolicy: 'skip_invalid' | 'include_with_warning';
 }
 
 export const WIZARD_STEP_IDS = ['template', 'scope', 'mapping', 'delivery', 'preview'] as const;
@@ -30,11 +33,13 @@ export function emptyDraft(): FeedDraft {
     name: '',
     code: '',
     codeTouched: false,
+    descriptor: {},
     locale: 'pl',
     currency: null,
     channelId: null,
     mappings: [],
     filterDsl: null,
+    skipPolicy: 'skip_invalid',
   };
 }
 
@@ -46,11 +51,13 @@ export function draftFromFeed(feed: FeedRow): FeedDraft {
     name: feed.name,
     code: feed.code,
     codeTouched: true,
+    descriptor: feed.descriptor,
     locale: feed.locale ?? 'pl',
     currency: feed.currency,
     channelId: feed.channel_id,
-    mappings: feed.field_mappings,
+    mappings: feed.field_mappings as unknown as SlotMapping[],
     filterDsl: (feed.filter as FilterDsl | null) ?? null,
+    skipPolicy: feed.validation_policy ?? 'skip_invalid',
   };
 }
 
@@ -98,5 +105,6 @@ export function patchPayload(draft: FeedDraft): Record<string, unknown> {
     currency: draft.currency,
     channel_id: draft.channelId,
     filter: draft.filterDsl,
+    validation_policy: draft.skipPolicy,
   };
 }

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1848,6 +1848,35 @@
       "detail": {
         "placeholder_title": "Feed detail — coming in the next ticket",
         "placeholder_hint": "The pipeline view, run history and per-product log drill-down land with XMLF-P5-05."
+      },
+      "mapper": {
+        "title": "Slot ↔ attribute mapping",
+        "subtitle": "Bind the template slots to PIM attributes; the sample column shows the writer's live output.",
+        "required_coverage": "Required",
+        "type_warnings": "Type warnings",
+        "skip_policy_aria": "Invalid product policy",
+        "skip_invalid": "skip invalid",
+        "include_with_warning": "include with warning",
+        "col": {
+          "slot": "Template slot",
+          "source": "Source · PIM attribute",
+          "transform": "Transform",
+          "sample": "Result · sample"
+        },
+        "required": "req.",
+        "one_of": "1 of {{count}}",
+        "source_aria": "Source for slot {{slot}}",
+        "value_aria": "Value for slot {{slot}}",
+        "transform_aria": "Transform for slot {{slot}}",
+        "source_none": "— not mapped —",
+        "source_attribute": "PIM attribute",
+        "source_other": "Other",
+        "source_static": "Static value…",
+        "source_template": "Template / interpolation…",
+        "static_placeholder": "constant value",
+        "missing_value": "no value — required",
+        "too_long": "over the {{max}}-char limit — add a truncate transform",
+        "category_note": "Slots with fmt=category (Ceneo cat, Google g:google_product_category) are resolved from the channel category tree's external codes at generation time; an explicit mapping value wins. Variants enter flat with item_group_id = the master's SKU."
       }
     },
     "shell": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1896,6 +1896,35 @@
       "detail": {
         "placeholder_title": "Detal feedu — w kolejnym tickecie",
         "placeholder_hint": "Widok pipeline, historia runów i drill-down logu per produkt wchodzą z XMLF-P5-05."
+      },
+      "mapper": {
+        "title": "Mapowanie slot ↔ atrybut",
+        "subtitle": "Zwiąż sloty szablonu z atrybutami PIM; kolumna próbki pokazuje wynik writera na żywo.",
+        "required_coverage": "Wymagane",
+        "type_warnings": "Ostrzeżenia typu",
+        "skip_policy_aria": "Polityka niepoprawnych produktów",
+        "skip_invalid": "pomiń niepoprawne",
+        "include_with_warning": "dołącz z ostrzeżeniem",
+        "col": {
+          "slot": "Slot szablonu",
+          "source": "Źródło · atrybut PIM",
+          "transform": "Transformacja",
+          "sample": "Wynik · próbka"
+        },
+        "required": "wym.",
+        "one_of": "1 z {{count}}",
+        "source_aria": "Źródło dla slotu {{slot}}",
+        "value_aria": "Wartość dla slotu {{slot}}",
+        "transform_aria": "Transformacja dla slotu {{slot}}",
+        "source_none": "— niezmapowany —",
+        "source_attribute": "Atrybut PIM",
+        "source_other": "Inne",
+        "source_static": "Wartość statyczna…",
+        "source_template": "Szablon / interpolacja…",
+        "static_placeholder": "stała wartość",
+        "missing_value": "brak wartości — wymagane",
+        "too_long": "ponad limit {{max}} znaków — dodaj transformację truncate",
+        "category_note": "Sloty z fmt=category (Ceneo cat, Google g:google_product_category) są rozwiązywane przy generacji z external_code drzewa kategorii kanału; jawna wartość z mapowania wygrywa. Warianty wchodzą płasko z item_group_id = SKU mastera."
       }
     },
     "shell": {


### PR DESCRIPTION
## Cel (XMLF-P5-03, #1931)
Komponent kluczowy konfiguratora (§9 pkt 3): krok 3 kreatora wiąże sloty szablonu z atrybutami PIM, dobiera transformacje z zamkniętej listy i pokazuje NA ŻYWO wynik writera na próbce. Czysty konsument backendu P3-01 — zero nowych endpointów.

## Jak działa
- **Tabela slotów** z `GET /api/feeds/{id}/mapping` (view model P3-01): font-mono target, badge `wym.`/`1 z N` (tooltip z grupą), SlotNodeBadge (element/attribute/repeatable/keyvalue), fmtHint (`price · ≤150 · enum(6)`).
- **SourcePicker:** optgroup „Atrybut PIM" (katalog tenanta z view — wielojęzyczne labelki przez `attributeLabel()`, bo `label` to JSONB `{pl,en}`), „Wartość statyczna…", „Szablon/interpolacja…" (input mono `{store_url}/p/{url_slug}`).
- **Transform dropdown** — dokładnie lista `transforms` z odpowiedzi BE (9 opcji); `truncate` auto-ustawia `to = max_length` slotu.
- **Kolumna „Wynik · próbka" live z BE:** debounce 500 ms → `POST /api/feeds/preview` (limit=1) → DOMParser na XML writera (namespace-aware) → wartości per slot. `tooLong` amber przy przekroczeniu max_length + hint truncate. Writer BE pozostaje JEDYNYM źródłem semantyki renderowania.
- **Stany:** required-niezmapowany → wiersz rose + „brak wartości — wymagane"; `type_warning` z BE → wiersz amber z komunikatem. Header: CoverageBar wymaganych (liczniki z BE), live licznik ostrzeżeń typu, Segmented skip-policy → `validation_policy` przez PATCH.
- **Default mappings = sugestia:** refy do atrybutów spoza katalogu tenanta czyszczone przy załadowaniu (BE słusznie 400-kuje nieznane kody — wykryte w live smoke na `stock_qty`), a wyjście z kroku PUT-uje **tylko zmapowane** sloty (source null = „niezmapowany", nie wpis).
- Wizard: krok 3 podmienia placeholder; PUT + PATCH przy „Dalej".

## Live smoke (pim.localhost, unmocked) ✅
```
kreator → krok 3: tabela slotów Google (13) z realnego GET mapping
kolumna próbki: POST /api/feeds/preview → 200 (realny katalog, XML writera)
zmiana źródła → Dalej → PUT /api/feeds/{id}/mapping → 200 (fresh view) → krok 4
```

## Testy
- **Playwright `1931-feed-mapper.spec.ts`** (mocked): tabela+badge'e, stan błędu required, próbka `KL-1` z XML, coverage 1/2, wybór źródła → PUT bez null-source'ów, axe 0 serious/critical. Spec 1930 zaktualizowany (krok 3 to teraz realny mapper).
- **Vitest 12/12:** + `sampleValuesFromXml` (namespace + malformed) i `sanitizeMappings`.
- tsc ✓ · Biome ✓ · build ✓ · guard jsonfetch-useeffect: 61 = baseline (strona kreatora bez transportu).

Refs #1931