### PR TITLE
feat(agent): search_catalog grounding tool over Search Contracts port

### DIFF
--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -208,6 +208,12 @@ services:
     App\Asset\Contracts\Service\AssetPreviewSigner:
         alias: App\Asset\Application\AssetPreviewUrlSigner
 
+    # AGENT-P2-01 (#1958) — grounding seam for cross-BC consumers (the
+    # agent's search_catalog tool): explicit alias so the Contracts
+    # interface resolves without importing Search internals.
+    App\Search\Contracts\CatalogQueryPort:
+        alias: App\Search\Application\AgentCatalogQueryAdapter
+
     # Per-AttributeType validator dispatcher (#39). The factory wires up
     # one validator per AttributeType so the rest of the app can ask
     # "is this {value: ...} payload valid against this Attribute?" without
@@ -666,4 +672,11 @@ when@test:
         # directly from the container.
         App\Catalog\Contracts\PendingChanges\PendingChangesPort:
             alias: App\Catalog\Application\PendingChanges\PendingChangesService
+            public: true
+
+        # AGENT-P2-01 (#1958) — same story: the grounding port's consumer
+        # chain (tool -> registry -> loop) is not merged in full yet, so
+        # the compiled container would remove it; tests fetch it directly.
+        App\Search\Contracts\CatalogQueryPort:
+            alias: App\Search\Application\AgentCatalogQueryAdapter
             public: true

--- a/apps/api/src/Agent/Application/Tool/SearchCatalogTool.php
+++ b/apps/api/src/Agent/Application/Tool/SearchCatalogTool.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Tool;
+
+use App\Search\Contracts\CatalogQueryPort;
+
+/**
+ * AGENT-P2-01 (#1958) — grounding read tool: find objects by full-text
+ * query and/or filter DSL, starting from the user's view context (the
+ * active filter rides in agent_runs.context and is used when the model
+ * passes no filter of its own).
+ *
+ * Results are a MINIMAL PROJECTION (id, code, kind, status, name,
+ * completeness_pct) — deliberately NOT the attribute map, so no
+ * attribute value can leak past a per-attribute grant (PRD 10.3 data
+ * minimisation; conscious MVP call documented in the PR): grounding
+ * needs counts + identities, not values. `degraded=true` from the
+ * engine is passed through so the model says "could not verify"
+ * instead of fabricating numbers.
+ */
+final readonly class SearchCatalogTool implements AgentToolInterface
+{
+    private const int MAX_PER_PAGE = 50;
+
+    public function __construct(
+        private CatalogQueryPort $catalogQuery,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'search_catalog';
+    }
+
+    public function description(): string
+    {
+        return 'Search the catalog with a full-text query and/or a filter DSL. Call it to ground any plan in real counts before proposing changes. '
+            .'If the user refers to "these products" / the current view, omit filter_dsl - the active view filter is applied automatically. '
+            .'Returns a minimal projection (id, code, status, name, completeness_pct) plus total_hits.';
+    }
+
+    public function parametersSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'object_kind' => [
+                    'type' => 'string',
+                    'description' => 'Object kind to search (product, category, asset, custom). Default: product.',
+                ],
+                'query' => [
+                    'type' => 'string',
+                    'description' => 'Optional full-text query.',
+                ],
+                'filter_dsl' => [
+                    'type' => 'object',
+                    'description' => 'Canonical filter DSL: condition {attr, op, value?} or group {operator: AND|OR, conditions: [...]}. Omit to use the active view filter.',
+                ],
+                'page' => ['type' => 'integer', 'description' => 'Page number (1-based).'],
+                'per_page' => ['type' => 'integer', 'description' => 'Hits per page, max 50.'],
+            ],
+            'required' => [],
+        ];
+    }
+
+    public function requiredPermission(): string
+    {
+        return 'object.read';
+    }
+
+    public function kind(): ToolKind
+    {
+        return ToolKind::Read;
+    }
+
+    public function execute(array $arguments, AgentToolContext $context): array
+    {
+        $kind = \is_string($arguments['object_kind'] ?? null) ? $arguments['object_kind'] : 'product';
+        $query = \is_string($arguments['query'] ?? null) ? $arguments['query'] : '';
+
+        $filterDsl = \is_array($arguments['filter_dsl'] ?? null) ? $arguments['filter_dsl'] : null;
+        $viewFilter = $context->viewContext['filter_dsl'] ?? null;
+        if (null === $filterDsl && \is_array($viewFilter)) {
+            $filterDsl = $viewFilter;
+        }
+
+        $page = \is_int($arguments['page'] ?? null) ? max(1, $arguments['page']) : 1;
+        $perPage = \is_int($arguments['per_page'] ?? null)
+            ? min(self::MAX_PER_PAGE, max(1, $arguments['per_page']))
+            : 20;
+
+        /** @var array<string, mixed> $filterDslArray */
+        $filterDslArray = $filterDsl ?? [];
+        $result = $this->catalogQuery->search($kind, $query, $filterDslArray, $page, $perPage);
+
+        return [
+            'total_hits' => $result->totalHits,
+            'degraded' => $result->degraded,
+            'note' => $result->degraded
+                ? 'Search engine unavailable - the numbers above are NOT verified; tell the user you could not verify.'
+                : null,
+            'page' => $page,
+            'per_page' => $perPage,
+            'hits' => array_map($this->project(...), $result->hits),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $hit
+     *
+     * @return array<string, mixed>
+     */
+    private function project(array $hit): array
+    {
+        $attributes = \is_array($hit['attributesIndexed'] ?? null) ? $hit['attributesIndexed'] : [];
+        $nameEnvelope = \is_array($attributes['name'] ?? null) ? $attributes['name'] : [];
+        $completeness = \is_array($hit['completeness'] ?? null) ? $hit['completeness'] : [];
+
+        return [
+            'id' => $hit['id'] ?? null,
+            'code' => $hit['code'] ?? null,
+            'kind' => $hit['kind'] ?? null,
+            'status' => $hit['status'] ?? null,
+            'name' => $nameEnvelope['value'] ?? null,
+            'completeness_pct' => $completeness['global'] ?? null,
+        ];
+    }
+}

--- a/apps/api/src/Search/Application/AgentCatalogQueryAdapter.php
+++ b/apps/api/src/Search/Application/AgentCatalogQueryAdapter.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Search\Application;
+
+use App\Catalog\Application\Filter\FilterDslResolver;
+use App\Catalog\Domain\ObjectKind;
+use App\Search\Contracts\CatalogQueryPort;
+use App\Search\Contracts\CatalogQueryResult;
+use InvalidArgumentException;
+use Throwable;
+
+/**
+ * AGENT-P2-01 (#1958) — the Contracts adapter over the existing search
+ * engine (CatalogSearchService + FilterDslResolver): the agent grounds
+ * its plans through EXACTLY the pipeline the manual list view uses —
+ * same validation, same Meili filter compilation, same tenant scoping,
+ * same `degraded` semantics on engine outage.
+ */
+final readonly class AgentCatalogQueryAdapter implements CatalogQueryPort
+{
+    public function __construct(
+        private CatalogSearchService $searchService,
+        private FilterDslResolver $filterResolver,
+    ) {
+    }
+
+    public function search(string $kind, string $query = '', array $filterDsl = [], int $page = 1, int $perPage = 20): CatalogQueryResult
+    {
+        $objectKind = ObjectKind::tryFrom($kind);
+        if (null === $objectKind) {
+            throw new InvalidArgumentException(\sprintf('Unknown object kind "%s".', $kind));
+        }
+
+        $filterExpression = null;
+        if ([] !== $filterDsl) {
+            try {
+                $this->filterResolver->validate($filterDsl);
+                $filterExpression = $this->filterResolver->toMeilisearchFilter($filterDsl);
+            } catch (Throwable $invalid) {
+                // Bad DSL is a caller error (the model gets it back as an
+                // error tool_result and can correct itself).
+                throw new InvalidArgumentException('Invalid filter DSL: '.$invalid->getMessage(), previous: $invalid);
+            }
+        }
+
+        $result = $this->searchService->search(
+            kind: $objectKind,
+            query: $query,
+            page: max(1, $page),
+            perPage: max(1, $perPage),
+            customFilterExpression: $filterExpression,
+        );
+
+        return new CatalogQueryResult(
+            hits: $result['hits'],
+            totalHits: $result['totalHits'],
+            degraded: $result['degraded'],
+        );
+    }
+}

--- a/apps/api/src/Search/Contracts/CatalogQueryPort.php
+++ b/apps/api/src/Search/Contracts/CatalogQueryPort.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Search\Contracts;
+
+use InvalidArgumentException;
+
+/**
+ * AGENT-P2-01 (#1958) — Contracts seam over catalog search for
+ * cross-BC consumers (the removable Agent BC first): full-text query +
+ * filter DSL -> tenant-scoped hits with a real total (grounding for
+ * "plans made of concrete numbers", ADR-0024 b).
+ *
+ * The filter DSL is validated against the attribute registry before it
+ * reaches the engine (unknown fields / operators throw); tenant scope
+ * comes from the active tenant context inside the engine.
+ */
+interface CatalogQueryPort
+{
+    /**
+     * @param array<string, mixed> $filterDsl canonical filter DSL ([] = match all)
+     *
+     * @throws InvalidArgumentException on invalid DSL (unknown field/operator)
+     */
+    public function search(string $kind, string $query = '', array $filterDsl = [], int $page = 1, int $perPage = 20): CatalogQueryResult;
+}

--- a/apps/api/src/Search/Contracts/CatalogQueryResult.php
+++ b/apps/api/src/Search/Contracts/CatalogQueryResult.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Search\Contracts;
+
+/**
+ * AGENT-P2-01 (#1958) — result of a grounding query. `hits` carries the
+ * caller-shaped projection rows; `degraded` mirrors the search-engine
+ * outage flag so consumers can say "I could not verify" instead of
+ * hallucinating counts.
+ */
+final readonly class CatalogQueryResult
+{
+    /**
+     * @param list<array<string, mixed>> $hits
+     */
+    public function __construct(
+        public array $hits,
+        public int $totalHits,
+        public bool $degraded,
+    ) {
+    }
+}

--- a/apps/api/tests/Integration/Agent/AgentCatalogQueryAdapterTest.php
+++ b/apps/api/tests/Integration/Agent/AgentCatalogQueryAdapterTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Agent;
+
+use App\Search\Contracts\CatalogQueryPort;
+use App\Search\Contracts\CatalogQueryResult;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * AGENT-P2-01 (#1958) — the Contracts adapter goes through the SAME
+ * validation/compilation pipeline as the manual list view: invalid
+ * kind and invalid DSL throw caller errors (the model can correct
+ * itself); a valid query returns the result shape with a boolean
+ * `degraded` flag (true when the engine is unreachable, e.g. in CI).
+ */
+final class AgentCatalogQueryAdapterTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function unknownKindIsACallerError(): void
+    {
+        $this->bootWithTenant();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/Unknown object kind/');
+        $this->port()->search('starship');
+    }
+
+    #[Test]
+    public function invalidFilterDslIsACallerError(): void
+    {
+        $this->bootWithTenant();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/Invalid filter DSL/');
+        $this->port()->search('product', filterDsl: ['nonsense' => true]);
+    }
+
+    #[Test]
+    public function validQueryReturnsResultShape(): void
+    {
+        $this->bootWithTenant();
+
+        $result = $this->port()->search('product', query: 'anything');
+
+        self::assertInstanceOf(CatalogQueryResult::class, $result);
+        self::assertGreaterThanOrEqual(0, $result->totalHits);
+        // In CI (no Meilisearch service) the engine reports degraded=true;
+        // on the dev stack it answers normally - both are valid shapes.
+        self::assertIsBool($result->degraded);
+    }
+
+    private function bootWithTenant(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha Tenant');
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+        $em->persist($tenant);
+        $em->flush();
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+    }
+
+    private function port(): CatalogQueryPort
+    {
+        return self::getContainer()->get(CatalogQueryPort::class);
+    }
+}

--- a/apps/api/tests/Unit/Agent/SearchCatalogToolTest.php
+++ b/apps/api/tests/Unit/Agent/SearchCatalogToolTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Agent;
+
+use App\Agent\Application\Tool\AgentToolContext;
+use App\Agent\Application\Tool\SearchCatalogTool;
+use App\Agent\Application\Tool\ToolKind;
+use App\Search\Contracts\CatalogQueryPort;
+use App\Search\Contracts\CatalogQueryResult;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * AGENT-P2-01 (#1958) — the grounding tool: view-context filter applies
+ * by default, explicit filter wins, per_page is capped, hits are the
+ * minimal projection (no attribute map -> no per-attribute leak by
+ * construction), and `degraded` carries an explicit do-not-fabricate
+ * note for the model.
+ */
+final class SearchCatalogToolTest extends TestCase
+{
+    #[Test]
+    public function viewContextFilterAppliesWhenModelPassesNone(): void
+    {
+        $port = $this->recordingPort(new CatalogQueryResult([], 1800, false));
+        $tool = new SearchCatalogTool($port);
+
+        $viewFilter = ['attr' => 'price', 'op' => 'IS EMPTY'];
+        $result = $tool->execute([], $this->context(['filter_dsl' => $viewFilter]));
+
+        self::assertSame(1800, $result['total_hits']);
+        self::assertSame($viewFilter, $port->lastFilterDsl);
+        self::assertSame('product', $port->lastKind);
+    }
+
+    #[Test]
+    public function explicitFilterOverridesViewContext(): void
+    {
+        $port = $this->recordingPort(new CatalogQueryResult([], 3, false));
+        $tool = new SearchCatalogTool($port);
+
+        $explicit = ['attr' => 'brand', 'op' => '=', 'value' => 'Festo'];
+        $tool->execute(
+            ['filter_dsl' => $explicit, 'object_kind' => 'category', 'per_page' => 500],
+            $this->context(['filter_dsl' => ['attr' => 'price', 'op' => 'IS EMPTY']]),
+        );
+
+        self::assertSame($explicit, $port->lastFilterDsl);
+        self::assertSame('category', $port->lastKind);
+        self::assertSame(50, $port->lastPerPage, 'per_page must be capped at 50');
+    }
+
+    #[Test]
+    public function hitsAreProjectedWithoutAttributeMap(): void
+    {
+        $hit = [
+            'id' => 'obj-1',
+            'code' => 'DEMO-100',
+            'kind' => 'product',
+            'status' => 'draft',
+            'attributesIndexed' => [
+                'name' => ['value' => 'Buty Air Max'],
+                'secret_margin' => ['value' => 42.0],
+            ],
+            'completeness' => ['global' => 62],
+        ];
+        $tool = new SearchCatalogTool($this->recordingPort(new CatalogQueryResult([$hit], 1, false)));
+
+        $result = $tool->execute([], $this->context());
+
+        $hits = $result['hits'];
+        self::assertIsArray($hits);
+        self::assertSame(
+            ['id' => 'obj-1', 'code' => 'DEMO-100', 'kind' => 'product', 'status' => 'draft', 'name' => 'Buty Air Max', 'completeness_pct' => 62],
+            $hits[0],
+        );
+        self::assertStringNotContainsString(
+            'secret_margin',
+            json_encode($result, JSON_THROW_ON_ERROR),
+            'the attribute map must never reach the model (field-level by construction)',
+        );
+    }
+
+    #[Test]
+    public function degradedEngineCarriesDoNotFabricateNote(): void
+    {
+        $tool = new SearchCatalogTool($this->recordingPort(new CatalogQueryResult([], 0, true)));
+
+        $result = $tool->execute([], $this->context());
+
+        self::assertTrue($result['degraded']);
+        self::assertIsString($result['note']);
+        self::assertStringContainsString('could not verify', $result['note']);
+        self::assertSame(ToolKind::Read, $tool->kind());
+        self::assertSame('object.read', $tool->requiredPermission());
+    }
+
+    /**
+     * @param array<string, mixed> $viewContext
+     */
+    private function context(array $viewContext = []): AgentToolContext
+    {
+        return new AgentToolContext(Uuid::v7(), new Tenant('alpha', 'Alpha'), $viewContext);
+    }
+
+    private function recordingPort(CatalogQueryResult $result): RecordingCatalogQueryPort
+    {
+        return new RecordingCatalogQueryPort($result);
+    }
+}
+
+/**
+ * Test-only recorder exposing the last call arguments.
+ */
+final class RecordingCatalogQueryPort implements CatalogQueryPort
+{
+    public string $lastKind = '';
+
+    /** @var array<string, mixed> */
+    public array $lastFilterDsl = [];
+
+    public int $lastPerPage = 0;
+
+    public function __construct(private readonly CatalogQueryResult $result)
+    {
+    }
+
+    public function search(string $kind, string $query = '', array $filterDsl = [], int $page = 1, int $perPage = 20): CatalogQueryResult
+    {
+        $this->lastKind = $kind;
+        $this->lastFilterDsl = $filterDsl;
+        $this->lastPerPage = $perPage;
+
+        return $this->result;
+    }
+}


### PR DESCRIPTION
## Cel (AGENT-P2-01 #1958, epik 0.7)

Grounding = fundament „planu z konkretnych liczb": agent znajduje obiekty wg filtra DSL i kontekstu widoku, zanim cokolwiek zaproponuje.

## Zakres

- **Port `Search\Contracts\CatalogQueryPort`** + `CatalogQueryResult`; adapter `AgentCatalogQueryAdapter` idzie **dokładnie tym samym pipeline'em co ręczna lista** (walidacja `FilterDslResolver` → kompilacja filtra Meili → `CatalogSearchService` z tenant scopingiem). Zły kind/DSL = błąd wołającego (model dostaje error tool_result i może się poprawić).
- **Narzędzie `search_catalog`** (kind=read, `object.read`): query + filter DSL; **aktywny filtr widoku stosuje się automatycznie**, gdy model nie poda własnego (kontekst z `agent_runs.context`); `per_page` cap 50; `degraded` z Meili przechodzi z jawną notą „could not verify" (agent informuje, nie halucynuje — AC).
- **Świadoma decyzja (field-level):** wynik to **minimalna projekcja** (id, code, kind, status, name, completeness_pct) — celowo BEZ mapy atrybutów, więc żadna wartość atrybutu nie może wyciec poza per-attribute grant (bezpieczeństwo by-construction + minimalizacja danych do modelu §10.3). Grounding potrzebuje liczb i tożsamości, nie wartości; ewentualny value-read z pełnym field-level filtrem (seam z P1-02) = przyszłe narzędzie.
- Alias portu w services.yaml (+ public w `when@test` — łańcuch konsumentów tool→registry→loop domyka się z merge P1-02/P1-03).

## Testy / bramki

- Unit 4/4: default filtra z kontekstu widoku; explicit override + cap per_page; projekcja z leak-guardem (`secret_margin` nie przechodzi); nota degraded.
- Integration 3/3: unknown kind → 4xx-owy błąd; invalid DSL → błąd z realnego resolvera; poprawne query → kształt wyniku (degraded bool — w CI bez Meili true, na dev stacku false; asercja stabilna w obu).
- PHPStan max 0 · Deptrac 0 (Agent → Search_Contracts) · CS-Fixer czysto.

## Smoke

Realny run „ile produktów bez ceny na aktywnym filtrze" przechodzi przez pętlę → wymaga klucza BYOK (LLM-live pending); kontrakt narzędzia + pipeline zweryfikowane testami na realnym resolverze/serwisie.

Closes #1958

🤖 Generated with [Claude Code](https://claude.com/claude-code)