### PR TITLE
feat(catalog): add pending_changes approval-gate hook with Contracts port

### DIFF
--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -654,3 +654,11 @@ when@test:
         App\Backup\Application\Service\BackupRunnerInterface:
             alias: App\Tests\Support\InMemoryBackupRunner
             public: true
+
+        # AGENT-P0-03 (#1946) — the pending-changes port has no runtime
+        # consumer until the agent tools land (epic 0.7 M3), so the compiled
+        # container would remove/inline it; integration tests fetch it
+        # directly from the container.
+        App\Catalog\Contracts\PendingChanges\PendingChangesPort:
+            alias: App\Catalog\Application\PendingChanges\PendingChangesService
+            public: true

--- a/apps/api/migrations/Version20260702090000.php
+++ b/apps/api/migrations/Version20260702090000.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * AGENT-P0-03 (#1946) — `pending_changes`: core approval-gate hook
+ * (ADR-0024 c). Producers (the agent BC first) materialize proposed
+ * changes here; nothing reaches the catalog before a human accept.
+ *
+ * Tenant-scoped with Postgres RLS (defence in depth on top of the
+ * Doctrine TenantFilter) using the `app.current_tenant` GUC, plus the
+ * Super Admin bypass flag — same pattern as import_staged_files.
+ */
+final class Version20260702090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'AGENT-P0-03: pending_changes table + tenant RLS policies';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE pending_changes (
+                id UUID NOT NULL,
+                tenant_id UUID NOT NULL,
+                batch_id UUID NOT NULL,
+                provenance VARCHAR(32) NOT NULL,
+                change_type VARCHAR(16) NOT NULL,
+                status VARCHAR(16) DEFAULT 'pending' NOT NULL,
+                target_object_id UUID DEFAULT NULL,
+                attribute_code VARCHAR(255) DEFAULT NULL,
+                scope_locale VARCHAR(16) DEFAULT NULL,
+                scope_channel VARCHAR(64) DEFAULT NULL,
+                before_state JSONB DEFAULT NULL,
+                after_state JSONB DEFAULT NULL,
+                meta JSONB DEFAULT NULL,
+                cost_usd NUMERIC(12, 6) DEFAULT NULL,
+                tokens INT DEFAULT NULL,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                decided_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+                PRIMARY KEY(id)
+            )
+            SQL);
+        $this->addSql('CREATE INDEX pending_changes_tenant_status_idx ON pending_changes (tenant_id, status)');
+        $this->addSql('CREATE INDEX pending_changes_batch_idx ON pending_changes (batch_id)');
+        $this->addSql(
+            'ALTER TABLE pending_changes ADD CONSTRAINT fk_pending_changes_tenant '
+            .'FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE RESTRICT NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+
+        $predicate = "tenant_id = NULLIF(current_setting('app.current_tenant', true), '')::uuid";
+        $this->addSql('ALTER TABLE pending_changes ENABLE ROW LEVEL SECURITY');
+        $this->addSql('ALTER TABLE pending_changes FORCE ROW LEVEL SECURITY');
+        $this->addSql(\sprintf(
+            'CREATE POLICY tenant_isolation_pending_changes ON pending_changes USING (%s) WITH CHECK (%s)',
+            $predicate,
+            $predicate,
+        ));
+        $this->addSql(
+            'CREATE POLICY super_admin_bypass_pending_changes ON pending_changes '
+            ."USING (current_setting('app.is_super_admin', true) = 'true') "
+            ."WITH CHECK (current_setting('app.is_super_admin', true) = 'true')"
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP POLICY IF EXISTS super_admin_bypass_pending_changes ON pending_changes');
+        $this->addSql('DROP POLICY IF EXISTS tenant_isolation_pending_changes ON pending_changes');
+        $this->addSql('ALTER TABLE pending_changes NO FORCE ROW LEVEL SECURITY');
+        $this->addSql('ALTER TABLE pending_changes DISABLE ROW LEVEL SECURITY');
+        $this->addSql('DROP TABLE pending_changes');
+    }
+}

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -125,6 +125,7 @@ parameters:
               - src/Agent/Domain/Entity/AgentRun.php
               - src/Agent/Domain/Entity/AgentMessage.php
               - src/Agent/Domain/Entity/AgentToolCall.php
+              - src/Catalog/Domain/Entity/PendingChange.php
               - src/Channel/Domain/Entity/Channel.php
               - src/Channel/Domain/Entity/ChannelCategoryNode.php
               - src/Channel/Domain/Entity/ObjectChannelPlacement.php

--- a/apps/api/src/Catalog/Application/PendingChanges/PendingChangesService.php
+++ b/apps/api/src/Catalog/Application/PendingChanges/PendingChangesService.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\PendingChanges;
+
+use App\Catalog\Contracts\PendingChanges\PendingChangeDraft;
+use App\Catalog\Contracts\PendingChanges\PendingChangesPort;
+use App\Catalog\Contracts\PendingChanges\PendingChangeStatus;
+use App\Catalog\Contracts\PendingChanges\PendingChangeType;
+use App\Catalog\Contracts\PendingChanges\PendingChangeView;
+use App\Catalog\Domain\Entity\PendingChange;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AGENT-P0-03 (#1946) — Doctrine implementation of the pending-changes
+ * approval gate (ADR-0024 c).
+ *
+ * Materialization is memory-safe under FrankenPHP worker mode: rows are
+ * flushed and the identity map cleared every CHUNK drafts, so a 50k-diff
+ * plan never accumulates managed entities. Status transitions run as
+ * single DQL UPDATE statements guarded on `pending` (idempotent).
+ */
+final class PendingChangesService implements PendingChangesPort
+{
+    private const int CHUNK = 200;
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly TenantContext $tenantContext,
+    ) {
+    }
+
+    public function materialize(Uuid $batchId, string $provenance, iterable $drafts): int
+    {
+        // Stamp the tenant explicitly via a per-EM reference instead of
+        // relying on TenantAssignmentListener: the per-chunk clear() below
+        // detaches the Tenant instance held by TenantContext, and flushing
+        // a new row pointing at a detached Tenant fails (lessons: XMLF
+        // "em->clear() detachuje -> rebind/reload").
+        $tenant = $this->tenantContext->get();
+        if (!$tenant instanceof Tenant) {
+            throw new LogicException('Cannot materialize pending changes without a current tenant.');
+        }
+        $tenantId = $tenant->getId();
+
+        $count = 0;
+        foreach ($drafts as $draft) {
+            $this->assertValueEnvelope($draft);
+
+            $change = new PendingChange(
+                batchId: $batchId,
+                provenance: $provenance,
+                changeType: $draft->changeType,
+                targetObjectId: $draft->targetObjectId,
+                attributeCode: $draft->attributeCode,
+                scopeLocale: $draft->scopeLocale,
+                scopeChannel: $draft->scopeChannel,
+                before: $draft->before,
+                after: $draft->after,
+                meta: $draft->meta,
+            );
+            $reference = $this->entityManager->getReference(Tenant::class, $tenantId);
+            \assert($reference instanceof Tenant);
+            $change->assignTenant($reference);
+            $this->entityManager->persist($change);
+
+            ++$count;
+            if (0 === $count % self::CHUNK) {
+                $this->entityManager->flush();
+                $this->entityManager->clear();
+            }
+        }
+
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        return $count;
+    }
+
+    public function listBatch(Uuid $batchId, int $limit = 100, int $offset = 0): array
+    {
+        /** @var list<PendingChange> $rows */
+        $rows = $this->entityManager->createQueryBuilder()
+            ->select('pc')
+            ->from(PendingChange::class, 'pc')
+            ->where('pc.batchId = :batch')
+            ->setParameter('batch', $batchId, 'uuid')
+            ->orderBy('pc.id', 'ASC')
+            ->setMaxResults($limit)
+            ->setFirstResult($offset)
+            ->getQuery()
+            ->getResult();
+
+        return array_map($this->toView(...), $rows);
+    }
+
+    public function iterateBatch(Uuid $batchId): iterable
+    {
+        $query = $this->entityManager->createQueryBuilder()
+            ->select('pc')
+            ->from(PendingChange::class, 'pc')
+            ->where('pc.batchId = :batch')
+            ->setParameter('batch', $batchId, 'uuid')
+            ->orderBy('pc.id', 'ASC')
+            ->getQuery();
+
+        /** @var iterable<PendingChange> $changes */
+        $changes = $query->toIterable();
+
+        $emitted = 0;
+        foreach ($changes as $change) {
+            yield $this->toView($change);
+
+            ++$emitted;
+            if (0 === $emitted % self::CHUNK) {
+                $this->entityManager->clear();
+            }
+        }
+        $this->entityManager->clear();
+    }
+
+    public function countBatch(Uuid $batchId): int
+    {
+        $count = $this->entityManager->createQueryBuilder()
+            ->select('COUNT(pc.id)')
+            ->from(PendingChange::class, 'pc')
+            ->where('pc.batchId = :batch')
+            ->setParameter('batch', $batchId, 'uuid')
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return (int) $count;
+    }
+
+    public function accept(Uuid $batchId): int
+    {
+        return $this->transition($batchId, PendingChangeStatus::Accepted);
+    }
+
+    public function reject(Uuid $batchId): int
+    {
+        return $this->transition($batchId, PendingChangeStatus::Rejected);
+    }
+
+    public function expire(Uuid $batchId): int
+    {
+        return $this->transition($batchId, PendingChangeStatus::Expired);
+    }
+
+    private function transition(Uuid $batchId, PendingChangeStatus $target): int
+    {
+        // Bulk DQL UPDATE bypasses the Doctrine TenantFilter (SQLFilter only
+        // constrains entity loading), so the tenant guard is explicit here —
+        // RLS remains the DB-level backstop.
+        $tenant = $this->tenantContext->get();
+        if (!$tenant instanceof Tenant) {
+            throw new LogicException('Cannot transition pending changes without a current tenant.');
+        }
+
+        $affected = $this->entityManager->createQueryBuilder()
+            ->update(PendingChange::class, 'pc')
+            ->set('pc.status', ':target')
+            ->set('pc.decidedAt', ':now')
+            ->where('pc.batchId = :batch')
+            ->andWhere('pc.status = :pending')
+            ->andWhere('pc.tenant = :tenant')
+            ->setParameter('target', $target->value)
+            ->setParameter('now', new DateTimeImmutable())
+            ->setParameter('batch', $batchId, 'uuid')
+            ->setParameter('pending', PendingChangeStatus::Pending->value)
+            ->setParameter('tenant', $tenant->getId(), 'uuid')
+            ->getQuery()
+            ->execute();
+
+        // Bulk DQL UPDATE bypasses the identity map — drop stale managed
+        // rows so subsequent reads in the same request see fresh statuses.
+        $this->entityManager->clear();
+
+        return $affected;
+    }
+
+    private function assertValueEnvelope(PendingChangeDraft $draft): void
+    {
+        if (PendingChangeType::Value !== $draft->changeType) {
+            return;
+        }
+
+        foreach (['before' => $draft->before, 'after' => $draft->after] as $side => $state) {
+            if (null !== $state && !\array_key_exists('value', $state)) {
+                throw new InvalidArgumentException(\sprintf(
+                    'Value-change draft %s state must be a value envelope with a "value" key (docs/api/jsonb-schemas.md); got keys: %s',
+                    $side,
+                    implode(', ', array_keys($state)),
+                ));
+            }
+        }
+    }
+
+    private function toView(PendingChange $change): PendingChangeView
+    {
+        return new PendingChangeView(
+            id: $change->getId(),
+            batchId: $change->getBatchId(),
+            provenance: $change->getProvenance(),
+            changeType: $change->getChangeType(),
+            status: $change->getStatus(),
+            targetObjectId: $change->getTargetObjectId(),
+            attributeCode: $change->getAttributeCode(),
+            scopeLocale: $change->getScopeLocale(),
+            scopeChannel: $change->getScopeChannel(),
+            before: $change->getBefore(),
+            after: $change->getAfter(),
+            meta: $change->getMeta(),
+            createdAt: $change->getCreatedAt(),
+            decidedAt: $change->getDecidedAt(),
+        );
+    }
+}

--- a/apps/api/src/Catalog/Contracts/PendingChanges/PendingChangeDraft.php
+++ b/apps/api/src/Catalog/Contracts/PendingChanges/PendingChangeDraft.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\PendingChanges;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * One proposed change handed to {@see PendingChangesPort::materialize()}.
+ *
+ * For {@see PendingChangeType::Value} drafts, `before`/`after` MUST be
+ * value envelopes per docs/api/jsonb-schemas.md (`['value' => ...]`),
+ * or null (no previous value / value removal).
+ *
+ * `meta` is free-form producer context (agent: run id, model, intent).
+ */
+final readonly class PendingChangeDraft
+{
+    /**
+     * @param array<string, mixed>|null $before
+     * @param array<string, mixed>|null $after
+     * @param array<string, mixed>|null $meta
+     */
+    public function __construct(
+        public PendingChangeType $changeType,
+        public ?Uuid $targetObjectId = null,
+        public ?string $attributeCode = null,
+        public ?string $scopeLocale = null,
+        public ?string $scopeChannel = null,
+        public ?array $before = null,
+        public ?array $after = null,
+        public ?array $meta = null,
+    ) {
+    }
+}

--- a/apps/api/src/Catalog/Contracts/PendingChanges/PendingChangeStatus.php
+++ b/apps/api/src/Catalog/Contracts/PendingChanges/PendingChangeStatus.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\PendingChanges;
+
+/**
+ * Lifecycle of a single proposed change row (ADR-0024 c).
+ *
+ * The whole batch moves together in MVP (all-or-nothing approval);
+ * the per-row status still exists so a partial-accept hook can land
+ * later without a schema migration.
+ */
+enum PendingChangeStatus: string
+{
+    case Pending = 'pending';
+    case Accepted = 'accepted';
+    case Rejected = 'rejected';
+    case Expired = 'expired';
+}

--- a/apps/api/src/Catalog/Contracts/PendingChanges/PendingChangeType.php
+++ b/apps/api/src/Catalog/Contracts/PendingChanges/PendingChangeType.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\PendingChanges;
+
+/**
+ * What kind of catalog mutation a pending change proposes (ADR-0024 c).
+ *
+ *   - `Value`    — an ObjectValue write (before/after are value envelopes
+ *                  per docs/api/jsonb-schemas.md).
+ *   - `Schema`   — a modeling operation (new/changed attribute or group).
+ *   - `Category` — a category assignment (add/remove/move).
+ */
+enum PendingChangeType: string
+{
+    case Value = 'value';
+    case Schema = 'schema';
+    case Category = 'category';
+}

--- a/apps/api/src/Catalog/Contracts/PendingChanges/PendingChangeView.php
+++ b/apps/api/src/Catalog/Contracts/PendingChanges/PendingChangeView.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\PendingChanges;
+
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Read model of a materialized pending change, returned by the port so
+ * consumers (the agent BC, future producers, the approval inbox) never
+ * touch the Catalog domain entity.
+ */
+final readonly class PendingChangeView
+{
+    /**
+     * @param array<string, mixed>|null $before
+     * @param array<string, mixed>|null $after
+     * @param array<string, mixed>|null $meta
+     */
+    public function __construct(
+        public Uuid $id,
+        public Uuid $batchId,
+        public string $provenance,
+        public PendingChangeType $changeType,
+        public PendingChangeStatus $status,
+        public ?Uuid $targetObjectId,
+        public ?string $attributeCode,
+        public ?string $scopeLocale,
+        public ?string $scopeChannel,
+        public ?array $before,
+        public ?array $after,
+        public ?array $meta,
+        public DateTimeImmutable $createdAt,
+        public ?DateTimeImmutable $decidedAt,
+    ) {
+    }
+}

--- a/apps/api/src/Catalog/Contracts/PendingChanges/PendingChangesPort.php
+++ b/apps/api/src/Catalog/Contracts/PendingChanges/PendingChangesPort.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\PendingChanges;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Single approval gate over the `pending_changes` table (ADR-0024 c).
+ *
+ * This port is the ONLY way producers (the agent BC, future integrations)
+ * touch pending changes. The materialized rows ARE the plan shown to the
+ * operator (plan == diff); nothing reaches the catalog before an accept.
+ *
+ * The batch id groups all proposals of one producer run; MVP approval is
+ * all-or-nothing per batch. Accept/reject/expire only transition rows
+ * that are still `pending` (idempotent — a second call affects 0 rows).
+ */
+interface PendingChangesPort
+{
+    /**
+     * Persist proposals for a batch. Memory-safe for large batches
+     * (chunked flush+clear). Returns the number of rows materialized.
+     *
+     * @param string                       $provenance coarse producer classifier (e.g. 'agent')
+     * @param iterable<PendingChangeDraft> $drafts
+     */
+    public function materialize(Uuid $batchId, string $provenance, iterable $drafts): int;
+
+    /**
+     * @return list<PendingChangeView>
+     */
+    public function listBatch(Uuid $batchId, int $limit = 100, int $offset = 0): array;
+
+    /**
+     * Stream the whole batch without hydrating it at once.
+     *
+     * @return iterable<PendingChangeView>
+     */
+    public function iterateBatch(Uuid $batchId): iterable;
+
+    public function countBatch(Uuid $batchId): int;
+
+    /**
+     * @return int rows transitioned pending -> accepted
+     */
+    public function accept(Uuid $batchId): int;
+
+    /**
+     * @return int rows transitioned pending -> rejected
+     */
+    public function reject(Uuid $batchId): int;
+
+    /**
+     * @return int rows transitioned pending -> expired
+     */
+    public function expire(Uuid $batchId): int;
+}

--- a/apps/api/src/Catalog/Domain/Entity/PendingChange.php
+++ b/apps/api/src/Catalog/Domain/Entity/PendingChange.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Domain\Entity;
+
+use App\Catalog\Contracts\PendingChanges\PendingChangeStatus;
+use App\Catalog\Contracts\PendingChanges\PendingChangeType;
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AGENT-P0-03 (#1946) — one proposed change awaiting a human decision
+ * (ADR-0024 c, single approval gate).
+ *
+ * This is a CORE hook, not agent code: the approval inbox ("what awaits
+ * my decision") lives in the product independently of the agent — the
+ * agent is just one producer. Rows are written and transitioned only
+ * through App\Catalog\Contracts\PendingChanges\PendingChangesPort.
+ *
+ * For `changeType=value`, `before`/`after` hold value envelopes per
+ * docs/api/jsonb-schemas.md. `costUsd`/`tokens` are optional per-row
+ * producer telemetry (the agent aggregates real cost on agent_runs).
+ */
+class PendingChange implements TenantScoped
+{
+    private Uuid $id;
+    private ?Tenant $tenant = null;
+    private Uuid $batchId;
+    private string $provenance;
+    private PendingChangeType $changeType;
+    private PendingChangeStatus $status = PendingChangeStatus::Pending;
+    private ?Uuid $targetObjectId;
+    private ?string $attributeCode;
+    private ?string $scopeLocale;
+    private ?string $scopeChannel;
+
+    /** @var array<string, mixed>|null */
+    private ?array $before;
+
+    /** @var array<string, mixed>|null */
+    private ?array $after;
+
+    /** @var array<string, mixed>|null */
+    private ?array $meta;
+
+    private ?string $costUsd = null;
+    private ?int $tokens = null;
+    private DateTimeImmutable $createdAt;
+    private ?DateTimeImmutable $decidedAt = null;
+
+    /**
+     * @param array<string, mixed>|null $before
+     * @param array<string, mixed>|null $after
+     * @param array<string, mixed>|null $meta
+     */
+    public function __construct(
+        Uuid $batchId,
+        string $provenance,
+        PendingChangeType $changeType,
+        ?Uuid $targetObjectId = null,
+        ?string $attributeCode = null,
+        ?string $scopeLocale = null,
+        ?string $scopeChannel = null,
+        ?array $before = null,
+        ?array $after = null,
+        ?array $meta = null,
+    ) {
+        $this->id = Uuid::v7();
+        $this->batchId = $batchId;
+        $this->provenance = $provenance;
+        $this->changeType = $changeType;
+        $this->targetObjectId = $targetObjectId;
+        $this->attributeCode = $attributeCode;
+        $this->scopeLocale = $scopeLocale;
+        $this->scopeChannel = $scopeChannel;
+        $this->before = $before;
+        $this->after = $after;
+        $this->meta = $meta;
+        $this->createdAt = new DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant already assigned.');
+        }
+        $this->tenant = $tenant;
+    }
+
+    public function getBatchId(): Uuid
+    {
+        return $this->batchId;
+    }
+
+    public function getProvenance(): string
+    {
+        return $this->provenance;
+    }
+
+    public function getChangeType(): PendingChangeType
+    {
+        return $this->changeType;
+    }
+
+    public function getStatus(): PendingChangeStatus
+    {
+        return $this->status;
+    }
+
+    public function getTargetObjectId(): ?Uuid
+    {
+        return $this->targetObjectId;
+    }
+
+    public function getAttributeCode(): ?string
+    {
+        return $this->attributeCode;
+    }
+
+    public function getScopeLocale(): ?string
+    {
+        return $this->scopeLocale;
+    }
+
+    public function getScopeChannel(): ?string
+    {
+        return $this->scopeChannel;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getBefore(): ?array
+    {
+        return $this->before;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getAfter(): ?array
+    {
+        return $this->after;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getMeta(): ?array
+    {
+        return $this->meta;
+    }
+
+    public function getCostUsd(): ?string
+    {
+        return $this->costUsd;
+    }
+
+    public function getTokens(): ?int
+    {
+        return $this->tokens;
+    }
+
+    public function setProducerTelemetry(?string $costUsd, ?int $tokens): void
+    {
+        $this->costUsd = $costUsd;
+        $this->tokens = $tokens;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getDecidedAt(): ?DateTimeImmutable
+    {
+        return $this->decidedAt;
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/PendingChange.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/PendingChange.orm.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Catalog\Domain\Entity\PendingChange" table="pending_changes">
+        <indexes>
+            <index name="pending_changes_tenant_status_idx" columns="tenant_id,status"/>
+            <index name="pending_changes_batch_idx" columns="batch_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <field name="batchId" type="uuid" column="batch_id"/>
+        <field name="provenance" type="string" length="32"/>
+        <field name="changeType" type="string" length="16" column="change_type" enum-type="App\Catalog\Contracts\PendingChanges\PendingChangeType"/>
+        <field name="status" type="string" length="16" enum-type="App\Catalog\Contracts\PendingChanges\PendingChangeStatus">
+            <options>
+                <option name="default">pending</option>
+            </options>
+        </field>
+
+        <field name="targetObjectId" type="uuid" column="target_object_id" nullable="true"/>
+        <field name="attributeCode" type="string" length="255" column="attribute_code" nullable="true"/>
+        <field name="scopeLocale" type="string" length="16" column="scope_locale" nullable="true"/>
+        <field name="scopeChannel" type="string" length="64" column="scope_channel" nullable="true"/>
+
+        <field name="before" type="json" column="before_state" nullable="true">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+        <field name="after" type="json" column="after_state" nullable="true">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+        <field name="meta" type="json" column="meta" nullable="true">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+
+        <field name="costUsd" type="decimal" precision="12" scale="6" column="cost_usd" nullable="true"/>
+        <field name="tokens" type="integer" column="tokens" nullable="true"/>
+
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+        <field name="decidedAt" type="datetime_immutable" column="decided_at" nullable="true"/>
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/tests/Integration/Catalog/PendingChangesPortTest.php
+++ b/apps/api/tests/Integration/Catalog/PendingChangesPortTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Catalog;
+
+use App\Catalog\Contracts\PendingChanges\PendingChangeDraft;
+use App\Catalog\Contracts\PendingChanges\PendingChangesPort;
+use App\Catalog\Contracts\PendingChanges\PendingChangeStatus;
+use App\Catalog\Contracts\PendingChanges\PendingChangeType;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use ArrayIterator;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use Iterator;
+use IteratorIterator;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * AGENT-P0-03 (#1946) — pending_changes approval-gate hook (ADR-0024 c).
+ *
+ * Covers the port surface end-to-end against real Postgres: materialize
+ * (chunked), list/iterate/count, pending->accepted/rejected/expired
+ * transitions with idempotency, the value-envelope canon guard, and the
+ * DoD tenant-isolation smoke (cross-read = 0).
+ */
+final class PendingChangesPortTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function materializeListAcceptRoundTrip(): void
+    {
+        $tenant = $this->createTenant('alpha');
+        $this->activateTenantFilter($tenant);
+
+        $port = $this->port();
+        $batchId = Uuid::v7();
+        $objectId = Uuid::v7();
+
+        $count = $port->materialize($batchId, 'agent', [
+            new PendingChangeDraft(
+                changeType: PendingChangeType::Value,
+                targetObjectId: $objectId,
+                attributeCode: 'price',
+                before: null,
+                after: ['value' => 100],
+                meta: ['run_id' => Uuid::v7()->toRfc4122(), 'model' => 'claude-sonnet-test'],
+            ),
+            new PendingChangeDraft(
+                changeType: PendingChangeType::Value,
+                targetObjectId: Uuid::v7(),
+                attributeCode: 'price',
+                scopeLocale: 'pl',
+                before: ['value' => 90],
+                after: ['value' => 100],
+            ),
+        ]);
+
+        self::assertSame(2, $count);
+        self::assertSame(2, $port->countBatch($batchId));
+
+        $rows = $port->listBatch($batchId);
+        self::assertCount(2, $rows);
+        self::assertSame('agent', $rows[0]->provenance);
+        self::assertSame(PendingChangeStatus::Pending, $rows[0]->status);
+        self::assertSame(['value' => 100], $rows[0]->after);
+        self::assertNull($rows[0]->before);
+        self::assertTrue($objectId->equals($rows[0]->targetObjectId ?? Uuid::v4()));
+        self::assertSame('pl', $rows[1]->scopeLocale);
+
+        $streamed = iterator_count($this->toIterator($port->iterateBatch($batchId)));
+        self::assertSame(2, $streamed);
+
+        // Accept transitions all pending rows exactly once (idempotent).
+        self::assertSame(2, $port->accept($batchId));
+        self::assertSame(0, $port->accept($batchId), 'second accept must transition 0 rows');
+
+        $accepted = $port->listBatch($batchId);
+        self::assertSame(PendingChangeStatus::Accepted, $accepted[0]->status);
+        self::assertNotNull($accepted[0]->decidedAt);
+    }
+
+    #[Test]
+    public function rejectAndExpireOnlyTouchPendingRows(): void
+    {
+        $tenant = $this->createTenant('alpha');
+        $this->activateTenantFilter($tenant);
+
+        $port = $this->port();
+
+        $rejectBatch = Uuid::v7();
+        $port->materialize($rejectBatch, 'agent', [
+            new PendingChangeDraft(changeType: PendingChangeType::Schema, after: ['attribute' => ['code' => 'weight']]),
+        ]);
+        self::assertSame(1, $port->reject($rejectBatch));
+        self::assertSame(PendingChangeStatus::Rejected, $port->listBatch($rejectBatch)[0]->status);
+        self::assertSame(0, $port->expire($rejectBatch), 'expire must not touch already-rejected rows');
+
+        $expireBatch = Uuid::v7();
+        $port->materialize($expireBatch, 'agent', [
+            new PendingChangeDraft(changeType: PendingChangeType::Category, targetObjectId: Uuid::v7()),
+        ]);
+        self::assertSame(1, $port->expire($expireBatch));
+        self::assertSame(PendingChangeStatus::Expired, $port->listBatch($expireBatch)[0]->status);
+    }
+
+    #[Test]
+    public function valueDraftWithoutEnvelopeIsRejected(): void
+    {
+        $tenant = $this->createTenant('alpha');
+        $this->activateTenantFilter($tenant);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/value envelope/');
+
+        $this->port()->materialize(Uuid::v7(), 'agent', [
+            new PendingChangeDraft(
+                changeType: PendingChangeType::Value,
+                targetObjectId: Uuid::v7(),
+                attributeCode: 'price',
+                after: ['raw' => 100],
+            ),
+        ]);
+    }
+
+    #[Test]
+    public function pendingChangesAreIsolatedByTenantFilter(): void
+    {
+        $alpha = $this->createTenant('alpha');
+        $beta = $this->createTenant('beta');
+
+        $port = $this->port();
+
+        $this->activateTenantFilter($alpha);
+        $alphaBatch = Uuid::v7();
+        $port->materialize($alphaBatch, 'agent', [
+            new PendingChangeDraft(
+                changeType: PendingChangeType::Value,
+                targetObjectId: Uuid::v7(),
+                attributeCode: 'price',
+                after: ['value' => 'alpha-only'],
+            ),
+        ]);
+        self::assertSame(1, $port->countBatch($alphaBatch));
+
+        // Beta context: alpha's batch is invisible (cross-read = 0) and
+        // cannot be transitioned (cross-write = 0 affected rows).
+        $this->activateTenantFilter($beta);
+        self::assertSame(0, $port->countBatch($alphaBatch), 'TenantFilter must hide alpha batch from beta context');
+        self::assertCount(0, $port->listBatch($alphaBatch));
+        self::assertSame(0, $port->accept($alphaBatch), 'beta context must not accept alpha rows');
+
+        $this->activateTenantFilter($alpha);
+        $alphaRows = $port->listBatch($alphaBatch);
+        self::assertCount(1, $alphaRows);
+        self::assertSame(PendingChangeStatus::Pending, $alphaRows[0]->status, 'alpha rows stay pending after beta cross-accept attempt');
+    }
+
+    #[Test]
+    public function materializeIsChunkSafeForLargeBatches(): void
+    {
+        $tenant = $this->createTenant('alpha');
+        $this->activateTenantFilter($tenant);
+
+        $port = $this->port();
+        $batchId = Uuid::v7();
+
+        $drafts = (static function (): iterable {
+            for ($i = 0; $i < 450; ++$i) {
+                yield new PendingChangeDraft(
+                    changeType: PendingChangeType::Value,
+                    targetObjectId: Uuid::v7(),
+                    attributeCode: 'price',
+                    after: ['value' => $i],
+                );
+            }
+        })();
+
+        self::assertSame(450, $port->materialize($batchId, 'agent', $drafts));
+        self::assertSame(450, $port->countBatch($batchId));
+        self::assertSame(450, $port->accept($batchId));
+    }
+
+    /**
+     * @param iterable<mixed> $iterable
+     *
+     * @return Iterator<mixed>
+     */
+    private function toIterator(iterable $iterable): Iterator
+    {
+        return \is_array($iterable) ? new ArrayIterator($iterable) : new IteratorIterator($iterable);
+    }
+
+    private function port(): PendingChangesPort
+    {
+        return self::getContainer()->get(PendingChangesPort::class);
+    }
+
+    private function activateTenantFilter(Tenant $tenant): void
+    {
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function createTenant(string $code): Tenant
+    {
+        $tenant = new Tenant($code, ucfirst($code).' Tenant');
+        $em = $this->em();
+        $em->persist($tenant);
+        $em->flush();
+
+        return $tenant;
+    }
+}


### PR DESCRIPTION
## Cel (AGENT-P0-03 #1946, epik 0.7)

Hook CORE dla single approval gate (ADR-0024 c): tabela `pending_changes` + port `Catalog\Contracts\PendingChanges` — jedyny sposób, w jaki producenci (agent jako pierwszy) dotykają propozycji. Inbox „co czeka na decyzję" żyje w produkcie niezależnie od agenta.

## Zakres

- **Encja `PendingChange`** (TenantScoped) + migracja: batch_id, provenance, change_type (`value|schema|category`), target (object id / attribute code / scope locale/channel), `before_state`/`after_state` JSONB (kanon envelope), status (`pending|accepted|rejected|expired`), meta + cost/tokens (nullable, wypełnia producent), indeksy (tenant,status) + (batch_id).
- **RLS**: FORCE + NULLIF predicate + WITH CHECK + super-admin bypass (najnowszy wzorzec XMLF).
- **Port**: `materialize / listBatch / iterateBatch (stream) / countBatch / accept / reject / expire` + DTO Draft/View + enumy Type/Status w Contracts (Agent nie dotyka Domain).
- **`PendingChangesService`**: chunked flush+clear (memory-safe pod 50k diffów; jawny tenant-stamp per chunk — `clear()` detachuje Tenant z kontekstu, lekcja XMLF); tranzycje jako pojedyncze DQL UPDATE guardowane na `pending` (idempotentne) **z jawnym tenant-guardem** (SQLFilter nie obejmuje bulk UPDATE; RLS = backstop DB); walidacja envelope dla `value`.

## Testy / bramki

- Integration 5/5: round-trip materialize→list→accept (idempotentny drugi accept = 0); reject/expire tylko pending; guard envelope; **cross-tenant read = 0 i cross-tenant accept = 0**; chunk-safety 450 wierszy przez generator.
- PHPStan max 0 · Deptrac 0 · CS-Fixer czysto.

## Smoke (psql, live)

Tabela + 2 polityki RLS + indeksy na dev DB (migracja wykonana); accept zmienia status z `decided_at` (pokryte testem na realnym Postgresie).

Closes #1946

🤖 Generated with [Claude Code](https://claude.com/claude-code)