### PR TITLE
feat(agent): tool registry + AgentTool contract with RBAC-scoped exposure

### DIFF
--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -70,6 +70,12 @@ services:
         App\Integration\Generic\Infrastructure\Http\Pagination\PaginationStrategy:
             tags: ['integration.pagination_strategy']
 
+        # AGENT-P0-07 (#1950) — every AgentToolInterface implementation is
+        # auto-registered in the ToolRegistry (ADR-0024 b: adding a tool =
+        # adding a service, zero loop changes).
+        App\Agent\Application\Tool\AgentToolInterface:
+            tags: ['agent.tool']
+
     App\:
         resource: '../src/'
 

--- a/apps/api/src/Agent/Application/Tool/AgentToolContext.php
+++ b/apps/api/src/Agent/Application/Tool/AgentToolContext.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Tool;
+
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AGENT-P0-07 (#1950) — execution context handed to every tool call.
+ *
+ * The agent always acts WITHIN the permissions of the initiating user
+ * (ADR-0024 b): userId identifies whose RBAC scope applies, tenant
+ * scopes every engine call. View context (active filter DSL, selection,
+ * locale/channel) is carried in `viewContext` verbatim from
+ * agent_runs.context (P1-01).
+ *
+ * @phpstan-type ViewContext array<string, mixed>
+ */
+final readonly class AgentToolContext
+{
+    /**
+     * @param array<string, mixed> $viewContext
+     */
+    public function __construct(
+        public Uuid $userId,
+        public Tenant $tenant,
+        public array $viewContext = [],
+    ) {
+    }
+}

--- a/apps/api/src/Agent/Application/Tool/AgentToolInterface.php
+++ b/apps/api/src/Agent/Application/Tool/AgentToolInterface.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Tool;
+
+/**
+ * AGENT-P0-07 (#1950) — the tool contract of the thin agent layer
+ * (ADR-0024 b): every tool is a thin adapter over a `*\Contracts` port
+ * of its host engine, declared to the model via the registry.
+ *
+ * Adding a tool = implement this interface (auto-tagged `agent.tool`)
+ * + the host-BC Contracts port. Zero changes in the agent loop.
+ */
+interface AgentToolInterface
+{
+    /**
+     * Stable tool name exposed to the model (snake_case).
+     */
+    public function name(): string;
+
+    /**
+     * Model-facing description — be prescriptive about WHEN to call it.
+     */
+    public function description(): string;
+
+    /**
+     * JSON Schema of the arguments (Anthropic tool-use `input_schema`
+     * shape: type/properties/required).
+     *
+     * @return array<string, mixed>
+     */
+    public function parametersSchema(): array;
+
+    /**
+     * Coarse RBAC permission code (`resource.action`, PRD-PIM-rbac §3.2)
+     * required to SEE and EXECUTE this tool. Fine-grained per-attribute/
+     * locale/channel checks are layered per call in P1-02.
+     */
+    public function requiredPermission(): string;
+
+    public function kind(): ToolKind;
+
+    /**
+     * Execute with validated-by-the-registry access. Returns the
+     * tool_result payload for the model (JSON-serializable; MUST NOT
+     * contain secrets).
+     *
+     * @param array<string, mixed> $arguments parsed tool-use input from the model
+     *
+     * @return array<string, mixed>
+     */
+    public function execute(array $arguments, AgentToolContext $context): array;
+}

--- a/apps/api/src/Agent/Application/Tool/PingTool.php
+++ b/apps/api/src/Agent/Application/Tool/PingTool.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Tool;
+
+/**
+ * AGENT-P0-07 (#1950) — trivial validation tool proving the registry
+ * contract end-to-end (declaration -> RBAC filter -> execute). Gated on
+ * catalog read so any user who can see the catalog can ping; it leaks
+ * nothing beyond the tenant code the user is already operating in.
+ */
+final readonly class PingTool implements AgentToolInterface
+{
+    public function name(): string
+    {
+        return 'ping';
+    }
+
+    public function description(): string
+    {
+        return 'Health-check tool. Call it only when asked to verify the agent tooling works; it returns a pong with the current tenant code.';
+    }
+
+    public function parametersSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'echo' => [
+                    'type' => 'string',
+                    'description' => 'Optional text echoed back verbatim.',
+                ],
+            ],
+            'required' => [],
+        ];
+    }
+
+    public function requiredPermission(): string
+    {
+        return 'object.read';
+    }
+
+    public function kind(): ToolKind
+    {
+        return ToolKind::Read;
+    }
+
+    public function execute(array $arguments, AgentToolContext $context): array
+    {
+        $echo = $arguments['echo'] ?? null;
+
+        return [
+            'pong' => true,
+            'tenant' => $context->tenant->getCode(),
+            'echo' => \is_string($echo) ? $echo : null,
+        ];
+    }
+}

--- a/apps/api/src/Agent/Application/Tool/ToolKind.php
+++ b/apps/api/src/Agent/Application/Tool/ToolKind.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Tool;
+
+/**
+ * AGENT-P0-07 (#1950) — coarse tool classification (ADR-0024 b).
+ *
+ * Drives (a) the model choice per run (`schema` -> Opus-tier, the rest
+ * -> Sonnet-tier default; AgentModelSelector) and (b) the write/approval
+ * semantics: `write`/`schema` tools materialize into pending_changes
+ * and commit only after human approval; `read` tools ground the plan;
+ * `action` tools trigger engines (e.g. export) without a catalog write.
+ */
+enum ToolKind: string
+{
+    case Read = 'read';
+    case Write = 'write';
+    case Schema = 'schema';
+    case Action = 'action';
+}

--- a/apps/api/src/Agent/Application/Tool/ToolRegistry.php
+++ b/apps/api/src/Agent/Application/Tool/ToolRegistry.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Tool;
+
+use App\Agent\Domain\Exception\ToolAccessDeniedException;
+use App\Identity\Contracts\Policy\PermissionCheckerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AGENT-P0-07 (#1950) — declarative tool registry (ADR-0024 b).
+ *
+ * The model gets ONLY the tools the initiating user is RBAC-allowed to
+ * use ({@see availableFor}); and even a direct/forged tool_use call is
+ * re-checked at {@see execute} (fail closed, SEC). Adding a tool is a
+ * service implementing AgentToolInterface — the loop never changes.
+ */
+final readonly class ToolRegistry
+{
+    /** @var list<AgentToolInterface> */
+    private array $tools;
+
+    /**
+     * @param iterable<AgentToolInterface> $tools
+     */
+    public function __construct(
+        #[AutowireIterator('agent.tool')]
+        iterable $tools,
+        private PermissionCheckerInterface $permissions,
+    ) {
+        $indexed = [];
+        foreach ($tools as $tool) {
+            $indexed[$tool->name()] = $tool;
+        }
+        $this->tools = array_values($indexed);
+    }
+
+    /**
+     * @return list<AgentToolInterface>
+     */
+    public function availableFor(Uuid $userId): array
+    {
+        return array_values(array_filter(
+            $this->tools,
+            fn (AgentToolInterface $tool): bool => $this->permissions->userHasPermission($userId, $tool->requiredPermission()),
+        ));
+    }
+
+    /**
+     * Anthropic tool-use definitions for the user-visible subset
+     * (PHP SDK camelCase key `inputSchema`).
+     *
+     * @return list<array{name: string, description: string, inputSchema: array<string, mixed>}>
+     */
+    public function toAnthropicToolDefs(Uuid $userId): array
+    {
+        return array_map(
+            static fn (AgentToolInterface $tool): array => [
+                'name' => $tool->name(),
+                'description' => $tool->description(),
+                'inputSchema' => $tool->parametersSchema(),
+            ],
+            $this->availableFor($userId),
+        );
+    }
+
+    /**
+     * Whether any of the user-visible tools is a schema-op — the loop
+     * uses this to pick the Opus-tier model (P0-06 AgentModelSelector).
+     */
+    public function hasKind(Uuid $userId, ToolKind $kind): bool
+    {
+        foreach ($this->availableFor($userId) as $tool) {
+            if ($kind === $tool->kind()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Guarded execution entry: unknown tool and missing permission are
+     * indistinguishable to the caller (no tool enumeration beyond the
+     * user's scope).
+     *
+     * @param array<string, mixed> $arguments
+     *
+     * @return array<string, mixed>
+     *
+     * @throws ToolAccessDeniedException
+     */
+    public function execute(string $toolName, array $arguments, AgentToolContext $context): array
+    {
+        $tool = $this->find($toolName);
+        if (null === $tool) {
+            throw ToolAccessDeniedException::unknownTool($toolName);
+        }
+
+        if (!$this->permissions->userHasPermission($context->userId, $tool->requiredPermission())) {
+            throw ToolAccessDeniedException::forTool($toolName);
+        }
+
+        return $tool->execute($arguments, $context);
+    }
+
+    public function find(string $toolName): ?AgentToolInterface
+    {
+        foreach ($this->tools as $tool) {
+            if ($tool->name() === $toolName) {
+                return $tool;
+            }
+        }
+
+        return null;
+    }
+}

--- a/apps/api/src/Agent/Domain/Exception/ToolAccessDeniedException.php
+++ b/apps/api/src/Agent/Domain/Exception/ToolAccessDeniedException.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Domain\Exception;
+
+use RuntimeException;
+
+/**
+ * AGENT-P0-07 (#1950) — a tool call outside the user's RBAC scope.
+ *
+ * Raised by the registry on execute() when the user lacks the tool's
+ * required permission — the hard boundary that makes prompt-injection
+ * harmless beyond the user's own scope (ADR-0024 b). The loop (P1-03)
+ * converts it into a "forbidden" tool_result so the model learns it
+ * cannot do that, and the attempt is audited (P1-02/P3-07).
+ */
+final class ToolAccessDeniedException extends RuntimeException
+{
+    public static function forTool(string $toolName): self
+    {
+        return new self(\sprintf('Tool "%s" is not available: missing required permission.', $toolName));
+    }
+
+    public static function unknownTool(string $toolName): self
+    {
+        // Same message shape as the permission denial on purpose: do not
+        // let a prompt enumerate which tools exist beyond the user scope.
+        return new self(\sprintf('Tool "%s" is not available: missing required permission.', $toolName));
+    }
+}

--- a/apps/api/src/Identity/Application/Policy/ContractsPermissionChecker.php
+++ b/apps/api/src/Identity/Application/Policy/ContractsPermissionChecker.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application\Policy;
+
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Contracts\Policy\PermissionCheckerInterface;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AGENT-P0-07 (#1950) — Identity-side adapter of the Contracts
+ * permission-check seam: loads the user and asks the RBAC
+ * PermissionResolver whether the resolved set carries the code.
+ *
+ * Unknown user id -> false (fail closed).
+ */
+final readonly class ContractsPermissionChecker implements PermissionCheckerInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private PermissionResolverInterface $permissions,
+    ) {
+    }
+
+    public function userHasPermission(Uuid $userId, string $permissionCode): bool
+    {
+        $user = $this->users->findById($userId);
+        if (null === $user) {
+            return false;
+        }
+
+        return $this->permissions->resolve($user)->has($permissionCode);
+    }
+}

--- a/apps/api/src/Identity/Contracts/Policy/PermissionCheckerInterface.php
+++ b/apps/api/src/Identity/Contracts/Policy/PermissionCheckerInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Contracts\Policy;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AGENT-P0-07 (#1950) — coarse RBAC check by user id, exposed as a
+ * Contracts seam so the removable Agent BC can filter its tool registry
+ * per user (ADR-0024 b) without reaching Identity internals.
+ *
+ * Permission codes follow the RBAC matrix `resource.action` format
+ * (PRD-PIM-rbac §3.2), e.g. `object.read`, `attribute.write`.
+ *
+ * This is the COARSE gate (tool visible / executable at all); the
+ * fine-grained per-attribute/locale/channel enforcement on every
+ * tool-call is layered on top in AGENT-P1-02.
+ */
+interface PermissionCheckerInterface
+{
+    public function userHasPermission(Uuid $userId, string $permissionCode): bool;
+}

--- a/apps/api/tests/Unit/Agent/ToolRegistryTest.php
+++ b/apps/api/tests/Unit/Agent/ToolRegistryTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Agent;
+
+use App\Agent\Application\Tool\AgentToolContext;
+use App\Agent\Application\Tool\AgentToolInterface;
+use App\Agent\Application\Tool\PingTool;
+use App\Agent\Application\Tool\ToolKind;
+use App\Agent\Application\Tool\ToolRegistry;
+use App\Agent\Domain\Exception\ToolAccessDeniedException;
+use App\Identity\Contracts\Policy\PermissionCheckerInterface;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AGENT-P0-07 (#1950, SEC failing-test-first) — the registry is a hard
+ * RBAC boundary: a tool whose permission the user lacks is (a) absent
+ * from the model-facing defs and (b) refused even on a direct execute()
+ * call. Prompt-injection cannot reach a tool outside the user's scope.
+ */
+final class ToolRegistryTest extends TestCase
+{
+    #[Test]
+    public function toolWithoutPermissionIsAbsentFromDefsAndBlockedOnDirectExecute(): void
+    {
+        $userId = Uuid::v7();
+        $registry = new ToolRegistry(
+            [new PingTool(), $this->schemaTool()],
+            // User may read the catalog but has NO modeling permission.
+            $this->checker(['object.read']),
+        );
+
+        $defs = $registry->toAnthropicToolDefs($userId);
+        self::assertSame(['ping'], array_column($defs, 'name'), 'schema tool must not be exposed to the model');
+
+        // Direct execute of the hidden tool (forged tool_use) is refused.
+        $this->expectException(ToolAccessDeniedException::class);
+        $registry->execute('create_attribute_stub', [], $this->context($userId));
+    }
+
+    #[Test]
+    public function unknownToolIsIndistinguishableFromForbiddenTool(): void
+    {
+        $userId = Uuid::v7();
+        $registry = new ToolRegistry([new PingTool()], $this->checker(['object.read']));
+
+        $forbidden = null;
+        $unknown = null;
+        try {
+            new ToolRegistry([new PingTool()], $this->checker([]))->execute('ping', [], $this->context($userId));
+        } catch (ToolAccessDeniedException $e) {
+            $forbidden = $e->getMessage();
+        }
+        try {
+            $registry->execute('no_such_tool', [], $this->context($userId));
+        } catch (ToolAccessDeniedException $e) {
+            $unknown = $e->getMessage();
+        }
+
+        self::assertNotNull($forbidden);
+        self::assertNotNull($unknown);
+        self::assertSame(
+            str_replace('ping', 'X', $forbidden),
+            str_replace('no_such_tool', 'X', $unknown),
+            'unknown vs forbidden must not be distinguishable (no tool enumeration)',
+        );
+    }
+
+    #[Test]
+    public function allowedToolIsListedAndExecutes(): void
+    {
+        $userId = Uuid::v7();
+        $registry = new ToolRegistry([new PingTool()], $this->checker(['object.read']));
+
+        $tools = $registry->availableFor($userId);
+        self::assertCount(1, $tools);
+        self::assertSame('ping', $tools[0]->name());
+        self::assertSame(ToolKind::Read, $tools[0]->kind());
+
+        $defs = $registry->toAnthropicToolDefs($userId);
+        self::assertSame('ping', $defs[0]['name']);
+        self::assertNotSame('', $defs[0]['description']);
+        self::assertSame('object', $defs[0]['inputSchema']['type']);
+
+        $result = $registry->execute('ping', ['echo' => 'hello'], $this->context($userId));
+        self::assertTrue($result['pong']);
+        self::assertSame('alpha', $result['tenant']);
+        self::assertSame('hello', $result['echo']);
+    }
+
+    #[Test]
+    public function kindLookupDrivesModelSelection(): void
+    {
+        $userId = Uuid::v7();
+
+        $withSchema = new ToolRegistry(
+            [new PingTool(), $this->schemaTool()],
+            $this->checker(['object.read', 'attribute.write']),
+        );
+        self::assertTrue($withSchema->hasKind($userId, ToolKind::Schema));
+
+        $schemaHidden = new ToolRegistry(
+            [new PingTool(), $this->schemaTool()],
+            $this->checker(['object.read']),
+        );
+        self::assertFalse($schemaHidden->hasKind($userId, ToolKind::Schema), 'RBAC-hidden schema tool must not flip the run onto the Opus tier');
+    }
+
+    /**
+     * @param list<string> $granted
+     */
+    private function checker(array $granted): PermissionCheckerInterface
+    {
+        return new class($granted) implements PermissionCheckerInterface {
+            /** @param list<string> $granted */
+            public function __construct(private readonly array $granted)
+            {
+            }
+
+            public function userHasPermission(Uuid $userId, string $permissionCode): bool
+            {
+                return \in_array($permissionCode, $this->granted, true);
+            }
+        };
+    }
+
+    private function schemaTool(): AgentToolInterface
+    {
+        return new class implements AgentToolInterface {
+            public function name(): string
+            {
+                return 'create_attribute_stub';
+            }
+
+            public function description(): string
+            {
+                return 'Test-only schema-op stub.';
+            }
+
+            public function parametersSchema(): array
+            {
+                return ['type' => 'object', 'properties' => [], 'required' => []];
+            }
+
+            public function requiredPermission(): string
+            {
+                return 'attribute.write';
+            }
+
+            public function kind(): ToolKind
+            {
+                return ToolKind::Schema;
+            }
+
+            public function execute(array $arguments, AgentToolContext $context): array
+            {
+                return ['ok' => true];
+            }
+        };
+    }
+
+    private function context(Uuid $userId): AgentToolContext
+    {
+        return new AgentToolContext($userId, new Tenant('alpha', 'Alpha Tenant'));
+    }
+}


### PR DESCRIPTION
## Cel (AGENT-P0-07 #1950, epik 0.7, [SEC])

Rdzeń „cienkiej warstwy" (ADR-0024 b): deklaratywny rejestr narzędzi, w którym model dostaje **wyłącznie** narzędzia RBAC-dozwolone dla zalogowanego usera — mechanizm rozszerzalności i twarda granica anty-prompt-injection w jednym.

## Zakres

- **`AgentToolInterface`**: `name()` / `description()` / `parametersSchema()` (JSON Schema) / `requiredPermission()` (kod `resource.action` z macierzy RBAC) / `kind()` (`read|write|schema|action`) / `execute(args, context)`. Rejestracja deklaratywna przez `_instanceof` → tag `agent.tool` → `#[AutowireIterator]` — dodanie narzędzia = nowy serwis, zero zmian w pętli.
- **`ToolRegistry`**: `availableFor(userId)` filtruje po RBAC; `toAnthropicToolDefs()` emituje format tool-use PHP SDK (camelCase `inputSchema`); `hasKind()` steruje wyborem modelu per kind (schema→Opus, spina się z `AgentModelSelector` z P0-06); **`execute()` re-checkuje permission nawet przy bezpośrednim (sforgowanym) wywołaniu** — fail-closed.
- **Nowy seam `Identity\Contracts\Policy\PermissionCheckerInterface`** + adapter `ContractsPermissionChecker` (UserRepository + PermissionResolver; nieznany user → false). Agent nie dotyka internals Identity.
- **Anty-enumeracja**: unknown tool i forbidden tool są nieodróżnialne w komunikacie błędu (prompt nie wyliczy narzędzi poza scope).
- **`PingTool`** (kind=read, `object.read`) — trywialne narzędzie walidacyjne z AC.

## Testy (SEC failing-test-first)

- Narzędzie bez uprawnienia: nieobecne w defs **i** zablokowane na bezpośrednim `execute` ✅
- Unknown ≡ forbidden (ten sam kształt komunikatu) ✅
- Narzędzie dozwolone: listowane + wykonuje się (pong z tenant code) ✅
- Schema-tool ukryty RBAC-iem **nie** przełącza runu na Opus-tier ✅

4/4 unit; PHPStan max 0; Deptrac 0; lint:container zielony; CS-Fixer czysto.

## Smoke

Testy SEC = smoke z AC (user bez permission X nie widzi X w defs; bezpośrednie execute → odmowa). Realny grounding-run przez pętlę → P1-03.

Closes #1950

🤖 Generated with [Claude Code](https://claude.com/claude-code)