### PR TITLE
feat(catalog): add EntityChanged lifecycle subscriber (core hook)

### DIFF
--- a/apps/api/src/Catalog/Contracts/Event/EntityChanged.php
+++ b/apps/api/src/Catalog/Contracts/Event/EntityChanged.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Event;
+
+use App\Shared\Application\TenantAwareMessage;
+use App\Shared\Domain\DomainEvent;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AGENT-P0-05 (#1948) — generic lifecycle "something changed" hook.
+ *
+ * Emitted by core (EntityChangedEmitter) on persist/update of catalog
+ * domain entities, independently of whether anyone listens. This is the
+ * substrate the proactive data steward (epic 0.7 M8, P8-01) and future
+ * audit consumers subscribe to — phase 2 attaches listeners without any
+ * core migration. No consumer ships in MVP.
+ *
+ * Coarser than the specific domain events (ObjectAttributesChanged,
+ * ObjectCategoriesChanged): those describe WHAT changed for targeted
+ * consumers; this one only says THAT an entity changed.
+ */
+final readonly class EntityChanged implements DomainEvent, TenantAwareMessage
+{
+    public const string KIND_CREATED = 'created';
+    public const string KIND_UPDATED = 'updated';
+
+    /**
+     * @param string $entityType short stable identifier (e.g. 'catalog_object', 'object_value')
+     * @param string $changeKind self::KIND_CREATED | self::KIND_UPDATED
+     */
+    public function __construct(
+        public string $entityType,
+        public Uuid $entityId,
+        public Uuid $tenantId,
+        public string $changeKind,
+        public DateTimeImmutable $occurredOn = new DateTimeImmutable(),
+    ) {
+    }
+
+    public function occurredOn(): DateTimeImmutable
+    {
+        return $this->occurredOn;
+    }
+
+    public function eventName(): string
+    {
+        return 'catalog.entity.changed';
+    }
+
+    public function aggregateId(): string
+    {
+        return $this->entityId->toRfc4122();
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenantId;
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/Listener/EntityChangedEmitter.php
+++ b/apps/api/src/Catalog/Infrastructure/Listener/EntityChangedEmitter.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\Listener;
+
+use App\Catalog\Contracts\Event\EntityChanged;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Shared\Domain\Tenant;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\PostPersistEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+use Doctrine\ORM\Events;
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * AGENT-P0-05 (#1948) — emits the generic {@see EntityChanged} core hook
+ * on persist/update of catalog domain entities (CatalogObject and
+ * ObjectValue for now — the entities the proactive data steward cares
+ * about; widening is additive).
+ *
+ * Dispatched through the in-process PSR event dispatcher, NOT Messenger:
+ * with zero listeners (the MVP state) a dispatch is a no-op array lookup,
+ * so a 50k-row import pays nothing, and Messenger's no-handler failure
+ * mode is avoided entirely. A phase-2 listener (P8-01) that needs async
+ * fan-out re-dispatches to its own transport.
+ *
+ * Worker-safe by construction: readonly, stateless, no buffering — every
+ * event leaves this class synchronously (FrankenPHP memory rule §3.10).
+ */
+#[AsDoctrineListener(event: Events::postPersist)]
+#[AsDoctrineListener(event: Events::postUpdate)]
+final readonly class EntityChangedEmitter
+{
+    public function __construct(
+        private EventDispatcherInterface $eventDispatcher,
+    ) {
+    }
+
+    public function postPersist(PostPersistEventArgs $args): void
+    {
+        $this->emit($args->getObject(), EntityChanged::KIND_CREATED);
+    }
+
+    public function postUpdate(PostUpdateEventArgs $args): void
+    {
+        $this->emit($args->getObject(), EntityChanged::KIND_UPDATED);
+    }
+
+    private function emit(object $entity, string $changeKind): void
+    {
+        $entityType = match (true) {
+            $entity instanceof CatalogObject => 'catalog_object',
+            $entity instanceof ObjectValue => 'object_value',
+            default => null,
+        };
+        if (null === $entityType) {
+            return;
+        }
+
+        /** @var CatalogObject|ObjectValue $entity */
+        $tenant = $entity->getTenant();
+        if (!$tenant instanceof Tenant) {
+            return;
+        }
+
+        $this->eventDispatcher->dispatch(new EntityChanged(
+            entityType: $entityType,
+            entityId: $entity->getId(),
+            tenantId: $tenant->getId(),
+            changeKind: $changeKind,
+        ));
+    }
+}

--- a/apps/api/tests/Integration/Catalog/EntityChangedEmitterTest.php
+++ b/apps/api/tests/Integration/Catalog/EntityChangedEmitterTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Catalog;
+
+use App\Catalog\Contracts\Event\EntityChanged;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\ObjectKind;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use ArrayObject;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * AGENT-P0-05 (#1948) — the EntityChanged core hook fires on catalog
+ * writes with the right tenant/id/kind, and with no listener registered
+ * it is a no-op (no side effects, nothing accumulates).
+ */
+final class EntityChangedEmitterTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function persistAndUpdateEmitEntityChangedWithTenantAndKind(): void
+    {
+        $tenant = $this->createTenant('alpha');
+        $this->tenantContext()->set($tenant);
+        $em = $this->em();
+
+        $captured = $this->captureEvents();
+
+        $type = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $em->persist($type);
+        $object = new CatalogObject($type, 'HOOK-1');
+        $em->persist($object);
+        $attribute = new Attribute('name', ['en' => 'Name'], AttributeType::Text);
+        $em->persist($attribute);
+        $value = new ObjectValue($object, $attribute, ['value' => 'before']);
+        $em->persist($value);
+        $em->flush();
+
+        $created = array_values(array_filter(
+            iterator_to_array($captured),
+            static fn (EntityChanged $e): bool => EntityChanged::KIND_CREATED === $e->changeKind,
+        ));
+        self::assertCount(2, $created, 'CatalogObject + ObjectValue persists must emit exactly two created events');
+
+        $byType = [];
+        foreach ($created as $event) {
+            $byType[$event->entityType] = $event;
+        }
+        self::assertArrayHasKey('catalog_object', $byType);
+        self::assertArrayHasKey('object_value', $byType);
+        self::assertTrue($object->getId()->equals($byType['catalog_object']->entityId));
+        self::assertTrue($value->getId()->equals($byType['object_value']->entityId));
+        self::assertTrue($tenant->getId()->equals($byType['object_value']->tenantId));
+        self::assertSame('catalog.entity.changed', $byType['object_value']->eventName());
+
+        // Update path: mutate the value -> exactly one `updated` event for it.
+        $captured->exchangeArray([]);
+        $value->updateValue(['value' => 'after']);
+        $em->flush();
+
+        $updated = array_values(array_filter(
+            iterator_to_array($captured),
+            static fn (EntityChanged $e): bool => EntityChanged::KIND_UPDATED === $e->changeKind
+                && 'object_value' === $e->entityType,
+        ));
+        self::assertCount(1, $updated);
+        self::assertTrue($value->getId()->equals($updated[0]->entityId));
+    }
+
+    #[Test]
+    public function noListenerMeansNoSideEffects(): void
+    {
+        // The hook exists independently of consumers (ADR-0024 a): a write
+        // without any EntityChanged listener must succeed exactly as before.
+        $tenant = $this->createTenant('alpha');
+        $this->tenantContext()->set($tenant);
+        $em = $this->em();
+
+        $type = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $em->persist($type);
+        $object = new CatalogObject($type, 'HOOK-2');
+        $em->persist($object);
+        $em->flush();
+
+        self::assertNotNull($object->getId());
+    }
+
+    /**
+     * @return ArrayObject<int, EntityChanged>
+     */
+    private function captureEvents(): ArrayObject
+    {
+        /** @var ArrayObject<int, EntityChanged> $captured */
+        $captured = new ArrayObject();
+        $dispatcher = self::getContainer()->get(EventDispatcherInterface::class);
+        $dispatcher->addListener(EntityChanged::class, static function (EntityChanged $event) use ($captured): void {
+            $captured->append($event);
+        });
+
+        return $captured;
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function createTenant(string $code): Tenant
+    {
+        $tenant = new Tenant($code, ucfirst($code).' Tenant');
+        $em = $this->em();
+        $em->persist($tenant);
+        $em->flush();
+
+        return $tenant;
+    }
+}


### PR DESCRIPTION
## Cel (AGENT-P0-05 #1948, epik 0.7)

Trzeci hook core z ADR-0024 (a): generyczny sygnał lifecycle `EntityChanged`, emitowany przez core niezależnie od tego, czy ktoś słucha. Fundament pod proaktywnego data stewarda (M8/P8-01) i przyszły audyt — Faza 2 dochodzi jako listener, bez migracji core.

## Zakres

- `Catalog\Contracts\Event\EntityChanged` — entity type ('catalog_object' | 'object_value'), entity id, tenant id, kind (created/updated); implementuje `DomainEvent` + `TenantAwareMessage` (forward-compat pod async re-dispatch w P8-01).
- `Catalog\Infrastructure\Listener\EntityChangedEmitter` — Doctrine postPersist/postUpdate, emisja przez **in-process PSR event dispatcher** (nie Messenger).

## Decyzja techniczna (default per ticket body, udokumentowana)

Ticket dopuszczał wybór mechanizmu emisji. Wybrany EventDispatcher zamiast Messengera, bo: (a) zero konsumentów w MVP → dispatch bez listenerów to no-op (import 50k wierszy nie płaci nic), (b) Messenger bez handlera = `NoHandlerForMessageException` albo konfiguracyjny `allow_no_handlers`, (c) listener P8-01, który będzie chciał async fan-out, sam re-dispatchnie do własnego transportu.

## Worker-safety

Emitter `readonly`, bezstanowy — zero akumulacji między requestami (§3.10). Test „no listener = no side effects" w suite.

## Testy / bramki

- Integration 2/2: persist+update → created/updated z poprawnym tenant/id/kind; zapis bez listenera bez efektów ubocznych.
- PHPStan max 0 · Deptrac 0 (event w Contracts) · CS-Fixer czysto.

Closes #1948

🤖 Generated with [Claude Code](https://claude.com/claude-code)