### PR TITLE
feat(agent): Mercure agent-runs topics + progress publisher

### DIFF
--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -180,6 +180,11 @@ services:
         arguments:
             $agentEnabled: '%pim.agent.enabled%'
 
+    # AGENT-P1-05 (#1957) — agent run SSE topics (tenant-scoped, private).
+    App\Agent\Application\Run\AgentProgressPublisher:
+        arguments:
+            $topicBase: '%env(MERCURE_TOPIC_BASE)%'
+
     # DAM MVP upload entry point (#438). The size caps are wired through
     # parameters so deployment-specific overrides land in env vars
     # (e.g. enterprise tier raises the PDF cap).

--- a/apps/api/src/Agent/Application/Run/AgentProgressPublisher.php
+++ b/apps/api/src/Agent/Application/Run/AgentProgressPublisher.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Run;
+
+use App\Agent\Domain\Entity\AgentRun;
+use App\Shared\Infrastructure\Mercure\MercureSubscribeTopics;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Mercure\HubInterface;
+use Symfony\Component\Mercure\Update;
+use Throwable;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * AGENT-P1-05 (#1957) — Mercure SSE publisher for agent runs, mirroring
+ * ExportProgressPublisher: two tenant-scoped PRIVATE topics
+ * (`tenant/{tid}/agent-runs/{run_id}` for the open panel,
+ * `tenant/{tid}/agent-runs/user/{user_id}` for the history/inbox list).
+ * Hub failures are logged, never abort the run — Mercure is a
+ * notification channel; agent_runs.status is the source of truth
+ * (FE falls back to polling, P6-07).
+ */
+final class AgentProgressPublisher
+{
+    private readonly LoggerInterface $logger;
+
+    public function __construct(
+        private readonly HubInterface $hub,
+        private readonly string $topicBase,
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    /**
+     * Fine-grained phase tick while the run works (planning, a named
+     * tool call, materializing) — more granular than the status enum.
+     */
+    public function progress(AgentRun $run, string $phase): void
+    {
+        $this->publish($run, 'progress', ['phase' => $phase]);
+    }
+
+    /**
+     * Status transition of the run lifecycle (awaiting_input /
+     * awaiting_approval / committing / done / error / rolled_back).
+     */
+    public function status(AgentRun $run): void
+    {
+        $this->publish($run, 'status', [
+            'status' => $run->getStatus()->value,
+            'affected_count' => $run->getAffectedCount(),
+            'error_message' => $run->getErrorMessage(),
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function publish(AgentRun $run, string $eventType, array $payload): void
+    {
+        $tenant = $run->getTenant();
+        if (null === $tenant) {
+            $this->logger->warning('Agent progress publish skipped: run has no tenant', [
+                'run_id' => $run->getId()->toRfc4122(),
+                'event' => $eventType,
+            ]);
+
+            return;
+        }
+
+        $encoded = json_encode([
+            'event' => $eventType,
+            'run_id' => $run->getId()->toRfc4122(),
+            ...$payload,
+        ], JSON_THROW_ON_ERROR);
+
+        $tenantId = $tenant->getId();
+        $runTopic = MercureSubscribeTopics::agentRun($tenantId, $this->topicBase, $run->getId()->toRfc4122());
+        $userTopic = MercureSubscribeTopics::agentUser($tenantId, $this->topicBase, $run->getUserId()->toRfc4122());
+
+        try {
+            $this->hub->publish(new Update($runTopic, $encoded, private: true));
+            $this->hub->publish(new Update($userTopic, $encoded, private: true));
+        } catch (Throwable $error) {
+            $this->logger->warning('Agent progress publish failed', [
+                'run_id' => $run->getId()->toRfc4122(),
+                'event' => $eventType,
+                'error' => $error->getMessage(),
+            ]);
+        }
+    }
+}

--- a/apps/api/src/Shared/Infrastructure/Mercure/MercureSubscribeTopics.php
+++ b/apps/api/src/Shared/Infrastructure/Mercure/MercureSubscribeTopics.php
@@ -81,6 +81,25 @@ final class MercureSubscribeTopics
         return self::tenantPrefix($tenantId, $base).'/feeds/'.$feedId.'/runs';
     }
 
+    /**
+     * Live phases of one agent run (AGENT-P1-05 #1957): planning /
+     * tool-call / materializing / awaiting_approval / committing / done
+     * / error / rolled_back — the chat panel + inbox subscribe per run.
+     */
+    public static function agentRun(Uuid $tenantId, string $base, string $runId): string
+    {
+        return self::tenantPrefix($tenantId, $base).'/agent-runs/'.$runId;
+    }
+
+    /**
+     * Per-user broadcast (AGENT-P1-05): any of the user's runs changing
+     * state refreshes their history/inbox list.
+     */
+    public static function agentUser(Uuid $tenantId, string $base, string $userId): string
+    {
+        return self::tenantPrefix($tenantId, $base).'/agent-runs/user/'.$userId;
+    }
+
     public static function identityUser(Uuid $tenantId, string $base, string $userId): string
     {
         return self::tenantPrefix($tenantId, $base).'/identity/user/'.$userId;
@@ -114,6 +133,9 @@ final class MercureSubscribeTopics
             $prefix.'/exports/{id}',
             // Feed regeneration progress (XMLF-P4-02, per-feed run stream).
             $prefix.'/feeds/{id}/runs',
+            // Agent run phases + per-user history refresh (AGENT-P1-05).
+            $prefix.'/agent-runs/{id}',
+            $prefix.'/agent-runs/user/{id}',
             // Permission invalidation (per-user + tenant-wide).
             $prefix.'/identity/user/{id}',
             $prefix.'/identity/tenant/{id}',

--- a/apps/api/tests/Integration/Agent/AgentProgressPublisherTest.php
+++ b/apps/api/tests/Integration/Agent/AgentProgressPublisherTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Agent;
+
+use App\Agent\Application\Run\AgentProgressPublisher;
+use App\Agent\Domain\AgentRunSurface;
+use App\Agent\Domain\Entity\AgentRun;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Mercure\MercureSubscribeTopics;
+use App\Tests\Support\InMemoryMercureHub;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\Mercure\HubInterface;
+use Symfony\Component\Mercure\Jwt\StaticTokenProvider;
+use Symfony\Component\Mercure\Jwt\TokenFactoryInterface;
+use Symfony\Component\Mercure\Jwt\TokenProviderInterface;
+use Symfony\Component\Mercure\Update;
+use Symfony\Component\Uid\Uuid;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * AGENT-P1-05 (#1957) — run updates go to the two tenant-scoped topics
+ * as PRIVATE updates (AUD-001 model: the hub only delivers them to a
+ * JWT authorised for that tenant's prefix), the subscribe claim covers
+ * the agent topics, and a hub failure never aborts the caller.
+ */
+final class AgentProgressPublisherTest extends TestCase
+{
+    private const string BASE = 'https://pim.localhost';
+
+    #[Test]
+    public function statusPublishesPrivateUpdatesToRunAndUserTopics(): void
+    {
+        $hub = new InMemoryMercureHub();
+        $publisher = new AgentProgressPublisher($hub, self::BASE);
+
+        [$run, $tenantId] = $this->makeRun();
+        $publisher->status($run);
+        $publisher->progress($run, 'materializing');
+
+        $updates = $hub->getCapturedUpdates();
+        self::assertCount(4, $updates);
+
+        $topics = [];
+        foreach ($updates as $captured) {
+            $first = $captured->getTopics()[0] ?? null;
+            $topics[] = \is_string($first) ? $first : '';
+        }
+        $runTopic = MercureSubscribeTopics::agentRun($tenantId, self::BASE, $run->getId()->toRfc4122());
+        $userTopic = MercureSubscribeTopics::agentUser($tenantId, self::BASE, $run->getUserId()->toRfc4122());
+        self::assertSame([$runTopic, $userTopic, $runTopic, $userTopic], $topics);
+
+        foreach ($updates as $update) {
+            self::assertTrue($update->isPrivate(), 'AUD-001: agent updates must be private');
+        }
+
+        $payload = json_decode($updates[0]->getData(), true, flags: JSON_THROW_ON_ERROR);
+        self::assertIsArray($payload);
+        self::assertSame('status', $payload['event']);
+        self::assertSame('planning', $payload['status']);
+
+        $progress = json_decode($updates[2]->getData(), true, flags: JSON_THROW_ON_ERROR);
+        self::assertIsArray($progress);
+        self::assertSame('materializing', $progress['phase']);
+    }
+
+    #[Test]
+    public function subscribeClaimCoversAgentTopicsWithinTenantPrefixOnly(): void
+    {
+        $tenantId = Uuid::v7();
+        $claim = MercureSubscribeTopics::forTenant($tenantId, self::BASE);
+        $prefix = MercureSubscribeTopics::tenantPrefix($tenantId, self::BASE);
+
+        self::assertContains($prefix.'/agent-runs/{id}', $claim);
+        self::assertContains($prefix.'/agent-runs/user/{id}', $claim);
+        foreach ($claim as $topic) {
+            self::assertStringStartsWith($prefix.'/', $topic, 'every claim entry must stay pinned to the tenant prefix');
+        }
+    }
+
+    #[Test]
+    public function hubFailureIsSwallowed(): void
+    {
+        $hub = new class implements HubInterface {
+            public function getUrl(): string
+            {
+                return 'http://localhost/.well-known/mercure';
+            }
+
+            public function getPublicUrl(): string
+            {
+                return $this->getUrl();
+            }
+
+            public function getProvider(): TokenProviderInterface
+            {
+                return new StaticTokenProvider('t');
+            }
+
+            public function getFactory(): ?TokenFactoryInterface
+            {
+                return null;
+            }
+
+            public function publish(Update $update): string
+            {
+                throw new RuntimeException('hub down');
+            }
+        };
+        $publisher = new AgentProgressPublisher($hub, self::BASE);
+
+        [$run] = $this->makeRun();
+        $publisher->status($run);
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @return array{0: AgentRun, 1: Uuid}
+     */
+    private function makeRun(): array
+    {
+        $tenant = new Tenant('alpha', 'Alpha Tenant');
+        $run = new AgentRun(Uuid::v7(), AgentRunSurface::Chat, 'intent');
+        $run->assignTenant($tenant);
+
+        return [$run, $tenant->getId()];
+    }
+}


### PR DESCRIPTION
## Cel (AGENT-P1-05 #1957, epik 0.7)

UI musi widzieć postęp runu na żywo (fazy planowania / tool-calls / gotowy-do-akceptu) — wzorzec 1:1 z eksportem (`export-jobs.{session_id}`), model bezpieczeństwa AUD-001 (private + tenant-scoped).

## Zakres

- **`MercureSubscribeTopics::agentRun/agentUser`**: `tenant/{tid}/agent-runs/{run_id}` (otwarty panel) + `tenant/{tid}/agent-runs/user/{user_id}` (odświeżenie historii/inboxu).
- **`forTenant` allow-list** rozszerzona o oba topiki — każdy wpis przypięty do prefixu tenanta (cudzy tenant nie zasubskrybuje).
- **`AgentProgressPublisher`** (lustro `ExportProgressPublisher`): `progress(run, phase)` + `status(run)`; zawsze `private: true`; awaria huba logowana, nigdy nie przerywa runu (source of truth = `agent_runs.status`; FE fallback polling w P6-07).

## Testy / bramki

- 3/3: private updates na dokładnie dwa topiki z payloadem faz/statusu; claim obejmuje topiki agenta i nic poza prefixem; rzucający hub połknięty.
- PHPStan max 0 · Deptrac 0 · lint:container zielony.

## Smoke

EventSource-smoke na żywym stacku wchodzi z pierwszym realnym publish z pętli — call-site'y publishera wpinam przy merge P1-03 (pass integracyjny P4-01); kontrakt topików i autoryzacji pokryty testami już teraz.

Closes #1957

🤖 Generated with [Claude Code](https://claude.com/claude-code)