### PR TITLE
feat(admin): feed wizard delivery + preview steps (kreator kompletny)

### DIFF
--- a/apps/admin/e2e/1931-feed-mapper.spec.ts
+++ b/apps/admin/e2e/1931-feed-mapper.spec.ts
@@ -163,7 +163,9 @@ test('XMLF-P5-03 — mapper: table, badges, source pick, sample, PUT on leave', 
     .first()
     .selectOption('name');
   await page.getByRole('button', { name: /Dalej|^Next$/ }).click();
-  await expect(page.getByText(/XMLF-P5-04/)).toBeVisible();
+  // Step 4 is the live delivery step since P5-04 — its schedule card proves
+  // the transition.
+  await expect(page.getByText(/Harmonogram regeneracji|Regeneration schedule/)).toBeVisible();
   expect(putBody?.mappings?.every((m) => m.source !== null)).toBe(true);
   expect(putBody?.mappings?.some((m) => m.slot === 'g:title')).toBe(true);
 

--- a/apps/admin/e2e/1932-feed-delivery-preview.spec.ts
+++ b/apps/admin/e2e/1932-feed-delivery-preview.spec.ts
@@ -1,0 +1,162 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * XMLF-P5-04 (#1932) — delivery + preview wizard steps: cron presets bind the
+ * draft, the gzip switch and auth segmented work (basic reveals write-only
+ * credentials), mint shows the token URL exactly once, leaving delivery
+ * PATCHes schedule+delivery, and the preview step renders the sample XML with
+ * the well-formed badge, the health report and the save-and-generate exit
+ * (regenerate + redirect to the hub). All endpoints mocked.
+ */
+
+const PREVIEW = {
+  sample_count: 2,
+  xml: '<?xml version="1.0"?><products><product><sku>KL-1</sku></product><product><sku>KL-2</sku></product></products>',
+  health: [{ sku: 'KL-9', slot: 'cat', level: 'warning', message: 'missing category' }],
+};
+
+test('XMLF-P5-04 — delivery + preview: schedule, auth, mint-once, preview, save', async ({
+  page,
+}) => {
+  await loginAsAdmin(page);
+
+  let patchedDelivery: unknown = null;
+  let regenerated = false;
+  await page.route('**/api/feeds/**', (route) => {
+    const url = route.request().url();
+    const method = route.request().method();
+    if (url.endsWith('/mapping')) {
+      return route.fulfill({
+        json: {
+          feed_id: 'f-1',
+          object_type_id: 'ot-1',
+          slots: [],
+          attributes: [],
+          coverage: {
+            slots_total: 0,
+            slots_mapped: 0,
+            required_total: 0,
+            required_mapped: 0,
+            missing_required: [],
+            one_of_groups: [],
+          },
+          transforms: ['none'],
+        },
+      });
+    }
+    if (url.endsWith('/token') && method === 'POST') {
+      return route.fulfill({
+        status: 201,
+        json: {
+          token: 'feedtokenfeedtokenfeedtoken12345',
+          url: '/api/feeds/pull/t-1/feedtokenfeedtokenfeedtoken12345.xml',
+        },
+      });
+    }
+    if (url.includes('/preview')) {
+      return route.fulfill({ json: PREVIEW });
+    }
+    if (url.endsWith('/health')) {
+      return route.fulfill({
+        json: {
+          items_syndicated: 95,
+          last_run: { item_count: 95, skipped_count: 3, warning_count: 4, health: 'warning' },
+        },
+      });
+    }
+    if (url.endsWith('/regenerate')) {
+      regenerated = true;
+      return route.fulfill({ status: 202, json: { run: { id: 'r-1', status: 'pending' } } });
+    }
+    if (method === 'PATCH') {
+      const body = route.request().postDataJSON() as { delivery?: unknown };
+      if (body.delivery !== undefined) {
+        patchedDelivery = body.delivery;
+      }
+      return route.fulfill({ json: body as Record<string, unknown> });
+    }
+    return route.fulfill({ json: {} });
+  });
+  await page.route('**/api/feeds/templates', (route) =>
+    route.fulfill({
+      json: {
+        items: [
+          {
+            kind: 'custom',
+            built_in: false,
+            root_element: 'products',
+            namespaces: [],
+            descriptor: { root: { element: 'products' }, item: { element: 'product', slots: [] } },
+            default_mappings: [],
+          },
+        ],
+      },
+    }),
+  );
+  await page.route('**/api/object_types*', (route) =>
+    route.fulfill({ json: { member: [{ id: 'ot-1', kind: 'product' }], totalItems: 1 } }),
+  );
+  await page.route('**/api/tenant-locales', (route) =>
+    route.fulfill({ json: { items: [{ code: 'pl', label: 'Polski', isActive: true }] } }),
+  );
+  await page.route('**/api/channels*', (route) =>
+    route.fulfill({ json: { member: [], totalItems: 0 } }),
+  );
+  await page.route('**/api/exports/preflight', (route) =>
+    route.fulfill({
+      json: { count: 95, mode: 'sync', threshold: 500, soft_cap: 100000, exceeds_cap: false },
+    }),
+  );
+  await page.route('**/api/feeds', (route) => {
+    if (route.request().method() === 'POST') {
+      return route.fulfill({
+        status: 201,
+        json: { ...(route.request().postDataJSON() as Record<string, unknown>), id: 'f-1' },
+      });
+    }
+    return route.fulfill({ json: { items: [] } });
+  });
+
+  await page.goto('/integrations/api-configurator/feeds/new');
+  await page.getByRole('button', { name: /Custom|Własny/ }).click();
+  await page.getByRole('button', { name: /Dalej|^Next$/ }).click();
+  await page.getByRole('button', { name: /Dalej|^Next$/ }).click();
+  await page.getByRole('button', { name: /Dalej|^Next$/ }).click();
+
+  // Step 4 — schedule preset binds the cron input.
+  await page.getByRole('button', { name: /codziennie|daily/ }).click();
+  await expect(page.getByPlaceholder(/tylko ręcznie|manual only/)).toHaveValue('0 3 * * *');
+
+  // Auth basic reveals write-only credentials.
+  await page.getByRole('button', { name: /HTTP Basic/ }).click();
+  await expect(page.getByLabel(/Hasło|Password/)).toBeVisible();
+  await page.getByRole('button', { name: /Token w URL|Token in URL/ }).click();
+
+  // Mint shows the URL exactly once.
+  await page.getByRole('button', { name: /Wygeneruj token|Mint token/ }).click();
+  await expect(page.getByText(/widoczny RAZ|shown ONCE/)).toBeVisible();
+  await expect(page.getByText(/feedtokenfeedtokenfeedtoken12345\.xml/)).toBeVisible();
+
+  // Leaving delivery persists schedule + delivery.
+  await page.getByRole('button', { name: /Dalej|^Next$/ }).click();
+  await expect(page.getByText(/well-formed/).first()).toBeVisible();
+  expect(patchedDelivery).toMatchObject({ gzip: true, auth: { type: 'none' } });
+
+  // Preview: sample XML + health line + projection from the last run.
+  await expect(page.getByText(/KL-1/).first()).toBeVisible();
+  await expect(page.getByText(/missing category/)).toBeVisible();
+  await expect(page.getByText('95', { exact: true }).first()).toBeVisible();
+
+  // Save & generate → regenerate + redirect to the hub.
+  await page.getByRole('button', { name: /Zapisz i wygeneruj|Save and generate/ }).click();
+  await expect(page).toHaveURL(/\/integrations\/api-configurator\/feeds$/);
+  expect(regenerated).toBe(true);
+
+  const axe = await new AxeBuilder({ page }).analyze();
+  expect(axe.violations.filter((v) => v.impact === 'serious' || v.impact === 'critical')).toEqual(
+    [],
+  );
+});

--- a/apps/admin/src/features/api-configurator/feeds/api/feeds.ts
+++ b/apps/admin/src/features/api-configurator/feeds/api/feeds.ts
@@ -27,6 +27,7 @@ export interface FeedRow {
   field_mappings: Array<Record<string, unknown>>;
   filter?: unknown;
   validation_policy?: 'skip_invalid' | 'include_with_warning';
+  delivery?: unknown;
   cached_item_count: number | null;
   cached_at: string | null;
   last_pulled_at: string | null;
@@ -130,6 +131,22 @@ export function useResumeFeed() {
 export interface MintedToken {
   token: string;
   url: string;
+}
+
+/** Fire-and-collect regeneration trigger (202 + pending run). */
+export async function regenerateFeed(id: string): Promise<unknown> {
+  return jsonFetch(`/api/feeds/${id}/regenerate`, { method: 'POST' });
+}
+
+/** Revoke the URL token — the public URL 404s immediately (P3-04/P3-05). */
+export function useRevokeToken() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => jsonFetch(`/api/feeds/${id}/token`, { method: 'DELETE' }),
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: FEEDS_QUERY_KEY });
+    },
+  });
 }
 
 /** Mint/rotate the URL token — the plaintext URL is shown once (P3-04/P3-05). */

--- a/apps/admin/src/features/api-configurator/feeds/wizard/FeedWizardPage.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/wizard/FeedWizardPage.tsx
@@ -11,7 +11,7 @@ import { useFilterDslState } from '@/lib/filters/use-filter-dsl-state';
 import { httpErrorDetail } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
-import { createFeed, fetchFeed, patchFeed } from '../api/feeds';
+import { createFeed, fetchFeed, patchFeed, regenerateFeed } from '../api/feeds';
 import {
   type SlotMapping,
   sanitizeMappings,
@@ -20,7 +20,9 @@ import {
 } from '../api/mapping';
 import { type FeedTemplateInfo, useFeedTemplates, useProductObjectTypeId } from '../api/templates';
 import { TemplateBadge } from '../components/primitives';
+import { StepDelivery } from './steps/StepDelivery';
 import { StepMapper } from './steps/StepMapper';
+import { StepPreview } from './steps/StepPreview';
 import { StepScope } from './steps/StepScope';
 import { StepTemplate } from './steps/StepTemplate';
 import {
@@ -166,6 +168,10 @@ export function FeedWizardPage() {
     if (step === 1 && !(await persistDraft())) {
       return;
     }
+    // Leaving delivery persists schedule + gzip/auth via PATCH.
+    if (step === 3 && !(await persistDraft())) {
+      return;
+    }
     // Leaving the mapper persists the slot mappings (PUT — the backend
     // validates and returns the fresh view) + the skip policy via PATCH.
     if (step === 2) {
@@ -183,6 +189,17 @@ export function FeedWizardPage() {
     }
     setStep((value) => Math.min(value + 1, WIZARD_STEP_IDS.length - 1));
   }
+
+  const rootPath = useMemo(() => {
+    const root = draft.descriptor.root;
+    const rootEl =
+      typeof root === 'object' && root !== null && 'element' in root
+        ? String((root as { element?: unknown }).element ?? '')
+        : '';
+    const hasChannel =
+      typeof draft.descriptor.channel === 'object' && draft.descriptor.channel !== null;
+    return hasChannel ? `${rootEl}/channel/item` : `${rootEl}/item`;
+  }, [draft.descriptor]);
 
   const last = WIZARD_STEP_IDS.length - 1;
   // Leaving scope needs the resolved product ObjectType id for the create
@@ -320,16 +337,23 @@ export function FeedWizardPage() {
             filter={filterState.dsl}
           />
         )}
-        {step >= 3 && (
-          <div className="rounded-3xl bg-white p-10 text-center soft-shadow">
-            <h2 className="font-display text-[16px] font-semibold tracking-tight">
-              {t(`api_configurator.feeds.wizard.placeholder.${WIZARD_STEP_IDS[step]}_title`)}
-            </h2>
-            <p className="mt-2 text-[13px] text-zinc-500">
-              {t(`api_configurator.feeds.wizard.placeholder.${WIZARD_STEP_IDS[step]}_hint`)}
-            </p>
-          </div>
+        {step === 3 && (
+          <StepDelivery
+            feedId={draft.id}
+            hasToken={editRow?.has_token ?? false}
+            cron={draft.cron}
+            onCron={(value) => setDraft((prev) => ({ ...prev, cron: value }))}
+            gzip={draft.gzip}
+            onGzip={(value) => setDraft((prev) => ({ ...prev, gzip: value }))}
+            authType={draft.authType}
+            onAuthType={(value) => setDraft((prev) => ({ ...prev, authType: value }))}
+            authUsername={draft.authUsername}
+            onAuthUsername={(value) => setDraft((prev) => ({ ...prev, authUsername: value }))}
+            authPassword={draft.authPassword}
+            onAuthPassword={(value) => setDraft((prev) => ({ ...prev, authPassword: value }))}
+          />
         )}
+        {step === 4 && <StepPreview feedId={draft.id} rootPath={rootPath} />}
       </div>
 
       <div className="flex items-center gap-3 pt-1">
@@ -370,11 +394,22 @@ export function FeedWizardPage() {
           <button
             type="button"
             onClick={() => {
-              void persistDraft().then((ok) => {
-                if (ok) {
-                  toast.success(t('api_configurator.feeds.wizard.saved'));
-                  void navigate(HUB_PATH);
+              void persistDraft().then(async (ok) => {
+                if (!ok) {
+                  return;
                 }
+                if (draft.id !== null) {
+                  // First publish: queue a regeneration so the public URL has
+                  // a file right away (manual trigger — the dedicated
+                  // first_publish enqueue is the P4-01 scheduler follow-up).
+                  try {
+                    await regenerateFeed(draft.id);
+                  } catch {
+                    // The feed is saved; regeneration can be retried from the hub.
+                  }
+                }
+                toast.success(t('api_configurator.feeds.wizard.saved_generating'));
+                void navigate(HUB_PATH);
               });
             }}
             disabled={saving}

--- a/apps/admin/src/features/api-configurator/feeds/wizard/steps/StepDelivery.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/wizard/steps/StepDelivery.tsx
@@ -1,0 +1,303 @@
+import { Clock, Link2, Lock, RefreshCw, ShieldCheck, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useToast } from '@/components/ui/toast';
+import { Segmented } from '@/features/api-configurator/components/primitives';
+import { httpErrorDetail } from '@/lib/http';
+import { cn } from '@/lib/utils';
+
+import { useRevokeToken, useRotateToken } from '../../api/feeds';
+import { CopyButton } from '../../components/primitives';
+
+const CRON_PRESETS = [
+  { value: '0 * * * *', labelKey: 'hourly' },
+  { value: '0 3 * * *', labelKey: 'daily' },
+  { value: '0 3,15 * * *', labelKey: 'twice' },
+  { value: '', labelKey: 'manual' },
+] as const;
+
+/**
+ * XMLF-P5-04 — wizard step 4 (design feed-wizard.jsx StepDelivery): the
+ * regeneration schedule (cron presets + a raw expression — the human
+ * next-run description ships with the P4-01 scheduler service follow-up),
+ * the gzip toggle, URL auth (none | HTTP Basic with a write-only AES-GCM
+ * password) and the FeedUrlCard with mint/rotate/revoke — the plaintext
+ * token URL is shown exactly once per mint (the API-key pattern).
+ */
+export function StepDelivery({
+  feedId,
+  hasToken,
+  cron,
+  onCron,
+  gzip,
+  onGzip,
+  authType,
+  onAuthType,
+  authUsername,
+  onAuthUsername,
+  authPassword,
+  onAuthPassword,
+}: {
+  feedId: string | null;
+  hasToken: boolean;
+  cron: string | null;
+  onCron: (value: string | null) => void;
+  gzip: boolean;
+  onGzip: (value: boolean) => void;
+  authType: 'none' | 'basic';
+  onAuthType: (value: 'none' | 'basic') => void;
+  authUsername: string;
+  onAuthUsername: (value: string) => void;
+  authPassword: string;
+  onAuthPassword: (value: string) => void;
+}) {
+  const { t } = useTranslation();
+  const toast = useToast();
+  const rotate = useRotateToken();
+  const revoke = useRevokeToken();
+  const [mintedUrl, setMintedUrl] = useState<string | null>(null);
+  const [revoked, setRevoked] = useState(false);
+
+  const presetValue = CRON_PRESETS.some((preset) => preset.value === (cron ?? ''))
+    ? (cron ?? '')
+    : 'custom';
+
+  function onRotate(): void {
+    if (feedId === null) {
+      return;
+    }
+    rotate.mutate(feedId, {
+      onSuccess: (minted) => {
+        setMintedUrl(
+          minted.url.startsWith('http') ? minted.url : `${window.location.origin}${minted.url}`,
+        );
+        setRevoked(false);
+        toast.success(t('api_configurator.feeds.delivery.rotate_success'));
+      },
+      onError: (error) =>
+        toast.error(httpErrorDetail(error) ?? t('api_configurator.feeds.card.action_error')),
+    });
+  }
+
+  function onRevoke(): void {
+    if (feedId === null) {
+      return;
+    }
+    revoke.mutate(feedId, {
+      onSuccess: () => {
+        setMintedUrl(null);
+        setRevoked(true);
+        toast.success(t('api_configurator.feeds.delivery.revoke_success'));
+      },
+      onError: (error) =>
+        toast.error(httpErrorDetail(error) ?? t('api_configurator.feeds.card.action_error')),
+    });
+  }
+
+  const tokenState = mintedUrl !== null ? 'minted' : revoked || !hasToken ? 'none' : 'hidden';
+
+  return (
+    <div className="grid grid-cols-1 items-start gap-4 lg:grid-cols-2">
+      <div className="space-y-4">
+        <div className="rounded-3xl bg-white p-6 soft-shadow">
+          <div className="mb-4 flex items-center gap-2.5">
+            <span className="grid h-7 w-7 place-items-center rounded-xl bg-zinc-100 text-zinc-700">
+              <Clock className="h-4 w-4" aria-hidden />
+            </span>
+            <div className="text-[14.5px] font-semibold tracking-tight">
+              {t('api_configurator.feeds.delivery.schedule_title')}
+            </div>
+          </div>
+          <fieldset
+            className="flex flex-wrap gap-1.5 border-0 p-0"
+            aria-label={t('api_configurator.feeds.delivery.presets_aria')}
+          >
+            {CRON_PRESETS.map((preset) => (
+              <button
+                key={preset.labelKey}
+                type="button"
+                aria-pressed={presetValue === preset.value}
+                onClick={() => onCron(preset.value === '' ? null : preset.value)}
+                className={cn(
+                  'h-8 rounded-lg border px-2.5 text-[12px] font-medium',
+                  presetValue === preset.value
+                    ? 'border-zinc-900 bg-zinc-900 text-white'
+                    : 'border-zinc-200 bg-white text-zinc-700 hover:bg-zinc-50',
+                )}
+              >
+                {t(`api_configurator.feeds.delivery.preset.${preset.labelKey}`)}
+              </button>
+            ))}
+          </fieldset>
+          <label className="mt-3 block">
+            <span className="text-[12px] font-medium text-zinc-700">
+              {t('api_configurator.feeds.delivery.cron_label')}
+              <span className="ml-1.5 text-[11px] font-normal text-zinc-500">
+                {t('api_configurator.feeds.delivery.cron_hint')}
+              </span>
+            </span>
+            <input
+              value={cron ?? ''}
+              onChange={(event) => onCron(event.target.value === '' ? null : event.target.value)}
+              placeholder={t('api_configurator.feeds.delivery.cron_placeholder')}
+              className="mt-1.5 h-10 w-full rounded-xl border border-zinc-200 bg-white px-3 font-mono text-[13px] outline-none focus:border-zinc-400"
+            />
+          </label>
+          <div className="mt-4 flex items-center gap-3 border-t border-zinc-100 pt-4">
+            <div className="flex-1">
+              <div className="text-[13px] font-medium text-zinc-800">
+                {t('api_configurator.feeds.delivery.gzip_title')}
+              </div>
+              <div className="text-[11.5px] text-zinc-500">
+                {t('api_configurator.feeds.delivery.gzip_hint')}
+              </div>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={gzip}
+              aria-label={t('api_configurator.feeds.delivery.gzip_title')}
+              onClick={() => onGzip(!gzip)}
+              className={cn(
+                'relative h-6 w-11 rounded-full transition',
+                gzip ? 'bg-emerald-500' : 'bg-zinc-200',
+              )}
+            >
+              <span
+                className={cn(
+                  'absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-all',
+                  gzip ? 'left-[22px]' : 'left-0.5',
+                )}
+              />
+            </button>
+          </div>
+        </div>
+
+        <div className="rounded-3xl bg-white p-6 soft-shadow">
+          <div className="mb-4 flex items-center gap-2.5">
+            <span className="grid h-7 w-7 place-items-center rounded-xl bg-zinc-100 text-zinc-700">
+              <Lock className="h-4 w-4" aria-hidden />
+            </span>
+            <div className="text-[14.5px] font-semibold tracking-tight">
+              {t('api_configurator.feeds.delivery.auth_title')}
+            </div>
+          </div>
+          <div className="text-[12px] font-medium text-zinc-700">
+            {t('api_configurator.feeds.delivery.auth_method')}
+            <span className="ml-1.5 text-[11px] font-normal text-zinc-500">
+              {t('api_configurator.feeds.delivery.auth_hint')}
+            </span>
+          </div>
+          <div className="mt-1.5">
+            <Segmented<'none' | 'basic'>
+              full
+              value={authType}
+              onChange={onAuthType}
+              ariaLabel={t('api_configurator.feeds.delivery.auth_method')}
+              options={[
+                { value: 'none', label: t('api_configurator.feeds.delivery.auth_none') },
+                { value: 'basic', label: t('api_configurator.feeds.delivery.auth_basic') },
+              ]}
+            />
+          </div>
+          {authType === 'basic' && (
+            <div className="mt-4 grid grid-cols-2 gap-x-5 gap-y-4">
+              <label className="block">
+                <span className="text-[12px] font-medium text-zinc-700">
+                  {t('api_configurator.feeds.delivery.auth_user')}
+                </span>
+                <input
+                  value={authUsername}
+                  onChange={(event) => onAuthUsername(event.target.value)}
+                  className="mt-1.5 h-10 w-full rounded-xl border border-zinc-200 bg-white px-3 font-mono text-[13px] outline-none focus:border-zinc-400"
+                />
+              </label>
+              <label className="block">
+                <span className="text-[12px] font-medium text-zinc-700">
+                  {t('api_configurator.feeds.delivery.auth_password')}
+                  <span className="ml-1.5 text-[11px] font-normal text-zinc-500">
+                    {t('api_configurator.feeds.delivery.auth_password_hint')}
+                  </span>
+                </span>
+                <input
+                  type="password"
+                  value={authPassword}
+                  onChange={(event) => onAuthPassword(event.target.value)}
+                  placeholder={hasToken ? '••••••••' : ''}
+                  className="mt-1.5 h-10 w-full rounded-xl border border-zinc-200 bg-white px-3 font-mono text-[13px] outline-none focus:border-zinc-400"
+                />
+              </label>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <div className="rounded-3xl bg-white p-6 soft-shadow">
+          <div className="mb-3 flex items-center gap-2.5">
+            <span className="grid h-7 w-7 place-items-center rounded-xl bg-zinc-100 text-zinc-700">
+              <Link2 className="h-4 w-4" aria-hidden />
+            </span>
+            <div className="text-[14.5px] font-semibold tracking-tight">
+              {t('api_configurator.feeds.delivery.url_title')}
+            </div>
+          </div>
+          {tokenState === 'minted' && mintedUrl !== null ? (
+            <>
+              <div className="rounded-xl border border-emerald-200 bg-emerald-50/60 px-3 py-2 text-[12px] text-emerald-900">
+                {t('api_configurator.feeds.delivery.url_once')}
+              </div>
+              <div className="mt-2 flex items-center gap-2">
+                <code className="min-w-0 flex-1 truncate rounded-lg border border-zinc-100 bg-zinc-50 px-2.5 py-1.5 font-mono text-[11.5px] text-zinc-700">
+                  {mintedUrl}
+                </code>
+                <CopyButton value={mintedUrl} />
+              </div>
+            </>
+          ) : (
+            <p className="text-[12.5px] text-zinc-500">
+              {t(
+                tokenState === 'hidden'
+                  ? 'api_configurator.feeds.delivery.url_hidden'
+                  : 'api_configurator.feeds.delivery.url_none',
+              )}
+            </p>
+          )}
+          <div className="mt-4 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onRotate}
+              disabled={feedId === null || rotate.isPending}
+              className="flex h-9 items-center gap-1.5 rounded-lg bg-zinc-900 px-3 text-[12px] font-medium text-white hover:bg-zinc-800 disabled:opacity-40"
+            >
+              <RefreshCw
+                className={cn('h-3.5 w-3.5', rotate.isPending && 'animate-spin')}
+                aria-hidden
+              />
+              {t(
+                tokenState === 'none'
+                  ? 'api_configurator.feeds.delivery.mint'
+                  : 'api_configurator.feeds.delivery.rotate',
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={onRevoke}
+              disabled={feedId === null || tokenState === 'none' || revoke.isPending}
+              className="flex h-9 items-center gap-1.5 rounded-lg border border-rose-200 bg-white px-3 text-[12px] font-medium text-rose-700 hover:bg-rose-50 disabled:opacity-40"
+            >
+              <Trash2 className="h-3.5 w-3.5" aria-hidden />
+              {t('api_configurator.feeds.delivery.revoke')}
+            </button>
+          </div>
+        </div>
+
+        <div className="flex items-start gap-2.5 rounded-2xl border border-emerald-200 bg-emerald-50/50 px-4 py-3 text-[12px] leading-relaxed text-emerald-900">
+          <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" aria-hidden />
+          <span>{t('api_configurator.feeds.delivery.pull_note')}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/api-configurator/feeds/wizard/steps/StepPreview.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/wizard/steps/StepPreview.tsx
@@ -1,0 +1,233 @@
+import { useQuery } from '@tanstack/react-query';
+import { AlertTriangle, BadgeCheck, FileCode2, HeartPulse, Sparkles } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Segmented } from '@/features/api-configurator/components/primitives';
+import { jsonFetch } from '@/lib/http';
+import { cn } from '@/lib/utils';
+
+import { CopyButton } from '../../components/primitives';
+
+interface PreviewResponse {
+  sample_count: number;
+  xml: string;
+  health: Array<{ sku: string | null; slot: string; level: string; message: string }>;
+}
+
+interface HealthResponse {
+  items_syndicated: number | null;
+  last_run: {
+    item_count: number;
+    skipped_count: number;
+    warning_count: number;
+    health: string;
+  } | null;
+}
+
+/**
+ * XMLF-P5-04 — wizard step 5 (design feed-preview.jsx): the left column
+ * renders the REAL sample XML from GET /api/feeds/{id}/preview (the same
+ * engine production uses — §6.11 "what you see == what the crawler gets")
+ * with a formatted/raw toggle and a well-formed badge; the right column is
+ * the health report from the preview response plus the full-catalog
+ * projection from the last run, and the Faza-2 AI-suggestions CTA
+ * (deliberately disabled).
+ */
+export function StepPreview({ feedId, rootPath }: { feedId: string | null; rootPath: string }) {
+  const { t } = useTranslation();
+  const [mode, setMode] = useState<'formatted' | 'raw'>('formatted');
+
+  const preview = useQuery({
+    queryKey: ['xmlf', 'feed-preview', feedId ?? 'none'],
+    enabled: feedId !== null,
+    queryFn: async () => jsonFetch<PreviewResponse>(`/api/feeds/${feedId}/preview?limit=5`),
+  });
+  const projection = useQuery({
+    queryKey: ['xmlf', 'feed-health', feedId ?? 'none'],
+    enabled: feedId !== null,
+    queryFn: async () => jsonFetch<HealthResponse>(`/api/feeds/${feedId}/health`),
+  });
+
+  const xml = preview.data?.xml ?? '';
+  const wellFormed = useMemo(() => {
+    if (xml === '') {
+      return false;
+    }
+    return (
+      new DOMParser().parseFromString(xml, 'application/xml').querySelector('parsererror') === null
+    );
+  }, [xml]);
+
+  const health = preview.data?.health ?? [];
+  const lastRun = projection.data?.last_run ?? null;
+
+  return (
+    <div className="grid grid-cols-1 items-start gap-4 lg:grid-cols-[1.4fr_1fr]">
+      <div className="overflow-hidden rounded-3xl bg-white soft-shadow">
+        <div className="flex flex-wrap items-center gap-2.5 border-b border-zinc-100 px-5 py-3">
+          <span className="grid h-7 w-7 place-items-center rounded-xl bg-zinc-100 text-zinc-700">
+            <FileCode2 className="h-4 w-4" aria-hidden />
+          </span>
+          <div className="text-[14.5px] font-semibold tracking-tight">
+            {t('api_configurator.feeds.preview.title', { count: preview.data?.sample_count ?? 0 })}
+          </div>
+          {wellFormed && (
+            <span className="inline-flex items-center gap-1 rounded-md bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
+              <BadgeCheck className="h-3.5 w-3.5" aria-hidden />
+              {t('api_configurator.feeds.preview.well_formed')}
+            </span>
+          )}
+          <div className="ml-auto flex items-center gap-2">
+            <Segmented<'formatted' | 'raw'>
+              value={mode}
+              onChange={setMode}
+              ariaLabel={t('api_configurator.feeds.preview.mode_aria')}
+              options={[
+                { value: 'formatted', label: t('api_configurator.feeds.preview.formatted') },
+                { value: 'raw', label: t('api_configurator.feeds.preview.raw') },
+              ]}
+            />
+            <CopyButton value={xml} disabled={xml === ''} />
+          </div>
+        </div>
+        <div className="max-h-[520px] overflow-auto bg-zinc-950 p-4">
+          {preview.isLoading ? (
+            <div className="h-40 animate-pulse rounded-xl bg-zinc-800" />
+          ) : mode === 'raw' ? (
+            <pre className="whitespace-pre-wrap break-all font-mono text-[11.5px] leading-relaxed text-zinc-200">
+              {xml}
+            </pre>
+          ) : (
+            <FormattedXml xml={xml} />
+          )}
+        </div>
+        <div className="border-t border-zinc-100 px-5 py-2 font-mono text-[11px] text-zinc-500">
+          {rootPath}
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <div className="rounded-3xl bg-white p-5 soft-shadow">
+          <div className="mb-3 flex items-center gap-2.5">
+            <span className="grid h-7 w-7 place-items-center rounded-xl bg-zinc-100 text-zinc-700">
+              <HeartPulse className="h-4 w-4" aria-hidden />
+            </span>
+            <div className="text-[14.5px] font-semibold tracking-tight">
+              {t('api_configurator.feeds.preview.health_title')}
+            </div>
+          </div>
+          {health.length === 0 ? (
+            <p className="text-[12.5px] text-emerald-700">
+              {t('api_configurator.feeds.preview.health_clean')}
+            </p>
+          ) : (
+            <ul className="space-y-1.5">
+              {health.slice(0, 20).map((line, index) => (
+                <li
+                  // biome-ignore lint/suspicious/noArrayIndexKey: preview lines are a static snapshot per response
+                  key={`${line.sku}-${line.slot}-${index}`}
+                  className="flex items-start gap-2 text-[12px]"
+                >
+                  <span
+                    className={cn(
+                      'mt-1 h-2 w-2 shrink-0 rounded-full',
+                      line.level === 'error' ? 'bg-rose-500' : 'bg-amber-400',
+                    )}
+                    aria-hidden
+                  />
+                  <span className="min-w-0">
+                    <span className="font-mono text-[11px] text-zinc-500">
+                      {line.sku ?? '—'} · {line.slot}
+                    </span>{' '}
+                    <span className="text-zinc-700">{line.message}</span>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+          {health.length > 20 && (
+            <p className="mt-2 text-[11.5px] text-zinc-500">
+              {t('api_configurator.feeds.preview.health_more', { count: health.length - 20 })}
+            </p>
+          )}
+        </div>
+
+        <div className="rounded-3xl bg-white p-5 soft-shadow">
+          <div className="text-[13px] font-semibold tracking-tight">
+            {t('api_configurator.feeds.preview.projection_title')}
+          </div>
+          {lastRun !== null ? (
+            <div className="mt-2 grid grid-cols-3 gap-2 text-center">
+              <div className="rounded-xl bg-zinc-50 px-2 py-2">
+                <div className="num text-[16px] font-semibold text-zinc-900">
+                  {lastRun.item_count.toLocaleString('pl-PL')}
+                </div>
+                <div className="text-[10px] uppercase tracking-wider text-zinc-500">
+                  {t('api_configurator.feeds.preview.projection_items')}
+                </div>
+              </div>
+              <div className="rounded-xl bg-zinc-50 px-2 py-2">
+                <div className="num text-[16px] font-semibold text-amber-700">
+                  {lastRun.skipped_count.toLocaleString('pl-PL')}
+                </div>
+                <div className="text-[10px] uppercase tracking-wider text-zinc-500">
+                  {t('api_configurator.feeds.preview.projection_skipped')}
+                </div>
+              </div>
+              <div className="rounded-xl bg-zinc-50 px-2 py-2">
+                <div className="num text-[16px] font-semibold text-zinc-700">
+                  {lastRun.warning_count.toLocaleString('pl-PL')}
+                </div>
+                <div className="text-[10px] uppercase tracking-wider text-zinc-500">
+                  {t('api_configurator.feeds.preview.projection_warnings')}
+                </div>
+              </div>
+            </div>
+          ) : (
+            <p className="mt-2 text-[12.5px] text-zinc-500">
+              {t('api_configurator.feeds.preview.projection_none')}
+            </p>
+          )}
+        </div>
+
+        <button
+          type="button"
+          disabled
+          title={t('api_configurator.feeds.preview.ai_soon')}
+          className="flex w-full cursor-not-allowed items-center gap-2 rounded-2xl border border-dashed border-zinc-200 bg-zinc-50/60 px-4 py-3 text-left text-[12.5px] text-zinc-400"
+        >
+          <Sparkles className="h-4 w-4" aria-hidden />
+          {t('api_configurator.feeds.preview.ai_cta')}
+        </button>
+
+        <div className="flex items-start gap-2.5 rounded-2xl border border-zinc-200 bg-white px-4 py-3 text-[12px] leading-relaxed text-zinc-600">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-zinc-500" aria-hidden />
+          <span>{t('api_configurator.feeds.preview.well_formed_note')}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Tiny tag-level highlighter — enough for a readable preview, no deps. */
+function FormattedXml({ xml }: { xml: string }) {
+  const parts = useMemo(() => xml.split(/(<[^>]+>)/g).filter((part) => part !== ''), [xml]);
+  return (
+    <pre className="whitespace-pre-wrap break-all font-mono text-[11.5px] leading-relaxed text-zinc-200">
+      {parts.map((part, index) =>
+        part.startsWith('<') ? (
+          // biome-ignore lint/suspicious/noArrayIndexKey: static split of an immutable string
+          <span key={index} className="text-violet-300">
+            {part}
+          </span>
+        ) : (
+          // biome-ignore lint/suspicious/noArrayIndexKey: static split of an immutable string
+          <span key={index} className="text-emerald-200">
+            {part}
+          </span>
+        ),
+      )}
+    </pre>
+  );
+}

--- a/apps/admin/src/features/api-configurator/feeds/wizard/wizard-state.ts
+++ b/apps/admin/src/features/api-configurator/feeds/wizard/wizard-state.ts
@@ -21,6 +21,12 @@ export interface FeedDraft {
   mappings: SlotMapping[];
   filterDsl: FilterDsl | null;
   skipPolicy: 'skip_invalid' | 'include_with_warning';
+  cron: string | null;
+  gzip: boolean;
+  authType: 'none' | 'basic';
+  authUsername: string;
+  /** Write-only — sent on PATCH when non-empty, never read back. */
+  authPassword: string;
 }
 
 export const WIZARD_STEP_IDS = ['template', 'scope', 'mapping', 'delivery', 'preview'] as const;
@@ -40,6 +46,11 @@ export function emptyDraft(): FeedDraft {
     mappings: [],
     filterDsl: null,
     skipPolicy: 'skip_invalid',
+    cron: null,
+    gzip: true,
+    authType: 'none',
+    authUsername: '',
+    authPassword: '',
   };
 }
 
@@ -58,7 +69,41 @@ export function draftFromFeed(feed: FeedRow): FeedDraft {
     mappings: feed.field_mappings as unknown as SlotMapping[],
     filterDsl: (feed.filter as FilterDsl | null) ?? null,
     skipPolicy: feed.validation_policy ?? 'skip_invalid',
+    cron: feed.schedule_cron,
+    gzip: feedDeliveryGzip(feed),
+    authType: feedDeliveryAuthType(feed),
+    authUsername: feedDeliveryUsername(feed),
+    authPassword: '',
   };
+}
+
+function feedDeliveryGzip(feed: FeedRow): boolean {
+  const delivery = feed.delivery;
+  return (
+    typeof delivery === 'object' &&
+    delivery !== null &&
+    (delivery as { gzip?: unknown }).gzip === true
+  );
+}
+
+function feedDeliveryAuthType(feed: FeedRow): 'none' | 'basic' {
+  const auth = deliveryAuth(feed);
+  return auth?.type === 'basic' ? 'basic' : 'none';
+}
+
+function feedDeliveryUsername(feed: FeedRow): string {
+  return deliveryAuth(feed)?.username ?? '';
+}
+
+function deliveryAuth(feed: FeedRow): { type?: string; username?: string } | null {
+  const delivery = feed.delivery;
+  if (typeof delivery !== 'object' || delivery === null) {
+    return null;
+  }
+  const auth = (delivery as { auth?: unknown }).auth;
+  return typeof auth === 'object' && auth !== null
+    ? (auth as { type?: string; username?: string })
+    : null;
 }
 
 /** Auto-slug for the code field: `Google Shopping — PL` → `google_shopping_pl`. */
@@ -106,5 +151,17 @@ export function patchPayload(draft: FeedDraft): Record<string, unknown> {
     channel_id: draft.channelId,
     filter: draft.filterDsl,
     validation_policy: draft.skipPolicy,
+    schedule_cron: draft.cron,
+    delivery: {
+      gzip: draft.gzip,
+      auth:
+        draft.authType === 'basic'
+          ? {
+              type: 'basic',
+              username: draft.authUsername,
+              ...(draft.authPassword !== '' ? { password: draft.authPassword } : {}),
+            }
+          : { type: 'none' },
+    },
   };
 }

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1843,7 +1843,8 @@
           "preview_title": "Preview — next ticket",
           "preview_hint": "The live XML preview with the health report lands with XMLF-P5-04."
         },
-        "back_to_hub": "Back to feeds"
+        "back_to_hub": "Back to feeds",
+        "saved_generating": "Feed saved — first regeneration queued."
       },
       "detail": {
         "placeholder_title": "Feed detail — coming in the next ticket",
@@ -1877,6 +1878,57 @@
         "missing_value": "no value — required",
         "too_long": "over the {{max}}-char limit — add a truncate transform",
         "category_note": "Slots with fmt=category (Ceneo cat, Google g:google_product_category) are resolved from the channel category tree's external codes at generation time; an explicit mapping value wins. Variants enter flat with item_group_id = the master's SKU."
+      },
+      "delivery": {
+        "schedule_title": "Regeneration schedule",
+        "presets_aria": "Schedule presets",
+        "preset": {
+          "hourly": "hourly",
+          "daily": "daily 03:00",
+          "twice": "twice a day",
+          "manual": "manual only"
+        },
+        "cron_label": "Cron expression",
+        "cron_hint": "human next-run preview ships with the scheduler service",
+        "cron_placeholder": "manual only — no schedule",
+        "gzip_title": "Gzip compression",
+        "gzip_hint": "Serve the .xml.gz variant when the crawler accepts it",
+        "auth_title": "URL authorisation",
+        "auth_method": "Method",
+        "auth_hint": "marketplace crawlers do not send auth headers",
+        "auth_none": "Token in URL",
+        "auth_basic": "Token + HTTP Basic",
+        "auth_user": "Username",
+        "auth_password": "Password",
+        "auth_password_hint": "AES-GCM encrypted, write-only",
+        "url_title": "Feed URL",
+        "url_once": "The URL below is shown ONCE — copy it now. Only its HMAC is stored.",
+        "url_hidden": "A token exists, but its URL cannot be re-displayed (only an HMAC is stored). Rotate to mint a fresh one.",
+        "url_none": "No token yet — mint one to get the public URL for the crawler.",
+        "mint": "Mint token",
+        "rotate": "Rotate token",
+        "revoke": "Revoke",
+        "rotate_success": "New token minted — copy the URL now, it is shown once.",
+        "revoke_success": "Token revoked — the public URL now returns 404.",
+        "pull_note": "Pull model — cache & serve. Regeneration (cron/manual) writes the file to storage; the public endpoint only serves the cache (no session, tenant from the token → RLS). A crawler can never trigger generation — no DoS. Per-token rate limit, 304 on conditional GET."
+      },
+      "preview": {
+        "title": "XML preview · {{count}} samples",
+        "well_formed": "well-formed",
+        "mode_aria": "Preview mode",
+        "formatted": "Formatted",
+        "raw": "Raw",
+        "health_title": "Health report",
+        "health_clean": "No issues in the sample — every required slot resolved.",
+        "health_more": "…and {{count}} more lines",
+        "projection_title": "Full-catalog projection (last run)",
+        "projection_items": "in feed",
+        "projection_skipped": "skipped",
+        "projection_warnings": "warnings",
+        "projection_none": "No run yet — the projection appears after the first regeneration.",
+        "ai_cta": "AI mapping suggestions",
+        "ai_soon": "Faza 2",
+        "well_formed_note": "The writer escapes every value (or wraps it in CDATA) — the feed stays well-formed XML regardless of catalog content. Preview and production share the same engine."
       }
     },
     "shell": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1891,7 +1891,8 @@
           "preview_title": "Podgląd — kolejny ticket",
           "preview_hint": "Podgląd XML na żywo z raportem zdrowia wchodzi z XMLF-P5-04."
         },
-        "back_to_hub": "Wróć do feedów"
+        "back_to_hub": "Wróć do feedów",
+        "saved_generating": "Feed zapisany — pierwsza regeneracja zakolejkowana."
       },
       "detail": {
         "placeholder_title": "Detal feedu — w kolejnym tickecie",
@@ -1925,6 +1926,57 @@
         "missing_value": "brak wartości — wymagane",
         "too_long": "ponad limit {{max}} znaków — dodaj transformację truncate",
         "category_note": "Sloty z fmt=category (Ceneo cat, Google g:google_product_category) są rozwiązywane przy generacji z external_code drzewa kategorii kanału; jawna wartość z mapowania wygrywa. Warianty wchodzą płasko z item_group_id = SKU mastera."
+      },
+      "delivery": {
+        "schedule_title": "Harmonogram regeneracji",
+        "presets_aria": "Presety harmonogramu",
+        "preset": {
+          "hourly": "co godzinę",
+          "daily": "codziennie 03:00",
+          "twice": "2× dziennie",
+          "manual": "tylko ręcznie"
+        },
+        "cron_label": "Wyrażenie cron",
+        "cron_hint": "czytelny podgląd next-run wchodzi z serwisem harmonogramu",
+        "cron_placeholder": "tylko ręcznie — bez harmonogramu",
+        "gzip_title": "Kompresja gzip",
+        "gzip_hint": "Serwuj wariant .xml.gz gdy crawler akceptuje",
+        "auth_title": "Autoryzacja URL",
+        "auth_method": "Metoda",
+        "auth_hint": "crawlery marketplace nie wysyłają nagłówków auth",
+        "auth_none": "Token w URL",
+        "auth_basic": "Token + HTTP Basic",
+        "auth_user": "Użytkownik",
+        "auth_password": "Hasło",
+        "auth_password_hint": "szyfrowane AES-GCM, write-only",
+        "url_title": "URL feedu",
+        "url_once": "Poniższy URL jest widoczny RAZ — skopiuj go teraz. Przechowujemy wyłącznie HMAC.",
+        "url_hidden": "Token istnieje, ale URL nie może być ponownie wyświetlony (przechowujemy tylko HMAC). Rotuj, by wygenerować nowy.",
+        "url_none": "Brak tokenu — wygeneruj go, by dostać publiczny URL dla crawlera.",
+        "mint": "Wygeneruj token",
+        "rotate": "Rotuj token",
+        "revoke": "Unieważnij",
+        "rotate_success": "Nowy token wygenerowany — skopiuj URL teraz, jest widoczny raz.",
+        "revoke_success": "Token unieważniony — publiczny URL zwraca 404.",
+        "pull_note": "Model pull — cache & serve. Regeneracja (cron/ręczna) zapisuje plik do storage; publiczny endpoint tylko serwuje cache (bez sesji, tenant z tokenu → RLS). Crawler nie uruchomi generacji — brak DoS. Rate-limit per token, 304 na conditional GET."
+      },
+      "preview": {
+        "title": "Podgląd XML · {{count}} sample",
+        "well_formed": "well-formed",
+        "mode_aria": "Tryb podglądu",
+        "formatted": "Sformatowany",
+        "raw": "Raw",
+        "health_title": "Raport zdrowia",
+        "health_clean": "Brak uwag w próbce — wszystkie wymagane sloty rozwiązane.",
+        "health_more": "…i {{count}} kolejnych linii",
+        "projection_title": "Projekcja na pełny katalog (ostatni run)",
+        "projection_items": "w feedzie",
+        "projection_skipped": "pominięte",
+        "projection_warnings": "ostrzeżenia",
+        "projection_none": "Brak runu — projekcja pojawi się po pierwszej regeneracji.",
+        "ai_cta": "AI-sugestie mapowania",
+        "ai_soon": "Faza 2",
+        "well_formed_note": "Writer escapuje każdą wartość (lub pakuje w CDATA) — feed pozostaje well-formed XML niezależnie od treści katalogu. Podgląd i produkcja używają tego samego silnika."
       }
     },
     "shell": {

--- a/apps/api/src/Export/Feed/Presentation/Controller/FeedProfileController.php
+++ b/apps/api/src/Export/Feed/Presentation/Controller/FeedProfileController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Export\Feed\Presentation\Controller;
 
+use App\Export\Feed\Application\Delivery\FeedDeliveryConfig;
 use App\Export\Feed\Application\Descriptor\FeedDescriptorGuard;
 use App\Export\Feed\Domain\Descriptor\InvalidDescriptorException;
 use App\Export\Feed\Domain\Entity\FeedProfile;
@@ -16,6 +17,7 @@ use App\Shared\Application\TenantContext;
 use App\Shared\Application\UserIdentityAware;
 use App\Shared\Domain\Tenant;
 use DateTimeInterface;
+use InvalidArgumentException;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -42,6 +44,7 @@ final class FeedProfileController
         private readonly Security $security,
         private readonly FeedDescriptorGuard $guard,
         private readonly FeedTemplateCatalog $catalog,
+        private readonly FeedDeliveryConfig $deliveryConfig,
     ) {
     }
 
@@ -128,6 +131,38 @@ final class FeedProfileController
         }
         if (\array_key_exists('schedule_cron', $payload)) {
             $feed->setScheduleCron($this->parseOptionalString($payload, 'schedule_cron'));
+        }
+        // Delivery block (XMLF-P5-04): gzip + URL auth. The password is
+        // write-only — it is encrypted here (AES-GCM) and never serialized
+        // back; omitting `password` while staying on basic keeps the stored
+        // secret untouched.
+        if (\array_key_exists('delivery', $payload) && \is_array($payload['delivery'])) {
+            $delivery = $payload['delivery'];
+            $gzip = (bool) ($delivery['gzip'] ?? false);
+            $auth = \is_array($delivery['auth'] ?? null) ? $delivery['auth'] : [];
+            $authType = \is_string($auth['type'] ?? null) ? $auth['type'] : 'none';
+            $username = \is_string($auth['username'] ?? null) && '' !== $auth['username'] ? $auth['username'] : null;
+            $password = \is_string($auth['password'] ?? null) && '' !== $auth['password'] ? $auth['password'] : null;
+            try {
+                if ('basic' === $authType && null === $password) {
+                    $current = $feed->getDelivery();
+                    $currentAuth = \is_array($current['auth'] ?? null) ? $current['auth'] : [];
+                    if ('basic' !== ($currentAuth['type'] ?? null)) {
+                        throw new BadRequestHttpException('HTTP Basic auth requires a password on first enable.');
+                    }
+                    // Keep the stored secret; allow a username change only.
+                    $currentAuth['username'] = $username ?? ($currentAuth['username'] ?? null);
+                    $feed->updateDelivery([
+                        'gzip' => $gzip,
+                        'auth' => $currentAuth,
+                    ] + array_diff_key($current, ['gzip' => true, 'auth' => true]));
+                } else {
+                    $preserved = array_diff_key($feed->getDelivery(), ['gzip' => true, 'auth' => true]);
+                    $feed->updateDelivery($this->deliveryConfig->build($gzip, $authType, $username, $password) + $preserved);
+                }
+            } catch (InvalidArgumentException $error) {
+                throw new BadRequestHttpException($error->getMessage(), $error);
+            }
         }
         if (\array_key_exists('validation_policy', $payload)) {
             $feed->setValidationPolicy($this->parsePolicy($payload));


### PR DESCRIPTION
## Cel (XMLF-P5-04, #1932)
Kroki 4 (Dostarczanie) i 5 (Podgląd) domykają kreator — **cały flow „feed w 5 minut bez developera" działa end-to-end**: szablon → zakres → mapowanie → dostarczanie → podgląd → „Zapisz i wygeneruj".

## Co jest w środku
- **Krok 4 Delivery:** presety crona (co godzinę / 03:00 / 2×dziennie / ręcznie) + surowe wyrażenie mono (czytelny next-run wchodzi z serwisem harmonogramu — leftover P4-01, udokumentowane); switch gzip; Segmented auth **none|basic** — hasło **write-only** (type=password, nota AES-GCM), nigdy nie wraca z GET.
- **BE (mały):** blok `delivery` w PATCH — walidacja + szyfrowanie przez istniejący `FeedDeliveryConfig` (AES-GCM z P3-04); pozostanie na basic bez nowego hasła zachowuje stary sekret (zmiana samego username OK); pierwsze włączenie basic bez hasła → 400.
- **FeedUrlCard:** mint/rotate (URL widoczny RAZ — wzorzec API key, kopiowalny) / revoke (nowy hook DELETE) + SecurityNote o modelu pull cache-and-serve.
- **Krok 5 Preview:** **prawdziwy XML 5 sample** z `GET /api/feeds/{id}/preview` (ten sam silnik co produkcja — §6.11), toggle Sformatowany|Raw (lekki tag-highlighter bez zależności), badge well-formed (weryfikowany DOMParserem na outpucie writera), CopyButton raw, footer root-path (`rss/channel/item` vs `products/item` z descriptora). Prawa kolumna: raport zdrowia z odpowiedzi preview (HealthDot per poziom, cap 20 linii z licznikiem), projekcja na pełny katalog z `/health` (ostatni run: items/skipped/warnings), disabled CTA AI-sugestii (Faza 2).
- **„Zapisz i wygeneruj":** persist → `POST /api/feeds/{id}/regenerate` (202; trigger=manual — dedykowany first_publish enqueue to follow-up P4-01) → redirect do huba z toastem.

## Live smoke (pim.localhost, unmocked — pełny kreator) ✅
```
template → scope → mapper → krok 4:
  preset „codziennie" → cron 0 3 * * * · MINT token → 201 (URL widoczny raz)
  Dalej → PATCH {schedule_cron, delivery:{gzip:true,auth:{type:none}}} → 200
krok 5: GET /api/feeds/{id}/preview → 200 · „XML preview · 5 samples" + well-formed badge
Zapisz i wygeneruj → POST regenerate → 202 → hub
```

## Testy
- **Playwright `1932-feed-delivery-preview.spec.ts`** (mocked): preset wiąże input crona, basic odsłania write-only credentials, mint pokazuje URL raz (pełny token widoczny), wyjście z delivery PATCH-uje `{gzip, auth}`, preview z well-formed + linia health + projekcja 95, save→regenerate→hub, axe 0 serious/critical.
- Vitest 12/12 (bez zmian) · tsc ✓ · Biome ✓ (fieldset zamiast role=group — a11y lint) · build ✓ · guard jsonfetch-useeffect 61=baseline (StepPreview: useQuery bez useEffect) · PHPStan max 0.

Refs #1932