### PR TITLE
feat(admin): descriptor structure editor step for custom feeds

### DIFF
--- a/apps/admin/e2e/1932-feed-delivery-preview.spec.ts
+++ b/apps/admin/e2e/1932-feed-delivery-preview.spec.ts
@@ -122,6 +122,9 @@ test('XMLF-P5-04 — delivery + preview: schedule, auth, mint-once, preview, sav
 
   await page.goto('/integrations/api-configurator/feeds/new');
   await page.getByRole('button', { name: /Custom|Własny/ }).click();
+  // Custom feeds pass through the structure editor (P5-06) on the way:
+  // template → structure → scope → mapping → delivery.
+  await page.getByRole('button', { name: /Dalej|^Next$/ }).click();
   await page.getByRole('button', { name: /Dalej|^Next$/ }).click();
   await page.getByRole('button', { name: /Dalej|^Next$/ }).click();
   await page.getByRole('button', { name: /Dalej|^Next$/ }).click();

--- a/apps/admin/e2e/1934-feed-structure-editor.spec.ts
+++ b/apps/admin/e2e/1934-feed-structure-editor.spec.ts
@@ -1,0 +1,120 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * XMLF-P5-06 (#1934) — the structure editor step for custom feeds: the step
+ * appears only for template_kind=custom, inline validation blocks illegal XML
+ * names and duplicate slots, and a valid structure lets the wizard continue
+ * into scope. All backend calls mocked.
+ */
+
+const TEMPLATES = {
+  items: [
+    {
+      kind: 'google_shopping',
+      built_in: true,
+      root_element: 'rss',
+      namespaces: ['g'],
+      descriptor: { root: { element: 'rss' } },
+      default_mappings: [{ slot: 'g:id', source: { kind: 'attribute', ref: 'sku' } }],
+    },
+    {
+      kind: 'custom',
+      built_in: false,
+      root_element: 'products',
+      namespaces: [],
+      descriptor: {
+        root: { element: 'products' },
+        item: {
+          element: 'product',
+          slots: [
+            { target: 'sku', node: 'element', element: 'sku', required: true, fmt: 'text' },
+            { target: 'name', node: 'element', element: 'name', maxLength: 255, fmt: 'text' },
+          ],
+        },
+      },
+      default_mappings: [
+        { slot: 'sku', source: { kind: 'attribute', ref: 'sku' } },
+        { slot: 'name', source: { kind: 'attribute', ref: 'name' } },
+      ],
+    },
+  ],
+};
+
+test('XMLF-P5-06 — structure editor: custom-only step, inline validation, outline', async ({
+  page,
+}) => {
+  await loginAsAdmin(page);
+
+  await page.route('**/api/feeds/**', (route) => route.fulfill({ json: {} }));
+  await page.route('**/api/feeds/templates', (route) => route.fulfill({ json: TEMPLATES }));
+  await page.route('**/api/object_types*', (route) =>
+    route.fulfill({
+      json: {
+        member: [{ id: '019f0000-0000-7000-8000-000000000001', kind: 'product' }],
+        totalItems: 1,
+      },
+    }),
+  );
+
+  await page.goto('/integrations/api-configurator/feeds/new');
+
+  const nextButton = page.getByRole('button', { name: /Dalej|^Next$/ });
+  const stepper = page.getByRole('navigation', { name: /kroki|steps/i });
+
+  // A predefined template has no structure step in the stepper.
+  await page.getByRole('button', { name: /Google Shopping/ }).click();
+  await expect(stepper.getByText(/Struktura|Structure/)).toHaveCount(0);
+
+  // Switching to Custom inserts the structure step between template and scope.
+  await page.getByRole('button', { name: /Własny|Custom/ }).click();
+  await expect(stepper.getByText(/Struktura|Structure/)).toBeVisible();
+  await nextButton.click();
+  await expect(page.getByText(/Struktura dokumentu|Document structure/)).toBeVisible();
+
+  // The blank starter renders root/item and the two seeded slots + outline.
+  const rootInput = page.getByRole('textbox', { name: /Element główny|Root element/ });
+  await expect(rootInput).toHaveValue('products');
+  const nameInputs = page.getByRole('textbox', { name: /Nazwa pola|Field name/ });
+  await expect(nameInputs).toHaveCount(2);
+  await expect(page.getByText('<products>')).toBeVisible();
+
+  // Illegal XML name → inline error + Next gated (backend guard mirrored).
+  await nameInputs.nth(1).fill('description.pl');
+  await expect(page.getByRole('alert').first()).toContainText(/description\.pl/);
+  await expect(nextButton).toBeDisabled();
+
+  // Duplicate slot names are flagged too.
+  await nameInputs.nth(1).fill('sku');
+  await expect(page.getByRole('alert').first()).toContainText(/sku/);
+  await expect(nextButton).toBeDisabled();
+
+  // Fix the name, add a fresh slot — the outline follows live.
+  await nameInputs.nth(1).fill('name');
+  await page.getByRole('button', { name: /Dodaj pole|Add field/ }).click();
+  await nameInputs.nth(2).fill('price');
+  await expect(page.getByText('<price>…</price>')).toBeVisible();
+  await expect(nextButton).toBeEnabled();
+
+  // An attribute node demands a parent element before the step can be left.
+  await page
+    .getByRole('combobox', { name: /Rodzaj węzła|Node kind/ })
+    .nth(2)
+    .selectOption('attribute');
+  await expect(nextButton).toBeDisabled();
+  await page.getByRole('textbox', { name: /Element nadrzędny|Parent element/ }).fill('o');
+  await expect(nextButton).toBeEnabled();
+
+  // a11y on the structure editor.
+  const axe = await new AxeBuilder({ page }).analyze();
+  expect(axe.violations.filter((v) => v.impact === 'serious' || v.impact === 'critical')).toEqual(
+    [],
+  );
+
+  // A valid structure continues into scope.
+  await nextButton.click();
+  await expect(page.getByRole('combobox').first()).toBeVisible();
+  await expect(page.getByText(/Struktura dokumentu|Document structure/)).toHaveCount(0);
+});

--- a/apps/admin/src/features/api-configurator/feeds/__tests__/descriptor-edit.test.ts
+++ b/apps/admin/src/features/api-configurator/feeds/__tests__/descriptor-edit.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  descriptorToEdit,
+  editToDescriptor,
+  emptySlot,
+  structureIssues,
+} from '../wizard/descriptor-edit';
+
+/**
+ * XMLF-P5-06 — the editable projection of a custom descriptor: round-trip
+ * fidelity (untouched rule fields survive), and the inline validation
+ * mirroring the backend guard (XML names, duplicates, attribute parent).
+ */
+
+const CUSTOM = {
+  root: { element: 'products', namespaces: { g: 'http://base.google.com/ns/1.0' } },
+  item: {
+    element: 'product',
+    slots: [
+      { target: 'sku', node: 'element', element: 'sku', required: true, fmt: 'text' },
+      {
+        target: 'condition',
+        node: 'element',
+        element: 'condition',
+        fmt: 'enum',
+        enums: ['new', 'used'],
+      },
+    ],
+  },
+};
+
+describe('descriptorToEdit / editToDescriptor', () => {
+  it('round-trips a descriptor preserving rule fields the editor does not own', () => {
+    const edit = descriptorToEdit(CUSTOM);
+    expect(edit.rootElement).toBe('products');
+    expect(edit.itemElement).toBe('product');
+    expect(edit.namespaces).toEqual([{ prefix: 'g', uri: 'http://base.google.com/ns/1.0' }]);
+    expect(edit.slots).toHaveLength(2);
+    expect(edit.slots[1]?.format).toBe('enum');
+
+    const back = editToDescriptor(edit, CUSTOM);
+    const item = back.item as { slots: Array<Record<string, unknown>> };
+    expect(item.slots[1]?.enums).toEqual(['new', 'used']);
+    expect(item.slots[0]?.required).toBe(true);
+    expect((back.root as Record<string, unknown>).namespaces).toEqual({
+      g: 'http://base.google.com/ns/1.0',
+    });
+  });
+
+  it('keeps the channel envelope of an RSS-shaped descriptor, replacing only its item', () => {
+    const rss = {
+      root: { element: 'rss', attributes: { version: '2.0' } },
+      channel: {
+        element: 'channel',
+        header: [{ element: 'title', source: { kind: 'static', value: 'x' } }],
+        item: { element: 'item', slots: [{ target: 'sku', node: 'element', element: 'sku' }] },
+      },
+    };
+    const edit = descriptorToEdit(rss);
+    expect(edit.itemElement).toBe('item');
+    edit.slots[0] = { ...(edit.slots[0] ?? emptySlot()), name: 'id' };
+    const back = editToDescriptor(edit, rss);
+    const channel = back.channel as Record<string, unknown>;
+    expect(channel.header).toEqual(rss.channel.header);
+    expect((back.root as Record<string, unknown>).attributes).toEqual({ version: '2.0' });
+    const item = channel.item as { slots: Array<Record<string, unknown>> };
+    expect(item.slots[0]?.target).toBe('id');
+    expect(back).not.toHaveProperty('item');
+  });
+
+  it('renaming a slot updates both target and element', () => {
+    const edit = descriptorToEdit(CUSTOM);
+    edit.slots[0] = { ...(edit.slots[0] ?? emptySlot()), name: 'ean' };
+    const back = editToDescriptor(edit, CUSTOM);
+    const slot = (back.item as { slots: Array<Record<string, unknown>> }).slots[0];
+    expect(slot?.target).toBe('ean');
+    expect(slot?.element).toBe('ean');
+  });
+});
+
+describe('structureIssues', () => {
+  it('accepts the valid starter', () => {
+    expect(structureIssues(descriptorToEdit(CUSTOM))).toEqual([]);
+  });
+
+  it('flags illegal XML names on root, item, prefixes and slots', () => {
+    const edit = descriptorToEdit(CUSTOM);
+    edit.rootElement = '1products';
+    edit.itemElement = 'pro duct';
+    edit.namespaces[0] = { prefix: '1g', uri: 'u' };
+    edit.slots[0] = { ...(edit.slots[0] ?? emptySlot()), name: 'description.pl' };
+    const issues = structureIssues(edit);
+    expect(issues.map((i) => i.field).sort()).toEqual(['item', 'namespace', 'root', 'slot_name']);
+    expect(issues.every((i) => i.key === 'invalid_name')).toBe(true);
+  });
+
+  it('flags duplicate slot names and attribute nodes without a parent', () => {
+    const edit = descriptorToEdit(CUSTOM);
+    edit.slots.push({ ...emptySlot(), name: 'sku' });
+    edit.slots.push({ ...emptySlot(), name: 'stock', node: 'attribute' });
+    const issues = structureIssues(edit);
+    expect(issues.some((i) => i.key === 'duplicate_slot' && i.slotIndex === 2)).toBe(true);
+    expect(issues.some((i) => i.key === 'parent_required' && i.slotIndex === 3)).toBe(true);
+  });
+
+  it('flags a non-positive max length', () => {
+    const edit = descriptorToEdit(CUSTOM);
+    edit.slots[0] = { ...(edit.slots[0] ?? emptySlot()), maxLength: '0' };
+    expect(structureIssues(edit).some((i) => i.key === 'invalid_max_length')).toBe(true);
+  });
+});

--- a/apps/admin/src/features/api-configurator/feeds/__tests__/wizard-state.test.ts
+++ b/apps/admin/src/features/api-configurator/feeds/__tests__/wizard-state.test.ts
@@ -1,11 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
 import type { FeedRow } from '../api/feeds';
-import { canLeaveStep, draftFromFeed, emptyDraft, slugifyCode } from '../wizard/wizard-state';
+import {
+  canLeaveStep,
+  createPayload,
+  draftFromFeed,
+  emptyDraft,
+  patchPayload,
+  slugifyCode,
+  stepsFor,
+} from '../wizard/wizard-state';
 
 /**
- * XMLF-P5-02 — pure wizard logic: the code auto-slug, step gating and the
- * edit-mode prefill mapping.
+ * XMLF-P5-02 (+P5-06 id-based steps) — pure wizard logic: the code auto-slug,
+ * the kind-dependent step list, step gating and the edit-mode prefill mapping.
  */
 
 describe('slugifyCode', () => {
@@ -16,22 +24,75 @@ describe('slugifyCode', () => {
   });
 });
 
+describe('stepsFor', () => {
+  it('inserts the structure step for custom feeds only', () => {
+    expect(stepsFor('custom')).toEqual([
+      'template',
+      'structure',
+      'scope',
+      'mapping',
+      'delivery',
+      'preview',
+    ]);
+    expect(stepsFor('google_shopping')).toEqual([
+      'template',
+      'scope',
+      'mapping',
+      'delivery',
+      'preview',
+    ]);
+    expect(stepsFor(null)).not.toContain('structure');
+  });
+});
+
 describe('canLeaveStep', () => {
-  it('gates step 0 on template and name', () => {
+  it('gates the template step on template and name', () => {
     const draft = emptyDraft();
-    expect(canLeaveStep(0, draft)).toBe(false);
+    expect(canLeaveStep('template', draft)).toBe(false);
     draft.kind = 'ceneo';
-    expect(canLeaveStep(0, draft)).toBe(false);
+    expect(canLeaveStep('template', draft)).toBe(false);
     draft.name = 'Ceneo PL';
-    expect(canLeaveStep(0, draft)).toBe(true);
+    expect(canLeaveStep('template', draft)).toBe(true);
   });
 
-  it('gates step 1 on a locale and lets later steps pass', () => {
+  it('gates scope on a locale and lets later steps pass', () => {
     const draft = { ...emptyDraft(), kind: 'ceneo' as const, name: 'x', locale: '' };
-    expect(canLeaveStep(1, draft)).toBe(false);
+    expect(canLeaveStep('scope', draft)).toBe(false);
     draft.locale = 'pl';
-    expect(canLeaveStep(1, draft)).toBe(true);
-    expect(canLeaveStep(2, draft)).toBe(true);
+    expect(canLeaveStep('scope', draft)).toBe(true);
+    expect(canLeaveStep('mapping', draft)).toBe(true);
+  });
+
+  it('gates structure on the inline validation verdict', () => {
+    const draft = { ...emptyDraft(), kind: 'custom' as const, name: 'x' };
+    expect(canLeaveStep('structure', draft, false)).toBe(false);
+    expect(canLeaveStep('structure', draft, true)).toBe(true);
+  });
+});
+
+describe('custom descriptor in payloads', () => {
+  it('sends descriptor + mapped-only field_mappings on create for custom', () => {
+    const draft = {
+      ...emptyDraft(),
+      kind: 'custom' as const,
+      name: 'B2B',
+      code: 'b2b',
+      descriptor: { root: { element: 'products' }, item: { element: 'product', slots: [] } },
+      mappings: [
+        { slot: 'sku', source: { kind: 'attribute', ref: 'sku' } },
+        { slot: 'name', source: null },
+      ] as never[],
+    };
+    const payload = createPayload(draft, 'type-1');
+    expect(payload.descriptor).toEqual(draft.descriptor);
+    expect(payload.field_mappings).toHaveLength(1);
+    expect(patchPayload(draft).descriptor).toEqual(draft.descriptor);
+  });
+
+  it('omits descriptor for predefined templates', () => {
+    const draft = { ...emptyDraft(), kind: 'ceneo' as const, name: 'x', code: 'x' };
+    expect(createPayload(draft, 'type-1')).not.toHaveProperty('descriptor');
+    expect(patchPayload(draft)).not.toHaveProperty('descriptor');
   });
 });
 

--- a/apps/admin/src/features/api-configurator/feeds/wizard/FeedWizardPage.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/wizard/FeedWizardPage.tsx
@@ -20,10 +20,17 @@ import {
 } from '../api/mapping';
 import { type FeedTemplateInfo, useFeedTemplates, useProductObjectTypeId } from '../api/templates';
 import { TemplateBadge } from '../components/primitives';
+import {
+  descriptorToEdit,
+  type EditableStructure,
+  editToDescriptor,
+  structureIssues,
+} from './descriptor-edit';
 import { StepDelivery } from './steps/StepDelivery';
 import { StepMapper } from './steps/StepMapper';
 import { StepPreview } from './steps/StepPreview';
 import { StepScope } from './steps/StepScope';
+import { StepStructure } from './steps/StepStructure';
 import { StepTemplate } from './steps/StepTemplate';
 import {
   canLeaveStep,
@@ -33,7 +40,7 @@ import {
   type FeedDraft,
   patchPayload,
   slugifyCode,
-  WIZARD_STEP_IDS,
+  stepsFor,
 } from './wizard-state';
 
 const HUB_PATH = '/integrations/api-configurator/feeds';
@@ -58,8 +65,14 @@ export function FeedWizardPage() {
   const [draft, setDraft] = useState<FeedDraft>(emptyDraft);
   const [saving, setSaving] = useState(false);
   const [loadedForEdit, setLoadedForEdit] = useState(false);
+  const [structureEdit, setStructureEdit] = useState<EditableStructure | null>(null);
   const filterState = useFilterDslState(draft.filterDsl);
   const setFilterConditions = filterState.setConditions;
+
+  // Steps are a function of the template kind (P5-06): custom feeds get the
+  // structure editor between template and scope; predefs skip it.
+  const steps = stepsFor(draft.kind);
+  const stepId = steps[Math.min(step, steps.length - 1)] ?? 'template';
 
   // Edit mode loads through useQuery (ADR-0021 — an effect-driven raw read
   // would be invisible to the query cache); the effect below only copies
@@ -81,7 +94,29 @@ export function FeedWizardPage() {
     setLoadedForEdit(true);
   }, [editRow, loadedForEdit, setFilterConditions]);
 
-  const mappingView = useFeedMapping(step >= 2 ? draft.id : null);
+  // Entering the structure step projects the draft's descriptor into the
+  // editable shape once; choosing a template resets the projection.
+  useEffect(() => {
+    if (stepId === 'structure') {
+      setStructureEdit((prev) => prev ?? descriptorToEdit(draft.descriptor));
+    }
+  }, [stepId, draft.descriptor]);
+
+  function applyStructure(next: EditableStructure): void {
+    setStructureEdit(next);
+    setDraft((prev) => {
+      const descriptor = editToDescriptor(next, prev.descriptor);
+      const names = new Set(next.slots.map((slot) => slot.name.trim()));
+      // A removed/renamed slot drops its mapping — the mapper re-offers it.
+      const mappings = prev.mappings.filter((m) => names.has(m.slot));
+      return { ...prev, descriptor, mappings };
+    });
+  }
+
+  const structureValid = structureEdit === null || structureIssues(structureEdit).length === 0;
+
+  const mappingIndex = steps.indexOf('mapping');
+  const mappingView = useFeedMapping(step >= mappingIndex ? draft.id : null);
   const saveMapping = useSaveFeedMapping(draft.id);
   const attributesKey = mappingView.data?.attributes.map((a) => a.code).join(',') ?? null;
   // biome-ignore lint/correctness/useExhaustiveDependencies: catalog tracked via its code key
@@ -104,7 +139,7 @@ export function FeedWizardPage() {
     targetScope: filterState.dsl === null ? 'all' : 'filter',
     filterDsl: filterState.dsl,
     selectedIds: null,
-    enabled: step === 1,
+    enabled: stepId === 'scope',
   });
   const resultCount = preflight.result?.count ?? null;
 
@@ -115,6 +150,8 @@ export function FeedWizardPage() {
   );
 
   function chooseTemplate(template: FeedTemplateInfo): void {
+    // A template switch replaces the descriptor — drop the stale projection.
+    setStructureEdit(null);
     setDraft((prev) => {
       const nextName =
         prev.name.trim() === ''
@@ -161,20 +198,20 @@ export function FeedWizardPage() {
   }
 
   async function next(): Promise<void> {
-    if (!canLeaveStep(step, currentDraft)) {
+    if (!canLeaveStep(stepId, currentDraft, structureValid)) {
       return;
     }
     // The mapper (P5-03) needs a persisted FeedProfile — save when leaving scope.
-    if (step === 1 && !(await persistDraft())) {
+    if (stepId === 'scope' && !(await persistDraft())) {
       return;
     }
     // Leaving delivery persists schedule + gzip/auth via PATCH.
-    if (step === 3 && !(await persistDraft())) {
+    if (stepId === 'delivery' && !(await persistDraft())) {
       return;
     }
     // Leaving the mapper persists the slot mappings (PUT — the backend
     // validates and returns the fresh view) + the skip policy via PATCH.
-    if (step === 2) {
+    if (stepId === 'mapping') {
       try {
         // Only mapped slots go to the backend — a null source means "unmapped"
         // in the UI, not a mapping entry.
@@ -187,7 +224,7 @@ export function FeedWizardPage() {
         return;
       }
     }
-    setStep((value) => Math.min(value + 1, WIZARD_STEP_IDS.length - 1));
+    setStep((value) => Math.min(value + 1, steps.length - 1));
   }
 
   const rootPath = useMemo(() => {
@@ -201,12 +238,12 @@ export function FeedWizardPage() {
     return hasChannel ? `${rootEl}/channel/item` : `${rootEl}/item`;
   }, [draft.descriptor]);
 
-  const last = WIZARD_STEP_IDS.length - 1;
+  const last = steps.length - 1;
   // Leaving scope needs the resolved product ObjectType id for the create
   // payload — hold the button until the lookup lands (fresh drafts only).
   const waitingForTypeId =
-    step === 1 && currentDraft.id === null && productTypeId.data === undefined;
-  const stepAllowed = canLeaveStep(step, currentDraft) && !waitingForTypeId;
+    stepId === 'scope' && currentDraft.id === null && productTypeId.data === undefined;
+  const stepAllowed = canLeaveStep(stepId, currentDraft, structureValid) && !waitingForTypeId;
 
   return (
     <div className="max-w-[1180px] space-y-5">
@@ -236,11 +273,11 @@ export function FeedWizardPage() {
 
       <nav aria-label={t('api_configurator.feeds.wizard.steps_aria')}>
         <ol className="flex items-stretch gap-2 rounded-3xl bg-white p-3 soft-shadow">
-          {WIZARD_STEP_IDS.map((stepId, index) => {
+          {steps.map((id, index) => {
             const state = index < step ? 'done' : index === step ? 'active' : 'pending';
             const clickable = index <= step;
             return (
-              <li key={stepId} className="flex min-w-0 flex-1 items-center gap-2">
+              <li key={id} className="flex min-w-0 flex-1 items-center gap-2">
                 <button
                   type="button"
                   onClick={() => clickable && setStep(index)}
@@ -272,7 +309,7 @@ export function FeedWizardPage() {
                         state === 'pending' && 'text-zinc-500',
                       )}
                     >
-                      {t(`api_configurator.feeds.wizard.step.${stepId}`)}
+                      {t(`api_configurator.feeds.wizard.step.${id}`)}
                     </span>
                   </div>
                   <div
@@ -281,7 +318,7 @@ export function FeedWizardPage() {
                       state === 'pending' ? 'text-zinc-400' : 'text-zinc-500',
                     )}
                   >
-                    {t(`api_configurator.feeds.wizard.step_note.${stepId}`)}
+                    {t(`api_configurator.feeds.wizard.step_note.${id}`)}
                   </div>
                 </button>
                 {index < last && (
@@ -294,7 +331,7 @@ export function FeedWizardPage() {
       </nav>
 
       <div key={step}>
-        {step === 0 && (
+        {stepId === 'template' && (
           <StepTemplate
             templates={templates.data ?? []}
             kind={draft.kind}
@@ -311,7 +348,10 @@ export function FeedWizardPage() {
             onCode={(value) => setDraft((prev) => ({ ...prev, code: value, codeTouched: true }))}
           />
         )}
-        {step === 1 && (
+        {stepId === 'structure' && structureEdit !== null && (
+          <StepStructure edit={structureEdit} onEdit={applyStructure} />
+        )}
+        {stepId === 'scope' && (
           <StepScope
             locale={draft.locale}
             onLocale={(value) => setDraft((prev) => ({ ...prev, locale: value }))}
@@ -324,7 +364,7 @@ export function FeedWizardPage() {
             countLoading={preflight.isLoading}
           />
         )}
-        {step === 2 && mappingView.data !== undefined && productTypeId.data != null && (
+        {stepId === 'mapping' && mappingView.data !== undefined && productTypeId.data != null && (
           <StepMapper
             view={mappingView.data}
             mappings={draft.mappings}
@@ -337,7 +377,7 @@ export function FeedWizardPage() {
             filter={filterState.dsl}
           />
         )}
-        {step === 3 && (
+        {stepId === 'delivery' && (
           <StepDelivery
             feedId={draft.id}
             hasToken={editRow?.has_token ?? false}
@@ -353,7 +393,7 @@ export function FeedWizardPage() {
             onAuthPassword={(value) => setDraft((prev) => ({ ...prev, authPassword: value }))}
           />
         )}
-        {step === 4 && <StepPreview feedId={draft.id} rootPath={rootPath} />}
+        {stepId === 'preview' && <StepPreview feedId={draft.id} rootPath={rootPath} />}
       </div>
 
       <div className="flex items-center gap-3 pt-1">
@@ -372,7 +412,7 @@ export function FeedWizardPage() {
         <div className="hidden text-[12px] text-zinc-500 sm:block">
           {t('api_configurator.feeds.wizard.progress', {
             current: step + 1,
-            total: WIZARD_STEP_IDS.length,
+            total: steps.length,
           })}
         </div>
         {step < last ? (

--- a/apps/admin/src/features/api-configurator/feeds/wizard/descriptor-edit.ts
+++ b/apps/admin/src/features/api-configurator/feeds/wizard/descriptor-edit.ts
@@ -1,0 +1,254 @@
+/**
+ * XMLF-P5-06 — the editable projection of a custom feed's descriptor
+ * (FeedDescriptor VO, ADR-0023 §6.3). The UI edits this flat shape; the
+ * builder folds it back into the canonical descriptor, preserving the parts
+ * the editor does not touch (channel header, enums/html/requiredOneOf rules).
+ * Validation mirrors the backend guard (XMLF-P1-04 / P2-07) so illegal names
+ * and duplicates are caught inline instead of as a PATCH 400.
+ */
+
+/** Mirror of FeedSlot::XML_NAME — optional single prefix + NCName, no dots. */
+export const XML_NAME = /^([A-Za-z_][A-Za-z0-9_-]*:)?[A-Za-z_][A-Za-z0-9_-]*$/;
+
+export const SLOT_NODE_KINDS = ['element', 'attribute', 'repeatable', 'keyvalue'] as const;
+export type SlotNodeKindId = (typeof SLOT_NODE_KINDS)[number];
+
+/** Formats offered by the editor — enum/category need companion config the
+ * structure step does not edit, so existing values are preserved but not
+ * offered for new slots. */
+export const SLOT_FORMATS = ['text', 'html', 'url', 'price', 'number', 'date'] as const;
+
+export interface EditableSlot {
+  /** Logical key == XML element name in the editor (custom feeds never split them). */
+  name: string;
+  node: SlotNodeKindId;
+  parent: string;
+  wrapIn: string;
+  required: boolean;
+  maxLength: string;
+  format: string;
+  /** Untouched rule fields (enums, html, requiredOneOf) carried through verbatim. */
+  rest: Record<string, unknown>;
+}
+
+export interface EditableStructure {
+  rootElement: string;
+  namespaces: Array<{ prefix: string; uri: string }>;
+  itemElement: string;
+  slots: EditableSlot[];
+}
+
+export interface StructureIssue {
+  /** i18n key under api_configurator.feeds.wizard.structure.issue.* */
+  key: 'invalid_name' | 'duplicate_slot' | 'parent_required' | 'invalid_max_length';
+  /** Which field the issue belongs to, for inline highlighting. */
+  field: 'root' | 'item' | 'namespace' | 'slot_name' | 'slot_parent' | 'slot_wrap' | 'max_length';
+  slotIndex?: number;
+  namespaceIndex?: number;
+  value: string;
+}
+
+const EDITED_KEYS = new Set([
+  'target',
+  'slot',
+  'node',
+  'element',
+  'parent',
+  'wrapIn',
+  'required',
+  'maxLength',
+  'fmt',
+]);
+
+export function descriptorToEdit(descriptor: Record<string, unknown>): EditableStructure {
+  const root = asRecord(descriptor.root);
+  const channel = asRecord(descriptor.channel);
+  const item = asRecord(channel?.item ?? descriptor.item);
+
+  const namespaces = Object.entries(asRecord(root?.namespaces) ?? {}).map(([prefix, uri]) => ({
+    prefix,
+    uri: String(uri),
+  }));
+
+  const slots: EditableSlot[] = [];
+  const rawSlots = Array.isArray(item?.slots) ? item.slots : [];
+  for (const raw of rawSlots) {
+    const slot = asRecord(raw);
+    if (slot === null) {
+      continue;
+    }
+    const rest: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(slot)) {
+      if (!EDITED_KEYS.has(key)) {
+        rest[key] = value;
+      }
+    }
+    slots.push({
+      name: String(slot.element ?? slot.target ?? slot.slot ?? ''),
+      node: (SLOT_NODE_KINDS as readonly string[]).includes(String(slot.node))
+        ? (String(slot.node) as SlotNodeKindId)
+        : 'element',
+      parent: typeof slot.parent === 'string' ? slot.parent : '',
+      wrapIn: typeof slot.wrapIn === 'string' ? slot.wrapIn : '',
+      required: slot.required === true,
+      maxLength: typeof slot.maxLength === 'number' ? String(slot.maxLength) : '',
+      format: typeof slot.fmt === 'string' ? slot.fmt : 'text',
+      rest,
+    });
+  }
+
+  return {
+    rootElement: String(root?.element ?? ''),
+    namespaces,
+    itemElement: String(item?.element ?? ''),
+    slots,
+  };
+}
+
+/**
+ * Fold the edited structure back into a canonical descriptor. `original`
+ * supplies everything the editor does not own: root attributes and the
+ * optional channel envelope (kept verbatim, only its item is replaced).
+ */
+export function editToDescriptor(
+  edit: EditableStructure,
+  original: Record<string, unknown>,
+): Record<string, unknown> {
+  const originalRoot = asRecord(original.root) ?? {};
+  const root: Record<string, unknown> = { ...originalRoot, element: edit.rootElement.trim() };
+  const namespaces: Record<string, string> = {};
+  for (const ns of edit.namespaces) {
+    if (ns.prefix.trim() !== '') {
+      namespaces[ns.prefix.trim()] = ns.uri.trim();
+    }
+  }
+  if (Object.keys(namespaces).length > 0) {
+    root.namespaces = namespaces;
+  } else {
+    delete root.namespaces;
+  }
+
+  const item = {
+    element: edit.itemElement.trim(),
+    slots: edit.slots.map((slot) => {
+      const name = slot.name.trim();
+      const out: Record<string, unknown> = {
+        ...slot.rest,
+        target: name,
+        node: slot.node,
+        element: name,
+      };
+      if (slot.node === 'attribute' && slot.parent.trim() !== '') {
+        out.parent = slot.parent.trim();
+      }
+      if (slot.wrapIn.trim() !== '') {
+        out.wrapIn = slot.wrapIn.trim();
+      }
+      if (slot.required) {
+        out.required = true;
+      }
+      const maxLength = Number.parseInt(slot.maxLength, 10);
+      if (slot.maxLength.trim() !== '' && Number.isFinite(maxLength)) {
+        out.maxLength = maxLength;
+      }
+      if (slot.format !== '' && slot.format !== 'text') {
+        out.fmt = slot.format;
+      } else {
+        out.fmt = 'text';
+      }
+      return out;
+    }),
+  };
+
+  const originalChannel = asRecord(original.channel);
+  if (originalChannel !== null) {
+    return { ...original, root, channel: { ...originalChannel, item } };
+  }
+  return { ...original, root, item };
+}
+
+/** Inline validation matching InvalidDescriptorException cases the editor can cause. */
+export function structureIssues(edit: EditableStructure): StructureIssue[] {
+  const issues: StructureIssue[] = [];
+
+  if (!XML_NAME.test(edit.rootElement.trim())) {
+    issues.push({ key: 'invalid_name', field: 'root', value: edit.rootElement });
+  }
+  if (!XML_NAME.test(edit.itemElement.trim())) {
+    issues.push({ key: 'invalid_name', field: 'item', value: edit.itemElement });
+  }
+  edit.namespaces.forEach((ns, index) => {
+    if (!XML_NAME.test(ns.prefix.trim())) {
+      issues.push({
+        key: 'invalid_name',
+        field: 'namespace',
+        namespaceIndex: index,
+        value: ns.prefix,
+      });
+    }
+  });
+
+  const seen = new Map<string, number>();
+  edit.slots.forEach((slot, index) => {
+    const name = slot.name.trim();
+    if (!XML_NAME.test(name)) {
+      issues.push({ key: 'invalid_name', field: 'slot_name', slotIndex: index, value: slot.name });
+    } else if (seen.has(name)) {
+      issues.push({ key: 'duplicate_slot', field: 'slot_name', slotIndex: index, value: name });
+    } else {
+      seen.set(name, index);
+    }
+    if (slot.node === 'attribute') {
+      if (slot.parent.trim() === '') {
+        issues.push({ key: 'parent_required', field: 'slot_parent', slotIndex: index, value: '' });
+      } else if (!XML_NAME.test(slot.parent.trim())) {
+        issues.push({
+          key: 'invalid_name',
+          field: 'slot_parent',
+          slotIndex: index,
+          value: slot.parent,
+        });
+      }
+    }
+    if (slot.wrapIn.trim() !== '' && !XML_NAME.test(slot.wrapIn.trim())) {
+      issues.push({
+        key: 'invalid_name',
+        field: 'slot_wrap',
+        slotIndex: index,
+        value: slot.wrapIn,
+      });
+    }
+    if (slot.maxLength.trim() !== '') {
+      const parsed = Number.parseInt(slot.maxLength, 10);
+      if (!Number.isFinite(parsed) || parsed < 1) {
+        issues.push({
+          key: 'invalid_max_length',
+          field: 'max_length',
+          slotIndex: index,
+          value: slot.maxLength,
+        });
+      }
+    }
+  });
+
+  return issues;
+}
+
+export function emptySlot(): EditableSlot {
+  return {
+    name: '',
+    node: 'element',
+    parent: '',
+    wrapIn: '',
+    required: false,
+    maxLength: '',
+    format: 'text',
+    rest: {},
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}

--- a/apps/admin/src/features/api-configurator/feeds/wizard/steps/StepStructure.tsx
+++ b/apps/admin/src/features/api-configurator/feeds/wizard/steps/StepStructure.tsx
@@ -1,0 +1,388 @@
+import { Braces, Plus, Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { cn } from '@/lib/utils';
+
+import {
+  type EditableSlot,
+  type EditableStructure,
+  emptySlot,
+  SLOT_FORMATS,
+  SLOT_NODE_KINDS,
+  type StructureIssue,
+  structureIssues,
+} from '../descriptor-edit';
+
+const FIELD_CLASS =
+  'h-9 w-full rounded-xl border bg-white px-2.5 font-mono text-[12.5px] outline-none focus:border-zinc-400';
+const LABEL_CLASS = 'text-[10.5px] font-medium uppercase tracking-wider text-zinc-500';
+
+/**
+ * XMLF-P5-06 — the structure editor step, custom feeds only: root element +
+ * namespaces, the item element and its slot list (name, node kind, format,
+ * required/maxLength, parent for attribute nodes, wrapIn for repeatable).
+ * Validation mirrors the backend descriptor guard inline; the live outline
+ * on the right previews the resulting XML shape.
+ */
+export function StepStructure({
+  edit,
+  onEdit,
+}: {
+  edit: EditableStructure;
+  onEdit: (next: EditableStructure) => void;
+}) {
+  const { t } = useTranslation();
+  const issues = structureIssues(edit);
+
+  const issueFor = (
+    field: StructureIssue['field'],
+    slotIndex?: number,
+    namespaceIndex?: number,
+  ): StructureIssue | undefined =>
+    issues.find(
+      (issue) =>
+        issue.field === field &&
+        issue.slotIndex === slotIndex &&
+        issue.namespaceIndex === namespaceIndex,
+    );
+
+  const patchSlot = (index: number, patch: Partial<EditableSlot>): void => {
+    onEdit({
+      ...edit,
+      slots: edit.slots.map((slot, i) => (i === index ? { ...slot, ...patch } : slot)),
+    });
+  };
+
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1fr_300px]">
+      <div className="space-y-4">
+        <div className="rounded-3xl bg-white p-6 soft-shadow">
+          <div className="flex items-center gap-2.5">
+            <span className="grid h-7 w-7 place-items-center rounded-xl bg-zinc-100 text-zinc-700">
+              <Braces className="h-4 w-4" aria-hidden />
+            </span>
+            <div className="text-[14.5px] font-semibold tracking-tight">
+              {t('api_configurator.feeds.wizard.structure.title')}
+            </div>
+            <span className="text-[11.5px] text-zinc-500">
+              {t('api_configurator.feeds.wizard.structure.subtitle')}
+            </span>
+          </div>
+
+          <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <NameField
+              label={t('api_configurator.feeds.wizard.structure.root_label')}
+              value={edit.rootElement}
+              onChange={(value) => onEdit({ ...edit, rootElement: value })}
+              issue={issueFor('root')}
+              t={t}
+            />
+            <NameField
+              label={t('api_configurator.feeds.wizard.structure.item_label')}
+              value={edit.itemElement}
+              onChange={(value) => onEdit({ ...edit, itemElement: value })}
+              issue={issueFor('item')}
+              t={t}
+            />
+          </div>
+
+          <div className="mt-5">
+            <div className={LABEL_CLASS}>
+              {t('api_configurator.feeds.wizard.structure.namespaces')}
+            </div>
+            {edit.namespaces.map((ns, index) => {
+              const issue = issueFor('namespace', undefined, index);
+              return (
+                // biome-ignore lint/suspicious/noArrayIndexKey: rows are positional while edited
+                <div key={index} className="mt-2 flex items-start gap-2">
+                  <div className="w-32 shrink-0">
+                    <input
+                      value={ns.prefix}
+                      onChange={(e) =>
+                        onEdit({
+                          ...edit,
+                          namespaces: edit.namespaces.map((n, i) =>
+                            i === index ? { ...n, prefix: e.target.value } : n,
+                          ),
+                        })
+                      }
+                      aria-label={t('api_configurator.feeds.wizard.structure.ns_prefix')}
+                      placeholder="g"
+                      className={cn(FIELD_CLASS, issue ? 'border-rose-400' : 'border-zinc-200')}
+                    />
+                    {issue && <IssueNote issue={issue} t={t} />}
+                  </div>
+                  <input
+                    value={ns.uri}
+                    onChange={(e) =>
+                      onEdit({
+                        ...edit,
+                        namespaces: edit.namespaces.map((n, i) =>
+                          i === index ? { ...n, uri: e.target.value } : n,
+                        ),
+                      })
+                    }
+                    aria-label={t('api_configurator.feeds.wizard.structure.ns_uri')}
+                    placeholder="http://example.com/ns"
+                    className={cn(FIELD_CLASS, 'border-zinc-200')}
+                  />
+                  <button
+                    type="button"
+                    onClick={() =>
+                      onEdit({ ...edit, namespaces: edit.namespaces.filter((_, i) => i !== index) })
+                    }
+                    aria-label={t('api_configurator.feeds.wizard.structure.ns_remove')}
+                    className="grid h-9 w-9 shrink-0 place-items-center rounded-xl text-zinc-400 hover:bg-rose-50 hover:text-rose-600"
+                  >
+                    <Trash2 className="h-4 w-4" aria-hidden />
+                  </button>
+                </div>
+              );
+            })}
+            <button
+              type="button"
+              onClick={() =>
+                onEdit({ ...edit, namespaces: [...edit.namespaces, { prefix: '', uri: '' }] })
+              }
+              className="mt-2 flex items-center gap-1.5 rounded-xl border border-dashed border-zinc-300 px-3 py-1.5 text-[12px] font-medium text-zinc-600 hover:border-zinc-400 hover:text-zinc-900"
+            >
+              <Plus className="h-3.5 w-3.5" aria-hidden />
+              {t('api_configurator.feeds.wizard.structure.ns_add')}
+            </button>
+          </div>
+        </div>
+
+        <div className="rounded-3xl bg-white p-6 soft-shadow">
+          <div className="text-[14.5px] font-semibold tracking-tight">
+            {t('api_configurator.feeds.wizard.structure.slots_title', {
+              item: edit.itemElement || 'item',
+            })}
+          </div>
+          <div className="mt-3 space-y-3">
+            {edit.slots.map((slot, index) => (
+              <SlotRow
+                // biome-ignore lint/suspicious/noArrayIndexKey: rows are positional while edited
+                key={index}
+                slot={slot}
+                nameIssue={issueFor('slot_name', index)}
+                parentIssue={issueFor('slot_parent', index)}
+                wrapIssue={issueFor('slot_wrap', index)}
+                lengthIssue={issueFor('max_length', index)}
+                onPatch={(patch) => patchSlot(index, patch)}
+                onRemove={() =>
+                  onEdit({ ...edit, slots: edit.slots.filter((_, i) => i !== index) })
+                }
+                t={t}
+              />
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={() => onEdit({ ...edit, slots: [...edit.slots, emptySlot()] })}
+            className="mt-3 flex items-center gap-1.5 rounded-xl border border-dashed border-zinc-300 px-3 py-2 text-[12.5px] font-medium text-zinc-600 hover:border-zinc-400 hover:text-zinc-900"
+          >
+            <Plus className="h-4 w-4" aria-hidden />
+            {t('api_configurator.feeds.wizard.structure.slot_add')}
+          </button>
+        </div>
+      </div>
+
+      <div className="rounded-3xl bg-zinc-900 p-5 text-zinc-100 soft-shadow lg:sticky lg:top-4 lg:self-start">
+        <div className="text-[10.5px] font-medium uppercase tracking-wider text-zinc-400">
+          {t('api_configurator.feeds.wizard.structure.preview_title')}
+        </div>
+        <pre className="mt-2 overflow-x-auto font-mono text-[11.5px] leading-6">
+          {outline(edit)}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+function NameField({
+  label,
+  value,
+  onChange,
+  issue,
+  t,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  issue: StructureIssue | undefined;
+  t: (key: string, params?: Record<string, unknown>) => string;
+}) {
+  return (
+    <div>
+      <span className={LABEL_CLASS}>{label}</span>
+      <input
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        aria-label={label}
+        className={cn(FIELD_CLASS, 'mt-1.5', issue ? 'border-rose-400' : 'border-zinc-200')}
+      />
+      {issue && <IssueNote issue={issue} t={t} />}
+    </div>
+  );
+}
+
+function SlotRow({
+  slot,
+  nameIssue,
+  parentIssue,
+  wrapIssue,
+  lengthIssue,
+  onPatch,
+  onRemove,
+  t,
+}: {
+  slot: EditableSlot;
+  nameIssue: StructureIssue | undefined;
+  parentIssue: StructureIssue | undefined;
+  wrapIssue: StructureIssue | undefined;
+  lengthIssue: StructureIssue | undefined;
+  onPatch: (patch: Partial<EditableSlot>) => void;
+  onRemove: () => void;
+  t: (key: string, params?: Record<string, unknown>) => string;
+}) {
+  const selectClass = cn(FIELD_CLASS, 'border-zinc-200 font-sans');
+  const formats = SLOT_FORMATS.includes(slot.format as (typeof SLOT_FORMATS)[number])
+    ? SLOT_FORMATS
+    : ([...SLOT_FORMATS, slot.format] as readonly string[]);
+
+  return (
+    <div className="rounded-2xl border border-zinc-100 bg-zinc-50/50 p-3">
+      <div className="grid grid-cols-2 items-start gap-2 md:grid-cols-[1.4fr_1fr_1fr_auto_5rem_auto]">
+        <div>
+          <input
+            value={slot.name}
+            onChange={(e) => onPatch({ name: e.target.value })}
+            aria-label={t('api_configurator.feeds.wizard.structure.slot_name')}
+            placeholder="price"
+            className={cn(FIELD_CLASS, nameIssue ? 'border-rose-400' : 'border-zinc-200')}
+          />
+          {nameIssue && <IssueNote issue={nameIssue} t={t} />}
+        </div>
+        <select
+          value={slot.node}
+          onChange={(e) => onPatch({ node: e.target.value as EditableSlot['node'] })}
+          aria-label={t('api_configurator.feeds.wizard.structure.node')}
+          className={selectClass}
+        >
+          {SLOT_NODE_KINDS.map((kind) => (
+            <option key={kind} value={kind}>
+              {t(`api_configurator.feeds.wizard.structure.node_kind.${kind}`)}
+            </option>
+          ))}
+        </select>
+        <select
+          value={slot.format}
+          onChange={(e) => onPatch({ format: e.target.value })}
+          aria-label={t('api_configurator.feeds.wizard.structure.format')}
+          className={selectClass}
+        >
+          {formats.map((format) => (
+            <option key={format} value={format}>
+              {t(`api_configurator.feeds.wizard.structure.format_kind.${format}`, {
+                defaultValue: format,
+              })}
+            </option>
+          ))}
+        </select>
+        <label className="flex h-9 items-center gap-1.5 text-[12px] text-zinc-600">
+          <input
+            type="checkbox"
+            checked={slot.required}
+            onChange={(e) => onPatch({ required: e.target.checked })}
+            className="h-3.5 w-3.5 rounded border-zinc-300"
+          />
+          {t('api_configurator.feeds.wizard.structure.required')}
+        </label>
+        <div>
+          <input
+            value={slot.maxLength}
+            onChange={(e) => onPatch({ maxLength: e.target.value })}
+            inputMode="numeric"
+            aria-label={t('api_configurator.feeds.wizard.structure.max_length')}
+            placeholder="max"
+            className={cn(FIELD_CLASS, lengthIssue ? 'border-rose-400' : 'border-zinc-200')}
+          />
+          {lengthIssue && <IssueNote issue={lengthIssue} t={t} />}
+        </div>
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={t('api_configurator.feeds.wizard.structure.slot_remove')}
+          className="grid h-9 w-9 place-items-center rounded-xl text-zinc-400 hover:bg-rose-50 hover:text-rose-600"
+        >
+          <Trash2 className="h-4 w-4" aria-hidden />
+        </button>
+      </div>
+      {slot.node === 'attribute' && (
+        <div className="mt-2 w-full md:w-64">
+          <span className={LABEL_CLASS}>{t('api_configurator.feeds.wizard.structure.parent')}</span>
+          <input
+            value={slot.parent}
+            onChange={(e) => onPatch({ parent: e.target.value })}
+            aria-label={t('api_configurator.feeds.wizard.structure.parent')}
+            placeholder="o"
+            className={cn(FIELD_CLASS, 'mt-1', parentIssue ? 'border-rose-400' : 'border-zinc-200')}
+          />
+          {parentIssue && <IssueNote issue={parentIssue} t={t} />}
+        </div>
+      )}
+      {slot.node === 'repeatable' && (
+        <div className="mt-2 w-full md:w-64">
+          <span className={LABEL_CLASS}>
+            {t('api_configurator.feeds.wizard.structure.wrap_in')}
+          </span>
+          <input
+            value={slot.wrapIn}
+            onChange={(e) => onPatch({ wrapIn: e.target.value })}
+            aria-label={t('api_configurator.feeds.wizard.structure.wrap_in')}
+            placeholder="imgs"
+            className={cn(FIELD_CLASS, 'mt-1', wrapIssue ? 'border-rose-400' : 'border-zinc-200')}
+          />
+          {wrapIssue && <IssueNote issue={wrapIssue} t={t} />}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function IssueNote({
+  issue,
+  t,
+}: {
+  issue: StructureIssue;
+  t: (key: string, params?: Record<string, unknown>) => string;
+}) {
+  return (
+    <p className="mt-1 text-[11px] text-rose-600" role="alert">
+      {t(`api_configurator.feeds.wizard.structure.issue.${issue.key}`, { value: issue.value })}
+    </p>
+  );
+}
+
+/** Plain-text XML outline of the edited structure for the preview panel. */
+function outline(edit: EditableStructure): string {
+  const ns = edit.namespaces
+    .filter((n) => n.prefix.trim() !== '')
+    .map((n) => ` xmlns:${n.prefix.trim()}="${n.uri.trim()}"`)
+    .join('');
+  const root = edit.rootElement.trim() || '?';
+  const item = edit.itemElement.trim() || '?';
+  const lines = [`<${root}${ns}>`, `  <${item}>`];
+  for (const slot of edit.slots) {
+    const name = slot.name.trim() || '?';
+    if (slot.node === 'attribute') {
+      lines.push(`    <${slot.parent.trim() || '?'} ${name}="…"/>`);
+    } else if (slot.node === 'repeatable' && slot.wrapIn.trim() !== '') {
+      lines.push(`    <${slot.wrapIn.trim()}><${name}>…</${name}>…</${slot.wrapIn.trim()}>`);
+    } else {
+      lines.push(`    <${name}>…</${name}>${slot.node === 'repeatable' ? ' ×n' : ''}`);
+    }
+  }
+  lines.push(`  </${item}>`, `</${root}>`);
+  return lines.join('\n');
+}

--- a/apps/admin/src/features/api-configurator/feeds/wizard/wizard-state.ts
+++ b/apps/admin/src/features/api-configurator/feeds/wizard/wizard-state.ts
@@ -29,8 +29,24 @@ export interface FeedDraft {
   authPassword: string;
 }
 
-export const WIZARD_STEP_IDS = ['template', 'scope', 'mapping', 'delivery', 'preview'] as const;
+export const WIZARD_STEP_IDS = [
+  'template',
+  'structure',
+  'scope',
+  'mapping',
+  'delivery',
+  'preview',
+] as const;
 export type WizardStepId = (typeof WIZARD_STEP_IDS)[number];
+
+/**
+ * XMLF-P5-06 — the step list is a function of the template kind: only a
+ * custom feed gets the structure editor (predefs have a fixed descriptor).
+ * Steps are addressed by id everywhere; indexes are derived per draft.
+ */
+export function stepsFor(kind: FeedTemplateKind | null): readonly WizardStepId[] {
+  return kind === 'custom' ? WIZARD_STEP_IDS : WIZARD_STEP_IDS.filter((s) => s !== 'structure');
+}
 
 export function emptyDraft(): FeedDraft {
   return {
@@ -117,18 +133,29 @@ export function slugifyCode(name: string): string {
     .replace(/^_+|_+$/g, '');
 }
 
-/** Step gating (design canNext): step 0 needs a template and a name. */
-export function canLeaveStep(step: number, draft: FeedDraft): boolean {
-  if (step === 0) {
+/** Step gating (design canNext), addressed by step id. The structure step
+ * gates on the inline descriptor validation (descriptor-edit.ts) — the page
+ * passes its verdict in, keeping this module free of the editor types. */
+export function canLeaveStep(
+  stepId: WizardStepId,
+  draft: FeedDraft,
+  structureValid = true,
+): boolean {
+  if (stepId === 'template') {
     return draft.kind !== null && draft.name.trim() !== '';
   }
-  if (step === 1) {
+  if (stepId === 'structure') {
+    return structureValid;
+  }
+  if (stepId === 'scope') {
     return draft.locale.trim() !== '';
   }
   return true;
 }
 
-/** POST /api/feeds payload for a fresh draft. */
+/** POST /api/feeds payload for a fresh draft. A custom feed sends its edited
+ * descriptor (+ pruned mappings) so create seeds the user's structure instead
+ * of the blank starter — the persist guard (P1-04) validates it server-side. */
 export function createPayload(draft: FeedDraft, objectTypeId: string): Record<string, unknown> {
   return {
     template_kind: draft.kind,
@@ -139,6 +166,9 @@ export function createPayload(draft: FeedDraft, objectTypeId: string): Record<st
     currency: draft.currency,
     channel_id: draft.channelId,
     filter: draft.filterDsl,
+    ...(draft.kind === 'custom'
+      ? { descriptor: draft.descriptor, field_mappings: draft.mappings.filter(isMapped) }
+      : {}),
   };
 }
 
@@ -152,6 +182,7 @@ export function patchPayload(draft: FeedDraft): Record<string, unknown> {
     filter: draft.filterDsl,
     validation_policy: draft.skipPolicy,
     schedule_cron: draft.cron,
+    ...(draft.kind === 'custom' ? { descriptor: draft.descriptor } : {}),
     delivery: {
       gzip: draft.gzip,
       auth:
@@ -164,4 +195,8 @@ export function patchPayload(draft: FeedDraft): Record<string, unknown> {
           : { type: 'none' },
     },
   };
+}
+
+function isMapped(mapping: SlotMapping): boolean {
+  return mapping.source !== null;
 }

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1785,14 +1785,16 @@
           "scope": "Scope",
           "mapping": "Mapping",
           "delivery": "Delivery",
-          "preview": "Preview"
+          "preview": "Preview",
+          "structure": "Structure"
         },
         "step_note": {
           "template": "target channel",
           "scope": "filter · scope",
           "mapping": "slots ↔ attributes",
           "delivery": "URL · schedule",
-          "preview": "XML · publish"
+          "preview": "XML · publish",
+          "structure": "root + fields"
         },
         "cancel": "Cancel",
         "back": "← Back",
@@ -1844,7 +1846,49 @@
           "preview_hint": "The live XML preview with the health report lands with XMLF-P5-04."
         },
         "back_to_hub": "Back to feeds",
-        "saved_generating": "Feed saved — first regeneration queued."
+        "saved_generating": "Feed saved — first regeneration queued.",
+        "structure": {
+          "title": "Document structure",
+          "subtitle": "custom XML — root, namespaces and item fields",
+          "root_label": "Root element",
+          "item_label": "Item element",
+          "namespaces": "Namespaces",
+          "ns_prefix": "Namespace prefix",
+          "ns_uri": "Namespace URI",
+          "ns_add": "Add namespace",
+          "ns_remove": "Remove namespace",
+          "slots_title": "Fields of <{{item}}>",
+          "slot_name": "Field name",
+          "node": "Node kind",
+          "format": "Format",
+          "required": "required",
+          "max_length": "Max length",
+          "parent": "Parent element (attribute goes on it)",
+          "wrap_in": "Wrap repeated values in",
+          "slot_add": "Add field",
+          "slot_remove": "Remove field",
+          "preview_title": "Structure preview",
+          "node_kind": {
+            "element": "Element",
+            "attribute": "Attribute",
+            "repeatable": "Repeatable",
+            "keyvalue": "Key-value"
+          },
+          "format_kind": {
+            "text": "Text",
+            "html": "HTML",
+            "url": "URL",
+            "price": "Price",
+            "number": "Number",
+            "date": "Date"
+          },
+          "issue": {
+            "invalid_name": "“{{value}}” is not a valid XML name",
+            "duplicate_slot": "Duplicate field “{{value}}”",
+            "parent_required": "An attribute needs a parent element",
+            "invalid_max_length": "Max length must be a positive number"
+          }
+        }
       },
       "detail": {
         "placeholder_title": "Feed detail — coming in the next ticket",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1833,14 +1833,16 @@
           "scope": "Zakres",
           "mapping": "Mapowanie",
           "delivery": "Dostarczanie",
-          "preview": "Podgląd"
+          "preview": "Podgląd",
+          "structure": "Struktura"
         },
         "step_note": {
           "template": "kanał docelowy",
           "scope": "filtr · scope",
           "mapping": "sloty ↔ atrybuty",
           "delivery": "URL · harmonogram",
-          "preview": "XML · publikacja"
+          "preview": "XML · publikacja",
+          "structure": "root + pola"
         },
         "cancel": "Anuluj",
         "back": "← Wstecz",
@@ -1892,7 +1894,49 @@
           "preview_hint": "Podgląd XML na żywo z raportem zdrowia wchodzi z XMLF-P5-04."
         },
         "back_to_hub": "Wróć do feedów",
-        "saved_generating": "Feed zapisany — pierwsza regeneracja zakolejkowana."
+        "saved_generating": "Feed zapisany — pierwsza regeneracja zakolejkowana.",
+        "structure": {
+          "title": "Struktura dokumentu",
+          "subtitle": "custom XML — root, przestrzenie nazw i pola pozycji",
+          "root_label": "Element główny (root)",
+          "item_label": "Element pozycji (item)",
+          "namespaces": "Przestrzenie nazw",
+          "ns_prefix": "Prefiks przestrzeni nazw",
+          "ns_uri": "URI przestrzeni nazw",
+          "ns_add": "Dodaj przestrzeń nazw",
+          "ns_remove": "Usuń przestrzeń nazw",
+          "slots_title": "Pola elementu <{{item}}>",
+          "slot_name": "Nazwa pola",
+          "node": "Rodzaj węzła",
+          "format": "Format",
+          "required": "wymagane",
+          "max_length": "Maks. długość",
+          "parent": "Element nadrzędny (atrybut trafia na niego)",
+          "wrap_in": "Opakuj powtórzenia w",
+          "slot_add": "Dodaj pole",
+          "slot_remove": "Usuń pole",
+          "preview_title": "Podgląd struktury",
+          "node_kind": {
+            "element": "Element",
+            "attribute": "Atrybut",
+            "repeatable": "Powtarzalny",
+            "keyvalue": "Klucz-wartość"
+          },
+          "format_kind": {
+            "text": "Tekst",
+            "html": "HTML",
+            "url": "URL",
+            "price": "Cena",
+            "number": "Liczba",
+            "date": "Data"
+          },
+          "issue": {
+            "invalid_name": "„{{value}}” nie jest poprawną nazwą XML",
+            "duplicate_slot": "Zduplikowane pole „{{value}}”",
+            "parent_required": "Atrybut wymaga elementu nadrzędnego",
+            "invalid_max_length": "Maks. długość musi być liczbą dodatnią"
+          }
+        }
       },
       "detail": {
         "placeholder_title": "Detal feedu — w kolejnym tickecie",


### PR DESCRIPTION
## XMLF-P5-06 — edytor struktury dla feedów custom (Closes #1934)

Para FE do edytora descriptora P2-07 — wybór „Własny" w kreatorze realizuje obietnicę „od zera" z planu §7:

- **Nowy krok „Struktura"** między Szablonem a Zakresem, widoczny **wyłącznie dla `template_kind=custom`** — kroki kreatora przechodzą z numerycznych na **id-based** (`stepsFor(kind)`); predefy zachowują 5-krokowy flow bez zmian.
- **Edytor**: element główny + przestrzenie nazw (prefix→URI, add/remove), element pozycji, lista pól: nazwa (jedno pole ustawia `target` i `element` — custom nie rozjeżdża ich nigdy), rodzaj węzła (element/atrybut/powtarzalny/klucz-wartość), format (text/html/url/price/number/date), `required`, maxLength, `parent` dla atrybutu, `wrapIn` dla powtarzalnych.
- **Walidacja inline = mirror guardu BE** (`descriptor-edit.ts`): regex XML-name z `FeedSlot::XML_NAME`, duplikaty targetów, atrybut-bez-parenta, maxLength ≥ 1 — złe struktury blokują „Dalej" zanim BE odpowie 400; **podgląd outline XML na żywo** obok edytora.
- **Round-trip zachowuje to, czego edytor nie dotyka**: enums/html/requiredOneOf per slot, atrybuty roota i envelope `channel` (podmieniany jest tylko `item`).
- Descriptor jedzie **istniejącymi payloadami**: create (POST z `descriptor`+`field_mappings` dla custom — resolveDescriptor bierze go zamiast blank startera) i PATCH `{descriptor}` — waliduje persist-guard P1-04. Rename/usunięcie slotu **przycina mapowania** (mapper od-oferowuje pole).
- Spec `1932` zaktualizowany: custom przechodzi teraz przez structure step (4×Dalej do delivery).

## Smoke test (live, pim.localhost)
Kreator → Własny → krok Struktura (starter products/product + sku/name) → dodaj pole `price` (format: cena) → outline pokazuje `<price>…</price>` → Dalej → Zakres → **create 201 z edytowanym descriptorem (price w slots)** → Mapowanie pokazuje `price` z katalogiem atrybutów → Dostarczanie → **Podgląd well-formed**. Console bez czerwonych errorów.

## Testy
- `e2e/1934-feed-structure-editor.spec.ts` (mocked): predef bez kroku struktury; custom z krokiem; nielegalna nazwa `description.pl` → alert + Dalej zablokowany; duplikat `sku` → alert; atrybut bez parenta → zablokowany, z parentem → odblokowany; outline live; axe 0 serious/critical; przejście do scope.
- Vitest: `descriptor-edit.test.ts` (round-trip z channel envelope + enums, rename target+element, issues: nazwy/duplikaty/parent/maxLength) + `wizard-state.test.ts` (stepsFor, gating structure, descriptor w payloadach custom-only). 23/23 w module feeds, 109/109 całość.
- tsc / biome / build / guard ADR-0021 zielone.
