### PR TITLE
feat(catalog): add Provenance::Agent enum case with provenance_meta shape

### DIFF
--- a/apps/api/src/Catalog/Domain/Provenance.php
+++ b/apps/api/src/Catalog/Domain/Provenance.php
@@ -9,21 +9,20 @@ namespace App\Catalog\Domain;
  *
  * Per CLAUDE.md "Architecture rules" point 5 — every value carries
  * provenance metadata so admins can answer "who/what set this field?"
- * Three sources are usable in MVP:
  *
  *   - `Manual`     — admin set it via the admin UI form.
- *   - `Import`     — a bulk import job (CSV / XLSX, future) wrote it.
+ *   - `Import`     — a bulk import job (CSV / XLSX) wrote it.
  *   - `Integration`— an upstream system pushed it via an integration
- *                    adapter (BaseLinker / Shopify, phase 1).
- *
- * `Agent` is reserved for phase 2 (epic 0.7) — when the agent layer
- * lands, this enum gains a fourth case + the admin gets an "approval
- * inbox" for agent-authored changes. For now we do NOT add the case
- * here so a stale fixture cannot accidentally claim agent provenance.
+ *                    adapter (Generic connector / BaseLinker / Shopify).
+ *   - `Agent`      — the agent layer committed it after human approval
+ *                    (epic 0.7, ADR-0024; AGENT-P0-04 #1947). Writes go
+ *                    through the same bulk-path as manual edits, but only
+ *                    after a pending_changes batch is accepted.
  *
  * `provenance_meta JSONB` on ObjectValue carries free-form context
- * (importer job id, integration profile, etc.) — this enum is the
- * coarse classifier used in filters and provenance badges in the UI
+ * (importer job id, integration profile, agent run id/model/intent —
+ * see docs/api/jsonb-schemas.md section 5) — this enum is the coarse
+ * classifier used in filters and provenance badges in the UI
  * (epic 0.6 #61).
  */
 enum Provenance: string
@@ -31,4 +30,5 @@ enum Provenance: string
     case Manual = 'manual';
     case Import = 'import';
     case Integration = 'integration';
+    case Agent = 'agent';
 }

--- a/apps/api/tests/Unit/Catalog/ProvenanceTest.php
+++ b/apps/api/tests/Unit/Catalog/ProvenanceTest.php
@@ -11,12 +11,12 @@ use PHPUnit\Framework\TestCase;
 final class ProvenanceTest extends TestCase
 {
     #[Test]
-    public function threeMvpCasesAreDefinedExactly(): void
+    public function fourCasesAreDefinedExactly(): void
     {
-        // Phase 2 adds the `agent` case (epic 0.7). Until then we ship
-        // exactly three so a stale fixture cannot accidentally claim
-        // agent provenance — guard against drift.
-        self::assertCount(3, Provenance::cases());
+        // AGENT-P0-04 (#1947) — epic 0.7 adds the `agent` case alongside
+        // the pending_changes approval gate (ADR-0024). Guard against
+        // further drift: a fifth source needs a conscious decision.
+        self::assertCount(4, Provenance::cases());
     }
 
     #[Test]
@@ -29,12 +29,13 @@ final class ProvenanceTest extends TestCase
     }
 
     #[Test]
-    public function agentCaseIsExplicitlyAbsent(): void
+    public function agentCaseIsPresent(): void
     {
-        // Negative guard: phase 2 will add this case alongside the agent
-        // approval inbox in epic 0.7. If someone adds it here without
-        // shipping the inbox, this test fails and forces a conscious
-        // change.
-        self::assertNull(Provenance::tryFrom('agent'));
+        // The agent commits values only after a human accepts the
+        // pending_changes batch — the enum case is the substrate for
+        // provenance=agent badges (P6-05) and agent bulk-path writes
+        // (P3-01/P3-02).
+        self::assertSame(Provenance::Agent, Provenance::from('agent'));
+        self::assertSame('agent', Provenance::Agent->value);
     }
 }

--- a/docs/api/jsonb-schemas.md
+++ b/docs/api/jsonb-schemas.md
@@ -240,12 +240,24 @@ Schema unionowa — pole `validation_rules` jest interpretowane przez validator 
     "source": { "type": "string", "description": "Identyfikator źródła (import session uuid, integration name, agent run id)" },
     "imported_at": { "type": "string", "format": "date-time" },
     "user_id": { "type": "string", "format": "uuid" },
-    "agent_run_id": { "type": "string", "format": "uuid", "description": "Faza 2 — id Anthropic conversation" },
+    "agent_run_id": { "type": "string", "format": "uuid", "description": "provenance=agent — id AgentRun (epik 0.7, tabela agent_runs)" },
+    "model": { "type": "string", "description": "provenance=agent — id modelu Anthropic użytego w runie (np. claude-sonnet-*)" },
+    "intent": { "type": "string", "description": "provenance=agent — intencja usera, z której powstała zmiana (skrót)" },
     "channel": { "type": "string", "description": "Integration channel id jeśli provenance=integration" }
   },
   "additionalProperties": true
 }
 ```
+
+### Shape per provenance=agent (AGENT-P0-04 #1947, ADR-0024)
+
+Wartości zapisane przez agenta (po akcepcie batcha `pending_changes`) niosą:
+
+```json
+{ "agent_run_id": "<uuid AgentRun>", "model": "claude-sonnet-…", "intent": "ustaw cenę 100 wszystkim bez ceny" }
+```
+
+`agent_run_id` linkuje wartość do runu (audyt + tooltip badge'a „agent" w UI, P6-05).
 
 ### Reguły
 


### PR DESCRIPTION
## Cel (AGENT-P0-04 #1947, epik 0.7)

Każda wartość zapisana przez agenta musi nieść `provenance=agent` + meta (run id, model, intencja). Enum świadomie tego nie miał (guard przeciw stale fixture) — teraz substrat approval gate (#1946) wchodzi w tym samym milestone, więc case dochodzi legalnie.

## Zakres

- `Provenance::Agent = 'agent'` + zaktualizowany docblock (już nie „reserved for phase 2").
- Test-guard odwrócony: `fourCasesAreDefinedExactly` + `agentCaseIsPresent` (dawny `agentCaseIsExplicitlyAbsent` był świadomym negative-guardem — flip jest zamierzony).
- `docs/api/jsonb-schemas.md` §5: shape `provenance_meta` dla agenta `{agent_run_id, model, intent}` + opis per-property.

## Weryfikacja

- Grep: brak exhaustive match/switch na `Provenance` w `src/` — żaden konsument nie wymagał rozszerzenia; `ImportRollbackService` używa tolerancyjnego `tryFrom`.
- FE `<ProvenanceBadge>` już renderuje wariant `agent` (badge polish → P6-05).
- Unit suite: **1389 testów zielone** w kontenerze; PHPStan max 0; Deptrac 0.

## Smoke

`Provenance::from('agent') === Provenance::Agent` (unit) ✅

Closes #1947

🤖 Generated with [Claude Code](https://claude.com/claude-code)