### PR TITLE
feat(agent): agent_runs / agent_messages / agent_tool_calls entities

### DIFF
--- a/apps/api/config/packages/agent.yaml
+++ b/apps/api/config/packages/agent.yaml
@@ -1,0 +1,24 @@
+# AGENT-P1-01 (#1953) — Doctrine surface of the removable Agent BC
+# (ADR-0024 a). Lives in its own package file so the whole module is
+# deletable: the removability CI job removes src/Agent,
+# config/services_agent.yaml AND this file; without it the core ORM has
+# no agent mappings and no agent migrations namespace. Agent tables
+# left behind in an existing database are inert (nothing references
+# them).
+
+doctrine:
+    orm:
+        mappings:
+            Agent:
+                type: xml
+                is_bundle: false
+                dir: '%kernel.project_dir%/src/Agent/Infrastructure/Doctrine/Orm/Mapping'
+                prefix: 'App\Agent\Domain\Entity'
+                alias: Agent
+
+doctrine_migrations:
+    migrations_paths:
+        # Module-namespace migrations (ADR-0024 a): agent entity DDL
+        # ships inside src/Agent so it disappears with the module. Core
+        # hooks (pending_changes etc.) stay in /migrations.
+        'AgentMigrations': '%kernel.project_dir%/src/Agent/Infrastructure/Migrations'

--- a/apps/api/config/packages/doctrine_migrations.yaml
+++ b/apps/api/config/packages/doctrine_migrations.yaml
@@ -13,3 +13,10 @@ doctrine_migrations:
     # (doctrine_migration_versions) therefore also lives on the owner
     # connection. See config/packages/doctrine.yaml dbal.connections.
     connection: owner
+
+    # AGENT-P1-01 (#1953) — with a second migrations namespace
+    # (AgentMigrations, ADR-0024) the default FQCN sort would run agent
+    # migrations before core ones on a fresh DB (alphabetical namespace
+    # order); compare by the Version timestamp instead.
+    services:
+        'Doctrine\Migrations\Version\Comparator': 'App\Shared\Infrastructure\DoctrineMigrations\TimestampVersionComparator'

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -84,6 +84,11 @@ services:
 
     App\:
         resource: '../src/'
+        exclude:
+            # AGENT-P1-01 (#1953) — module-namespace migrations
+            # (AgentMigrations\*, ADR-0024 a) are not App\* classes;
+            # excluding them keeps the PSR-4 discovery honest.
+            - '../src/Agent/Infrastructure/Migrations/'
 
     # W2-7 / AUD-042 — single RFC 7807 contract for custom controllers.
     # `$debug` is bound to the kernel flag so the listener can keep the

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -122,6 +122,9 @@ parameters:
               - src/Catalog/Domain/Entity/BulkEditJob.php
               - src/Catalog/Domain/Entity/SavedView.php
               - src/Catalog/Domain/Entity/BulkSession.php
+              - src/Agent/Domain/Entity/AgentRun.php
+              - src/Agent/Domain/Entity/AgentMessage.php
+              - src/Agent/Domain/Entity/AgentToolCall.php
               - src/Channel/Domain/Entity/Channel.php
               - src/Channel/Domain/Entity/ChannelCategoryNode.php
               - src/Channel/Domain/Entity/ObjectChannelPlacement.php

--- a/apps/api/src/Agent/Domain/AgentRunStatus.php
+++ b/apps/api/src/Agent/Domain/AgentRunStatus.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Domain;
+
+/**
+ * AGENT-P1-01 (#1953) — lifecycle of an agent run (PRD 5.8, ADR-0024 c).
+ *
+ * Autonomy ends BEFORE approval: planning -> (awaiting_input) ->
+ * awaiting_approval is the autonomous stretch; committing/done happen
+ * only after a human accepts the pending_changes batch (P3-02).
+ */
+enum AgentRunStatus: string
+{
+    case Planning = 'planning';
+    case AwaitingInput = 'awaiting_input';
+    case AwaitingApproval = 'awaiting_approval';
+    case Committing = 'committing';
+    case Done = 'done';
+    case Rejected = 'rejected';
+    case Cancelled = 'cancelled';
+    case Error = 'error';
+    case RolledBack = 'rolled_back';
+
+    public function isTerminal(): bool
+    {
+        return match ($this) {
+            self::Done, self::Rejected, self::Cancelled, self::Error, self::RolledBack => true,
+            default => false,
+        };
+    }
+}

--- a/apps/api/src/Agent/Domain/AgentRunSurface.php
+++ b/apps/api/src/Agent/Domain/AgentRunSurface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Domain;
+
+/**
+ * AGENT-P1-01 (#1953) — where the run was initiated (PRD 5.1): the
+ * docked chat panel or the Cmd+K palette. Both are equal-rights entry
+ * points into the same loop/approval flow.
+ */
+enum AgentRunSurface: string
+{
+    case Chat = 'chat';
+    case CmdK = 'cmdk';
+}

--- a/apps/api/src/Agent/Domain/Entity/AgentMessage.php
+++ b/apps/api/src/Agent/Domain/Entity/AgentMessage.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Domain\Entity;
+
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AGENT-P1-01 (#1953) — one conversation turn of a run, stored in the
+ * Anthropic content shape (PRD 5.8). Cascade-deleted with the run.
+ * Retention is per-user; hard delete rides the offboarding purge.
+ */
+class AgentMessage implements TenantScoped
+{
+    public const string ROLE_USER = 'user';
+    public const string ROLE_ASSISTANT = 'assistant';
+    public const string ROLE_TOOL = 'tool';
+
+    private Uuid $id;
+    private ?Tenant $tenant = null;
+    private AgentRun $run;
+    private string $role;
+
+    /** @var array<int|string, mixed> */
+    private array $content;
+
+    private DateTimeImmutable $createdAt;
+
+    /**
+     * @param array<int|string, mixed> $content Anthropic message content shape
+     */
+    public function __construct(AgentRun $run, string $role, array $content)
+    {
+        if (!\in_array($role, [self::ROLE_USER, self::ROLE_ASSISTANT, self::ROLE_TOOL], true)) {
+            throw new LogicException(\sprintf('Unknown agent message role "%s".', $role));
+        }
+
+        $this->id = Uuid::v7();
+        $this->run = $run;
+        $this->role = $role;
+        $this->content = $content;
+        $this->createdAt = new DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant already assigned.');
+        }
+        $this->tenant = $tenant;
+    }
+
+    public function getRun(): AgentRun
+    {
+        return $this->run;
+    }
+
+    public function getRole(): string
+    {
+        return $this->role;
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    public function getContent(): array
+    {
+        return $this->content;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/apps/api/src/Agent/Domain/Entity/AgentRun.php
+++ b/apps/api/src/Agent/Domain/Entity/AgentRun.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Domain\Entity;
+
+use App\Agent\Domain\AgentRunStatus;
+use App\Agent\Domain\AgentRunSurface;
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AGENT-P1-01 (#1953) — one agent run: intent + view context in,
+ * plan/proposal out, human decision, optional rollback (PRD 5.8).
+ *
+ * The run always acts within the initiating user's permissions
+ * (user_id). `context` carries the view context (objectType, filter
+ * DSL, selection, locale/channel) verbatim. Cost/token counters are
+ * accumulated per Anthropic call; `pending_change_batch_id` links the
+ * materialized proposal (P0-03), `bulk_operation_id` the post-approval
+ * BulkSession used for rollback (P3-04).
+ */
+class AgentRun implements TenantScoped
+{
+    private Uuid $id;
+    private ?Tenant $tenant = null;
+    private Uuid $userId;
+    private AgentRunSurface $surface;
+    private string $intent;
+
+    /** @var array<string, mixed> */
+    private array $context;
+
+    private AgentRunStatus $status = AgentRunStatus::Planning;
+    private ?string $model = null;
+    private ?Uuid $pendingChangeBatchId = null;
+    private ?Uuid $bulkOperationId = null;
+    private ?int $affectedCount = null;
+    private int $tokensInput = 0;
+    private int $tokensOutput = 0;
+    private string $costUsd = '0';
+    private ?string $errorMessage = null;
+    private DateTimeImmutable $startedAt;
+    private ?DateTimeImmutable $approvedAt = null;
+    private ?Uuid $approvedBy = null;
+    private ?DateTimeImmutable $completedAt = null;
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function __construct(
+        Uuid $userId,
+        AgentRunSurface $surface,
+        string $intent,
+        array $context = [],
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->userId = $userId;
+        $this->surface = $surface;
+        $this->intent = $intent;
+        $this->context = $context;
+        $this->startedAt = new DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant already assigned.');
+        }
+        $this->tenant = $tenant;
+    }
+
+    public function getUserId(): Uuid
+    {
+        return $this->userId;
+    }
+
+    public function getSurface(): AgentRunSurface
+    {
+        return $this->surface;
+    }
+
+    public function getIntent(): string
+    {
+        return $this->intent;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getContext(): array
+    {
+        return $this->context;
+    }
+
+    public function getStatus(): AgentRunStatus
+    {
+        return $this->status;
+    }
+
+    public function getModel(): ?string
+    {
+        return $this->model;
+    }
+
+    public function setModel(string $model): void
+    {
+        $this->model = $model;
+    }
+
+    public function getPendingChangeBatchId(): ?Uuid
+    {
+        return $this->pendingChangeBatchId;
+    }
+
+    public function getBulkOperationId(): ?Uuid
+    {
+        return $this->bulkOperationId;
+    }
+
+    public function getAffectedCount(): ?int
+    {
+        return $this->affectedCount;
+    }
+
+    public function getTokensInput(): int
+    {
+        return $this->tokensInput;
+    }
+
+    public function getTokensOutput(): int
+    {
+        return $this->tokensOutput;
+    }
+
+    public function getCostUsd(): string
+    {
+        return $this->costUsd;
+    }
+
+    public function getErrorMessage(): ?string
+    {
+        return $this->errorMessage;
+    }
+
+    public function getStartedAt(): DateTimeImmutable
+    {
+        return $this->startedAt;
+    }
+
+    public function getApprovedAt(): ?DateTimeImmutable
+    {
+        return $this->approvedAt;
+    }
+
+    public function getApprovedBy(): ?Uuid
+    {
+        return $this->approvedBy;
+    }
+
+    public function getCompletedAt(): ?DateTimeImmutable
+    {
+        return $this->completedAt;
+    }
+
+    /**
+     * Accumulate Anthropic usage after each model call (P1-03).
+     * Cost is summed in integer micro-dollars (no bcmath on the image;
+     * float rounding at 6 decimals would drift over many calls).
+     */
+    public function addUsage(int $tokensInput, int $tokensOutput, string $costUsd): void
+    {
+        $this->tokensInput += $tokensInput;
+        $this->tokensOutput += $tokensOutput;
+
+        $microSum = (int) round((float) $this->costUsd * 1_000_000) + (int) round((float) $costUsd * 1_000_000);
+        $this->costUsd = number_format($microSum / 1_000_000, 6, '.', '');
+    }
+
+    public function markAwaitingInput(): void
+    {
+        $this->assertNotTerminal();
+        $this->status = AgentRunStatus::AwaitingInput;
+    }
+
+    public function resumePlanning(): void
+    {
+        $this->assertNotTerminal();
+        $this->status = AgentRunStatus::Planning;
+    }
+
+    public function markAwaitingApproval(Uuid $pendingChangeBatchId, int $affectedCount): void
+    {
+        $this->assertNotTerminal();
+        $this->status = AgentRunStatus::AwaitingApproval;
+        $this->pendingChangeBatchId = $pendingChangeBatchId;
+        $this->affectedCount = $affectedCount;
+    }
+
+    public function markCommitting(Uuid $approvedBy): void
+    {
+        if (AgentRunStatus::AwaitingApproval !== $this->status) {
+            throw new LogicException(\sprintf('Cannot commit a run in status "%s".', $this->status->value));
+        }
+        $this->status = AgentRunStatus::Committing;
+        $this->approvedAt = new DateTimeImmutable();
+        $this->approvedBy = $approvedBy;
+    }
+
+    public function markDone(Uuid $bulkOperationId): void
+    {
+        $this->status = AgentRunStatus::Done;
+        $this->bulkOperationId = $bulkOperationId;
+        $this->completedAt = new DateTimeImmutable();
+    }
+
+    public function markRejected(): void
+    {
+        $this->status = AgentRunStatus::Rejected;
+        $this->completedAt = new DateTimeImmutable();
+    }
+
+    public function markCancelled(): void
+    {
+        $this->status = AgentRunStatus::Cancelled;
+        $this->completedAt = new DateTimeImmutable();
+    }
+
+    public function markError(string $message): void
+    {
+        $this->status = AgentRunStatus::Error;
+        $this->errorMessage = $message;
+        $this->completedAt = new DateTimeImmutable();
+    }
+
+    public function markRolledBack(): void
+    {
+        if (AgentRunStatus::Done !== $this->status) {
+            throw new LogicException(\sprintf('Only a done run can be rolled back; got "%s".', $this->status->value));
+        }
+        $this->status = AgentRunStatus::RolledBack;
+    }
+
+    private function assertNotTerminal(): void
+    {
+        if ($this->status->isTerminal()) {
+            throw new LogicException(\sprintf('Run is terminal ("%s").', $this->status->value));
+        }
+    }
+}

--- a/apps/api/src/Agent/Domain/Entity/AgentToolCall.php
+++ b/apps/api/src/Agent/Domain/Entity/AgentToolCall.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Domain\Entity;
+
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AGENT-P1-01 (#1953) — technical step-by-step record of one tool call
+ * (PRD 5.8): what the model called, with which arguments (secrets never
+ * land here), whether the RBAC check ran, and a compact result summary.
+ * DH Auditor (P3-07) is the accountability layer on top of this detail.
+ */
+class AgentToolCall implements TenantScoped
+{
+    private Uuid $id;
+    private ?Tenant $tenant = null;
+    private AgentRun $run;
+    private string $toolName;
+    private string $kind;
+
+    /** @var array<string, mixed> */
+    private array $arguments;
+
+    /** @var array<string, mixed>|null */
+    private ?array $resultSummary = null;
+
+    private bool $rbacChecked = false;
+    private ?int $durationMs = null;
+    private DateTimeImmutable $createdAt;
+
+    /**
+     * @param array<string, mixed> $arguments
+     */
+    public function __construct(AgentRun $run, string $toolName, string $kind, array $arguments)
+    {
+        $this->id = Uuid::v7();
+        $this->run = $run;
+        $this->toolName = $toolName;
+        $this->kind = $kind;
+        $this->arguments = $arguments;
+        $this->createdAt = new DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant already assigned.');
+        }
+        $this->tenant = $tenant;
+    }
+
+    public function getRun(): AgentRun
+    {
+        return $this->run;
+    }
+
+    public function getToolName(): string
+    {
+        return $this->toolName;
+    }
+
+    public function getKind(): string
+    {
+        return $this->kind;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getArguments(): array
+    {
+        return $this->arguments;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getResultSummary(): ?array
+    {
+        return $this->resultSummary;
+    }
+
+    public function isRbacChecked(): bool
+    {
+        return $this->rbacChecked;
+    }
+
+    public function getDurationMs(): ?int
+    {
+        return $this->durationMs;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @param array<string, mixed> $resultSummary
+     */
+    public function complete(array $resultSummary, bool $rbacChecked, int $durationMs): void
+    {
+        $this->resultSummary = $resultSummary;
+        $this->rbacChecked = $rbacChecked;
+        $this->durationMs = $durationMs;
+    }
+}

--- a/apps/api/src/Agent/Domain/Repository/AgentRunRepositoryInterface.php
+++ b/apps/api/src/Agent/Domain/Repository/AgentRunRepositoryInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Domain\Repository;
+
+use App\Agent\Domain\Entity\AgentRun;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AGENT-P1-01 (#1953) — persistence port of the run lifecycle. Reads
+ * are tenant-scoped by the Doctrine TenantFilter (+ RLS underneath).
+ */
+interface AgentRunRepositoryInterface
+{
+    public function save(AgentRun $run): void;
+
+    public function find(Uuid $id): ?AgentRun;
+}

--- a/apps/api/src/Agent/Infrastructure/Doctrine/Orm/Mapping/AgentMessage.orm.xml
+++ b/apps/api/src/Agent/Infrastructure/Doctrine/Orm/Mapping/AgentMessage.orm.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Agent\Domain\Entity\AgentMessage" table="agent_messages">
+        <indexes>
+            <index name="idx_agent_messages_run" columns="agent_run_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <many-to-one field="run" target-entity="App\Agent\Domain\Entity\AgentRun">
+            <join-column name="agent_run_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="role" type="string" length="16"/>
+
+        <field name="content" type="json">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Agent/Infrastructure/Doctrine/Orm/Mapping/AgentRun.orm.xml
+++ b/apps/api/src/Agent/Infrastructure/Doctrine/Orm/Mapping/AgentRun.orm.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Agent\Domain\Entity\AgentRun" table="agent_runs">
+        <indexes>
+            <index name="idx_agent_runs_tenant" columns="tenant_id,started_at"/>
+            <index name="idx_agent_runs_user" columns="tenant_id,user_id"/>
+            <index name="idx_agent_runs_status" columns="tenant_id,status"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <field name="userId" type="uuid" column="user_id"/>
+        <field name="surface" type="string" length="16" enum-type="App\Agent\Domain\AgentRunSurface"/>
+        <field name="intent" type="text"/>
+
+        <field name="context" type="json">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+
+        <field name="status" type="string" length="32" enum-type="App\Agent\Domain\AgentRunStatus">
+            <options>
+                <option name="default">planning</option>
+            </options>
+        </field>
+
+        <field name="model" type="string" length="64" nullable="true"/>
+        <field name="pendingChangeBatchId" type="uuid" column="pending_change_batch_id" nullable="true"/>
+        <field name="bulkOperationId" type="uuid" column="bulk_operation_id" nullable="true"/>
+        <field name="affectedCount" type="integer" column="affected_count" nullable="true"/>
+        <field name="tokensInput" type="integer" column="tokens_input">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+        <field name="tokensOutput" type="integer" column="tokens_output">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+        <field name="costUsd" type="decimal" precision="12" scale="6" column="cost_usd">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+        <field name="errorMessage" type="text" column="error_message" nullable="true"/>
+
+        <field name="startedAt" type="datetime_immutable" column="started_at"/>
+        <field name="approvedAt" type="datetime_immutable" column="approved_at" nullable="true"/>
+        <field name="approvedBy" type="uuid" column="approved_by" nullable="true"/>
+        <field name="completedAt" type="datetime_immutable" column="completed_at" nullable="true"/>
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Agent/Infrastructure/Doctrine/Orm/Mapping/AgentToolCall.orm.xml
+++ b/apps/api/src/Agent/Infrastructure/Doctrine/Orm/Mapping/AgentToolCall.orm.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Agent\Domain\Entity\AgentToolCall" table="agent_tool_calls">
+        <indexes>
+            <index name="idx_agent_tool_calls_run" columns="agent_run_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <many-to-one field="run" target-entity="App\Agent\Domain\Entity\AgentRun">
+            <join-column name="agent_run_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="toolName" type="string" length="128" column="tool_name"/>
+        <field name="kind" type="string" length="16"/>
+
+        <field name="arguments" type="json">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+        <field name="resultSummary" type="json" column="result_summary" nullable="true">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+
+        <field name="rbacChecked" type="boolean" column="rbac_checked">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
+        <field name="durationMs" type="integer" column="duration_ms" nullable="true"/>
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Agent/Infrastructure/Doctrine/Repository/DoctrineAgentRunRepository.php
+++ b/apps/api/src/Agent/Infrastructure/Doctrine/Repository/DoctrineAgentRunRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Infrastructure\Doctrine\Repository;
+
+use App\Agent\Domain\Entity\AgentRun;
+use App\Agent\Domain\Repository\AgentRunRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+
+final readonly class DoctrineAgentRunRepository implements AgentRunRepositoryInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function save(AgentRun $run): void
+    {
+        $this->entityManager->persist($run);
+        $this->entityManager->flush();
+    }
+
+    public function find(Uuid $id): ?AgentRun
+    {
+        // find()-by-PK skips the TenantFilter via the identity map (APIC
+        // P5-01 lesson) — query through DQL so the filter always applies.
+        /** @var AgentRun|null $run */
+        $run = $this->entityManager->createQueryBuilder()
+            ->select('r')
+            ->from(AgentRun::class, 'r')
+            ->where('r.id = :id')
+            ->setParameter('id', $id, 'uuid')
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $run;
+    }
+}

--- a/apps/api/src/Agent/Infrastructure/Migrations/Version20260702150000.php
+++ b/apps/api/src/Agent/Infrastructure/Migrations/Version20260702150000.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AgentMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * AGENT-P1-01 (#1953) — orchestration skeleton of the agent lifecycle
+ * (PRD 5.8): agent_runs / agent_messages / agent_tool_calls.
+ *
+ * Module-namespace migration (ADR-0024 a): ships inside src/Agent and
+ * disappears with it. All three tables are TenantScoped with Postgres
+ * RLS (FORCE, NULLIF predicate + WITH CHECK, super-admin bypass) —
+ * same pattern as pending_changes (P0-03).
+ */
+final class Version20260702150000 extends AbstractMigration
+{
+    private const array TABLES = ['agent_runs', 'agent_messages', 'agent_tool_calls'];
+
+    public function getDescription(): string
+    {
+        return 'AGENT-P1-01: agent_runs / agent_messages / agent_tool_calls + tenant RLS policies';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE agent_runs (
+                id UUID NOT NULL,
+                tenant_id UUID NOT NULL,
+                user_id UUID NOT NULL,
+                surface VARCHAR(16) NOT NULL,
+                intent TEXT NOT NULL,
+                context JSONB NOT NULL,
+                status VARCHAR(32) DEFAULT 'planning' NOT NULL,
+                model VARCHAR(64) DEFAULT NULL,
+                pending_change_batch_id UUID DEFAULT NULL,
+                bulk_operation_id UUID DEFAULT NULL,
+                affected_count INT DEFAULT NULL,
+                tokens_input INT DEFAULT 0 NOT NULL,
+                tokens_output INT DEFAULT 0 NOT NULL,
+                cost_usd NUMERIC(12, 6) DEFAULT 0 NOT NULL,
+                error_message TEXT DEFAULT NULL,
+                started_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                approved_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+                approved_by UUID DEFAULT NULL,
+                completed_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+                PRIMARY KEY(id)
+            )
+            SQL);
+        $this->addSql('CREATE INDEX idx_agent_runs_tenant ON agent_runs (tenant_id, started_at)');
+        $this->addSql('CREATE INDEX idx_agent_runs_user ON agent_runs (tenant_id, user_id)');
+        $this->addSql('CREATE INDEX idx_agent_runs_status ON agent_runs (tenant_id, status)');
+        $this->addSql(
+            'ALTER TABLE agent_runs ADD CONSTRAINT fk_agent_runs_tenant '
+            .'FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE RESTRICT NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE agent_messages (
+                id UUID NOT NULL,
+                tenant_id UUID NOT NULL,
+                agent_run_id UUID NOT NULL,
+                role VARCHAR(16) NOT NULL,
+                content JSONB NOT NULL,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY(id)
+            )
+            SQL);
+        $this->addSql('CREATE INDEX idx_agent_messages_run ON agent_messages (agent_run_id)');
+        $this->addSql(
+            'ALTER TABLE agent_messages ADD CONSTRAINT fk_agent_messages_tenant '
+            .'FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE RESTRICT NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+        $this->addSql(
+            'ALTER TABLE agent_messages ADD CONSTRAINT fk_agent_messages_run '
+            .'FOREIGN KEY (agent_run_id) REFERENCES agent_runs (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE agent_tool_calls (
+                id UUID NOT NULL,
+                tenant_id UUID NOT NULL,
+                agent_run_id UUID NOT NULL,
+                tool_name VARCHAR(128) NOT NULL,
+                kind VARCHAR(16) NOT NULL,
+                arguments JSONB NOT NULL,
+                result_summary JSONB DEFAULT NULL,
+                rbac_checked BOOLEAN DEFAULT false NOT NULL,
+                duration_ms INT DEFAULT NULL,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY(id)
+            )
+            SQL);
+        $this->addSql('CREATE INDEX idx_agent_tool_calls_run ON agent_tool_calls (agent_run_id)');
+        $this->addSql(
+            'ALTER TABLE agent_tool_calls ADD CONSTRAINT fk_agent_tool_calls_tenant '
+            .'FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE RESTRICT NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+        $this->addSql(
+            'ALTER TABLE agent_tool_calls ADD CONSTRAINT fk_agent_tool_calls_run '
+            .'FOREIGN KEY (agent_run_id) REFERENCES agent_runs (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+
+        $predicate = "tenant_id = NULLIF(current_setting('app.current_tenant', true), '')::uuid";
+        foreach (self::TABLES as $table) {
+            $this->addSql(\sprintf('ALTER TABLE %s ENABLE ROW LEVEL SECURITY', $table));
+            $this->addSql(\sprintf('ALTER TABLE %s FORCE ROW LEVEL SECURITY', $table));
+            $this->addSql(\sprintf(
+                'CREATE POLICY tenant_isolation_%s ON %s USING (%s) WITH CHECK (%s)',
+                $table,
+                $table,
+                $predicate,
+                $predicate,
+            ));
+            $this->addSql(\sprintf(
+                'CREATE POLICY super_admin_bypass_%s ON %s '
+                ."USING (current_setting('app.is_super_admin', true) = 'true') "
+                ."WITH CHECK (current_setting('app.is_super_admin', true) = 'true')",
+                $table,
+                $table,
+            ));
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (array_reverse(self::TABLES) as $table) {
+            $this->addSql(\sprintf('DROP POLICY IF EXISTS super_admin_bypass_%s ON %s', $table, $table));
+            $this->addSql(\sprintf('DROP POLICY IF EXISTS tenant_isolation_%s ON %s', $table, $table));
+            $this->addSql(\sprintf('ALTER TABLE %s NO FORCE ROW LEVEL SECURITY', $table));
+            $this->addSql(\sprintf('ALTER TABLE %s DISABLE ROW LEVEL SECURITY', $table));
+            $this->addSql(\sprintf('DROP TABLE %s', $table));
+        }
+    }
+}

--- a/apps/api/src/Shared/Infrastructure/DoctrineMigrations/TimestampVersionComparator.php
+++ b/apps/api/src/Shared/Infrastructure/DoctrineMigrations/TimestampVersionComparator.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\DoctrineMigrations;
+
+use Doctrine\Migrations\Version\Comparator;
+use Doctrine\Migrations\Version\Version;
+
+/**
+ * AGENT-P1-01 (#1953) — order migrations by their VersionYYYYMMDDHHMMSS
+ * timestamp across ALL namespaces.
+ *
+ * The default comparator sorts by FQCN, so a second migrations
+ * namespace (AgentMigrations, ADR-0024 module-namespace migrations)
+ * would run alphabetically BEFORE DoctrineMigrations — on a fresh
+ * database the agent tables tried to reference `tenants` before the
+ * core migration created it (Playwright CI). Timestamp order restores
+ * the intended global chronology regardless of namespace.
+ */
+final class TimestampVersionComparator implements Comparator
+{
+    public function compare(Version $a, Version $b): int
+    {
+        return strcmp($this->sortKey((string) $a), $this->sortKey((string) $b));
+    }
+
+    private function sortKey(string $version): string
+    {
+        $lastSeparator = strrpos($version, '\\');
+        $shortName = false === $lastSeparator ? $version : substr($version, $lastSeparator + 1);
+
+        // "Version20260702150000" -> "20260702150000"; fall back to the
+        // full short name for anything not matching the convention.
+        return str_starts_with($shortName, 'Version') ? substr($shortName, 7) : $shortName;
+    }
+}

--- a/apps/api/tests/Integration/Agent/AgentEntitiesTest.php
+++ b/apps/api/tests/Integration/Agent/AgentEntitiesTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Agent;
+
+use App\Agent\Domain\AgentRunStatus;
+use App\Agent\Domain\AgentRunSurface;
+use App\Agent\Domain\Entity\AgentMessage;
+use App\Agent\Domain\Entity\AgentRun;
+use App\Agent\Domain\Entity\AgentToolCall;
+use App\Agent\Domain\Repository\AgentRunRepositoryInterface;
+use App\Agent\Infrastructure\Doctrine\Repository\DoctrineAgentRunRepository;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\ORM\EntityManagerInterface;
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * AGENT-P1-01 (#1953) — orchestration entities against real Postgres:
+ * lifecycle round-trip with usage accumulation, tenant isolation
+ * (cross-read = 0, DoD), and run-cascade delete of messages/tool calls.
+ */
+final class AgentEntitiesTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function runLifecycleRoundTripsWithUsageAndProposalLink(): void
+    {
+        $tenant = $this->createTenant('alpha');
+        $this->activateTenantFilter($tenant);
+        $em = $this->em();
+
+        $run = new AgentRun(
+            userId: Uuid::v7(),
+            surface: AgentRunSurface::Chat,
+            intent: 'ustaw cenę 100 wszystkim bez ceny',
+            context: ['object_type' => 'product', 'filter_dsl' => ['field' => 'price', 'op' => 'is_empty']],
+        );
+        $run->setModel('claude-sonnet-test');
+        $run->addUsage(1200, 340, '0.011400');
+        $run->addUsage(800, 120, '0.006200');
+
+        $batchId = Uuid::v7();
+        $run->markAwaitingApproval($batchId, 1800);
+
+        $repo = $this->repo();
+        $repo->save($run);
+
+        $em->persist(new AgentMessage($run, AgentMessage::ROLE_USER, [['type' => 'text', 'text' => 'hej']]));
+        $toolCall = new AgentToolCall($run, 'search', 'read', ['filter' => 'price is empty']);
+        $toolCall->complete(['matched' => 1800], rbacChecked: true, durationMs: 42);
+        $em->persist($toolCall);
+        $em->flush();
+        $em->clear();
+
+        $reloaded = $repo->find($run->getId());
+        self::assertNotNull($reloaded);
+        self::assertSame(AgentRunStatus::AwaitingApproval, $reloaded->getStatus());
+        self::assertSame(2000, $reloaded->getTokensInput());
+        self::assertSame(460, $reloaded->getTokensOutput());
+        self::assertSame('0.017600', $reloaded->getCostUsd());
+        self::assertSame(1800, $reloaded->getAffectedCount());
+        self::assertTrue($batchId->equals($reloaded->getPendingChangeBatchId() ?? Uuid::v4()));
+        self::assertSame('claude-sonnet-test', $reloaded->getModel());
+    }
+
+    #[Test]
+    public function runsAreIsolatedByTenantFilter(): void
+    {
+        $alpha = $this->createTenant('alpha');
+        $beta = $this->createTenant('beta');
+        $repo = $this->repo();
+
+        $this->activateTenantFilter($alpha);
+        $alphaRun = new AgentRun(Uuid::v7(), AgentRunSurface::CmdK, 'alpha intent');
+        $repo->save($alphaRun);
+
+        $this->em()->clear();
+        $this->activateTenantFilter($beta);
+        self::assertNull($repo->find($alphaRun->getId()), 'TenantFilter must hide alpha runs from beta context');
+
+        $this->em()->clear();
+        $this->activateTenantFilter($alpha);
+        self::assertNotNull($repo->find($alphaRun->getId()));
+    }
+
+    #[Test]
+    public function deletingARunCascadesMessagesAndToolCalls(): void
+    {
+        $tenant = $this->createTenant('alpha');
+        $this->activateTenantFilter($tenant);
+        $em = $this->em();
+
+        $run = new AgentRun(Uuid::v7(), AgentRunSurface::Chat, 'cascade check');
+        $em->persist($run);
+        $em->persist(new AgentMessage($run, AgentMessage::ROLE_ASSISTANT, [['type' => 'text', 'text' => 'plan']]));
+        $em->persist(new AgentToolCall($run, 'ping', 'read', []));
+        $em->flush();
+
+        $runId = $run->getId()->toRfc4122();
+        $conn = $em->getConnection();
+        self::assertSame(1, $this->countRows($conn, 'agent_messages', $runId));
+
+        $conn->executeStatement('DELETE FROM agent_runs WHERE id = ?', [$runId]);
+        self::assertSame(0, $this->countRows($conn, 'agent_messages', $runId), 'messages must cascade with the run');
+        self::assertSame(0, $this->countRows($conn, 'agent_tool_calls', $runId), 'tool calls must cascade with the run');
+    }
+
+    #[Test]
+    public function statusGuardsProtectTheApprovalBoundary(): void
+    {
+        $run = new AgentRun(Uuid::v7(), AgentRunSurface::Chat, 'guards');
+
+        $this->expectException(LogicException::class);
+        // Committing without an accepted proposal is a forbidden shortcut.
+        $run->markCommitting(Uuid::v7());
+    }
+
+    private function countRows(\Doctrine\DBAL\Connection $conn, string $table, string $runId): int
+    {
+        $count = $conn->fetchOne(\sprintf('SELECT COUNT(*) FROM %s WHERE agent_run_id = ?', $table), [$runId]);
+
+        return (int) (\is_scalar($count) ? $count : -1);
+    }
+
+    private function repo(): AgentRunRepositoryInterface
+    {
+        // Constructed directly: the repository has no runtime consumer
+        // until P1-03, so the compiled container would inline/remove it.
+        return new DoctrineAgentRunRepository($this->em());
+    }
+
+    private function activateTenantFilter(Tenant $tenant): void
+    {
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function createTenant(string $code): Tenant
+    {
+        $tenant = new Tenant($code, ucfirst($code).' Tenant');
+        $em = $this->em();
+        $em->persist($tenant);
+        $em->flush();
+
+        return $tenant;
+    }
+}


### PR DESCRIPTION
## Cel (AGENT-P1-01 #1953, epik 0.7)

Szkielet cyklu życia runu agenta (PRD §5.8): trzy encje orkiestracji, na których stoi pętla (P1-03), API (P4-01) i audyt.

## Zakres

- **`AgentRun`** (UUIDv7, TenantScoped): surface `chat|cmdk`, intent, kontekst widoku JSONB, status enum (9 stanów) z **guardowanymi przejściami** (commit tylko z `awaiting_approval`; rollback tylko z `done` — granica approvalu z ADR-0024 c), model, `pending_change_batch_id`, `bulk_operation_id`, `affected_count`, liczniki tokenów + koszt (sumowanie w mikro-dolarach int — brak bcmath na obrazie), `approved_at/by`.
- **`AgentMessage`** (kształt Anthropic content) i **`AgentToolCall`** (argumenty bez sekretów, result summary, `rbac_checked`, duration) — cascade-delete z runem.
- **Migracja w namespace modułu** (ADR-0024 a): `AgentMigrations\*` w `src/Agent/Infrastructure/Migrations`, rejestrowana przez usuwalny `config/packages/agent.yaml` (mapping ORM + migrations path) — cała powierzchnia Doctrine znika razem z modułem. Główny discovery `App\` excluduje katalog migracji (nie-App namespace).
- **RLS na 3 tabelach** (FORCE, NULLIF+WITH CHECK, super-admin bypass) + indeksy z PRD.
- `DoctrineAgentRunRepository` czyta przez DQL (lekcja APIC P5-01: `find()`-by-PK omija TenantFilter).

## Testy / bramki

- Integration 4/4: round-trip lifecycle z akumulacją usage/kosztu i linkiem do batcha; **cross-tenant read = 0**; cascade messages/tool_calls; guard granicy approvalu.
- PHPStan max 0 · Deptrac 0 + `debug:unassigned` czysto · lint:container zielony · CS-Fixer czysto.

## Smoke (psql, live)

`\dt agent_*` → 3 tabele; `pg_policy` → 6 polityk (tenant_isolation + super_admin_bypass × 3); cascade delete zweryfikowany w teście na realnym Postgresie.

## Uwaga koordynacyjna

`services.yaml` exclude `src/Agent/Infrastructure/Migrations/` nachodzi na refactor P0-09 (exclude całego `src/Agent/` + `services_agent.yaml`) — spójne kierunkowo; rozstrzygnę przy rebase tego, który merguje później.

Closes #1953

🤖 Generated with [Claude Code](https://claude.com/claude-code)