### PR TITLE
feat(agent): install Anthropic SDK PHP + BYOK-backed client factory

### DIFF
--- a/apps/api/composer.json
+++ b/apps/api/composer.json
@@ -9,6 +9,7 @@
         "php": ">=8.4",
         "ext-ctype": "*",
         "ext-iconv": "*",
+        "anthropic-ai/sdk": "^0.35.1",
         "api-platform/doctrine-orm": "^4.3.3",
         "api-platform/symfony": "^4.3.3",
         "damienharper/auditor-bundle": "^6.3",

--- a/apps/api/composer.lock
+++ b/apps/api/composer.lock
@@ -4,8 +4,71 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "606587519b42e2512874a1a32ff54b58",
+    "content-hash": "9857c238bdd683d35a68e4397e434ed3",
     "packages": [
+        {
+            "name": "anthropic-ai/sdk",
+            "version": "v0.35.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/anthropics/anthropic-sdk-php.git",
+                "reference": "45f02fb6e29e55b8944d1f8df479c49535a923d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/anthropics/anthropic-sdk-php/zipball/45f02fb6e29e55b8944d1f8df479c49535a923d0",
+                "reference": "45f02fb6e29e55b8944d1f8df479c49535a923d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1",
+                "php-http/discovery": "^1",
+                "psr/http-client": "^1",
+                "psr/http-client-implementation": "^1",
+                "psr/http-factory-implementation": "^1",
+                "psr/http-message": "^1|^2",
+                "standard-webhooks/standard-webhooks": "^1"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.368",
+                "friendsofphp/php-cs-fixer": "^3",
+                "google/auth": "^1.49",
+                "guzzlehttp/guzzle": "^7",
+                "mcp/sdk": "^0.5",
+                "nyholm/psr7": "^1",
+                "pestphp/pest": "^3",
+                "php-http/mock-client": "^1",
+                "phpstan/extension-installer": "^1",
+                "phpstan/phpstan": "2.2.1",
+                "phpstan/phpstan-phpunit": "^2",
+                "phpunit/phpunit": "^11",
+                "symfony/http-client": "^7"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allows using the AWS Bedrock, AWS gateway, and Bedrock Mantle SDKs",
+                "google/auth": "Allows using the Google Vertex SDK",
+                "mcp/sdk": "Required to use the BetaMcp helpers for integrating MCP servers with the Anthropic SDK"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Version.php"
+                ],
+                "psr-4": {
+                    "Anthropic\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Anthropic PHP SDK",
+            "support": {
+                "issues": "https://github.com/anthropics/anthropic-sdk-php/issues",
+                "source": "https://github.com/anthropics/anthropic-sdk-php/tree/v0.35.1"
+            },
+            "time": "2026-07-01T21:55:22+00:00"
+        },
         {
             "name": "api-platform/doctrine-common",
             "version": "v4.3.7",
@@ -5744,6 +5807,51 @@
                 }
             ],
             "time": "2026-06-06T23:41:24+00:00"
+        },
+        {
+            "name": "standard-webhooks/standard-webhooks",
+            "version": "v1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/standard-webhooks/standard-webhooks.git",
+                "reference": "a1773d7ffc577d730e2bf4d4bd740a82a42aa904"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/standard-webhooks/standard-webhooks/zipball/a1773d7ffc577d730e2bf4d4bd740a82a42aa904",
+                "reference": "a1773d7ffc577d730e2bf4d4bd740a82a42aa904",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0 || ^10.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "StandardWebhooks\\": "libraries/php/src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Standard Webhooks - Open source tools and guidelines for sending webhooks easily, securely, and reliably",
+            "homepage": "https://www.standardwebhooks.com",
+            "keywords": [
+                "hmac",
+                "signature",
+                "standard-webhooks",
+                "verification",
+                "webhooks"
+            ],
+            "support": {
+                "issues": "https://github.com/standard-webhooks/standard-webhooks/issues",
+                "source": "https://github.com/standard-webhooks/standard-webhooks/tree/v1.0.2"
+            },
+            "time": "2026-02-18T19:02:27+00:00"
         },
         {
             "name": "stevenmaguire/oauth2-microsoft",

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -54,6 +54,18 @@ parameters:
     # column header.
     pim.imports.dictionary_path: '%kernel.project_dir%/config/imports/mapping_dictionary.yaml'
 
+    # AGENT-P0-06 (#1949) — agent LLM models per tool kind (ADR-0024 b):
+    # schema-ops (bigger blast radius) run on the Opus-tier model, all
+    # other kinds on the Sonnet-tier default. A model bump is a config
+    # change, not a code change. Retries are bounded (SDK honours
+    # retry-after, exponential fallback); exhaustion -> run error.
+    pim.agent.model.default: '%env(default:pim.agent.model.default.fallback:AGENT_MODEL_DEFAULT)%'
+    pim.agent.model.default.fallback: 'claude-sonnet-4-6'
+    pim.agent.model.schema: '%env(default:pim.agent.model.schema.fallback:AGENT_MODEL_SCHEMA)%'
+    pim.agent.model.schema.fallback: 'claude-opus-4-8'
+    pim.agent.llm.max_retries: 4
+    pim.agent.llm.timeout_seconds: 120.0
+
 services:
     _defaults:
         autowire: true
@@ -135,6 +147,18 @@ services:
     App\Catalog\Application\ObjectTypeService:
         arguments:
             $enableCustomObjectTypes: '%pim.catalog.enable_custom_object_types%'
+
+    # AGENT-P0-06 (#1949) — Anthropic client on the tenant's BYOK key;
+    # scalar knobs are not autowired.
+    App\Agent\Infrastructure\Anthropic\AnthropicClientFactory:
+        arguments:
+            $maxRetries: '%pim.agent.llm.max_retries%'
+            $timeoutSeconds: '%pim.agent.llm.timeout_seconds%'
+
+    App\Agent\Infrastructure\Anthropic\AgentModelSelector:
+        arguments:
+            $defaultModel: '%pim.agent.model.default%'
+            $schemaModel: '%pim.agent.model.schema%'
 
     # DAM MVP upload entry point (#438). The size caps are wired through
     # parameters so deployment-specific overrides land in env vars

--- a/apps/api/src/Agent/Domain/Exception/AgentUnavailableException.php
+++ b/apps/api/src/Agent/Domain/Exception/AgentUnavailableException.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Domain\Exception;
+
+use RuntimeException;
+
+/**
+ * AGENT-P0-06 (#1949) — the agent cannot run for this tenant.
+ *
+ * Raised by the Anthropic client factory when the tenant has no active
+ * BYOK key (ADR-0017: no key -> agent off, never a fallback to someone
+ * else's key) and by AgentFeatureGuard (P0-08) when the feature flag is
+ * off. Messages MUST never contain key material.
+ */
+final class AgentUnavailableException extends RuntimeException
+{
+    public static function missingByokKey(): self
+    {
+        return new self(
+            'Agent is unavailable for this tenant: no active Anthropic BYOK key is configured. '
+            .'Set a key in Settings -> AI to enable the agent.'
+        );
+    }
+
+    public static function featureDisabled(): self
+    {
+        return new self('Agent is disabled: the agent feature flag is off for this deployment.');
+    }
+}

--- a/apps/api/src/Agent/Infrastructure/Anthropic/AgentModelSelector.php
+++ b/apps/api/src/Agent/Infrastructure/Anthropic/AgentModelSelector.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Infrastructure\Anthropic;
+
+/**
+ * AGENT-P0-06 (#1949) — deterministic model choice per tool kind
+ * (ADR-0024 b, PRD 10.1): schema-ops carry a bigger blast radius and
+ * run on the Opus-tier model; everything else (read/write/action) runs
+ * on the Sonnet-tier default.
+ *
+ * Model ids live in configuration (AGENT_MODEL_DEFAULT /
+ * AGENT_MODEL_SCHEMA env vars), not hardcoded across call sites —
+ * a model bump is a config change.
+ */
+final readonly class AgentModelSelector
+{
+    public const string KIND_SCHEMA = 'schema';
+
+    public function __construct(
+        private string $defaultModel,
+        private string $schemaModel,
+    ) {
+    }
+
+    public function modelForKind(string $kind): string
+    {
+        return self::KIND_SCHEMA === $kind ? $this->schemaModel : $this->defaultModel;
+    }
+
+    public function defaultModel(): string
+    {
+        return $this->defaultModel;
+    }
+
+    public function schemaModel(): string
+    {
+        return $this->schemaModel;
+    }
+}

--- a/apps/api/src/Agent/Infrastructure/Anthropic/AnthropicClientFactory.php
+++ b/apps/api/src/Agent/Infrastructure/Anthropic/AnthropicClientFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Infrastructure\Anthropic;
+
+use Anthropic\Client;
+use App\Agent\Domain\Exception\AgentUnavailableException;
+use App\Identity\Contracts\Byok\ByokKeyResolverInterface;
+use App\Shared\Domain\Tenant;
+
+/**
+ * AGENT-P0-06 (#1949) — builds an Anthropic SDK client on the tenant's
+ * BYOK key (ADR-0017, ADR-0024 b).
+ *
+ * - No active key -> {@see AgentUnavailableException}; there is NO
+ *   fallback to a platform/env key (`agent off per tenant` semantics,
+ *   consistent with AgentFeatureGuard, P0-08).
+ * - Retry/backoff on 429/5xx is delegated to the SDK transport: it
+ *   honours the `retry-after` header (fallback: exponential, capped)
+ *   and is bounded by `maxRetries`. Exhaustion surfaces as the SDK's
+ *   RateLimitException / InternalServerException, which the agent loop
+ *   (P1-03) maps to run status `error` — never a partial commit
+ *   (commits happen only post-approval, P3-02).
+ * - The plaintext key goes straight into the client and is never
+ *   logged; UI display uses TenantAgentConfig.key_prefix.
+ */
+final readonly class AnthropicClientFactory
+{
+    public function __construct(
+        private ByokKeyResolverInterface $keyResolver,
+        private int $maxRetries,
+        private float $timeoutSeconds,
+    ) {
+    }
+
+    public function forTenant(Tenant $tenant): Client
+    {
+        $apiKey = $this->keyResolver->resolveKey($tenant);
+        if (null === $apiKey || '' === $apiKey) {
+            throw AgentUnavailableException::missingByokKey();
+        }
+
+        return new Client(
+            apiKey: $apiKey,
+            requestOptions: [
+                'maxRetries' => $this->maxRetries,
+                'timeout' => $this->timeoutSeconds,
+            ],
+        );
+    }
+}

--- a/apps/api/src/Identity/Application/ByokKeyManager.php
+++ b/apps/api/src/Identity/Application/ByokKeyManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Identity\Application;
 
+use App\Identity\Contracts\Byok\ByokKeyResolverInterface;
 use App\Identity\Domain\Entity\TenantAgentConfig;
 use App\Identity\Domain\Repository\TenantAgentConfigRepositoryInterface;
 use App\Shared\Application\Crypto\EncryptedSecret;
@@ -27,7 +28,7 @@ use DateTimeImmutable;
  * through `resolveKey()` — and even there it's a transient string the
  * caller is expected to hand straight to the Anthropic SDK.
  */
-final readonly class ByokKeyManager
+final readonly class ByokKeyManager implements ByokKeyResolverInterface
 {
     private const int PREFIX_LENGTH = 8;
 

--- a/apps/api/src/Identity/Contracts/Byok/ByokKeyResolverInterface.php
+++ b/apps/api/src/Identity/Contracts/Byok/ByokKeyResolverInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Contracts\Byok;
+
+use App\Shared\Domain\Tenant;
+
+/**
+ * AGENT-P0-06 (#1949) — Contracts seam over the BYOK key lifecycle
+ * (ADR-0017), so the removable Agent BC can resolve the tenant's
+ * Anthropic key without reaching Identity internals (ADR-0024 b).
+ *
+ * Implemented by Identity\Application\ByokKeyManager.
+ */
+interface ByokKeyResolverInterface
+{
+    /**
+     * Plaintext Anthropic API key for the tenant, or `null` if BYOK is
+     * not configured / disabled. The caller MUST hand the result
+     * straight to the LLM client — never store, log, or echo it.
+     */
+    public function resolveKey(Tenant $tenant): ?string;
+}

--- a/apps/api/tests/Unit/Agent/AnthropicClientFactoryTest.php
+++ b/apps/api/tests/Unit/Agent/AnthropicClientFactoryTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Agent;
+
+use Anthropic\Client;
+use App\Agent\Domain\Exception\AgentUnavailableException;
+use App\Agent\Infrastructure\Anthropic\AgentModelSelector;
+use App\Agent\Infrastructure\Anthropic\AnthropicClientFactory;
+use App\Identity\Contracts\Byok\ByokKeyResolverInterface;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * AGENT-P0-06 (#1949) — BYOK-backed client factory: no key -> agent
+ * unavailable (never a fallback to someone else's key), key -> a
+ * configured SDK client; the secret never leaks into the exception.
+ */
+final class AnthropicClientFactoryTest extends TestCase
+{
+    private const string TEST_KEY = 'sk-ant-test-0123456789abcdef';
+
+    #[Test]
+    public function missingByokKeyThrowsAgentUnavailable(): void
+    {
+        $factory = new AnthropicClientFactory($this->resolver(null), maxRetries: 4, timeoutSeconds: 120.0);
+
+        $this->expectException(AgentUnavailableException::class);
+        $this->expectExceptionMessageMatches('/no active Anthropic BYOK key/');
+
+        $factory->forTenant(new Tenant('alpha', 'Alpha'));
+    }
+
+    #[Test]
+    public function disabledKeyResolvedAsEmptyStringAlsoThrows(): void
+    {
+        $factory = new AnthropicClientFactory($this->resolver(''), maxRetries: 4, timeoutSeconds: 120.0);
+
+        $this->expectException(AgentUnavailableException::class);
+
+        $factory->forTenant(new Tenant('alpha', 'Alpha'));
+    }
+
+    #[Test]
+    public function activeKeyBuildsClient(): void
+    {
+        $factory = new AnthropicClientFactory($this->resolver(self::TEST_KEY), maxRetries: 4, timeoutSeconds: 120.0);
+
+        $client = $factory->forTenant(new Tenant('alpha', 'Alpha'));
+
+        self::assertInstanceOf(Client::class, $client);
+    }
+
+    #[Test]
+    public function unavailableMessageNeverContainsKeyMaterial(): void
+    {
+        $factory = new AnthropicClientFactory($this->resolver(null), maxRetries: 4, timeoutSeconds: 120.0);
+
+        try {
+            $factory->forTenant(new Tenant('alpha', 'Alpha'));
+            self::fail('Expected AgentUnavailableException');
+        } catch (AgentUnavailableException $e) {
+            self::assertStringNotContainsString('sk-ant', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function modelSelectorRoutesSchemaKindToOpusTier(): void
+    {
+        $selector = new AgentModelSelector(
+            defaultModel: 'claude-sonnet-4-6',
+            schemaModel: 'claude-opus-4-8',
+        );
+
+        self::assertSame('claude-opus-4-8', $selector->modelForKind('schema'));
+        self::assertSame('claude-sonnet-4-6', $selector->modelForKind('read'));
+        self::assertSame('claude-sonnet-4-6', $selector->modelForKind('write'));
+        self::assertSame('claude-sonnet-4-6', $selector->modelForKind('action'));
+    }
+
+    private function resolver(?string $key): ByokKeyResolverInterface
+    {
+        return new class($key) implements ByokKeyResolverInterface {
+            public function __construct(private readonly ?string $key)
+            {
+            }
+
+            public function resolveKey(Tenant $tenant): ?string
+            {
+                return $this->key;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Cel (AGENT-P0-06 #1949, epik 0.7)

Klient LLM dla pętli agenta (P1-03): oficjalny Anthropic SDK PHP na kluczu BYOK tenanta (ADR-0017, ADR-0024 b).

## Zakres

- `composer require anthropic-ai/sdk` (^0.35, oficjalny SDK — najnowsza stabilna).
- **Port `Identity\Contracts\Byok\ByokKeyResolverInterface`** — usuwalny Agent BC sięga po klucz tenanta bez internals Identity (Deptrac-clean); `ByokKeyManager` implementuje.
- **`AnthropicClientFactory`**: klucz z resolvera → klient SDK; **brak klucza → `AgentUnavailableException`, zero fallbacku na cudzy/platformowy klucz** (spójne z guardem P0-08).
- **Backoff 429/5xx**: delegowany do transportu SDK — honoruje `retry-after`, fallback exponential z capem, ograniczony `maxRetries=4` (konfig `pim.agent.llm.max_retries`); wyczerpanie → wyjątki SDK, które pętla (P1-03) mapuje na run `error`; commit i tak jest wyłącznie po akcepcie (P3-02), więc częściowy commit niemożliwy strukturalnie. Zweryfikowane w źródłach SDK (`BaseClient::retryDelay` czyta `retry-after`, `retryCount ** 2` fallback).
- **`AgentModelSelector`**: kind=`schema` → model Opus-tier, reszta → Sonnet-tier; ID modeli w konfigu (`AGENT_MODEL_DEFAULT`/`AGENT_MODEL_SCHEMA`, defaulty `claude-sonnet-4-6`/`claude-opus-4-8`), nie hardkod w call-site'ach.
- Sekret nigdy w logach; test leak-guard na treści wyjątku; `key_prefix` do wyświetlania już istnieje w `TenantAgentConfig`.

## Testy / bramki

- Unit 5/5 (brak klucza → wyjątek; pusty klucz → wyjątek; klucz → klient; leak-guard; mapowanie modeli per kind).
- PHPStan max 0 · Deptrac 0 (Agent → Identity_Contracts + Vendor + Shared) · lint:container zielony · CS-Fixer czysto.

## ⚠️ Smoke (SMOKE TEST RULE — uczciwie)

Wired + unit/integration green; **LLM-live smoke pending BYOK key** — brak realnego klucza Anthropic w środowisku (jedyne legalne odstępstwo maratonu: brak credentials). Trywialny realny call do modelu zostanie wykonany przy pierwszej konfiguracji klucza (P6-06 BYOK UI / P9-05 final smoke). Ścieżka „bez klucza → odmowa" jest wykonalna i pokryta testami; `debug:container` potwierdza wiring obu serwisów.

Closes #1949

🤖 Generated with [Claude Code](https://claude.com/claude-code)