### PR TITLE
feat(agent): async agent loop orchestrator (plan → ask → materialize)

### DIFF
--- a/apps/api/config/packages/agent.yaml
+++ b/apps/api/config/packages/agent.yaml
@@ -22,3 +22,11 @@ doctrine_migrations:
         # ships inside src/Agent so it disappears with the module. Core
         # hooks (pending_changes etc.) stay in /migrations.
         'AgentMigrations': '%kernel.project_dir%/src/Agent/Infrastructure/Migrations'
+
+framework:
+    messenger:
+        routing:
+            # AGENT-P1-03 (#1955) — the loop runs async on the queue the
+            # dev/prod worker already consumes; TenantAwareMessage rebinds
+            # tenant + RLS GUC in the worker middlewares.
+            App\Agent\Application\Run\AgentRunMessage: import

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -76,6 +76,12 @@ services:
         App\Integration\Generic\Infrastructure\Http\Pagination\PaginationStrategy:
             tags: ['integration.pagination_strategy']
 
+        # AGENT-P0-07 (#1950) — every AgentToolInterface implementation is
+        # auto-registered in the ToolRegistry (ADR-0024 b: adding a tool =
+        # adding a service, zero loop changes).
+        App\Agent\Application\Tool\AgentToolInterface:
+            tags: ['agent.tool']
+
     App\:
         resource: '../src/'
         exclude:

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -76,12 +76,6 @@ services:
         App\Integration\Generic\Infrastructure\Http\Pagination\PaginationStrategy:
             tags: ['integration.pagination_strategy']
 
-        # AGENT-P0-07 (#1950) — every AgentToolInterface implementation is
-        # auto-registered in the ToolRegistry (ADR-0024 b: adding a tool =
-        # adding a service, zero loop changes).
-        App\Agent\Application\Tool\AgentToolInterface:
-            tags: ['agent.tool']
-
     App\:
         resource: '../src/'
         exclude:

--- a/apps/api/config/services_agent.yaml
+++ b/apps/api/config/services_agent.yaml
@@ -22,6 +22,17 @@ parameters:
     # availability additionally requires an active BYOK key.
     pim.agent.enabled: '%env(bool:AGENT_ENABLED)%'
 
+    # AGENT-P1-03 (#1955) — in-run hard limits (PRD 10.4 / architecture
+    # 8.5 subset enforced inside the loop; hourly/daily/monthly budgets
+    # + kill-switch land in P1-04) and per-MTok USD pricing per model
+    # tier (cost accounting on agent_runs).
+    pim.agent.limits.tool_calls_per_run: 10
+    pim.agent.limits.tokens_per_run: 100000
+    pim.agent.pricing.default_input_per_mtok: 3.0
+    pim.agent.pricing.default_output_per_mtok: 15.0
+    pim.agent.pricing.schema_input_per_mtok: 5.0
+    pim.agent.pricing.schema_output_per_mtok: 25.0
+
 services:
     _defaults:
         autowire: true
@@ -65,3 +76,16 @@ services:
     App\Agent\Application\Run\AgentProgressPublisher:
         arguments:
             $topicBase: '%env(MERCURE_TOPIC_BASE)%'
+
+    # AGENT-P1-03 (#1955) — loop limits + cost accounting knobs.
+    App\Agent\Application\Run\AgentLoopRunner:
+        arguments:
+            $maxToolCallsPerRun: '%pim.agent.limits.tool_calls_per_run%'
+            $maxTokensPerRun: '%pim.agent.limits.tokens_per_run%'
+
+    App\Agent\Application\Run\UsageCostCalculator:
+        arguments:
+            $defaultInputPerMtok: '%pim.agent.pricing.default_input_per_mtok%'
+            $defaultOutputPerMtok: '%pim.agent.pricing.default_output_per_mtok%'
+            $schemaInputPerMtok: '%pim.agent.pricing.schema_input_per_mtok%'
+            $schemaOutputPerMtok: '%pim.agent.pricing.schema_output_per_mtok%'

--- a/apps/api/src/Agent/Application/Llm/AgentLlmClientInterface.php
+++ b/apps/api/src/Agent/Application/Llm/AgentLlmClientInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Llm;
+
+use App\Shared\Domain\Tenant;
+
+/**
+ * AGENT-P1-03 (#1955) — thin seam over the Anthropic Messages API so
+ * the loop is deterministic and fully testable without a live model
+ * (tests script responses; the SDK adapter is the only network code).
+ */
+interface AgentLlmClientInterface
+{
+    /**
+     * @param list<array<string, mixed>> $messages Anthropic message shapes (camelCase SDK keys)
+     * @param list<array<string, mixed>> $tools    tool definitions from the registry
+     */
+    public function create(Tenant $tenant, string $model, string $system, array $messages, array $tools): AgentLlmResponse;
+}

--- a/apps/api/src/Agent/Application/Llm/AgentLlmResponse.php
+++ b/apps/api/src/Agent/Application/Llm/AgentLlmResponse.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Llm;
+
+/**
+ * AGENT-P1-03 (#1955) — provider-agnostic view of one model turn.
+ *
+ * `contentBlocks` uses the Anthropic wire shape as plain arrays:
+ * `{type: 'text', text}` and `{type: 'tool_use', id, name, input}` —
+ * exactly what gets persisted into agent_messages and echoed back on
+ * the next request.
+ *
+ * @phpstan-type ContentBlock array<string, mixed>
+ */
+final readonly class AgentLlmResponse
+{
+    public const string STOP_TOOL_USE = 'tool_use';
+    public const string STOP_END_TURN = 'end_turn';
+
+    /**
+     * @param list<array<string, mixed>> $contentBlocks
+     */
+    public function __construct(
+        public string $stopReason,
+        public array $contentBlocks,
+        public int $inputTokens,
+        public int $outputTokens,
+    ) {
+    }
+
+    /**
+     * @return list<array{id: string, name: string, input: array<string, mixed>}>
+     */
+    public function toolUses(): array
+    {
+        $uses = [];
+        foreach ($this->contentBlocks as $block) {
+            if (($block['type'] ?? null) !== 'tool_use') {
+                continue;
+            }
+            $id = $block['id'] ?? null;
+            $name = $block['name'] ?? null;
+            if (!\is_string($id) || !\is_string($name)) {
+                continue;
+            }
+            /** @var array<string, mixed> $input */
+            $input = \is_array($block['input'] ?? null) ? $block['input'] : [];
+            $uses[] = ['id' => $id, 'name' => $name, 'input' => $input];
+        }
+
+        return $uses;
+    }
+}

--- a/apps/api/src/Agent/Application/Run/AgentLoopRunner.php
+++ b/apps/api/src/Agent/Application/Run/AgentLoopRunner.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Run;
+
+use App\Agent\Application\Llm\AgentLlmClientInterface;
+use App\Agent\Application\Llm\AgentLlmResponse;
+use App\Agent\Application\Tool\AgentToolContext;
+use App\Agent\Application\Tool\GuardedToolExecutor;
+use App\Agent\Application\Tool\ToolKind;
+use App\Agent\Application\Tool\ToolRegistry;
+use App\Agent\Domain\Entity\AgentMessage;
+use App\Agent\Domain\Entity\AgentRun;
+use App\Agent\Infrastructure\Anthropic\AgentModelSelector;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Throwable;
+
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+
+/**
+ * AGENT-P1-03 (#1955) — the agent loop (PRD 5.2):
+ * plan -> (read tools) -> clarifying question | materialized proposal.
+ *
+ * Autonomy ends BEFORE approval (ADR-0024 c): the loop stops at
+ * `awaiting_approval` the moment a write tool materializes a
+ * pending_changes batch (its result carries `pending_change_batch_id`);
+ * the commit happens in P3-02 after a human accepts. A turn with no
+ * tool calls is a clarifying question / final answer -> `awaiting_input`.
+ *
+ * In-run limits (PRD 10.4, hard 8.5 subset): tool calls per run and
+ * tokens per run are enforced INSIDE the loop; hourly/daily/monthly
+ * budgets + kill-switch layer on top in P1-04. Any exhaustion or LLM
+ * failure -> run `error`, zero partial commit (there is nothing to
+ * commit before approval by construction).
+ */
+final readonly class AgentLoopRunner
+{
+    public function __construct(
+        private AgentLlmClientInterface $llm,
+        private ToolRegistry $registry,
+        private GuardedToolExecutor $executor,
+        private AgentModelSelector $models,
+        private AgentSystemPromptBuilder $prompts,
+        private UsageCostCalculator $costs,
+        private EntityManagerInterface $entityManager,
+        private int $maxToolCallsPerRun,
+        private int $maxTokensPerRun,
+    ) {
+    }
+
+    public function run(AgentRun $run, Tenant $tenant): void
+    {
+        $userId = $run->getUserId();
+        $context = new AgentToolContext($userId, $tenant, $run->getContext());
+
+        $tools = $this->registry->toAnthropicToolDefs($userId);
+        $model = $this->registry->hasKind($userId, ToolKind::Schema)
+            ? $this->models->schemaModel()
+            : $this->models->defaultModel();
+        $run->setModel($model);
+
+        $system = $this->prompts->build($run);
+        $userTurn = [['type' => 'text', 'text' => $run->getIntent()]];
+        $messages = [['role' => 'user', 'content' => $userTurn]];
+        $this->persistMessage($run, AgentMessage::ROLE_USER, $userTurn);
+
+        $toolCallCount = 0;
+
+        try {
+            while (true) {
+                $response = $this->llm->create($tenant, $model, $system, $messages, $tools);
+                $run->addUsage(
+                    $response->inputTokens,
+                    $response->outputTokens,
+                    $this->costs->costUsd($model, $response->inputTokens, $response->outputTokens),
+                );
+                $this->persistMessage($run, AgentMessage::ROLE_ASSISTANT, $response->contentBlocks);
+                $messages[] = ['role' => 'assistant', 'content' => $response->contentBlocks];
+
+                if ($run->getTokensInput() + $run->getTokensOutput() > $this->maxTokensPerRun) {
+                    $run->markError(\sprintf('Token limit per run exceeded (%d).', $this->maxTokensPerRun));
+
+                    return;
+                }
+
+                $toolUses = $response->toolUses();
+                if ([] === $toolUses || AgentLlmResponse::STOP_TOOL_USE !== $response->stopReason) {
+                    // Plain-text turn: a clarifying question or the final
+                    // summary — hand control back to the user.
+                    $run->markAwaitingInput();
+
+                    return;
+                }
+
+                if ($toolCallCount + \count($toolUses) > $this->maxToolCallsPerRun) {
+                    $run->markError(\sprintf('Tool-call limit per run exceeded (%d).', $this->maxToolCallsPerRun));
+
+                    return;
+                }
+
+                $toolResults = [];
+                $materialized = null;
+                foreach ($toolUses as $toolUse) {
+                    $outcome = $this->executor->execute($run, $toolUse['name'], $toolUse['input'], $context);
+                    ++$toolCallCount;
+
+                    $toolResults[] = [
+                        'type' => 'tool_result',
+                        'toolUseID' => $toolUse['id'],
+                        'content' => $this->encodeToolResult($outcome['content']),
+                        'isError' => $outcome['is_error'],
+                    ];
+
+                    $batchId = $outcome['content']['pending_change_batch_id'] ?? null;
+                    if (!$outcome['is_error'] && \is_string($batchId)) {
+                        $affected = $outcome['content']['affected_count'] ?? 0;
+                        $materialized = [
+                            'batch_id' => $batchId,
+                            'affected_count' => \is_int($affected) ? $affected : 0,
+                        ];
+                    }
+                }
+
+                $this->persistMessage($run, AgentMessage::ROLE_TOOL, $toolResults);
+                $messages[] = ['role' => 'user', 'content' => $toolResults];
+
+                if (null !== $materialized) {
+                    // Plan == diff (ADR-0024 c): the materialized batch IS
+                    // the plan; stop before approval.
+                    $run->markAwaitingApproval(
+                        \Symfony\Component\Uid\Uuid::fromString($materialized['batch_id']),
+                        $materialized['affected_count'],
+                    );
+
+                    return;
+                }
+            }
+        } catch (Throwable $failure) {
+            // Backoff exhaustion (SDK), missing key, or an unexpected bug:
+            // the run ends in `error`; nothing was committed (commits only
+            // happen post-approval in P3-02).
+            $run->markError($failure::class.': '.$failure->getMessage());
+        } finally {
+            $this->entityManager->flush();
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $content
+     */
+    private function encodeToolResult(array $content): string
+    {
+        $encoded = json_encode($content, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        return false === $encoded ? '{}' : $encoded;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $content
+     */
+    private function persistMessage(AgentRun $run, string $role, array $content): void
+    {
+        $message = new AgentMessage($run, $role, $content);
+        $this->entityManager->persist($message);
+        $this->entityManager->flush();
+    }
+}

--- a/apps/api/src/Agent/Application/Run/AgentRunHandler.php
+++ b/apps/api/src/Agent/Application/Run/AgentRunHandler.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Run;
+
+use App\Agent\Application\AgentFeatureGuard;
+use App\Agent\Domain\Entity\AgentRun;
+use App\Agent\Domain\Exception\AgentUnavailableException;
+use App\Shared\Application\AbstractBatchHandler;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * AGENT-P1-03 (#1955) — worker entry of the loop. Tenant context + RLS
+ * GUC are rebound by the shared middlewares (TenantAwareMessage); the
+ * feature guard re-checks availability IN the worker (the key may have
+ * been disabled between dispatch and pickup). Extends
+ * AbstractBatchHandler for the final flush+clear (worker memory rule).
+ */
+#[AsMessageHandler]
+final class AgentRunHandler extends AbstractBatchHandler
+{
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        private readonly AgentLoopRunner $loop,
+        private readonly AgentFeatureGuard $guard,
+    ) {
+        parent::__construct($entityManager);
+    }
+
+    public function __invoke(AgentRunMessage $message): void
+    {
+        try {
+            $run = $this->entityManager->createQueryBuilder()
+                ->select('r')
+                ->from(AgentRun::class, 'r')
+                ->where('r.id = :id')
+                ->setParameter('id', $message->runId, 'uuid')
+                ->getQuery()
+                ->getOneOrNullResult();
+
+            if (!$run instanceof AgentRun) {
+                // Deleted / foreign-tenant run: nothing to do.
+                return;
+            }
+
+            $tenant = $run->getTenant();
+            if (!$tenant instanceof Tenant) {
+                return;
+            }
+
+            try {
+                $this->guard->assertEnabled($tenant);
+            } catch (AgentUnavailableException $unavailable) {
+                $run->markError($unavailable->getMessage());
+                $this->entityManager->flush();
+
+                return;
+            }
+
+            $this->loop->run($run, $tenant);
+        } finally {
+            $this->flushAndClear();
+        }
+    }
+}

--- a/apps/api/src/Agent/Application/Run/AgentRunMessage.php
+++ b/apps/api/src/Agent/Application/Run/AgentRunMessage.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Run;
+
+use App\Shared\Application\TenantAwareMessage;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AGENT-P1-03 (#1955) — async trigger of the loop. TenantAwareMessage
+ * so the worker middlewares rebind the tenant context + RLS GUC before
+ * the handler touches the database. Routed to the `import` transport
+ * (the queue the dev/prod worker consumes) via config/packages/agent.yaml.
+ */
+final readonly class AgentRunMessage implements TenantAwareMessage
+{
+    public function __construct(
+        public Uuid $runId,
+        public Uuid $tenantId,
+    ) {
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenantId;
+    }
+}

--- a/apps/api/src/Agent/Application/Run/AgentRunStarter.php
+++ b/apps/api/src/Agent/Application/Run/AgentRunStarter.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Run;
+
+use App\Agent\Application\AgentFeatureGuard;
+use App\Agent\Domain\AgentRunStatus;
+use App\Agent\Domain\AgentRunSurface;
+use App\Agent\Domain\Entity\AgentRun;
+use App\Agent\Domain\Exception\ActiveRunConflictException;
+use App\Shared\Domain\Tenant;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AGENT-P1-03 (#1955) — the single entry point that starts a run:
+ * feature guard -> persist AgentRun (a partial unique index on active
+ * statuses makes "1 active run per user" race-proof at the DB level)
+ * -> dispatch the async loop message.
+ */
+final readonly class AgentRunStarter
+{
+    public function __construct(
+        private AgentFeatureGuard $guard,
+        private EntityManagerInterface $entityManager,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $context view context (filter DSL, selection, locale/channel)
+     */
+    public function start(Tenant $tenant, Uuid $userId, AgentRunSurface $surface, string $intent, array $context = []): AgentRun
+    {
+        $this->guard->assertEnabled($tenant);
+
+        if ($this->hasActiveRun($userId)) {
+            throw ActiveRunConflictException::forUser();
+        }
+
+        $run = new AgentRun($userId, $surface, $intent, $context);
+
+        try {
+            $this->entityManager->persist($run);
+            $this->entityManager->flush();
+        } catch (UniqueConstraintViolationException) {
+            // uniq_agent_runs_active_per_user: a concurrent start lost the
+            // race - same answer as the friendly pre-check would give.
+            throw ActiveRunConflictException::forUser();
+        }
+
+        $this->messageBus->dispatch(new AgentRunMessage($run->getId(), $tenant->getId()));
+
+        return $run;
+    }
+
+    private function hasActiveRun(Uuid $userId): bool
+    {
+        $count = $this->entityManager->createQueryBuilder()
+            ->select('COUNT(r.id)')
+            ->from(AgentRun::class, 'r')
+            ->where('r.userId = :user')
+            ->andWhere('r.status IN (:active)')
+            ->setParameter('user', $userId, 'uuid')
+            ->setParameter('active', [
+                AgentRunStatus::Planning->value,
+                AgentRunStatus::AwaitingInput->value,
+                AgentRunStatus::AwaitingApproval->value,
+                AgentRunStatus::Committing->value,
+            ])
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return (int) (\is_scalar($count) ? $count : 0) > 0;
+    }
+}

--- a/apps/api/src/Agent/Application/Run/AgentSystemPromptBuilder.php
+++ b/apps/api/src/Agent/Application/Run/AgentSystemPromptBuilder.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Run;
+
+use App\Agent\Domain\Entity\AgentRun;
+
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+
+/**
+ * AGENT-P1-03 (#1955) — deterministic system prompt of the loop
+ * (PRD 5.2): ground plans in read tools, ask when ambiguous, write
+ * only through approval-gated tools, never fabricate numbers.
+ */
+final readonly class AgentSystemPromptBuilder
+{
+    public function build(AgentRun $run): string
+    {
+        $context = $run->getContext();
+        $contextJson = [] === $context
+            ? 'none'
+            : json_encode($context, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        return <<<PROMPT
+            You are the catalog agent of a PIM system, acting strictly within the permissions of the initiating user.
+
+            Rules:
+            - Ground every plan in real numbers obtained from the read tools; never estimate or fabricate counts.
+            - When the intent is ambiguous, ask ONE precise clarifying question as plain text and stop.
+            - Catalog writes happen ONLY through the provided write tools, which materialize proposals for human approval; you never commit changes yourself.
+            - A "forbidden" tool result means the action is outside the user's permissions - do not retry it; tell the user instead.
+            - When you are done (proposal materialized or question asked), reply with a short plain-text summary in the user's language.
+
+            View context of the initiating user (carry it into tool calls instead of asking for it):
+            {$contextJson}
+            PROMPT;
+    }
+}

--- a/apps/api/src/Agent/Application/Run/UsageCostCalculator.php
+++ b/apps/api/src/Agent/Application/Run/UsageCostCalculator.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Run;
+
+use App\Agent\Infrastructure\Anthropic\AgentModelSelector;
+
+/**
+ * AGENT-P1-03 (#1955) — per-call USD cost from token usage. Prices are
+ * configuration (per MTok, matching the two model tiers of the
+ * selector) so a pricing change never touches code. Cost feeds
+ * agent_runs accounting and the 8.5 limits (P1-04).
+ */
+final readonly class UsageCostCalculator
+{
+    public function __construct(
+        private AgentModelSelector $models,
+        private float $defaultInputPerMtok,
+        private float $defaultOutputPerMtok,
+        private float $schemaInputPerMtok,
+        private float $schemaOutputPerMtok,
+    ) {
+    }
+
+    /**
+     * @return numeric-string USD with 6 decimals
+     */
+    public function costUsd(string $model, int $inputTokens, int $outputTokens): string
+    {
+        [$in, $out] = $model === $this->models->schemaModel()
+            ? [$this->schemaInputPerMtok, $this->schemaOutputPerMtok]
+            : [$this->defaultInputPerMtok, $this->defaultOutputPerMtok];
+
+        $cost = ($inputTokens * $in + $outputTokens * $out) / 1_000_000;
+
+        return number_format($cost, 6, '.', '');
+    }
+}

--- a/apps/api/src/Agent/Domain/Exception/ActiveRunConflictException.php
+++ b/apps/api/src/Agent/Domain/Exception/ActiveRunConflictException.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Domain\Exception;
+
+use RuntimeException;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+
+/**
+ * AGENT-P1-03 (#1955) — one active run per user (PRD 14.2 decision 3).
+ * Renders as a 409 problem document via the shared RFC 7807 listener.
+ */
+final class ActiveRunConflictException extends RuntimeException implements HttpExceptionInterface
+{
+    public static function forUser(): self
+    {
+        return new self('You already have an active agent run. Wait for it to finish (or cancel it) before starting another.');
+    }
+
+    public function getStatusCode(): int
+    {
+        return 409;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getHeaders(): array
+    {
+        return [];
+    }
+}

--- a/apps/api/src/Agent/Infrastructure/Anthropic/SdkAgentLlmClient.php
+++ b/apps/api/src/Agent/Infrastructure/Anthropic/SdkAgentLlmClient.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Infrastructure\Anthropic;
+
+use Anthropic\Messages\TextBlock;
+use Anthropic\Messages\ToolUseBlock;
+use App\Agent\Application\Llm\AgentLlmClientInterface;
+use App\Agent\Application\Llm\AgentLlmResponse;
+use App\Shared\Domain\Tenant;
+
+/**
+ * AGENT-P1-03 (#1955) — the only network-facing piece of the loop:
+ * builds the per-tenant SDK client (BYOK, P0-06; retry/backoff lives
+ * in the SDK transport) and normalizes the response into the
+ * provider-agnostic {@see AgentLlmResponse}.
+ */
+final readonly class SdkAgentLlmClient implements AgentLlmClientInterface
+{
+    private const int MAX_TOKENS = 4096;
+
+    public function __construct(
+        private AnthropicClientFactory $clientFactory,
+    ) {
+    }
+
+    public function create(Tenant $tenant, string $model, string $system, array $messages, array $tools): AgentLlmResponse
+    {
+        $client = $this->clientFactory->forTenant($tenant);
+
+        $message = $client->messages->create(
+            model: $model,
+            maxTokens: self::MAX_TOKENS,
+            system: $system,
+            // Wire-shape arrays; the SDK normalizes them (camelCase keys).
+            // @phpstan-ignore argument.type
+            messages: $messages,
+            // @phpstan-ignore argument.type
+            tools: $tools,
+        );
+
+        $blocks = [];
+        foreach ($message->content as $block) {
+            if ($block instanceof TextBlock) {
+                $blocks[] = ['type' => 'text', 'text' => $block->text];
+            } elseif ($block instanceof ToolUseBlock) {
+                $blocks[] = ['type' => 'tool_use', 'id' => $block->id, 'name' => $block->name, 'input' => $block->input];
+            }
+        }
+
+        return new AgentLlmResponse(
+            stopReason: $message->stopReason ?? AgentLlmResponse::STOP_END_TURN,
+            contentBlocks: $blocks,
+            inputTokens: $message->usage->inputTokens,
+            outputTokens: $message->usage->outputTokens,
+        );
+    }
+}

--- a/apps/api/src/Agent/Infrastructure/Migrations/Version20260702170000.php
+++ b/apps/api/src/Agent/Infrastructure/Migrations/Version20260702170000.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AgentMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * AGENT-P1-03 (#1955) — "1 active run per user" (PRD 14.2 decision 3)
+ * enforced at the database level: a partial unique index over the
+ * non-terminal statuses makes concurrent starts race-proof; the app
+ * layer translates the violation into a 409.
+ */
+final class Version20260702170000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'AGENT-P1-03: one active agent run per user (partial unique index)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(
+            'CREATE UNIQUE INDEX uniq_agent_runs_active_per_user ON agent_runs (tenant_id, user_id) '
+            ."WHERE status IN ('planning', 'awaiting_input', 'awaiting_approval', 'committing')"
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX uniq_agent_runs_active_per_user');
+    }
+}

--- a/apps/api/src/Agent/Presentation/Command/StartAgentRunCommand.php
+++ b/apps/api/src/Agent/Presentation/Command/StartAgentRunCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Presentation\Command;
+
+use App\Agent\Application\Run\AgentRunStarter;
+use App\Agent\Domain\AgentRunSurface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AGENT-P1-03 (#1955) — operator smoke entry for the loop before the
+ * public API lands (P4-01): starts an async run in the given user's
+ * scope. With no BYOK key configured the guard refuses - which is
+ * itself the live wire-through smoke of dispatch/worker/guard.
+ */
+#[AsCommand(
+    name: 'pim:agent:start',
+    description: 'Start an agent run (async) for a tenant/user - smoke entry until the public API (P4-01).',
+)]
+final class StartAgentRunCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly TenantContext $tenantContext,
+        private readonly AgentRunStarter $starter,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('tenant-code', InputArgument::REQUIRED, 'Tenant code (e.g. demo)')
+            ->addArgument('user-id', InputArgument::REQUIRED, 'Initiating user UUID (the run acts within their permissions)')
+            ->addArgument('intent', InputArgument::REQUIRED, 'Natural-language intent');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $tenantCode = (string) $input->getArgument('tenant-code'); // @phpstan-ignore cast.useless
+        $tenant = $this->entityManager->getRepository(Tenant::class)->findOneBy(['code' => $tenantCode]);
+        if (!$tenant instanceof Tenant) {
+            $io->error(\sprintf('Unknown tenant "%s".', $tenantCode));
+
+            return Command::FAILURE;
+        }
+
+        $this->tenantContext->set($tenant);
+
+        $run = $this->starter->start(
+            $tenant,
+            Uuid::fromString((string) $input->getArgument('user-id')), // @phpstan-ignore cast.useless
+            AgentRunSurface::Chat,
+            (string) $input->getArgument('intent'), // @phpstan-ignore cast.useless
+        );
+
+        $io->success(\sprintf('Agent run %s dispatched (status: %s).', $run->getId()->toRfc4122(), $run->getStatus()->value));
+
+        return Command::SUCCESS;
+    }
+}

--- a/apps/api/tests/Integration/Agent/AgentLoopRunnerTest.php
+++ b/apps/api/tests/Integration/Agent/AgentLoopRunnerTest.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Agent;
+
+use App\Agent\Application\Llm\AgentLlmClientInterface;
+use App\Agent\Application\Llm\AgentLlmResponse;
+use App\Agent\Application\Run\AgentLoopRunner;
+use App\Agent\Application\Run\AgentSystemPromptBuilder;
+use App\Agent\Application\Run\UsageCostCalculator;
+use App\Agent\Application\Tool\AgentToolContext;
+use App\Agent\Application\Tool\AgentToolInterface;
+use App\Agent\Application\Tool\GuardedToolExecutor;
+use App\Agent\Application\Tool\PingTool;
+use App\Agent\Application\Tool\ToolKind;
+use App\Agent\Application\Tool\ToolRegistry;
+use App\Agent\Domain\AgentRunStatus;
+use App\Agent\Domain\AgentRunSurface;
+use App\Agent\Domain\Entity\AgentMessage;
+use App\Agent\Domain\Entity\AgentRun;
+use App\Agent\Infrastructure\Anthropic\AgentModelSelector;
+use App\Identity\Contracts\Policy\PermissionCheckerInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\ORM\EntityManagerInterface;
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * AGENT-P1-03 (#1955) — the loop against real Postgres with a scripted
+ * LLM (deterministic; the SDK adapter is the only network code):
+ * grounding turn -> tool trace + messages persisted; write-tool
+ * materialization -> awaiting_approval with batch id (autonomy stops
+ * BEFORE approval); tool-call and token limits -> run error; LLM
+ * failure -> run error, nothing committed.
+ */
+final class AgentLoopRunnerTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public const string BATCH_ID = '0197c3b0-0000-7000-8000-000000000001';
+
+    #[Test]
+    public function groundingTurnEndsAwaitingInputWithFullTrace(): void
+    {
+        [$run, $tenant, $em] = $this->fixture();
+
+        $llm = $this->scriptedLlm([
+            new AgentLlmResponse('tool_use', [
+                ['type' => 'text', 'text' => 'Sprawdzam katalog.'],
+                ['type' => 'tool_use', 'id' => 'tu_1', 'name' => 'ping', 'input' => ['echo' => 'ground']],
+            ], 1000, 200),
+            new AgentLlmResponse('end_turn', [
+                ['type' => 'text', 'text' => 'Znalazłem 0 produktów — doprecyzuj filtr?'],
+            ], 1500, 100),
+        ]);
+
+        $this->runner($llm, $em)->run($run, $tenant);
+
+        self::assertSame(AgentRunStatus::AwaitingInput, $run->getStatus());
+        self::assertSame(2500, $run->getTokensInput());
+        self::assertSame(300, $run->getTokensOutput());
+        self::assertSame('claude-sonnet-test', $run->getModel());
+        self::assertGreaterThan(0.0, (float) $run->getCostUsd());
+
+        $roles = $this->messageRoles($em, $run);
+        self::assertSame(
+            [AgentMessage::ROLE_USER, AgentMessage::ROLE_ASSISTANT, AgentMessage::ROLE_TOOL, AgentMessage::ROLE_ASSISTANT],
+            $roles,
+        );
+    }
+
+    #[Test]
+    public function writeToolMaterializationStopsAtAwaitingApproval(): void
+    {
+        [$run, $tenant, $em] = $this->fixture();
+
+        $llm = $this->scriptedLlm([
+            new AgentLlmResponse('tool_use', [
+                ['type' => 'tool_use', 'id' => 'tu_1', 'name' => 'fake_write', 'input' => ['value' => 100]],
+            ], 900, 150),
+            // Would be a next turn — the loop must never request it.
+            new AgentLlmResponse('end_turn', [['type' => 'text', 'text' => 'unreachable']], 1, 1),
+        ]);
+
+        $this->runner($llm, $em, [new PingTool(), $this->fakeWriteTool()])->run($run, $tenant);
+
+        self::assertSame(AgentRunStatus::AwaitingApproval, $run->getStatus());
+        self::assertSame(self::BATCH_ID, $run->getPendingChangeBatchId()?->toRfc4122());
+        self::assertSame(1800, $run->getAffectedCount());
+        self::assertSame(900, $run->getTokensInput(), 'the loop must stop right after materialization (no extra LLM turn)');
+    }
+
+    #[Test]
+    public function toolCallLimitEndsInError(): void
+    {
+        [$run, $tenant, $em] = $this->fixture();
+
+        $manyUses = [];
+        for ($i = 0; $i < 11; ++$i) {
+            $manyUses[] = ['type' => 'tool_use', 'id' => 'tu_'.$i, 'name' => 'ping', 'input' => []];
+        }
+        $llm = $this->scriptedLlm([new AgentLlmResponse('tool_use', $manyUses, 500, 50)]);
+
+        $this->runner($llm, $em)->run($run, $tenant);
+
+        self::assertSame(AgentRunStatus::Error, $run->getStatus());
+        self::assertStringContainsString('Tool-call limit', (string) $run->getErrorMessage());
+    }
+
+    #[Test]
+    public function tokenLimitEndsInError(): void
+    {
+        [$run, $tenant, $em] = $this->fixture();
+
+        $llm = $this->scriptedLlm([
+            new AgentLlmResponse('tool_use', [
+                ['type' => 'tool_use', 'id' => 'tu_1', 'name' => 'ping', 'input' => []],
+            ], 99_000, 2_000),
+        ]);
+
+        $this->runner($llm, $em)->run($run, $tenant);
+
+        self::assertSame(AgentRunStatus::Error, $run->getStatus());
+        self::assertStringContainsString('Token limit', (string) $run->getErrorMessage());
+    }
+
+    #[Test]
+    public function llmFailureEndsInErrorWithoutThrowing(): void
+    {
+        [$run, $tenant, $em] = $this->fixture();
+
+        $llm = new class implements AgentLlmClientInterface {
+            public function create(Tenant $tenant, string $model, string $system, array $messages, array $tools): AgentLlmResponse
+            {
+                throw new RuntimeException('backoff exhausted');
+            }
+        };
+
+        $this->runner($llm, $em)->run($run, $tenant);
+
+        self::assertSame(AgentRunStatus::Error, $run->getStatus());
+        self::assertStringContainsString('backoff exhausted', (string) $run->getErrorMessage());
+    }
+
+    /**
+     * @return array{0: AgentRun, 1: Tenant, 2: EntityManagerInterface}
+     */
+    private function fixture(): array
+    {
+        $tenant = new Tenant('alpha', 'Alpha Tenant');
+        $em = $this->em();
+        $em->persist($tenant);
+        $em->flush();
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+
+        $run = new AgentRun(Uuid::v7(), AgentRunSurface::Chat, 'ustaw cenę 100 wszystkim bez ceny', ['filter_dsl' => ['price' => 'empty']]);
+        $em->persist($run);
+        $em->flush();
+
+        return [$run, $tenant, $em];
+    }
+
+    /**
+     * @param list<AgentLlmResponse> $script
+     */
+    private function scriptedLlm(array $script): AgentLlmClientInterface
+    {
+        return new class($script) implements AgentLlmClientInterface {
+            private int $turn = 0;
+
+            /** @param list<AgentLlmResponse> $script */
+            public function __construct(private readonly array $script)
+            {
+            }
+
+            public function create(Tenant $tenant, string $model, string $system, array $messages, array $tools): AgentLlmResponse
+            {
+                $response = $this->script[$this->turn] ?? null;
+                if (null === $response) {
+                    throw new LogicException('LLM called more times than scripted.');
+                }
+                ++$this->turn;
+
+                return $response;
+            }
+        };
+    }
+
+    /**
+     * @param list<AgentToolInterface>|null $tools
+     */
+    private function runner(AgentLlmClientInterface $llm, EntityManagerInterface $em, ?array $tools = null): AgentLoopRunner
+    {
+        $checker = new class implements PermissionCheckerInterface {
+            public function userHasPermission(Uuid $userId, string $permissionCode): bool
+            {
+                return true;
+            }
+        };
+        $registry = new ToolRegistry($tools ?? [new PingTool()], $checker);
+        $selector = new AgentModelSelector('claude-sonnet-test', 'claude-opus-test');
+
+        return new AgentLoopRunner(
+            llm: $llm,
+            registry: $registry,
+            executor: new GuardedToolExecutor($registry, $em),
+            models: $selector,
+            prompts: new AgentSystemPromptBuilder(),
+            costs: new UsageCostCalculator($selector, 3.0, 15.0, 5.0, 25.0),
+            entityManager: $em,
+            maxToolCallsPerRun: 10,
+            maxTokensPerRun: 100_000,
+        );
+    }
+
+    private function fakeWriteTool(): AgentToolInterface
+    {
+        return new class implements AgentToolInterface {
+            public function name(): string
+            {
+                return 'fake_write';
+            }
+
+            public function description(): string
+            {
+                return 'Test-only write tool that materializes a proposal.';
+            }
+
+            public function parametersSchema(): array
+            {
+                return ['type' => 'object', 'properties' => [], 'required' => []];
+            }
+
+            public function requiredPermission(): string
+            {
+                return 'object.write';
+            }
+
+            public function kind(): ToolKind
+            {
+                return ToolKind::Write;
+            }
+
+            public function execute(array $arguments, AgentToolContext $context): array
+            {
+                return [
+                    'pending_change_batch_id' => AgentLoopRunnerTest::BATCH_ID,
+                    'affected_count' => 1800,
+                ];
+            }
+        };
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function messageRoles(EntityManagerInterface $em, AgentRun $run): array
+    {
+        /** @var list<AgentMessage> $messages */
+        $messages = $em->createQueryBuilder()
+            ->select('m')
+            ->from(AgentMessage::class, 'm')
+            ->where('m.run = :run')
+            ->setParameter('run', $run->getId(), 'uuid')
+            ->orderBy('m.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return array_map(static fn (AgentMessage $m): string => $m->getRole(), $messages);
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}

--- a/apps/api/tests/Integration/Agent/AgentRunStarterTest.php
+++ b/apps/api/tests/Integration/Agent/AgentRunStarterTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Agent;
+
+use App\Agent\Application\AgentFeatureGuard;
+use App\Agent\Application\Run\AgentRunStarter;
+use App\Agent\Domain\AgentRunStatus;
+use App\Agent\Domain\AgentRunSurface;
+use App\Agent\Domain\Entity\AgentRun;
+use App\Agent\Domain\Exception\ActiveRunConflictException;
+use App\Agent\Domain\Exception\AgentUnavailableException;
+use App\Identity\Contracts\Byok\ByokKeyResolverInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * AGENT-P1-03 (#1955) — run start path: guard-first, DB-enforced
+ * "1 active run per user" (409), and the real dispatch wire-through
+ * (sync transport in tests executes the worker handler inline - with
+ * no BYOK key the guard inside the worker marks the run `error`, which
+ * is exactly the live keyless behavior).
+ */
+final class AgentRunStarterTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function secondActiveRunForTheSameUserConflicts(): void
+    {
+        [$tenant, $em] = $this->tenantFixture();
+        $starter = new AgentRunStarter($this->guard(true), $em, $this->noopBus());
+        $userId = Uuid::v7();
+
+        $first = $starter->start($tenant, $userId, AgentRunSurface::Chat, 'first intent');
+        self::assertSame(AgentRunStatus::Planning, $first->getStatus());
+
+        $this->expectException(ActiveRunConflictException::class);
+        $starter->start($tenant, $userId, AgentRunSurface::Chat, 'second intent');
+    }
+
+    #[Test]
+    public function guardRefusalPersistsNothing(): void
+    {
+        [$tenant, $em] = $this->tenantFixture();
+        $starter = new AgentRunStarter($this->guard(false), $em, $this->noopBus());
+
+        try {
+            $starter->start($tenant, Uuid::v7(), AgentRunSurface::Chat, 'intent');
+            self::fail('Expected AgentUnavailableException');
+        } catch (AgentUnavailableException) {
+        }
+
+        $count = $em->createQueryBuilder()
+            ->select('COUNT(r.id)')
+            ->from(AgentRun::class, 'r')
+            ->getQuery()
+            ->getSingleScalarResult();
+        self::assertSame(0, (int) (\is_scalar($count) ? $count : -1));
+    }
+
+    #[Test]
+    public function realDispatchRunsWorkerInlineAndKeylessTenantEndsInError(): void
+    {
+        [$tenant, $em] = $this->tenantFixture();
+
+        // Starter-side guard passes (fake key); the WORKER-side guard is
+        // the real container service - the tenant has no BYOK key, so the
+        // handler must mark the run error instead of crashing the queue.
+        $bus = self::getContainer()->get(MessageBusInterface::class);
+        $starter = new AgentRunStarter($this->guard(true), $em, $bus);
+
+        $run = $starter->start($tenant, Uuid::v7(), AgentRunSurface::Chat, 'live wire-through');
+
+        $em->clear();
+        $reloaded = $em->createQueryBuilder()
+            ->select('r')
+            ->from(AgentRun::class, 'r')
+            ->where('r.id = :id')
+            ->setParameter('id', $run->getId(), 'uuid')
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        self::assertInstanceOf(AgentRun::class, $reloaded);
+        self::assertSame(AgentRunStatus::Error, $reloaded->getStatus());
+        self::assertStringContainsString('BYOK', (string) $reloaded->getErrorMessage());
+    }
+
+    /**
+     * @return array{0: Tenant, 1: EntityManagerInterface}
+     */
+    private function tenantFixture(): array
+    {
+        $tenant = new Tenant('alpha', 'Alpha Tenant');
+        $em = $this->em();
+        $em->persist($tenant);
+        $em->flush();
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+
+        return [$tenant, $em];
+    }
+
+    private function guard(bool $hasKey): AgentFeatureGuard
+    {
+        $resolver = new class($hasKey) implements ByokKeyResolverInterface {
+            public function __construct(private readonly bool $hasKey)
+            {
+            }
+
+            public function resolveKey(Tenant $tenant): ?string
+            {
+                return $this->hasKey ? 'sk-ant-test' : null;
+            }
+
+            public function hasActiveKey(Tenant $tenant): bool
+            {
+                return $this->hasKey;
+            }
+        };
+
+        return new AgentFeatureGuard($resolver, agentEnabled: true);
+    }
+
+    private function noopBus(): MessageBusInterface
+    {
+        return new class implements MessageBusInterface {
+            public function dispatch(object $message, array $stamps = []): Envelope
+            {
+                return new Envelope($message, $stamps);
+            }
+        };
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}


### PR DESCRIPTION
## Cel (AGENT-P1-03 #1955, epik 0.7)

Serce feature'a (PRD §5.2): pętla tool-calling, która rozumie intencję, groundinguje przez read-toole, dopytuje przy niejasności i materializuje propozycję. **Autonomia kończy się PRZED approvalem** (ADR-0024 c).

## Zakres

- **`AgentLoopRunner`**: pętla nad RBAC-filtrowanym rejestrem. Tura plain-text = dopytanie/odpowiedź → `awaiting_input`; wynik write-toola z `pending_change_batch_id` → `awaiting_approval` i **STOP** (plan == diff; commit = P3-02). Limity in-run: **10 tool-calls/run + 100k tokenów/run** (konfig); przekroczenie lub błąd LLM → run `error`, zero częściowego commitu (strukturalnie niemożliwy przed akceptem).
- **Seam LLM** `AgentLlmClientInterface` + `AgentLlmResponse` — pętla deterministyczna i testowalna skryptowanymi odpowiedziami; `SdkAgentLlmClient` (BYOK z P0-06, retry/backoff w transporcie SDK) to jedyny kod sieciowy.
- **Async**: `AgentRunMessage` (TenantAwareMessage) → transport `import` (routing w usuwalnym `config/packages/agent.yaml`); `AgentRunHandler` extends `AbstractBatchHandler` (finalny flush+clear), **re-check guardu W workerze** (klucz mógł zniknąć między dispatch a pickup) → refusal = run error, nie crash kolejki.
- **`AgentRunStarter`**: guard → limity → friendly pre-check aktywnego runu → persist → dispatch. **„1 aktywny run/user" race-proof na poziomie DB** (partial unique index na statusach nieterminalnych, migracja w namespace modułu); violation → **409 RFC 7807**. Decyzja techniczna: własny DB-constraint zamiast reuse `BulkOperationLock` (Catalog internals — Deptrac zabrania; semantyka per-user ≠ per-tenant) — udokumentowana tutaj.
- `UsageCostCalculator` (ceny per MTok z konfigu per tier) + `AgentSystemPromptBuilder` (zasady: grounding, jedno pytanie przy niejasności, writes tylko przez approval-toole, zakaz fabrykowania liczb).
- `pim:agent:start` CLI — wejście smoke dla operatora do czasu P4-01.

## Testy / bramki

- Integration 8/8: pełny cykl grounding (user→assistant→tool→assistant, akumulacja tokenów+kosztu, model=sonnet-tier); materializacja → `awaiting_approval` z batch id **bez dodatkowej tury LLM**; limit tool-calls i limit tokenów → `error`; wyjątek LLM → `error` bez wybuchu; **409 przy drugim aktywnym runie**; odmowa guardu nie persystuje nic; **realny dispatch wire-through** (sync transport w teście): tenant bez klucza → run `error` z hintem BYOK — dokładnie zachowanie live bez klucza.
- PHPStan max 0 · Deptrac 0 · lint:container zielony · 32/32 agent suite na zrebase'owanym drzewie.

## ⚠️ Smoke (SMOKE TEST RULE — uczciwie)

Pętla wired + unit/integration green; **LLM-live smoke pending BYOK key** (brak realnego klucza — jedyne legalne odstępstwo maratonu). Ścieżka dispatch→worker→guard-deny jest wykonalna live i pokryta testem wire-through; pełny run e2e z realnym modelem = P9-05 po konfiguracji klucza.

Closes #1955

🤖 Generated with [Claude Code](https://claude.com/claude-code)