### PR TITLE
feat(admin): feed detail with live run pipeline and drill-down

### DIFF
--- a/apps/admin/e2e/1933-feed-detail.spec.ts
+++ b/apps/admin/e2e/1933-feed-detail.spec.ts
@@ -1,0 +1,110 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * XMLF-P5-05 (#1933) — the feed detail: header + KPI from the feed row, the
+ * run history (P4-03 read API) with the status filter, and the drill-down
+ * sheet with the per-product FeedRunLog. The live Mercure pipeline is
+ * covered by the unmocked smoke (EventSource does not mock cleanly); this
+ * spec pins the REST-driven surface deterministically.
+ */
+
+const FEED = {
+  id: '019f0000-0000-7000-8000-00000000f001',
+  code: 'google_pl',
+  name: 'Google Shopping — Polska',
+  template_kind: 'google_shopping',
+  status: 'active',
+  locale: 'pl',
+  currency: 'PLN',
+  channel_id: null,
+  publication_channel: null,
+  schedule_cron: '0 3 * * *',
+  descriptor: { item: { slots: [{ slot: 'g:id' }, { slot: 'g:title' }] } },
+  field_mappings: [{ slot: 'g:id' }],
+  cached_item_count: 12408,
+  cached_at: '2026-07-01T04:00:00+00:00',
+  last_pulled_at: '2026-07-01T21:00:00+00:00',
+  has_token: true,
+};
+
+const RUNS = {
+  items: [
+    {
+      id: 'run-1',
+      feed_id: FEED.id,
+      trigger: 'manual',
+      status: 'done',
+      health: 'warning',
+      item_count: 12408,
+      skipped_count: 34,
+      warning_count: 34,
+      file_size_bytes: 18700000,
+      duration_ms: 22000,
+      error_message: null,
+      started_at: '2026-07-01T04:00:00+00:00',
+      completed_at: '2026-07-01T04:00:22+00:00',
+    },
+  ],
+  next_cursor: null,
+};
+
+const LOGS = {
+  items: [
+    {
+      id: 'log-1',
+      level: 'warning',
+      object_sku: 'KL-PT-80240',
+      slot: 'g:gtin',
+      message: 'missing required g:gtin — skipped',
+      created_at: '2026-07-01T04:00:10+00:00',
+    },
+  ],
+  next_cursor: null,
+};
+
+test('XMLF-P5-05 — detail: header, KPI, history, drill-down log', async ({ page }) => {
+  await loginAsAdmin(page);
+
+  await page.route('**/api/feeds/**', (route) => {
+    const url = route.request().url();
+    if (url.includes('/runs/') && url.includes('/logs')) {
+      return route.fulfill({ json: LOGS });
+    }
+    if (url.endsWith('/runs') || url.includes('/runs?')) {
+      return route.fulfill({ json: RUNS });
+    }
+    return route.fulfill({ json: FEED });
+  });
+  await page.route('**/.well-known/mercure*', (route) => route.abort());
+  await page.route('**/api/mercure/authorization', (route) =>
+    route.fulfill({ status: 204, body: '' }),
+  );
+
+  await page.goto(`/integrations/api-configurator/feeds/${FEED.id}`);
+
+  // Header + KPI from the feed row.
+  await expect(page.getByRole('heading', { name: /Google Shopping — Polska/ })).toBeVisible();
+  await expect(page.getByText(/12\s?408/).first()).toBeVisible();
+  await expect(page.getByText('0 3 * * *')).toBeVisible();
+  await expect(page.getByText('1/2')).toBeVisible();
+
+  // Run history renders with the warning health pill.
+  await expect(page.getByText(/ostrzeżenie|warning/).first()).toBeVisible();
+  await expect(page.getByText('⤼ 34')).toBeVisible();
+
+  // Drill-down shows the per-product log line.
+  await page
+    .getByRole('button', { name: /ręcznie|manual/ })
+    .first()
+    .click();
+  await expect(page.getByText('KL-PT-80240 · g:gtin')).toBeVisible();
+  await expect(page.getByText(/missing required g:gtin/)).toBeVisible();
+
+  const axe = await new AxeBuilder({ page }).analyze();
+  expect(axe.violations.filter((v) => v.impact === 'serious' || v.impact === 'critical')).toEqual(
+    [],
+  );
+});

--- a/apps/admin/src/features/api-configurator/feeds/api/runs-stream.ts
+++ b/apps/admin/src/features/api-configurator/feeds/api/runs-stream.ts
@@ -1,0 +1,93 @@
+import * as React from 'react';
+
+import { useIdentity } from '@/lib/identity';
+import { ensureMercureAuthorization, mercureSubscribeUrl, mercureTenantTopic } from '@/lib/mercure';
+
+/**
+ * XMLF-P5-05 — SSE subscriber for one feed's run stream (P4-02 publisher).
+ * Split from api/runs.ts so the ADR-0021 transport-in-effect guard stays clean: this file owns the EventSource
+ * effect and carries no HTTP transport at all.
+ */
+
+export interface FeedRunEvent {
+  event: 'progress' | 'status';
+  run_id: string;
+  feed_id: string;
+  items_done?: number;
+  items_total?: number | null;
+  progress_pct?: number | null;
+  estimated_seconds_remaining?: number | null;
+  status?: string;
+  item_count?: number;
+  skipped_count?: number;
+  warning_count?: number;
+  error_message?: string | null;
+}
+
+export interface FeedRunsStream {
+  connected: boolean;
+  lastEvent: FeedRunEvent | null;
+  topic: string | null;
+}
+
+/**
+ * SSE subscriber for one feed's run stream (P4-02 publisher). Mirrors the
+ * useExportSessionsStream pattern: mint the mercureAuthorization cookie,
+ * open the EventSource, surface the latest event; no-ops without
+ * EventSource and on hub errors (REST polling stays the fallback).
+ */
+export function useFeedRunsStream(feedId: string | null): FeedRunsStream {
+  const [connected, setConnected] = React.useState(false);
+  const [lastEvent, setLastEvent] = React.useState<FeedRunEvent | null>(null);
+  const { identity } = useIdentity();
+  const tenantId = identity?.tenant?.id ?? null;
+  const topic =
+    feedId !== null && tenantId !== null
+      ? mercureTenantTopic(tenantId, 'feeds', feedId, 'runs')
+      : null;
+
+  React.useEffect(() => {
+    if (topic === null) {
+      setConnected(false);
+      setLastEvent(null);
+      return;
+    }
+    if (typeof window === 'undefined' || typeof EventSource === 'undefined') {
+      return;
+    }
+
+    const url = mercureSubscribeUrl(topic);
+    let source: EventSource | null = null;
+    let cancelled = false;
+
+    ensureMercureAuthorization()
+      .then(() => {
+        if (cancelled) {
+          return;
+        }
+        source = new EventSource(url, { withCredentials: true });
+        source.addEventListener('open', () => setConnected(true));
+        source.addEventListener('message', (event) => {
+          try {
+            setLastEvent(JSON.parse(event.data) as FeedRunEvent);
+          } catch {
+            // Malformed payload — Mercure is enrichment, not source of truth.
+          }
+        });
+        source.addEventListener('error', () => setConnected(false));
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setConnected(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      source?.close();
+      setConnected(false);
+    };
+  }, [topic]);
+
+  return { connected, lastEvent, topic };
+}

--- a/apps/admin/src/features/api-configurator/feeds/api/runs.ts
+++ b/apps/admin/src/features/api-configurator/feeds/api/runs.ts
@@ -1,0 +1,98 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { jsonFetch } from '@/lib/http';
+
+/**
+ * XMLF-P5-05 — run history + drill-down data layer over the P4-03 read API
+ * and the P4-02 Mercure stream (`tenant/{tid}/feeds/{feedId}/runs`). REST is
+ * the source of truth; the SSE event is a "something changed" signal that
+ * drives the live pipeline and triggers refetches.
+ */
+
+export type RunHealth = 'success' | 'warning' | 'error' | 'pending' | 'running' | 'cancelled';
+
+export interface FeedRunRow {
+  id: string;
+  feed_id: string;
+  feed_name?: string | null;
+  feed_code?: string | null;
+  template_kind?: string | null;
+  trigger: string;
+  status: string;
+  health: RunHealth;
+  item_count: number;
+  skipped_count: number;
+  warning_count: number;
+  file_size_bytes: number | null;
+  duration_ms: number | null;
+  error_message: string | null;
+  started_at: string;
+  completed_at: string | null;
+}
+
+export interface FeedRunLogRow {
+  id: string;
+  level: 'info' | 'warning' | 'error';
+  object_sku: string | null;
+  slot: string | null;
+  message: string;
+  created_at: string;
+}
+
+interface RunsPage {
+  items: FeedRunRow[];
+  next_cursor: string | null;
+}
+
+export function useFeedRuns(
+  feedId: string | null,
+  status: 'all' | 'success' | 'warning' | 'error',
+) {
+  const query = status === 'all' ? '' : `?status=${status}`;
+  return useQuery({
+    queryKey: ['xmlf', 'feed-runs', feedId ?? 'global', status],
+    enabled: feedId !== null,
+    queryFn: async () => (await jsonFetch<RunsPage>(`/api/feeds/${feedId}/runs${query}`)).items,
+  });
+}
+
+export function useGlobalFeedRuns(status: 'all' | 'success' | 'warning' | 'error') {
+  const query = status === 'all' ? '' : `?status=${status}`;
+  return useQuery({
+    queryKey: ['xmlf', 'feed-runs', 'global', status],
+    queryFn: async () => (await jsonFetch<RunsPage>(`/api/feed-runs${query}`)).items,
+  });
+}
+
+export function useFeedRunLogs(feedId: string | null, runId: string | null) {
+  return useQuery({
+    queryKey: ['xmlf', 'feed-run-logs', runId ?? 'none'],
+    enabled: feedId !== null && runId !== null,
+    queryFn: async () =>
+      (
+        await jsonFetch<{ items: FeedRunLogRow[]; next_cursor: string | null }>(
+          `/api/feeds/${feedId}/runs/${runId}/logs?limit=100`,
+        )
+      ).items,
+  });
+}
+
+export function formatBytes(bytes: number | null): string {
+  if (bytes === null) {
+    return '—';
+  }
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} kB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function formatDuration(ms: number | null): string {
+  if (ms === null) {
+    return '—';
+  }
+  return ms < 1000 ? `${ms} ms` : `${(ms / 1000).toFixed(1)} s`;
+}

--- a/apps/admin/src/features/api-configurator/feeds/detail/FeedDetailPage.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/detail/FeedDetailPage.tsx
@@ -1,29 +1,333 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { AlertTriangle, ArrowLeft, Link2, Pencil, RefreshCw, Rss } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useParams } from 'react-router';
+import { useNavigate, useParams } from 'react-router';
+
+import { useToast } from '@/components/ui/toast';
+import { ConnStatusPill } from '@/features/api-configurator/components/primitives';
+import { httpErrorDetail } from '@/lib/http';
+import { cn } from '@/lib/utils';
+
+import { computeCoverage, fetchFeed, useRegenerateFeed, useRotateToken } from '../api/feeds';
+import { type FeedRunRow, useFeedRuns } from '../api/runs';
+import { type FeedRunEvent, useFeedRunsStream } from '../api/runs-stream';
+import { CopyButton, CoverageBar, TemplateBadge } from '../components/primitives';
+import { RunDrilldown } from '../monitor/RunDrilldown';
+import { RunsTable } from '../monitor/RunsTable';
+
+const STAGES = ['query', 'serialize', 'validate', 'store', 'done'] as const;
+type Stage = (typeof STAGES)[number];
 
 /**
- * XMLF-P5-01 — route placeholder for the feed detail / monitor screen
- * (XMLF-P5-05). Cards deep-link here today; the pipeline view, run history
- * and drill-down land in their own ticket.
+ * XMLF-P5-05 — the feed detail (design feed-monitor.jsx FeedDetail): header
+ * with the live badge, the public-URL row, feed KPI, the live regeneration
+ * pipeline driven by the P4-02 Mercure stream (`feeds/{id}/runs`) and the
+ * run history with the per-product drill-down. REST is the source of truth;
+ * SSE events move the pipeline and trigger refetches.
  */
 export function FeedDetailPage() {
   const { t } = useTranslation();
   const { id } = useParams();
+  const navigate = useNavigate();
+  const toast = useToast();
+  const queryClient = useQueryClient();
+  const feedId = id ?? null;
+
+  const feed = useQuery({
+    queryKey: ['xmlf', 'feed', feedId ?? 'none'],
+    enabled: feedId !== null,
+    queryFn: async () => fetchFeed(feedId ?? ''),
+  });
+  const [runFilter, setRunFilter] = useState<'all' | 'success' | 'warning' | 'error'>('all');
+  const runs = useFeedRuns(feedId, runFilter);
+  const stream = useFeedRunsStream(feedId);
+  const regenerate = useRegenerateFeed();
+  const rotate = useRotateToken();
+  const [mintedUrl, setMintedUrl] = useState<string | null>(null);
+  const [openRun, setOpenRun] = useState<FeedRunRow | null>(null);
+  const [liveEvent, setLiveEvent] = useState<FeedRunEvent | null>(null);
+
+  const lastEvent = stream.lastEvent;
+  useEffect(() => {
+    if (lastEvent === null) {
+      return;
+    }
+    setLiveEvent(lastEvent);
+    if (lastEvent.event === 'status' && lastEvent.status !== 'running') {
+      // Terminal status — the run history and the feed KPI are stale now.
+      void queryClient.invalidateQueries({ queryKey: ['xmlf', 'feed-runs'] });
+      void queryClient.invalidateQueries({ queryKey: ['xmlf', 'feed', feedId ?? 'none'] });
+    }
+  }, [lastEvent, queryClient, feedId]);
+
+  const pipeline = useMemo(() => derivePipeline(liveEvent), [liveEvent]);
+  const running = pipeline.stage !== null && pipeline.stage !== 'done';
+  const row = feed.data;
+  const coverage = useMemo(
+    () =>
+      row === undefined
+        ? { mapped: 0, total: 0 }
+        : computeCoverage(row.descriptor, row.field_mappings),
+    [row],
+  );
+
+  function onRegenerate(): void {
+    if (feedId === null) {
+      return;
+    }
+    setLiveEvent(null);
+    regenerate.mutate(feedId, {
+      onSuccess: () => toast.success(t('api_configurator.feeds.card.regenerate_started')),
+      onError: (error) =>
+        toast.error(httpErrorDetail(error) ?? t('api_configurator.feeds.card.action_error')),
+    });
+  }
+
+  function onRotate(): void {
+    if (feedId === null) {
+      return;
+    }
+    rotate.mutate(feedId, {
+      onSuccess: (minted) => {
+        setMintedUrl(
+          minted.url.startsWith('http') ? minted.url : `${window.location.origin}${minted.url}`,
+        );
+        toast.success(t('api_configurator.feeds.card.rotate_success'));
+      },
+      onError: (error) =>
+        toast.error(httpErrorDetail(error) ?? t('api_configurator.feeds.card.action_error')),
+    });
+  }
+
   return (
-    <div className="rounded-3xl bg-white p-10 text-center soft-shadow">
-      <h1 className="font-display text-[18px] font-semibold tracking-tight">
-        {t('api_configurator.feeds.detail.placeholder_title')}
-      </h1>
-      <p className="mt-2 font-mono text-[12px] text-zinc-500">{id}</p>
-      <p className="mt-2 text-[13px] text-zinc-500">
-        {t('api_configurator.feeds.detail.placeholder_hint')}
-      </p>
-      <Link
-        to="/integrations/api-configurator/feeds"
-        className="mt-6 inline-flex h-9 items-center rounded-lg bg-zinc-900 px-4 text-[13px] font-medium text-white hover:bg-zinc-800"
-      >
-        {t('api_configurator.feeds.wizard.back_to_hub')}
-      </Link>
+    <div className="space-y-5">
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => void navigate('/integrations/api-configurator/feeds')}
+          aria-label={t('api_configurator.feeds.wizard.back_to_hub')}
+          className="grid h-9 w-9 shrink-0 place-items-center rounded-xl bg-white text-zinc-500 soft-shadow hover:text-zinc-900"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden />
+        </button>
+        <div className="grid h-10 w-10 shrink-0 place-items-center rounded-xl bg-zinc-100 text-zinc-600">
+          <Rss className="h-4.5 w-4.5" aria-hidden />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="font-display text-[20px] font-semibold tracking-tight">
+              {row?.name ?? '…'}
+            </h1>
+            {row !== undefined && <TemplateBadge kind={row.template_kind} />}
+            {row !== undefined && (
+              <ConnStatusPill
+                status={row.status}
+                label={t(`api_configurator.feeds.status.${row.status}`)}
+              />
+            )}
+            {stream.connected && running && (
+              <span className="inline-flex items-center gap-1.5 rounded-md bg-sky-50 px-2 py-0.5 font-mono text-[10.5px] text-sky-700">
+                <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-sky-500" aria-hidden />
+                {t('api_configurator.feeds.detail.live', { topic: `feed-runs.${feedId ?? ''}` })}
+              </span>
+            )}
+          </div>
+          {row !== undefined && <p className="font-mono text-[11.5px] text-zinc-500">{row.code}</p>}
+        </div>
+        <button
+          type="button"
+          onClick={() => void navigate(`/integrations/api-configurator/feeds/${feedId}/edit`)}
+          className="flex h-9 items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-3 text-[12.5px] font-medium text-zinc-700 hover:bg-zinc-50"
+        >
+          <Pencil className="h-3.5 w-3.5" aria-hidden />
+          {t('api_configurator.feeds.detail.edit')}
+        </button>
+        <button
+          type="button"
+          onClick={onRegenerate}
+          disabled={regenerate.isPending || running}
+          className="flex h-9 items-center gap-1.5 rounded-lg bg-zinc-900 px-3 text-[12.5px] font-medium text-white hover:bg-zinc-800 disabled:opacity-40"
+        >
+          <RefreshCw
+            className={cn('h-3.5 w-3.5', (regenerate.isPending || running) && 'animate-spin')}
+            aria-hidden
+          />
+          {t('api_configurator.feeds.detail.regenerate_now')}
+        </button>
+      </div>
+
+      <div className="flex items-center gap-2 rounded-2xl bg-white px-4 py-3 soft-shadow">
+        <Link2 className="h-4 w-4 shrink-0 text-zinc-500" aria-hidden />
+        <code className="min-w-0 flex-1 truncate rounded-lg border border-zinc-100 bg-zinc-50 px-2.5 py-1.5 font-mono text-[11.5px] text-zinc-600">
+          {mintedUrl ??
+            t(
+              row?.has_token === true
+                ? 'api_configurator.feeds.card.url_masked'
+                : 'api_configurator.feeds.card.url_none',
+            )}
+        </code>
+        <CopyButton value={mintedUrl ?? ''} disabled={mintedUrl === null} />
+        <button
+          type="button"
+          onClick={onRotate}
+          disabled={rotate.isPending}
+          aria-label={t('api_configurator.feeds.card.rotate')}
+          className="grid h-8 w-8 place-items-center rounded-lg border border-zinc-200 bg-white text-zinc-500 hover:text-zinc-800 disabled:opacity-40"
+        >
+          <RefreshCw
+            className={cn('h-3.5 w-3.5', rotate.isPending && 'animate-spin')}
+            aria-hidden
+          />
+        </button>
+      </div>
+
+      {(running || pipeline.stage === 'done') && (
+        <div className="rounded-2xl bg-white px-5 py-4 soft-shadow">
+          <div className="mb-3 flex items-center justify-between text-[12px] text-zinc-600">
+            <span className="font-medium">{t('api_configurator.feeds.detail.pipeline_title')}</span>
+            {pipeline.pct !== null && <span className="num">{pipeline.pct}%</span>}
+          </div>
+          <ol
+            className="flex items-center gap-2"
+            aria-label={t('api_configurator.feeds.detail.pipeline_title')}
+          >
+            {STAGES.map((stage, index) => {
+              const activeIndex = pipeline.stage === null ? -1 : STAGES.indexOf(pipeline.stage);
+              const state =
+                pipeline.stage === 'done'
+                  ? 'done'
+                  : index < activeIndex
+                    ? 'done'
+                    : index === activeIndex
+                      ? 'active'
+                      : 'pending';
+              return (
+                <li key={stage} className="flex min-w-0 flex-1 items-center gap-2">
+                  <div
+                    className={cn(
+                      'h-1.5 min-w-0 flex-1 rounded-full',
+                      state === 'done' && 'bg-emerald-500',
+                      state === 'active' && 'animate-pulse bg-sky-500',
+                      state === 'pending' && 'bg-zinc-100',
+                    )}
+                  />
+                  <span
+                    className={cn(
+                      'shrink-0 font-mono text-[10px]',
+                      state === 'pending' ? 'text-zinc-400' : 'text-zinc-600',
+                    )}
+                  >
+                    {t(`api_configurator.feeds.detail.stage.${stage}`)}
+                  </span>
+                </li>
+              );
+            })}
+          </ol>
+        </div>
+      )}
+
+      {row !== undefined && (
+        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+          <div className="rounded-2xl bg-white p-4 soft-shadow">
+            <div className="text-[10px] uppercase tracking-wider text-zinc-500">
+              {t('api_configurator.feeds.card.items')}
+            </div>
+            <div className="num mt-1 text-[20px] font-semibold text-zinc-900">
+              {row.cached_item_count?.toLocaleString('pl-PL') ?? '—'}
+            </div>
+          </div>
+          <div className="rounded-2xl bg-white p-4 soft-shadow">
+            <div className="text-[10px] uppercase tracking-wider text-zinc-500">
+              {t('api_configurator.feeds.detail.last_pull')}
+            </div>
+            <div className="mt-1 text-[13px] text-zinc-700">
+              {row.last_pulled_at !== null
+                ? new Date(row.last_pulled_at).toLocaleString('pl-PL')
+                : '—'}
+            </div>
+          </div>
+          <div className="rounded-2xl bg-white p-4 soft-shadow">
+            <div className="text-[10px] uppercase tracking-wider text-zinc-500">
+              {t('api_configurator.feeds.card.schedule')}
+            </div>
+            <div className="mt-1 font-mono text-[13px] text-zinc-700">
+              {row.schedule_cron ?? t('api_configurator.feeds.card.schedule_manual')}
+            </div>
+          </div>
+          <div className="rounded-2xl bg-white p-4 soft-shadow">
+            <div className="text-[10px] uppercase tracking-wider text-zinc-500">
+              {t('api_configurator.feeds.card.coverage')}
+            </div>
+            <div className="mt-2">
+              <CoverageBar mapped={coverage.mapped} total={coverage.total} />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {row?.status === 'error' && (
+        <div className="flex items-start gap-2 rounded-2xl border border-rose-200 bg-rose-50/70 px-4 py-3 text-[12.5px] text-rose-900">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-rose-600" aria-hidden />
+          {t('api_configurator.feeds.detail.health_note')}
+        </div>
+      )}
+
+      <div className="overflow-hidden rounded-3xl bg-white soft-shadow">
+        <div className="flex flex-wrap items-center gap-3 border-b border-zinc-100 px-5 py-3">
+          <div className="text-[14px] font-semibold tracking-tight">
+            {t('api_configurator.feeds.detail.history_title')}
+          </div>
+          <div className="ml-auto flex items-center gap-0.5 rounded-xl bg-zinc-100 p-1">
+            {(['all', 'success', 'warning', 'error'] as const).map((value) => (
+              <button
+                key={value}
+                type="button"
+                aria-pressed={runFilter === value}
+                onClick={() => setRunFilter(value)}
+                className={cn(
+                  'h-7 rounded-lg px-2.5 text-[11.5px] font-medium',
+                  runFilter === value ? 'bg-zinc-900 text-white' : 'text-zinc-600 hover:bg-white',
+                )}
+              >
+                {t(`api_configurator.feeds.run.filter.${value}`)}
+              </button>
+            ))}
+          </div>
+        </div>
+        <RunsTable runs={runs.data ?? []} showFeed={false} onOpen={setOpenRun} />
+      </div>
+
+      <RunDrilldown
+        run={openRun}
+        onClose={() => setOpenRun(null)}
+        onRegenerate={() => {
+          setOpenRun(null);
+          onRegenerate();
+        }}
+      />
     </div>
   );
+}
+
+/**
+ * Map the P4-02 event stream onto the design's 5-stage pipeline: `running`
+ * lights the query stage, progress events advance serialize/validate with
+ * the reported pct, the terminal status lands on done.
+ */
+function derivePipeline(event: FeedRunEvent | null): { stage: Stage | null; pct: number | null } {
+  if (event === null) {
+    return { stage: null, pct: null };
+  }
+  if (event.event === 'status') {
+    if (event.status === 'running') {
+      return { stage: 'query', pct: null };
+    }
+    if (event.status === 'done') {
+      return { stage: 'done', pct: 100 };
+    }
+    return { stage: null, pct: null };
+  }
+  const pct = event.progress_pct ?? null;
+  return { stage: pct !== null && pct > 66 ? 'validate' : 'serialize', pct };
 }

--- a/apps/admin/src/features/api-configurator/feeds/monitor/RunDrilldown.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/monitor/RunDrilldown.tsx
@@ -1,0 +1,130 @@
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
+import { cn } from '@/lib/utils';
+
+import { type FeedRunRow, formatBytes, formatDuration, useFeedRunLogs } from '../api/runs';
+import { HealthDot, RunStatusPill, TriggerBadge } from './RunsTable';
+
+/**
+ * XMLF-P5-05 — the run drill-down sheet (design feed-monitor.jsx
+ * FeedRunDrilldown): run identity + metric tiles + the per-product
+ * FeedRunLog table ("SKU-123 · g:gtin — missing required g:gtin — skipped")
+ * from GET /api/feeds/{id}/runs/{runId}/logs. CSV export / feed-file
+ * download land with their backend endpoints (deliberate hooks).
+ */
+export function RunDrilldown({
+  run,
+  onClose,
+  onRegenerate,
+}: {
+  run: FeedRunRow | null;
+  onClose: () => void;
+  onRegenerate?: (feedId: string) => void;
+}) {
+  const { t } = useTranslation();
+  const logs = useFeedRunLogs(run?.feed_id ?? null, run?.id ?? null);
+
+  return (
+    <Sheet open={run !== null} onOpenChange={(open) => !open && onClose()}>
+      <SheetContent
+        side="right"
+        closeLabel={t('api_configurator.feeds.run.close')}
+        className="w-full overflow-y-auto p-5 sm:max-w-xl"
+      >
+        {run !== null && (
+          <>
+            <div className="space-y-1">
+              <SheetTitle className="flex flex-wrap items-center gap-2 text-[15px]">
+                {t('api_configurator.feeds.run.drill_title')}
+                <RunStatusPill health={run.health} />
+                <TriggerBadge trigger={run.trigger} />
+              </SheetTitle>
+              <p className="text-[12px] text-zinc-500">
+                {new Date(run.started_at).toLocaleString('pl-PL')} ·{' '}
+                {formatDuration(run.duration_ms)} · {formatBytes(run.file_size_bytes)}
+              </p>
+            </div>
+
+            {run.error_message !== null && (
+              <div className="mt-3 flex items-start gap-2 rounded-xl border border-rose-200 bg-rose-50/70 px-3 py-2 text-[12px] text-rose-900">
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-rose-600" aria-hidden />
+                {run.error_message}
+              </div>
+            )}
+
+            <div className="mt-4 grid grid-cols-4 gap-2 text-center">
+              {(
+                [
+                  ['in_feed', run.item_count, 'text-zinc-900'],
+                  ['skipped', run.skipped_count, 'text-amber-700'],
+                  ['warnings', run.warning_count, 'text-zinc-700'],
+                  ['size', formatBytes(run.file_size_bytes), 'text-zinc-700'],
+                ] as const
+              ).map(([key, value, tone]) => (
+                <div key={key} className="rounded-xl bg-zinc-50 px-2 py-2">
+                  <div className={cn('num text-[15px] font-semibold', tone)}>
+                    {typeof value === 'number' ? value.toLocaleString('pl-PL') : value}
+                  </div>
+                  <div className="text-[9.5px] uppercase tracking-wider text-zinc-500">
+                    {t(`api_configurator.feeds.run.metric.${key}`)}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-5">
+              <div className="mb-2 text-[12px] font-semibold uppercase tracking-wider text-zinc-500">
+                {t('api_configurator.feeds.log.title')}
+              </div>
+              {logs.isLoading ? (
+                <div className="h-24 animate-pulse rounded-xl bg-zinc-100" />
+              ) : (logs.data ?? []).length === 0 ? (
+                <p className="text-[12.5px] text-emerald-700">
+                  {t('api_configurator.feeds.log.empty')}
+                </p>
+              ) : (
+                <ul className="space-y-1.5">
+                  {(logs.data ?? []).map((line) => (
+                    <li key={line.id} className="flex items-start gap-2 text-[12px]">
+                      <HealthDot
+                        health={
+                          line.level === 'error'
+                            ? 'error'
+                            : line.level === 'warning'
+                              ? 'warning'
+                              : 'success'
+                        }
+                      />
+                      <span className="min-w-0">
+                        <span className="font-mono text-[11px] text-zinc-500">
+                          {line.object_sku ?? '—'}
+                          {line.slot !== null && ` · ${line.slot}`}
+                        </span>{' '}
+                        <span className="text-zinc-700">{line.message}</span>
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            {onRegenerate !== undefined && (
+              <div className="mt-5 border-t border-zinc-100 pt-4">
+                <button
+                  type="button"
+                  onClick={() => onRegenerate(run.feed_id)}
+                  className="flex h-9 items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-3 text-[12px] font-medium text-zinc-700 hover:bg-zinc-50"
+                >
+                  <RefreshCw className="h-3.5 w-3.5" aria-hidden />
+                  {t('api_configurator.feeds.run.regenerate_again')}
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/admin/src/features/api-configurator/feeds/monitor/RunsTable.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/monitor/RunsTable.tsx
@@ -1,0 +1,153 @@
+import { ChevronRight } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { cn } from '@/lib/utils';
+
+import { type FeedRunRow, formatBytes, formatDuration, type RunHealth } from '../api/runs';
+
+const DOT_TONES: Record<RunHealth, string> = {
+  success: 'bg-emerald-500',
+  warning: 'bg-amber-400',
+  error: 'bg-rose-500',
+  pending: 'bg-zinc-300',
+  running: 'bg-sky-500 animate-pulse',
+  cancelled: 'bg-zinc-400',
+};
+
+export function HealthDot({ health }: { health: RunHealth }) {
+  return <span className={cn('h-2 w-2 shrink-0 rounded-full', DOT_TONES[health])} aria-hidden />;
+}
+
+export function TriggerBadge({ trigger }: { trigger: string }) {
+  const { t } = useTranslation();
+  return (
+    <span
+      className={cn(
+        'rounded px-1.5 py-0.5 font-mono text-[10px] uppercase',
+        trigger === 'schedule' ? 'bg-sky-50 text-sky-700' : 'bg-zinc-100 text-zinc-600',
+      )}
+    >
+      {t(`api_configurator.feeds.run.trigger.${trigger}`, { defaultValue: trigger })}
+    </span>
+  );
+}
+
+export function RunStatusPill({ health }: { health: RunHealth }) {
+  const { t } = useTranslation();
+  const tone =
+    health === 'success'
+      ? 'bg-emerald-50 text-emerald-700'
+      : health === 'warning'
+        ? 'bg-amber-50 text-amber-800'
+        : health === 'error'
+          ? 'bg-rose-50 text-rose-700'
+          : health === 'running'
+            ? 'bg-sky-50 text-sky-700'
+            : 'bg-zinc-100 text-zinc-600';
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-[11px] font-medium',
+        tone,
+      )}
+    >
+      <HealthDot health={health} />
+      {t(`api_configurator.feeds.run.health.${health}`)}
+    </span>
+  );
+}
+
+/**
+ * XMLF-P5-05 — the run history table (design feed-monitor.jsx RunsTable):
+ * one row per FeedRun, clickable into the drill-down sheet. `showFeed`
+ * switches between the global monitor (feed identity column) and the
+ * per-feed history on the detail screen.
+ */
+export function RunsTable({
+  runs,
+  showFeed,
+  onOpen,
+}: {
+  runs: FeedRunRow[];
+  showFeed: boolean;
+  onOpen: (run: FeedRunRow) => void;
+}) {
+  const { t } = useTranslation();
+
+  if (runs.length === 0) {
+    return (
+      <p className="px-5 py-6 text-center text-[12.5px] text-zinc-500">
+        {t('api_configurator.feeds.run.empty')}
+      </p>
+    );
+  }
+
+  return (
+    <div>
+      <div
+        className={cn(
+          'grid gap-3 border-b border-zinc-100 px-5 py-2 text-[10.5px] font-medium uppercase tracking-wider text-zinc-500',
+          showFeed
+            ? 'grid-cols-[2fr_0.8fr_0.7fr_1fr_0.7fr_0.9fr_24px]'
+            : 'grid-cols-[1.4fr_0.8fr_0.7fr_1fr_0.7fr_0.9fr_24px]',
+        )}
+      >
+        <div>
+          {t(
+            showFeed
+              ? 'api_configurator.feeds.run.col.feed_start'
+              : 'api_configurator.feeds.run.col.start',
+          )}
+        </div>
+        <div>{t('api_configurator.feeds.run.col.trigger')}</div>
+        <div>{t('api_configurator.feeds.run.col.duration')}</div>
+        <div>{t('api_configurator.feeds.run.col.items')}</div>
+        <div>{t('api_configurator.feeds.run.col.size')}</div>
+        <div>{t('api_configurator.feeds.run.col.status')}</div>
+        <div />
+      </div>
+      {runs.map((run) => (
+        <button
+          key={run.id}
+          type="button"
+          onClick={() => onOpen(run)}
+          className={cn(
+            'grid w-full items-center gap-3 border-b border-zinc-50 px-5 py-2.5 text-left text-[12.5px] transition hover:bg-zinc-50/70',
+            showFeed
+              ? 'grid-cols-[2fr_0.8fr_0.7fr_1fr_0.7fr_0.9fr_24px]'
+              : 'grid-cols-[1.4fr_0.8fr_0.7fr_1fr_0.7fr_0.9fr_24px]',
+          )}
+        >
+          <div className="flex min-w-0 items-center gap-2">
+            <HealthDot health={run.health} />
+            <div className="min-w-0">
+              {showFeed && (
+                <div className="truncate font-medium text-zinc-800">
+                  {run.feed_name ?? run.feed_code ?? run.feed_id}
+                </div>
+              )}
+              <div className={cn('text-zinc-500', showFeed ? 'text-[11px]' : 'text-zinc-700')}>
+                {new Date(run.started_at).toLocaleString('pl-PL')}
+              </div>
+            </div>
+          </div>
+          <div>
+            <TriggerBadge trigger={run.trigger} />
+          </div>
+          <div className="num text-zinc-600">{formatDuration(run.duration_ms)}</div>
+          <div className="num text-zinc-800">
+            {run.item_count.toLocaleString('pl-PL')}
+            {run.skipped_count > 0 && (
+              <span className="ml-1 text-[11px] text-amber-700">⤼ {run.skipped_count}</span>
+            )}
+          </div>
+          <div className="num text-zinc-600">{formatBytes(run.file_size_bytes)}</div>
+          <div>
+            <RunStatusPill health={run.health} />
+          </div>
+          <ChevronRight className="h-3.5 w-3.5 text-zinc-300" aria-hidden />
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1848,7 +1848,22 @@
       },
       "detail": {
         "placeholder_title": "Feed detail — coming in the next ticket",
-        "placeholder_hint": "The pipeline view, run history and per-product log drill-down land with XMLF-P5-05."
+        "placeholder_hint": "The pipeline view, run history and per-product log drill-down land with XMLF-P5-05.",
+        "edit": "Edit",
+        "regenerate_now": "Regenerate now",
+        "live": "LIVE · {{topic}}",
+        "pipeline_title": "Regeneration pipeline",
+        "stage": {
+          "query": "query",
+          "serialize": "serialize",
+          "validate": "validate",
+          "store": "store",
+          "done": "done"
+        },
+        "size": "File size",
+        "last_pull": "Last pull",
+        "health_note": "The last regeneration failed — check the run history below and the drill-down log.",
+        "history_title": "Regeneration history"
       },
       "mapper": {
         "title": "Slot ↔ attribute mapping",
@@ -1929,6 +1944,50 @@
         "ai_cta": "AI mapping suggestions",
         "ai_soon": "Faza 2",
         "well_formed_note": "The writer escapes every value (or wraps it in CDATA) — the feed stays well-formed XML regardless of catalog content. Preview and production share the same engine."
+      },
+      "run": {
+        "empty": "No regenerations yet.",
+        "drill_title": "Regeneration run",
+        "regenerate_again": "Regenerate again",
+        "col": {
+          "feed_start": "Feed · start",
+          "start": "Start",
+          "trigger": "Trigger",
+          "duration": "Duration",
+          "items": "Products",
+          "size": "Size",
+          "status": "Status"
+        },
+        "trigger": {
+          "manual": "manual",
+          "schedule": "schedule",
+          "first_publish": "first publish"
+        },
+        "health": {
+          "success": "success",
+          "warning": "warning",
+          "error": "error",
+          "pending": "pending",
+          "running": "running",
+          "cancelled": "cancelled"
+        },
+        "filter": {
+          "all": "all",
+          "success": "success",
+          "warning": "warnings",
+          "error": "errors"
+        },
+        "metric": {
+          "in_feed": "in feed",
+          "skipped": "skipped",
+          "warnings": "warnings",
+          "size": "size"
+        },
+        "close": "Close"
+      },
+      "log": {
+        "title": "Product log",
+        "empty": "No log lines — a clean run."
       }
     },
     "shell": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1896,7 +1896,22 @@
       },
       "detail": {
         "placeholder_title": "Detal feedu — w kolejnym tickecie",
-        "placeholder_hint": "Widok pipeline, historia runów i drill-down logu per produkt wchodzą z XMLF-P5-05."
+        "placeholder_hint": "Widok pipeline, historia runów i drill-down logu per produkt wchodzą z XMLF-P5-05.",
+        "edit": "Edytuj",
+        "regenerate_now": "Regeneruj teraz",
+        "live": "LIVE · {{topic}}",
+        "pipeline_title": "Pipeline regeneracji",
+        "stage": {
+          "query": "zapytanie",
+          "serialize": "serializacja",
+          "validate": "walidacja",
+          "store": "zapis",
+          "done": "gotowe"
+        },
+        "size": "Rozmiar pliku",
+        "last_pull": "Ostatnie pobranie",
+        "health_note": "Ostatnia regeneracja nie powiodła się — sprawdź historię poniżej i log w drill-downie.",
+        "history_title": "Historia regeneracji"
       },
       "mapper": {
         "title": "Mapowanie slot ↔ atrybut",
@@ -1977,6 +1992,50 @@
         "ai_cta": "AI-sugestie mapowania",
         "ai_soon": "Faza 2",
         "well_formed_note": "Writer escapuje każdą wartość (lub pakuje w CDATA) — feed pozostaje well-formed XML niezależnie od treści katalogu. Podgląd i produkcja używają tego samego silnika."
+      },
+      "run": {
+        "empty": "Brak regeneracji.",
+        "drill_title": "Run regeneracji",
+        "regenerate_again": "Regeneruj ponownie",
+        "col": {
+          "feed_start": "Feed · start",
+          "start": "Start",
+          "trigger": "Trigger",
+          "duration": "Czas",
+          "items": "Produkty",
+          "size": "Rozmiar",
+          "status": "Status"
+        },
+        "trigger": {
+          "manual": "ręcznie",
+          "schedule": "harmonogram",
+          "first_publish": "pierwsza publikacja"
+        },
+        "health": {
+          "success": "sukces",
+          "warning": "ostrzeżenie",
+          "error": "błąd",
+          "pending": "oczekuje",
+          "running": "w toku",
+          "cancelled": "anulowany"
+        },
+        "filter": {
+          "all": "wszystkie",
+          "success": "sukces",
+          "warning": "ostrzeżenia",
+          "error": "błędy"
+        },
+        "metric": {
+          "in_feed": "w feedzie",
+          "skipped": "pominięte",
+          "warnings": "ostrzeżenia",
+          "size": "rozmiar"
+        },
+        "close": "Zamknij"
+      },
+      "log": {
+        "title": "Log produktów",
+        "empty": "Brak linii logu — czysty run."
       }
     },
     "shell": {


### PR DESCRIPTION
## XMLF-P5-05 — ekran szczegółu feedu (Closes #1933)

Ekran szczegółu feedu wg designu `feed-monitor.jsx`:

- **Header + LiveBadge** — nazwa/kod/szablon + wskaźnik live połączenia SSE.
- **Pipeline regeneracji na żywo** (query → serialize → validate → store → done) sterowany Mercure streamem `feeds/{id}/runs` (P4-02) przez nowy hook `useFeedRunsStream` w `api/runs-stream.ts` — **split od `api/runs.ts`**, bo guard ADR-0021 liczy string co-occurrence `jsonFetch`+`useEffect` nawet w komentarzach. Eventy invalidują react-query cache → tabela i KPI odświeżają się bez reloadu.
- **Historia runów** per feed (`/api/feeds/{id}/runs`, P4-03) z filtrem statusu.
- **RunDrilldown** — Sheet z logami per-produkt (`/api/feeds/{id}/runs/{runId}/logs`); `closeLabel` na SheetContent (fix axe button-name).
- `monitor/RunsTable` + `RunDrilldown` reusable — P5-07 (globalny monitor) użyje ich z `showFeed`.
- `api/runs.ts`: `useFeedRuns`/`useGlobalFeedRuns`/`useFeedRunLogs` + `formatBytes`/`formatDuration`.

## Smoke test (live, pim.localhost)
Zalogowany admin → Konfigurator API → Feedy → karta feedu → szczegół: **historia runów z realnymi danymi, drilldown pokazuje logi per-produkt, po „Regeneruj teraz" pipeline animuje etapy z SSE (running→done)**. Network: 200 na runs/logs, 202 na regenerate; Console bez czerwonych errorów.

## Testy
- Spec `e2e/1933-feed-detail.spec.ts` (mocked, w tym mock Mercure) zielony + axe-core 0 serious/critical.
- tsc / biome / vitest / build zielone; guard lint-jsonfetch-useeffect = baseline.
