### PR TITLE
fix(tests): restore array narrowing dropped by the maintenance sweep

### DIFF
--- a/apps/api/tests/Api/Catalog/EffectiveAttributeGroupsApiTest.php
+++ b/apps/api/tests/Api/Catalog/EffectiveAttributeGroupsApiTest.php
@@ -177,6 +177,7 @@ final class EffectiveAttributeGroupsApiTest extends CatalogApiTestCase
         self::assertContains('pl', $codes);
         self::assertContains('en', $codes);
         $first = $locales[0];
+        self::assertIsArray($first);
         self::assertTrue($first['is_default'], 'Default locale is listed first.');
         self::assertSame('pl', $first['code']);
     }

--- a/apps/api/tests/Api/Catalog/SmartFilterPresetsApiTest.php
+++ b/apps/api/tests/Api/Catalog/SmartFilterPresetsApiTest.php
@@ -73,6 +73,7 @@ final class SmartFilterPresetsApiTest extends CatalogApiTestCase
         self::assertContains('no-category', $slugs);
 
         foreach ($data as $row) {
+            self::assertIsArray($row);
             if ('red-low-completeness' === ($row['slug'] ?? null)) {
                 self::assertTrue($row['is_built_in']);
                 self::assertTrue($row['is_system']);


### PR DESCRIPTION
PR #2068 (maintenance sweep) usunął narrowing `is_array` w dwóch testach Api — **PHPStan max na main jest czerwony** ("Cannot access offset on mixed"), a runy Quality PHP dla #2068 były `cancelled`, więc weszło niezauważone. `assertIsArray` przywraca narrowing i dodatkowo asertuje realny kształt odpowiedzi.

Blokuje CI wszystkich otwartych PR-ów epiku 0.7 — proszę o szybki merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)