### PR TITLE
feat(admin): global feeds monitor with cross-feed run history

### DIFF
--- a/apps/admin/e2e/1929-feeds-hub.spec.ts
+++ b/apps/admin/e2e/1929-feeds-hub.spec.ts
@@ -78,8 +78,12 @@ test('XMLF-P5-01 — feeds hub: tab, KPI, cards, filtering, a11y', async ({ page
 
   await page.goto('/integrations/api-configurator/feeds');
 
-  // Shell: the fourth tab exists and is active for the /feeds prefix.
-  const feedsTab = page.getByRole('tab', { name: /Feedy|Feeds/ });
+  // Shell: the fourth tab exists and is active for the /feeds prefix
+  // (scoped to the layout tablist — the P5-07 feeds sub-nav has its own
+  // same-named "Feeds" tab).
+  const feedsTab = page
+    .getByLabel(/API Configurator|Konfigurator API/)
+    .getByRole('tab', { name: /Feedy|Feeds/ });
   await expect(feedsTab).toBeVisible();
   await expect(feedsTab).toHaveAttribute('aria-selected', 'true');
 

--- a/apps/admin/e2e/1935-feeds-monitor.spec.ts
+++ b/apps/admin/e2e/1935-feeds-monitor.spec.ts
@@ -1,0 +1,130 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * XMLF-P5-07 (#1935) — the global cross-feed monitor: sub-nav, the four 24h
+ * KPI tiles from /api/feed-runs/kpi, the all-feeds run history with the feed
+ * column and the status filter, and the shared drill-down. All mocked.
+ */
+
+const RUNS = {
+  items: [
+    {
+      id: 'run-a',
+      feed_id: 'f-a',
+      feed_name: 'Google Shopping — Polska',
+      feed_code: 'google_pl',
+      trigger: 'schedule',
+      status: 'done',
+      health: 'success',
+      item_count: 12408,
+      skipped_count: 0,
+      warning_count: 0,
+      file_size_bytes: 18700000,
+      duration_ms: 22000,
+      error_message: null,
+      started_at: '2026-07-02T04:00:00+00:00',
+      completed_at: '2026-07-02T04:00:22+00:00',
+    },
+    {
+      id: 'run-b',
+      feed_id: 'f-b',
+      feed_name: 'Ceneo — Elektronika',
+      feed_code: 'ceneo_elektro',
+      trigger: 'manual',
+      status: 'error',
+      health: 'error',
+      item_count: 0,
+      skipped_count: 0,
+      warning_count: 0,
+      file_size_bytes: null,
+      duration_ms: 3000,
+      error_message: 'missing required <price> slot',
+      started_at: '2026-07-02T02:00:00+00:00',
+      completed_at: '2026-07-02T02:00:03+00:00',
+    },
+  ],
+  next_cursor: null,
+};
+
+test('XMLF-P5-07 — global monitor: KPI, cross-feed history, filter, drill-down', async ({
+  page,
+}) => {
+  await loginAsAdmin(page);
+
+  await page.route('**/api/feed-runs**', (route) => {
+    const url = route.request().url();
+    if (url.includes('/kpi')) {
+      return route.fulfill({
+        json: {
+          regenerations_24h: 6,
+          skipped_24h: 112,
+          errors_24h: 1,
+          last_error: null,
+          items_syndicated: 20529,
+          last_regenerated_at: '2026-07-02T04:00:00+00:00',
+          feeds: { active: 2, paused: 0, error: 1 },
+        },
+      });
+    }
+    if (url.includes('status=error')) {
+      return route.fulfill({ json: { items: [RUNS.items[1]], next_cursor: null } });
+    }
+    return route.fulfill({ json: RUNS });
+  });
+  await page.route('**/api/feeds/pull-stats', (route) =>
+    route.fulfill({ json: { pulls_24h: 1284, spark: [] } }),
+  );
+  await page.route('**/api/feeds/*/runs/*/logs*', (route) =>
+    route.fulfill({
+      json: {
+        items: [
+          {
+            id: 'log-1',
+            level: 'error',
+            object_sku: null,
+            slot: 'price',
+            message: 'missing required <price> slot',
+            created_at: '2026-07-02T02:00:01+00:00',
+          },
+        ],
+        next_cursor: null,
+      },
+    }),
+  );
+
+  await page.goto('/integrations/api-configurator/feeds/monitor');
+
+  // Sub-nav with the monitor tab active (scoped: the layout has its own tablist).
+  await expect(
+    page.getByLabel(/Feeds sections|Sekcje feedów/).getByRole('tab', { name: /^Monitor$/ }),
+  ).toHaveAttribute('aria-selected', 'true');
+
+  // KPI tiles from the aggregates.
+  await expect(page.getByText(/Regeneracje · 24h|Regenerations · 24h/)).toBeVisible();
+  await expect(page.getByText(/20\s?529/)).toBeVisible();
+  await expect(page.getByText('112', { exact: true })).toBeVisible();
+
+  // Cross-feed history carries the feed identity column.
+  await expect(page.getByText('Google Shopping — Polska')).toBeVisible();
+  await expect(page.getByText('Ceneo — Elektronika')).toBeVisible();
+
+  // Status filter narrows to errors only.
+  await page.getByRole('button', { name: /błędy|errors/ }).click();
+  await expect(page.getByText('Google Shopping — Polska')).not.toBeVisible();
+  await expect(page.getByText('Ceneo — Elektronika')).toBeVisible();
+
+  // Drill-down opens the shared sheet with the log line.
+  await page
+    .getByRole('button', { name: /ręcznie|manual/ })
+    .first()
+    .click();
+  await expect(page.getByText(/— · price|— · price/)).toBeVisible();
+
+  const axe = await new AxeBuilder({ page }).analyze();
+  expect(axe.violations.filter((v) => v.impact === 'serious' || v.impact === 'critical')).toEqual(
+    [],
+  );
+});

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -95,6 +95,10 @@ const FeedDetailPage = lazyPage(
   () => import('@/features/api-configurator/feeds/detail/FeedDetailPage'),
   'FeedDetailPage',
 );
+const FeedsMonitorPage = lazyPage(
+  () => import('@/features/api-configurator/feeds/monitor/FeedsMonitorPage'),
+  'FeedsMonitorPage',
+);
 const AssetsListPage = lazyPage(() => import('@/features/asset/assets/list'), 'AssetsListPage');
 const AssetShowPage = lazyPage(() => import('@/features/asset/assets/show'), 'AssetShowPage');
 const AttributeGroupCreatePage = lazyPage(
@@ -692,6 +696,10 @@ function App() {
                         under the same shell; wizard + detail are placeholder
                         targets until P5-02..P5-05 replace them. */}
                     <Route path="/integrations/api-configurator/feeds" element={<FeedsHubPage />} />
+                    <Route
+                      path="/integrations/api-configurator/feeds/monitor"
+                      element={<FeedsMonitorPage />}
+                    />
                     <Route
                       path="/integrations/api-configurator/feeds/new"
                       element={<FeedWizardPage />}

--- a/apps/admin/src/features/api-configurator/feeds/api/feeds.ts
+++ b/apps/admin/src/features/api-configurator/feeds/api/feeds.ts
@@ -41,6 +41,9 @@ export interface FeedKpi {
   itemsSyndicated: number;
   pulls24h: number;
   spark: Array<{ bucket: string; count: number }>;
+  regenerations24h: number;
+  skipped24h: number;
+  errors24h: number;
 }
 
 interface FeedsResponse {
@@ -50,6 +53,9 @@ interface FeedsResponse {
 interface RunsKpiResponse {
   items_syndicated: number;
   feeds: { active: number; paused: number; error: number };
+  regenerations_24h: number;
+  skipped_24h: number;
+  errors_24h: number;
 }
 
 interface PullStatsResponse {
@@ -100,6 +106,9 @@ export function useFeedKpi() {
         itemsSyndicated: kpi.items_syndicated,
         pulls24h: pulls.pulls_24h,
         spark: pulls.spark,
+        regenerations24h: kpi.regenerations_24h,
+        skipped24h: kpi.skipped_24h,
+        errors24h: kpi.errors_24h,
       };
     },
   });

--- a/apps/admin/src/features/api-configurator/feeds/components/FeedsSubnav.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/components/FeedsSubnav.tsx
@@ -1,0 +1,43 @@
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+
+import { cn } from '@/lib/utils';
+
+const BASE = '/integrations/api-configurator/feeds';
+
+/**
+ * XMLF-P5-07 — the two-tab sub-navigation of the Feeds area (design
+ * feed-app.jsx): the hub list and the global cross-feed monitor.
+ */
+export function FeedsSubnav({ active }: { active: 'hub' | 'monitor' }) {
+  const { t } = useTranslation();
+  return (
+    <div
+      role="tablist"
+      aria-label={t('api_configurator.feeds.subnav.aria')}
+      className="flex flex-wrap gap-1 border-b border-zinc-200"
+    >
+      {(
+        [
+          ['hub', BASE],
+          ['monitor', `${BASE}/monitor`],
+        ] as const
+      ).map(([id, to]) => (
+        <Link
+          key={id}
+          to={to}
+          role="tab"
+          aria-selected={active === id}
+          className={cn(
+            '-mb-px border-b-2 px-3 py-2 text-[13px] font-medium transition',
+            active === id
+              ? 'border-zinc-900 text-zinc-900'
+              : 'border-transparent text-zinc-500 hover:text-zinc-800',
+          )}
+        >
+          {t(`api_configurator.feeds.subnav.${id}`)}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/apps/admin/src/features/api-configurator/feeds/hub/FeedsHubPage.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/hub/FeedsHubPage.tsx
@@ -6,6 +6,7 @@ import { Link, useNavigate } from 'react-router';
 import { Segmented } from '@/features/api-configurator/components/primitives';
 
 import { type FeedStatus, filterFeeds, useFeedKpi, useFeeds } from '../api/feeds';
+import { FeedsSubnav } from '../components/FeedsSubnav';
 import { FeedCard } from './FeedCard';
 import { FeedKpiStrip } from './FeedKpiStrip';
 
@@ -29,6 +30,7 @@ export function FeedsHubPage() {
 
   return (
     <div className="space-y-6">
+      <FeedsSubnav active="hub" />
       <FeedKpiStrip kpi={kpiQuery.data} />
 
       <div className="flex flex-wrap items-center gap-3">

--- a/apps/admin/src/features/api-configurator/feeds/monitor/FeedsMonitorPage.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/monitor/FeedsMonitorPage.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+import { useFeedKpi } from '../api/feeds';
+import { type FeedRunRow, useGlobalFeedRuns } from '../api/runs';
+import { FeedsSubnav } from '../components/FeedsSubnav';
+import { RunDrilldown } from './RunDrilldown';
+import { RunsTable } from './RunsTable';
+
+/**
+ * XMLF-P5-07 — the global cross-feed monitor (design feed-monitor.jsx
+ * FeedMonitor): the four 24h KPI tiles over /api/feed-runs/kpi (+ the P3-06
+ * pull counter already surfaced on the hub strip) and the run history of
+ * EVERY feed (P4-03 global endpoint) with the status filter and the same
+ * drill-down sheet the per-feed detail uses.
+ */
+export function FeedsMonitorPage() {
+  const { t } = useTranslation();
+  const kpi = useFeedKpi();
+  const [filter, setFilter] = useState<'all' | 'success' | 'warning' | 'error'>('all');
+  const runs = useGlobalFeedRuns(filter);
+  const [openRun, setOpenRun] = useState<FeedRunRow | null>(null);
+
+  const kpiTiles = [
+    {
+      key: 'regenerations',
+      value: kpi.data?.regenerations24h ?? 0,
+      tone: 'text-zinc-900',
+    },
+    {
+      key: 'syndicated',
+      value: kpi.data?.itemsSyndicated ?? 0,
+      tone: 'text-zinc-900',
+    },
+    { key: 'skipped', value: kpi.data?.skipped24h ?? 0, tone: 'text-amber-700' },
+    { key: 'errors', value: kpi.data?.errors24h ?? 0, tone: 'text-rose-700' },
+  ] as const;
+
+  return (
+    <div className="space-y-5">
+      <FeedsSubnav active="monitor" />
+
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        {kpiTiles.map((tile) => (
+          <div key={tile.key} className="rounded-2xl bg-white p-4 soft-shadow">
+            <div className="text-[10.5px] font-medium uppercase tracking-wider text-zinc-500">
+              {t(`api_configurator.feeds.monitor.kpi.${tile.key}`)}
+            </div>
+            <div className={cn('num mt-1 font-display text-[24px] font-semibold', tile.tone)}>
+              {tile.value.toLocaleString('pl-PL')}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="overflow-hidden rounded-3xl bg-white soft-shadow">
+        <div className="flex flex-wrap items-center gap-3 border-b border-zinc-100 px-5 py-3">
+          <div className="text-[14px] font-semibold tracking-tight">
+            {t('api_configurator.feeds.monitor.history_title')}
+          </div>
+          <div className="ml-auto flex items-center gap-0.5 rounded-xl bg-zinc-100 p-1">
+            {(['all', 'success', 'warning', 'error'] as const).map((value) => (
+              <button
+                key={value}
+                type="button"
+                aria-pressed={filter === value}
+                onClick={() => setFilter(value)}
+                className={cn(
+                  'h-7 rounded-lg px-2.5 text-[11.5px] font-medium',
+                  filter === value ? 'bg-zinc-900 text-white' : 'text-zinc-600 hover:bg-white',
+                )}
+              >
+                {t(`api_configurator.feeds.run.filter.${value}`)}
+              </button>
+            ))}
+          </div>
+        </div>
+        <RunsTable runs={runs.data ?? []} showFeed onOpen={setOpenRun} />
+      </div>
+
+      <RunDrilldown run={openRun} onClose={() => setOpenRun(null)} />
+    </div>
+  );
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1988,6 +1988,20 @@
       "log": {
         "title": "Product log",
         "empty": "No log lines — a clean run."
+      },
+      "subnav": {
+        "aria": "Feeds sections",
+        "hub": "Feeds",
+        "monitor": "Monitor"
+      },
+      "monitor": {
+        "history_title": "Regeneration history — all feeds",
+        "kpi": {
+          "regenerations": "Regenerations · 24h",
+          "syndicated": "Products syndicated",
+          "skipped": "Skipped · 24h",
+          "errors": "Errors · 24h"
+        }
       }
     },
     "shell": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -2036,6 +2036,20 @@
       "log": {
         "title": "Log produktów",
         "empty": "Brak linii logu — czysty run."
+      },
+      "subnav": {
+        "aria": "Sekcje feedów",
+        "hub": "Feedy",
+        "monitor": "Monitor"
+      },
+      "monitor": {
+        "history_title": "Historia regeneracji — wszystkie feedy",
+        "kpi": {
+          "regenerations": "Regeneracje · 24h",
+          "syndicated": "Produkty syndykowane",
+          "skipped": "Pominięte · 24h",
+          "errors": "Błędy · 24h"
+        }
       }
     },
     "shell": {


### PR DESCRIPTION
## XMLF-P5-07 — globalny monitor feedów (Closes #1935)

Globalny, cross-feedowy monitor wg designu `feed-monitor.jsx` (FeedMonitor), pod nową dwutabową subnawigacją obszaru Feedy (hub | monitor):

- **4 kafle KPI 24h** (regeneracje, items syndicated, pominięte, błędy) z `/api/feed-runs/kpi` (P4-03) — `useFeedKpi` rozszerzony o `regenerations_24h`/`skipped_24h`/`errors_24h`.
- **Historia runów wszystkich feedów** z globalnego `/api/feed-runs` (P4-03) z filtrem statusu i kolumną tożsamości feedu (`RunsTable showFeed` — reuse z P5-05).
- **Drilldown** — ten sam `RunDrilldown` Sheet co na szczególe feedu.
- `FeedsSubnav` (role=tablist) na hubie i monitorze; route `/integrations/api-configurator/feeds/monitor`.

## Smoke test (live, pim.localhost)
Konfigurator API → Feedy → tab **Monitor**: kafle KPI z realnych agregatów, historia z 10 runami cross-feed (nazwa feedu w kolumnie), drilldown z logami per-produkt otwiera się z wiersza. Network 200 na `/api/feed-runs` + `/api/feed-runs/kpi` + `/api/feeds/pull-stats`; Console bez czerwonych errorów.

## Testy
- Spec `e2e/1935-feeds-monitor.spec.ts` (mocked: KPI, cross-feed history, filtr błędów, drilldown) zielony + axe-core 0 serious/critical.
- tsc / biome / vitest / build zielone; guard lint-jsonfetch-useeffect = baseline.
