### PR TITLE
feat(admin): promote XML Configurator (feeds) to its own sidebar entry

### DIFF
--- a/apps/admin/e2e/1929-feeds-hub.spec.ts
+++ b/apps/admin/e2e/1929-feeds-hub.spec.ts
@@ -78,14 +78,15 @@ test('XMLF-P5-01 — feeds hub: tab, KPI, cards, filtering, a11y', async ({ page
 
   await page.goto('/integrations/api-configurator/feeds');
 
-  // Shell: the fourth tab exists and is active for the /feeds prefix
-  // (scoped to the layout tablist — the P5-07 feeds sub-nav has its own
-  // same-named "Feeds" tab).
-  const feedsTab = page
-    .getByLabel(/API Configurator|Konfigurator API/)
-    .getByRole('tab', { name: /Feedy|Feeds/ });
-  await expect(feedsTab).toBeVisible();
-  await expect(feedsTab).toHaveAttribute('aria-selected', 'true');
+  // XMLF-FUP-01 (#2028): feeds live under their own sidebar entry
+  // ("Konfigurator XML"), highlighted for the /feeds prefix — and the
+  // Konfigurator API shell no longer renders its pill tabs here.
+  const sidebarEntry = page.getByRole('link', { name: /Konfigurator XML|XML Configurator/ });
+  await expect(sidebarEntry).toBeVisible();
+  await expect(sidebarEntry).toHaveClass(/bg-zinc-100/);
+  await expect(
+    page.getByLabel(/API Configurator|Konfigurator API/).getByRole('tab', { name: /Feedy|Feeds/ }),
+  ).toHaveCount(0);
 
   // KPI strip renders the merged aggregates. pl-PL grouping starts at five
   // digits (CLDR minimumGroupingDigits=2), so 1284 renders bare and 12408 gets

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -692,26 +692,6 @@ function App() {
                       path="/integrations/api-configurator/monitor"
                       element={<SyncMonitorScreen />}
                     />
-                    {/* XMLF-P5-01 — product XML feeds (hub / wizard / detail)
-                        under the same shell; wizard + detail are placeholder
-                        targets until P5-02..P5-05 replace them. */}
-                    <Route path="/integrations/api-configurator/feeds" element={<FeedsHubPage />} />
-                    <Route
-                      path="/integrations/api-configurator/feeds/monitor"
-                      element={<FeedsMonitorPage />}
-                    />
-                    <Route
-                      path="/integrations/api-configurator/feeds/new"
-                      element={<FeedWizardPage />}
-                    />
-                    <Route
-                      path="/integrations/api-configurator/feeds/:id/edit"
-                      element={<FeedWizardPage />}
-                    />
-                    <Route
-                      path="/integrations/api-configurator/feeds/:id"
-                      element={<FeedDetailPage />}
-                    />
                     <Route
                       path="/integrations/api-configurator/:id/edit"
                       element={<ApiProfileEditPage />}
@@ -721,6 +701,28 @@ function App() {
                       element={<ApiProfileShowPage />}
                     />
                   </Route>
+                  {/* XMLF — product XML feeds (hub / monitor / wizard / detail).
+                      Shipped as a tab of the Konfigurator API shell, promoted
+                      to its own sidebar entry in XMLF-FUP-01 (#2028): same
+                      URLs, rendered outside the shell (FeedsSubnav is the
+                      area's own hub|monitor navigation). */}
+                  <Route path="/integrations/api-configurator/feeds" element={<FeedsHubPage />} />
+                  <Route
+                    path="/integrations/api-configurator/feeds/monitor"
+                    element={<FeedsMonitorPage />}
+                  />
+                  <Route
+                    path="/integrations/api-configurator/feeds/new"
+                    element={<FeedWizardPage />}
+                  />
+                  <Route
+                    path="/integrations/api-configurator/feeds/:id/edit"
+                    element={<FeedWizardPage />}
+                  />
+                  <Route
+                    path="/integrations/api-configurator/feeds/:id"
+                    element={<FeedDetailPage />}
+                  />
                   <Route
                     path="/integrations"
                     element={<Navigate to="/integrations/imports/sessions" replace />}

--- a/apps/admin/src/features/api-configurator/layout/KonfiguratorApiLayout.tsx
+++ b/apps/admin/src/features/api-configurator/layout/KonfiguratorApiLayout.tsx
@@ -5,19 +5,20 @@ import { PillTabs } from '@/components/ui-v2/pill-tabs';
 
 const BASE = '/integrations/api-configurator';
 
-type ShellTab = 'connections' | 'producer' | 'feeds' | 'monitor';
+type ShellTab = 'connections' | 'producer' | 'monitor';
 
 /**
  * APIC-P0-04 / P4-08 — shared shell unifying the faces of the Konfigurator API
  * area (ADR-0022, api-app.jsx prototype): a pill-tab split over an Outlet
  * between the **consumer** side (Połączenia — hub/wizard/detail/mapping/sync,
  * P1-07/P2/P3-11/P3-12), the **producer** side (Moje API — the hub with
- * Profile/Keys/Webhooks tabs + the profile builder, P4-06/P4-07), the product
- * XML **Feeds** hub (XMLF-P5-01 — the third citizen of the area, ADR-0023) and
- * the sync **Monitor** (P4-02). The active tab is derived from the path prefix
- * so every sub-route (connection detail, profile builder, feed detail, monitor
- * drill-down) keeps its face highlighted; switching tabs deep-links to each
- * face's landing.
+ * Profile/Keys/Webhooks tabs + the profile builder, P4-06/P4-07) and the sync
+ * **Monitor** (P4-02). The XML feeds area (XMLF, ADR-0023) shipped here as a
+ * fourth tab and was then promoted to its own sidebar entry (XMLF-FUP-01
+ * #2028) — its routes render outside this shell, same URLs. The active tab is
+ * derived from the path prefix so every sub-route (connection detail, profile
+ * builder, monitor drill-down) keeps its face highlighted; switching tabs
+ * deep-links to each face's landing.
  */
 export function KonfiguratorApiLayout() {
   const { t } = useTranslation();
@@ -26,11 +27,9 @@ export function KonfiguratorApiLayout() {
 
   const activeId: ShellTab = pathname.startsWith(`${BASE}/connections`)
     ? 'connections'
-    : pathname.startsWith(`${BASE}/feeds`)
-      ? 'feeds'
-      : pathname.startsWith(`${BASE}/monitor`)
-        ? 'monitor'
-        : 'producer';
+    : pathname.startsWith(`${BASE}/monitor`)
+      ? 'monitor'
+      : 'producer';
 
   return (
     <div className="space-y-5">
@@ -43,7 +42,6 @@ export function KonfiguratorApiLayout() {
         items={[
           { id: 'connections', label: t('api_configurator.shell.tabs.connections') },
           { id: 'producer', label: t('api_configurator.shell.tabs.producer') },
-          { id: 'feeds', label: t('api_configurator.shell.tabs.feeds') },
           { id: 'monitor', label: t('api_configurator.shell.tabs.monitor') },
         ]}
       />

--- a/apps/admin/src/layout/sidebar-nav.tsx
+++ b/apps/admin/src/layout/sidebar-nav.tsx
@@ -156,6 +156,8 @@ interface IntegrationChild {
   countKey?: string;
   /** NUI-01 — pulsing dot next to the count while the counter is > 0 (live sessions). */
   live?: boolean;
+  /** A sibling owns this deeper prefix — do not highlight this item there. */
+  excludePrefix?: string;
 }
 
 const INTEGRATION_CHILDREN: IntegrationChild[] = [
@@ -171,6 +173,14 @@ const INTEGRATION_CHILDREN: IntegrationChild[] = [
     key: 'api_configurator',
     labelKey: 'nav.api_configurator',
     route: '/integrations/api-configurator',
+    // XMLF-FUP-01 — the feeds area is its own menu entry below; without this
+    // exclusion both items would light up on /api-configurator/feeds/*.
+    excludePrefix: '/integrations/api-configurator/feeds',
+  },
+  {
+    key: 'xml_configurator',
+    labelKey: 'nav.xml_configurator',
+    route: '/integrations/api-configurator/feeds',
   },
 ];
 
@@ -277,7 +287,11 @@ export function SidebarNav({ onNavigate }: SidebarNavProps) {
                 className={({ isActive }) =>
                   cn(
                     'flex items-center gap-3 rounded-xl py-1.5 pr-3 pl-10 text-[13px] font-medium transition',
-                    isActive ? 'bg-zinc-100 text-ink' : 'text-zinc-500 hover:bg-zinc-50',
+                    isActive &&
+                      (child.excludePrefix === undefined ||
+                        !pathname.startsWith(child.excludePrefix))
+                      ? 'bg-zinc-100 text-ink'
+                      : 'text-zinc-500 hover:bg-zinc-50',
                   )
                 }
                 end={false}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -97,7 +97,8 @@
     "add_custom_module": "Add custom module",
     "imports": "Imports",
     "exports": "Exports",
-    "api_configurator": "API Configurator"
+    "api_configurator": "API Configurator",
+    "xml_configurator": "XML Configurator"
   },
   "admin": {
     "tenants": {
@@ -2053,7 +2054,6 @@
       "tabs": {
         "connections": "Connections",
         "producer": "My API",
-        "feeds": "Feeds",
         "monitor": "Monitor"
       },
       "connections_soon_title": "Connections — coming soon",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -99,7 +99,8 @@
     "add_custom_module": "Dodaj własny moduł",
     "imports": "Importy",
     "exports": "Eksporty",
-    "api_configurator": "Konfigurator API"
+    "api_configurator": "Konfigurator API",
+    "xml_configurator": "Konfigurator XML"
   },
   "admin": {
     "tenants": {
@@ -2101,7 +2102,6 @@
       "tabs": {
         "connections": "Połączenia",
         "producer": "Moje API",
-        "feeds": "Feedy",
         "monitor": "Monitor"
       },
       "connections_soon_title": "Połączenia — wkrótce",


### PR DESCRIPTION
## XMLF-FUP-01 — Konfigurator XML jako pozycja lewego menu (Closes #2028)

Decyzja operatora po zamknięciu epiku XMLF (wariant B): feedy były za głęboko jako 4. tab shellu Konfiguratora API.

- **Sidebar**: nowa pozycja **Integracje → Konfigurator XML** (`nav.xml_configurator`, EN „XML Configurator") → `/integrations/api-configurator/feeds`; pozycja „Konfigurator API" wyklucza prefiks `/feeds` z highlightu (świeci się dokładnie jedna).
- **Shell Konfiguratora API** wraca do 3 tabów (Połączenia | Moje API | Monitor); route'y feedów renderują się **poza shellem** — wewnętrzną nawigacją obszaru pozostaje FeedsSubnav (hub | monitor) z P5-07.
- **URL-e bez zmian** — zakładki użytkowników i specy e2e (goto) działają jak dotąd; martwy klucz i18n `shell.tabs.feeds` usunięty.
- Spec `1929` zaktualizowany: asercja pozycji sidebar (aktywna dla prefiksu /feeds) + brak taba „Feedy" w shellu.

## Smoke test (live, pim.localhost)
Dashboard → Integracje → **Konfigurator XML** widoczny → klik → `/integrations/api-configurator/feeds`, hub z własnym subnav, **zero pill-tabs shellu**, pozycja menu podświetlona (a „Konfigurator API" nie) → klik „Konfigurator API" → shell z **3 tabami**. Console bez czerwonych errorów.

## Testy
7/7 speców feedowych (1929–1935) zielonych po wyniesieniu + axe bez regresji; vitest 42/42 (api-configurator + layout); tsc / biome / build / guard ADR-0021 zielone.
