### PR TITLE
feat(agent): enforce RBAC on every tool-call (guarded executor + by-user-id seam)

### DIFF
--- a/apps/api/src/Agent/Application/Tool/GuardedToolExecutor.php
+++ b/apps/api/src/Agent/Application/Tool/GuardedToolExecutor.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Tool;
+
+use App\Agent\Domain\Entity\AgentRun;
+use App\Agent\Domain\Entity\AgentToolCall;
+use App\Agent\Domain\Exception\ToolAccessDeniedException;
+use Doctrine\ORM\EntityManagerInterface;
+use Throwable;
+
+/**
+ * AGENT-P1-02 (#1954) — runtime enforcement wrapper around the tool
+ * registry: EVERY tool call the loop executes goes through here.
+ *
+ * - The registry re-checks the coarse permission on execute (P0-07);
+ *   fine-grained per-attribute/locale/channel checks run INSIDE the
+ *   tools via {@see \App\Identity\Contracts\Policy\UserScopedPermissionCheckerInterface}
+ *   (the loop has no security token — checks go by the initiating
+ *   user's id).
+ * - A denial is NOT an exception to the loop: it becomes a "forbidden"
+ *   tool_result the model can read (it learns it cannot do that), and
+ *   the attempt is recorded.
+ * - Every call — allowed, forbidden or crashed — persists an
+ *   AgentToolCall row (rbac_checked, duration, compact summary) so the
+ *   run's technical trace is complete (accountability layer on top is
+ *   DH Auditor, P3-07).
+ */
+final readonly class GuardedToolExecutor
+{
+    public function __construct(
+        private ToolRegistry $registry,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $arguments
+     *
+     * @return array{is_error: bool, content: array<string, mixed>}
+     */
+    public function execute(AgentRun $run, string $toolName, array $arguments, AgentToolContext $context): array
+    {
+        $tool = $this->registry->find($toolName);
+        $kind = null !== $tool ? $tool->kind()->value : 'unknown';
+
+        $toolCall = new AgentToolCall($run, $toolName, $kind, $arguments);
+        $startedAt = microtime(true);
+
+        try {
+            $result = $this->registry->execute($toolName, $arguments, $context);
+            $toolCall->complete(
+                $this->summarize($result),
+                rbacChecked: true,
+                durationMs: $this->elapsedMs($startedAt),
+            );
+
+            return ['is_error' => false, 'content' => $result];
+        } catch (ToolAccessDeniedException $denied) {
+            $toolCall->complete(
+                ['forbidden' => true],
+                rbacChecked: true,
+                durationMs: $this->elapsedMs($startedAt),
+            );
+
+            return [
+                'is_error' => true,
+                'content' => ['error' => 'forbidden', 'message' => $denied->getMessage()],
+            ];
+        } catch (Throwable $failure) {
+            $toolCall->complete(
+                ['failed' => true],
+                rbacChecked: true,
+                durationMs: $this->elapsedMs($startedAt),
+            );
+
+            // The message may reference internals; the model gets a
+            // generic failure, the trace keeps the exception class only.
+            return [
+                'is_error' => true,
+                'content' => ['error' => 'tool_failed', 'exception' => $failure::class],
+            ];
+        } finally {
+            $this->entityManager->persist($toolCall);
+            $this->entityManager->flush();
+        }
+    }
+
+    /**
+     * Compact, secret-free summary for the technical trace: top-level
+     * scalar fields + counts for arrays. Full payloads stay out of the
+     * DB (a search result can be megabytes).
+     *
+     * @param array<string, mixed> $result
+     *
+     * @return array<string, mixed>
+     */
+    private function summarize(array $result): array
+    {
+        $summary = [];
+        foreach ($result as $key => $value) {
+            if (\is_scalar($value) || null === $value) {
+                $summary[$key] = $value;
+            } elseif (\is_array($value)) {
+                $summary[$key] = \sprintf('array(%d)', \count($value));
+            } else {
+                $summary[$key] = \get_debug_type($value);
+            }
+        }
+
+        return $summary;
+    }
+
+    private function elapsedMs(float $startedAt): int
+    {
+        return (int) round((microtime(true) - $startedAt) * 1000);
+    }
+}

--- a/apps/api/src/Identity/Application/Policy/ContractsUserScopedPermissionChecker.php
+++ b/apps/api/src/Identity/Application/Policy/ContractsUserScopedPermissionChecker.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application\Policy;
+
+use App\Identity\Contracts\Policy\UserScopedPermissionCheckerInterface;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AGENT-P1-02 (#1954) — Identity-side adapter of the by-user-id RBAC
+ * seam: loads the user and delegates to the same policies every manual
+ * action goes through (AttributePermissionPolicy 3-state resolution,
+ * LocaleChannelScopePolicy). Unknown user id -> false (fail closed).
+ */
+final readonly class ContractsUserScopedPermissionChecker implements UserScopedPermissionCheckerInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private AttributePermissionPolicy $attributePolicy,
+        private LocaleChannelScopePolicy $scopePolicy,
+    ) {
+    }
+
+    public function canViewAttribute(Uuid $userId, Uuid $attributeId): bool
+    {
+        $user = $this->users->findById($userId);
+
+        return null !== $user && $this->attributePolicy->canViewAttribute($user, $attributeId);
+    }
+
+    public function canEditAttribute(Uuid $userId, Uuid $attributeId): bool
+    {
+        $user = $this->users->findById($userId);
+
+        return null !== $user && $this->attributePolicy->canEditAttribute($user, $attributeId);
+    }
+
+    public function canEditLocale(Uuid $userId, string $locale): bool
+    {
+        $user = $this->users->findById($userId);
+
+        return null !== $user && $this->scopePolicy->canEditLocale($user, $locale);
+    }
+
+    public function canEditChannel(Uuid $userId, string $channel): bool
+    {
+        $user = $this->users->findById($userId);
+
+        return null !== $user && $this->scopePolicy->canEditChannel($user, $channel);
+    }
+}

--- a/apps/api/src/Identity/Contracts/Policy/UserScopedPermissionCheckerInterface.php
+++ b/apps/api/src/Identity/Contracts/Policy/UserScopedPermissionCheckerInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Contracts\Policy;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AGENT-P1-02 (#1954) — fine-grained RBAC checks BY USER ID for
+ * contexts with no security token (the agent loop runs in a Messenger
+ * worker acting within the initiating user's permissions, ADR-0024 b).
+ *
+ * Complements {@see AttributePermissionReader} (current-token variant)
+ * and {@see PermissionCheckerInterface} (coarse permission codes):
+ * per-attribute 3-state resolution (PRD-PIM-rbac §3.5) and per-locale/
+ * channel scope (§3.2). Implementations MUST fail closed for unknown
+ * users.
+ */
+interface UserScopedPermissionCheckerInterface
+{
+    public function canViewAttribute(Uuid $userId, Uuid $attributeId): bool;
+
+    public function canEditAttribute(Uuid $userId, Uuid $attributeId): bool;
+
+    public function canEditLocale(Uuid $userId, string $locale): bool;
+
+    public function canEditChannel(Uuid $userId, string $channel): bool;
+}

--- a/apps/api/tests/Integration/Agent/GuardedToolExecutorTest.php
+++ b/apps/api/tests/Integration/Agent/GuardedToolExecutorTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Agent;
+
+use App\Agent\Application\Tool\AgentToolContext;
+use App\Agent\Application\Tool\AgentToolInterface;
+use App\Agent\Application\Tool\GuardedToolExecutor;
+use App\Agent\Application\Tool\PingTool;
+use App\Agent\Application\Tool\ToolKind;
+use App\Agent\Application\Tool\ToolRegistry;
+use App\Agent\Domain\AgentRunSurface;
+use App\Agent\Domain\Entity\AgentRun;
+use App\Agent\Domain\Entity\AgentToolCall;
+use App\Identity\Contracts\Policy\PermissionCheckerInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * AGENT-P1-02 (#1954, SEC failing-test-first) — every tool call runs
+ * through the guarded executor: allowed calls persist a complete
+ * technical trace (rbac_checked, duration, compact summary); a denial
+ * becomes a "forbidden" tool_result for the model (not a loop crash)
+ * and the ATTEMPT is recorded; a crashing tool leaks no internals.
+ */
+final class GuardedToolExecutorTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function allowedCallPersistsTraceWithRbacChecked(): void
+    {
+        [$run, $context, $em] = $this->fixture();
+        $executor = new GuardedToolExecutor($this->registry(['object.read']), $em);
+
+        $result = $executor->execute($run, 'ping', ['echo' => 'hi'], $context);
+
+        self::assertFalse($result['is_error']);
+        self::assertTrue($result['content']['pong']);
+
+        $calls = $this->callsFor($em, $run);
+        self::assertCount(1, $calls);
+        self::assertSame('ping', $calls[0]->getToolName());
+        self::assertSame('read', $calls[0]->getKind());
+        self::assertTrue($calls[0]->isRbacChecked());
+        self::assertNotNull($calls[0]->getDurationMs());
+        self::assertSame(['pong' => true, 'tenant' => 'alpha', 'echo' => 'hi'], $calls[0]->getResultSummary());
+    }
+
+    #[Test]
+    public function forbiddenCallBecomesToolResultAndAttemptIsRecorded(): void
+    {
+        [$run, $context, $em] = $this->fixture();
+        // No permissions at all: ping is outside the user's scope.
+        $executor = new GuardedToolExecutor($this->registry([]), $em);
+
+        $result = $executor->execute($run, 'ping', [], $context);
+
+        self::assertTrue($result['is_error']);
+        self::assertSame('forbidden', $result['content']['error']);
+
+        $calls = $this->callsFor($em, $run);
+        self::assertCount(1, $calls, 'the denied ATTEMPT must be recorded');
+        self::assertTrue($calls[0]->isRbacChecked());
+        self::assertSame(['forbidden' => true], $calls[0]->getResultSummary());
+    }
+
+    #[Test]
+    public function crashingToolLeaksNoInternalsToTheModel(): void
+    {
+        [$run, $context, $em] = $this->fixture();
+        $crashing = new class implements AgentToolInterface {
+            public function name(): string
+            {
+                return 'crashy';
+            }
+
+            public function description(): string
+            {
+                return 'test';
+            }
+
+            public function parametersSchema(): array
+            {
+                return ['type' => 'object', 'properties' => [], 'required' => []];
+            }
+
+            public function requiredPermission(): string
+            {
+                return 'object.read';
+            }
+
+            public function kind(): ToolKind
+            {
+                return ToolKind::Read;
+            }
+
+            public function execute(array $arguments, AgentToolContext $context): array
+            {
+                throw new RuntimeException('internal secret marker xyzzy-internal-detail');
+            }
+        };
+        $registry = new ToolRegistry([$crashing], $this->checker(['object.read']));
+        $executor = new GuardedToolExecutor($registry, $em);
+
+        $result = $executor->execute($run, 'crashy', [], $context);
+
+        self::assertTrue($result['is_error']);
+        self::assertSame('tool_failed', $result['content']['error']);
+        self::assertStringNotContainsString('xyzzy-internal', json_encode($result, JSON_THROW_ON_ERROR), 'internals must not reach the model');
+
+        $calls = $this->callsFor($em, $run);
+        self::assertSame(['failed' => true], $calls[0]->getResultSummary());
+    }
+
+    /**
+     * @return array{0: AgentRun, 1: AgentToolContext, 2: EntityManagerInterface}
+     */
+    private function fixture(): array
+    {
+        $tenant = new Tenant('alpha', 'Alpha Tenant');
+        $em = $this->em();
+        $em->persist($tenant);
+        $em->flush();
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+
+        $userId = Uuid::v7();
+        $run = new AgentRun($userId, AgentRunSurface::Chat, 'test intent');
+        $em->persist($run);
+        $em->flush();
+
+        return [$run, new AgentToolContext($userId, $tenant), $em];
+    }
+
+    /**
+     * @param list<string> $granted
+     */
+    private function registry(array $granted): ToolRegistry
+    {
+        return new ToolRegistry([new PingTool()], $this->checker($granted));
+    }
+
+    /**
+     * @param list<string> $granted
+     */
+    private function checker(array $granted): PermissionCheckerInterface
+    {
+        return new class($granted) implements PermissionCheckerInterface {
+            /** @param list<string> $granted */
+            public function __construct(private readonly array $granted)
+            {
+            }
+
+            public function userHasPermission(Uuid $userId, string $permissionCode): bool
+            {
+                return \in_array($permissionCode, $this->granted, true);
+            }
+        };
+    }
+
+    /**
+     * @return list<AgentToolCall>
+     */
+    private function callsFor(EntityManagerInterface $em, AgentRun $run): array
+    {
+        /** @var list<AgentToolCall> $calls */
+        $calls = $em->createQueryBuilder()
+            ->select('c')
+            ->from(AgentToolCall::class, 'c')
+            ->where('c.run = :run')
+            ->setParameter('run', $run->getId(), 'uuid')
+            ->getQuery()
+            ->getResult();
+
+        return $calls;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}

--- a/apps/api/tests/Unit/Agent/ContractsUserScopedPermissionCheckerTest.php
+++ b/apps/api/tests/Unit/Agent/ContractsUserScopedPermissionCheckerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Agent;
+
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Application\Policy\AttributePermissionPolicy;
+use App\Identity\Application\Policy\ContractsUserScopedPermissionChecker;
+use App\Identity\Application\Policy\LocaleChannelScopePolicy;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\PermissionSet;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AGENT-P1-02 (#1954, SEC) — the by-user-id RBAC seam fails closed for
+ * unknown users and delegates to the SAME policies manual actions use
+ * (per-attribute 3-state + per-locale/channel scope).
+ */
+final class ContractsUserScopedPermissionCheckerTest extends TestCase
+{
+    #[Test]
+    public function unknownUserFailsClosedOnEveryCheck(): void
+    {
+        $users = $this->createStub(UserRepositoryInterface::class);
+        $users->method('findById')->willReturn(null);
+
+        $checker = new ContractsUserScopedPermissionChecker(
+            $users,
+            $this->createStub(AttributePermissionPolicy::class),
+            // Final class - build it on a resolver stub that would allow
+            // everything; the unknown-user guard must still deny first.
+            new LocaleChannelScopePolicy($this->resolver(new PermissionSet([], [], []))),
+        );
+
+        $userId = Uuid::v7();
+        self::assertFalse($checker->canViewAttribute($userId, Uuid::v7()));
+        self::assertFalse($checker->canEditAttribute($userId, Uuid::v7()));
+        self::assertFalse($checker->canEditLocale($userId, 'pl'));
+        self::assertFalse($checker->canEditChannel($userId, 'web'));
+    }
+
+    #[Test]
+    public function knownUserDelegatesToTheSamePoliciesAsManualActions(): void
+    {
+        $user = new User(new Tenant('alpha', 'Alpha'), 'kasia@example.com', 'hash');
+
+        $users = $this->createStub(UserRepositoryInterface::class);
+        $users->method('findById')->willReturn($user);
+
+        $attributeId = Uuid::v7();
+
+        $attributePolicy = $this->createMock(AttributePermissionPolicy::class);
+        $attributePolicy->expects(self::once())->method('canViewAttribute')->with($user, $attributeId)->willReturn(true);
+        $attributePolicy->expects(self::once())->method('canEditAttribute')->with($user, $attributeId)->willReturn(false);
+
+        // Final class - exercise it for real on a resolved scope of
+        // locale=pl only and channel scope without 'web'.
+        $scopePolicy = new LocaleChannelScopePolicy($this->resolver(new PermissionSet([], ['pl'], ['retail'])));
+
+        $checker = new ContractsUserScopedPermissionChecker($users, $attributePolicy, $scopePolicy);
+
+        $userId = $user->getId();
+        self::assertTrue($checker->canViewAttribute($userId, $attributeId));
+        self::assertFalse($checker->canEditAttribute($userId, $attributeId));
+        self::assertTrue($checker->canEditLocale($userId, 'pl'));
+        self::assertFalse($checker->canEditChannel($userId, 'web'));
+    }
+
+    private function resolver(PermissionSet $set): PermissionResolverInterface
+    {
+        return new class($set) implements PermissionResolverInterface {
+            public function __construct(private readonly PermissionSet $set)
+            {
+            }
+
+            public function resolve(User $user): PermissionSet
+            {
+                return $this->set;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Cel (AGENT-P1-02 #1954, epik 0.7, [SEC])

Warstwa runtime twardej granicy z ADR-0024 (b): agent działa wyłącznie w uprawnieniach inicjującego usera, egzekwowanych **na każdym tool-callu** — to czyni prompt-injection niegroźnym poza scope usera.

## Zakres

- **`Identity\Contracts\Policy\UserScopedPermissionCheckerInterface`** — fine-grained checki **po user id** (pętla działa w workerze Messenger bez security tokena): per-atrybut 3-state view/edit (PRD-RBAC §3.5) + per-locale/channel scope (§3.2). Adapter deleguje do **tych samych polityk co ręczna akcja** (`AttributePermissionPolicy`, `LocaleChannelScopePolicy`); nieznany user → false (fail closed).
- **`GuardedToolExecutor`** — obowiązkowy wrapper każdego tool-calla pętli: odmowa → tool_result `forbidden` czytelny dla modelu (agent dowiaduje się, że nie może — bez crashu pętli); crash narzędzia → generyczny `tool_failed` z samą klasą wyjątku (**zero internals do modelu**, test leak-guard z sekretnym DSN); **każda próba — dozwolona, forbidden, crashed — persystuje wiersz `agent_tool_calls`** (rbac_checked, duration, compact secret-free summary).
- Field-level filtering read-wyników i write-scope per atrybut/locale/kanał wchodzą **wewnątrz konkretnych narzędzi** (P2-01/P3-01) na tym seamie — zgodnie z zakresem ticketu (warstwa egzekucji, nie narzędzia).

## Testy (SEC failing-test-first)

- Integration 3/3: allowed → pełny trace z `rbac_checked=true`; denied → forbidden tool_result + **zarejestrowana próba**; crash → brak internals.
- Unit 2/2: seam fail-closed dla nieznanego usera; delegacja do realnych polityk (locale=pl w scope, channel spoza scope odmówiony na prawdziwej `LocaleChannelScopePolicy`).
- PHPStan max 0 · Deptrac 0 (Agent → Identity_Contracts) · CS-Fixer czysto.

Closes #1954

🤖 Generated with [Claude Code](https://claude.com/claude-code)