### PR TITLE
feat(agent): AgentFeatureGuard + per-tenant feature flag

### DIFF
--- a/apps/api/.env
+++ b/apps/api/.env
@@ -93,6 +93,11 @@ APP_DEFAULT_TENANT_CODE=demo
 # /api/object_types POST + the modeling UI Create button (Faza 1
 # ADR-013 will tie this to per-role permissions).
 CATALOG_ENABLE_CUSTOM_OBJECT_TYPES=true
+# AGENT-P0-08 (#1951) — global agent kill-switch (open-core: a deploy
+# without the agent sets 0 and every /api/agent/* endpoint refuses with
+# a 403 problem document). Per-tenant availability additionally
+# requires an active BYOK key (no key -> agent off for that tenant).
+AGENT_ENABLED=1
 ###< app/feature-flags ###
 
 ###> app/byok ###

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -66,6 +66,10 @@ parameters:
     pim.agent.llm.max_retries: 4
     pim.agent.llm.timeout_seconds: 120.0
 
+    # AGENT-P0-08 (#1951) — global agent feature flag; per-tenant
+    # availability additionally requires an active BYOK key.
+    pim.agent.enabled: '%env(bool:AGENT_ENABLED)%'
+
 services:
     _defaults:
         autowire: true
@@ -159,6 +163,11 @@ services:
         arguments:
             $defaultModel: '%pim.agent.model.default%'
             $schemaModel: '%pim.agent.model.schema%'
+
+    # AGENT-P0-08 (#1951) — global flag + per-tenant BYOK availability.
+    App\Agent\Application\AgentFeatureGuard:
+        arguments:
+            $agentEnabled: '%pim.agent.enabled%'
 
     # DAM MVP upload entry point (#438). The size caps are wired through
     # parameters so deployment-specific overrides land in env vars

--- a/apps/api/src/Agent/Application/AgentFeatureGuard.php
+++ b/apps/api/src/Agent/Application/AgentFeatureGuard.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application;
+
+use App\Agent\Domain\Exception\AgentUnavailableException;
+use App\Identity\Contracts\Byok\ByokKeyResolverInterface;
+use App\Shared\Domain\Tenant;
+
+/**
+ * AGENT-P0-08 (#1951) — two-layer agent availability gate:
+ *
+ *   1. global feature flag (`AGENT_ENABLED` env, open-core: a deploy
+ *      without the agent flips it off and the API surface refuses);
+ *   2. per-tenant BYOK key (ADR-0017): no active key -> agent off for
+ *      that tenant — a deliberate consequence, not an error state.
+ *
+ * Wired into every /api/agent/* endpoint (P4-01) and the loop start
+ * (P1-03). Refusal renders as a 403 RFC 7807 problem document via the
+ * shared listener (AgentUnavailableException implements
+ * HttpExceptionInterface) — never a 500.
+ */
+final readonly class AgentFeatureGuard
+{
+    public function __construct(
+        private ByokKeyResolverInterface $keyResolver,
+        private bool $agentEnabled,
+    ) {
+    }
+
+    /**
+     * @throws AgentUnavailableException
+     */
+    public function assertEnabled(Tenant $tenant): void
+    {
+        if (!$this->agentEnabled) {
+            throw AgentUnavailableException::featureDisabled();
+        }
+
+        if (!$this->keyResolver->hasActiveKey($tenant)) {
+            throw AgentUnavailableException::missingByokKey();
+        }
+    }
+
+    public function isEnabled(Tenant $tenant): bool
+    {
+        return $this->agentEnabled && $this->keyResolver->hasActiveKey($tenant);
+    }
+}

--- a/apps/api/src/Agent/Domain/Exception/AgentUnavailableException.php
+++ b/apps/api/src/Agent/Domain/Exception/AgentUnavailableException.php
@@ -5,16 +5,21 @@ declare(strict_types=1);
 namespace App\Agent\Domain\Exception;
 
 use RuntimeException;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 /**
- * AGENT-P0-06 (#1949) — the agent cannot run for this tenant.
+ * AGENT-P0-06 (#1949) / AGENT-P0-08 (#1951) — the agent cannot run for
+ * this tenant.
  *
  * Raised by the Anthropic client factory when the tenant has no active
  * BYOK key (ADR-0017: no key -> agent off, never a fallback to someone
- * else's key) and by AgentFeatureGuard (P0-08) when the feature flag is
- * off. Messages MUST never contain key material.
+ * else's key) and by AgentFeatureGuard when the feature flag is off.
+ * Implements HttpExceptionInterface so the shared RFC 7807 listener
+ * renders it as a 403 problem document on the /api/agent/* endpoints
+ * (P4-01) without per-controller mapping. Messages MUST never contain
+ * key material.
  */
-final class AgentUnavailableException extends RuntimeException
+final class AgentUnavailableException extends RuntimeException implements HttpExceptionInterface
 {
     public static function missingByokKey(): self
     {
@@ -27,5 +32,18 @@ final class AgentUnavailableException extends RuntimeException
     public static function featureDisabled(): self
     {
         return new self('Agent is disabled: the agent feature flag is off for this deployment.');
+    }
+
+    public function getStatusCode(): int
+    {
+        return 403;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getHeaders(): array
+    {
+        return [];
     }
 }

--- a/apps/api/src/Identity/Application/ByokKeyManager.php
+++ b/apps/api/src/Identity/Application/ByokKeyManager.php
@@ -100,4 +100,11 @@ final readonly class ByokKeyManager implements ByokKeyResolverInterface
 
         return $plaintext;
     }
+
+    public function hasActiveKey(Tenant $tenant): bool
+    {
+        $config = $this->configs->findForTenant($tenant);
+
+        return null !== $config && $config->isEnabled();
+    }
 }

--- a/apps/api/src/Identity/Contracts/Byok/ByokKeyResolverInterface.php
+++ b/apps/api/src/Identity/Contracts/Byok/ByokKeyResolverInterface.php
@@ -21,4 +21,11 @@ interface ByokKeyResolverInterface
      * straight to the LLM client — never store, log, or echo it.
      */
     public function resolveKey(Tenant $tenant): ?string;
+
+    /**
+     * Cheap availability probe for guards (AGENT-P0-08): true when the
+     * tenant has an enabled BYOK key. Unlike {@see resolveKey()} it
+     * neither decrypts the key nor bumps `last_used_at`.
+     */
+    public function hasActiveKey(Tenant $tenant): bool;
 }

--- a/apps/api/tests/Unit/Agent/AgentFeatureGuardTest.php
+++ b/apps/api/tests/Unit/Agent/AgentFeatureGuardTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Agent;
+
+use App\Agent\Application\AgentFeatureGuard;
+use App\Agent\Domain\Exception\AgentUnavailableException;
+use App\Identity\Contracts\Byok\ByokKeyResolverInterface;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * AGENT-P0-08 (#1951) — the guard refuses when the global flag is off
+ * OR the tenant has no active BYOK key; refusal is a 403 problem (not a
+ * 500). Tenant without a key -> agent off is a deliberate state.
+ */
+final class AgentFeatureGuardTest extends TestCase
+{
+    #[Test]
+    public function globalFlagOffRefusesEvenWithActiveKey(): void
+    {
+        $guard = new AgentFeatureGuard($this->keys(true), agentEnabled: false);
+
+        self::assertFalse($guard->isEnabled($this->tenant()));
+
+        $this->expectException(AgentUnavailableException::class);
+        $this->expectExceptionMessageMatches('/feature flag is off/');
+        $guard->assertEnabled($this->tenant());
+    }
+
+    #[Test]
+    public function tenantWithoutActiveKeyRefusesWith403(): void
+    {
+        $guard = new AgentFeatureGuard($this->keys(false), agentEnabled: true);
+
+        self::assertFalse($guard->isEnabled($this->tenant()));
+
+        try {
+            $guard->assertEnabled($this->tenant());
+            self::fail('Expected AgentUnavailableException');
+        } catch (AgentUnavailableException $e) {
+            // HttpExceptionInterface -> shared RFC 7807 listener renders 403.
+            self::assertSame(403, $e->getStatusCode());
+            self::assertStringContainsString('BYOK', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function flagOnAndActiveKeyPasses(): void
+    {
+        $guard = new AgentFeatureGuard($this->keys(true), agentEnabled: true);
+
+        self::assertTrue($guard->isEnabled($this->tenant()));
+        $guard->assertEnabled($this->tenant());
+        $this->addToAssertionCount(1);
+    }
+
+    private function keys(bool $active): ByokKeyResolverInterface
+    {
+        return new class($active) implements ByokKeyResolverInterface {
+            public function __construct(private readonly bool $active)
+            {
+            }
+
+            public function resolveKey(Tenant $tenant): ?string
+            {
+                return $this->active ? 'sk-ant-test' : null;
+            }
+
+            public function hasActiveKey(Tenant $tenant): bool
+            {
+                return $this->active;
+            }
+        };
+    }
+
+    private function tenant(): Tenant
+    {
+        return new Tenant('alpha', 'Alpha Tenant');
+    }
+}

--- a/apps/api/tests/Unit/Agent/AnthropicClientFactoryTest.php
+++ b/apps/api/tests/Unit/Agent/AnthropicClientFactoryTest.php
@@ -91,6 +91,11 @@ final class AnthropicClientFactoryTest extends TestCase
             {
                 return $this->key;
             }
+
+            public function hasActiveKey(Tenant $tenant): bool
+            {
+                return null !== $this->key && '' !== $this->key;
+            }
         };
     }
 }


### PR DESCRIPTION
## Cel (AGENT-P0-08 #1951, epik 0.7)

Dwuwarstwowa bramka dostępności agenta (open-core + prywatność, PRD §10.2): globalny flag `AGENT_ENABLED` + wymóg aktywnego klucza BYOK per tenant („brak klucza = agent off" to świadomy stan, nie błąd).

## Zakres

- **`AgentFeatureGuard`** (`assertEnabled(Tenant)` / `isEnabled(Tenant)`): flag off → `featureDisabled`; brak aktywnego klucza → `missingByokKey`.
- **`AgentUnavailableException` implementuje `HttpExceptionInterface` (403)** → wspólny listener RFC 7807 renderuje odmowę jako problem document na `/api/agent/*` (P4-01) bez per-controller mappingu; nigdy 500.
- **`ByokKeyResolverInterface::hasActiveKey()`** — tania sonda (bez decrypt, bez bump `last_used_at`), impl w `ByokKeyManager`; anonimowy fake w teście factory uzupełniony (lekcja XMLF).
- Parametr `pim.agent.enabled` = `%env(bool:AGENT_ENABLED)%`; `AGENT_ENABLED=1` w dev `.env` (prod overlay może wyłączyć; removability job P0-09 buduje z `0`).

## Testy / bramki

- Unit 3/3 guard (flag off odmawia mimo klucza; tenant bez klucza → 403 z hintem BYOK; flag+klucz przechodzi) + 8/8 cały `tests/Unit/Agent`.
- PHPStan max 0 · Deptrac 0 · lint:container zielony · CS-Fixer czysto.

## Smoke

- `debug:container --parameter=pim.agent.enabled` → wired ✅
- psql: `tenant_agent_configs` = 0 wierszy w dev → guard dziś odmawia każdemu tenantowi (poprawny stan domyślny) ✅
- Curl-smoke 403 RFC7807 na realnym endpoincie = P4-01 (endpointy `/api/agent/*` jeszcze nie istnieją — guard będzie w nie wpięty tam).

Closes #1951

🤖 Generated with [Claude Code](https://claude.com/claude-code)