### PR TITLE
feat(agent): aggregate_count grounding tool (matched N)

### DIFF
--- a/apps/api/src/Agent/Application/Tool/AggregateCatalogTool.php
+++ b/apps/api/src/Agent/Application/Tool/AggregateCatalogTool.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Tool;
+
+use App\Search\Contracts\CatalogQueryPort;
+
+/**
+ * AGENT-P2-02 (#1959) — the "matched N" grounding tool: a hard,
+ * RBAC/tenant-scoped count for a filter DSL, cheaper and more explicit
+ * than paging through search_catalog. The number it returns is the one
+ * that lands in the plan shown to the operator ("1 800 objects will
+ * change").
+ *
+ * Richer statistics (median/min/max) are NOT available through the
+ * search engine cheaply - the tool says so instead of estimating
+ * (PRD 8.1 median checks arrive with the read-SQL port of P2-03 /
+ * future analytics; conscious MVP scope per ticket AC).
+ */
+final readonly class AggregateCatalogTool implements AgentToolInterface
+{
+    public function __construct(
+        private CatalogQueryPort $catalogQuery,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'aggregate_count';
+    }
+
+    public function description(): string
+    {
+        return 'Count catalog objects matching a filter DSL (and/or full-text query). Call it to get the exact affected-object count BEFORE proposing any change. '
+            .'If the user refers to the current view, omit filter_dsl - the active view filter is applied automatically. Returns matched (exact count).';
+    }
+
+    public function parametersSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'object_kind' => [
+                    'type' => 'string',
+                    'description' => 'Object kind to count (product, category, asset, custom). Default: product.',
+                ],
+                'query' => ['type' => 'string', 'description' => 'Optional full-text query narrowing the count.'],
+                'filter_dsl' => [
+                    'type' => 'object',
+                    'description' => 'Canonical filter DSL. Omit to use the active view filter.',
+                ],
+            ],
+            'required' => [],
+        ];
+    }
+
+    public function requiredPermission(): string
+    {
+        return 'object.read';
+    }
+
+    public function kind(): ToolKind
+    {
+        return ToolKind::Read;
+    }
+
+    public function execute(array $arguments, AgentToolContext $context): array
+    {
+        $kind = \is_string($arguments['object_kind'] ?? null) ? $arguments['object_kind'] : 'product';
+        $query = \is_string($arguments['query'] ?? null) ? $arguments['query'] : '';
+
+        $filterDsl = \is_array($arguments['filter_dsl'] ?? null) ? $arguments['filter_dsl'] : null;
+        $viewFilter = $context->viewContext['filter_dsl'] ?? null;
+        if (null === $filterDsl && \is_array($viewFilter)) {
+            $filterDsl = $viewFilter;
+        }
+
+        /** @var array<string, mixed> $filterDslArray */
+        $filterDslArray = $filterDsl ?? [];
+        $result = $this->catalogQuery->search($kind, $query, $filterDslArray, page: 1, perPage: 1);
+
+        return [
+            'matched' => $result->totalHits,
+            'degraded' => $result->degraded,
+            'note' => $result->degraded
+                ? 'Search engine unavailable - the count is NOT verified; tell the user you could not verify.'
+                : 'Exact count. Median/min/max statistics are not available through this tool - do not estimate them.',
+        ];
+    }
+}

--- a/apps/api/tests/Unit/Agent/AggregateCatalogToolTest.php
+++ b/apps/api/tests/Unit/Agent/AggregateCatalogToolTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Agent;
+
+use App\Agent\Application\Tool\AgentToolContext;
+use App\Agent\Application\Tool\AggregateCatalogTool;
+use App\Agent\Application\Tool\ToolKind;
+use App\Search\Contracts\CatalogQueryResult;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AGENT-P2-02 (#1959) — the count tool grounds "matched N" through the
+ * same port as search: view-context filter by default, exact count via
+ * a perPage=1 probe, degraded honesty, and an explicit no-statistics
+ * note (do not estimate medians).
+ */
+final class AggregateCatalogToolTest extends TestCase
+{
+    #[Test]
+    public function countsWithViewContextFilterByDefault(): void
+    {
+        $port = new RecordingCatalogQueryPort(new CatalogQueryResult([], 1800, false));
+        $tool = new AggregateCatalogTool($port);
+
+        $viewFilter = ['attr' => 'price', 'op' => 'IS EMPTY'];
+        $result = $tool->execute([], $this->context(['filter_dsl' => $viewFilter]));
+
+        self::assertSame(1800, $result['matched']);
+        self::assertFalse($result['degraded']);
+        $note = $result['note'];
+        self::assertIsString($note);
+        self::assertStringContainsString('do not estimate', $note);
+        self::assertSame($viewFilter, $port->lastFilterDsl);
+        self::assertSame(1, $port->lastPerPage, 'count probe must not fetch hit pages');
+        self::assertSame(ToolKind::Read, $tool->kind());
+        self::assertSame('object.read', $tool->requiredPermission());
+    }
+
+    #[Test]
+    public function degradedEngineIsHonest(): void
+    {
+        $tool = new AggregateCatalogTool(new RecordingCatalogQueryPort(new CatalogQueryResult([], 0, true)));
+
+        $result = $tool->execute(['filter_dsl' => ['attr' => 'brand', 'op' => '=', 'value' => 'Festo']], $this->context());
+
+        self::assertTrue($result['degraded']);
+        $note = $result['note'];
+        self::assertIsString($note);
+        self::assertStringContainsString('could not verify', $note);
+    }
+
+    /**
+     * @param array<string, mixed> $viewContext
+     */
+    private function context(array $viewContext = []): AgentToolContext
+    {
+        return new AgentToolContext(Uuid::v7(), new Tenant('alpha', 'Alpha'), $viewContext);
+    }
+}

--- a/apps/api/tests/Unit/Agent/RecordingCatalogQueryPort.php
+++ b/apps/api/tests/Unit/Agent/RecordingCatalogQueryPort.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Agent;
+
+use App\Search\Contracts\CatalogQueryPort;
+use App\Search\Contracts\CatalogQueryResult;
+
+/**
+ * Test-only recorder exposing the last call arguments.
+ */
+final class RecordingCatalogQueryPort implements CatalogQueryPort
+{
+    public string $lastKind = '';
+
+    /** @var array<string, mixed> */
+    public array $lastFilterDsl = [];
+
+    public int $lastPerPage = 0;
+
+    public function __construct(private readonly CatalogQueryResult $result)
+    {
+    }
+
+    public function search(string $kind, string $query = '', array $filterDsl = [], int $page = 1, int $perPage = 20): CatalogQueryResult
+    {
+        $this->lastKind = $kind;
+        $this->lastFilterDsl = $filterDsl;
+        $this->lastPerPage = $perPage;
+
+        return $this->result;
+    }
+}

--- a/apps/api/tests/Unit/Agent/SearchCatalogToolTest.php
+++ b/apps/api/tests/Unit/Agent/SearchCatalogToolTest.php
@@ -7,7 +7,6 @@ namespace App\Tests\Unit\Agent;
 use App\Agent\Application\Tool\AgentToolContext;
 use App\Agent\Application\Tool\SearchCatalogTool;
 use App\Agent\Application\Tool\ToolKind;
-use App\Search\Contracts\CatalogQueryPort;
 use App\Search\Contracts\CatalogQueryResult;
 use App\Shared\Domain\Tenant;
 use PHPUnit\Framework\Attributes\Test;
@@ -112,31 +111,5 @@ final class SearchCatalogToolTest extends TestCase
     private function recordingPort(CatalogQueryResult $result): RecordingCatalogQueryPort
     {
         return new RecordingCatalogQueryPort($result);
-    }
-}
-
-/**
- * Test-only recorder exposing the last call arguments.
- */
-final class RecordingCatalogQueryPort implements CatalogQueryPort
-{
-    public string $lastKind = '';
-
-    /** @var array<string, mixed> */
-    public array $lastFilterDsl = [];
-
-    public int $lastPerPage = 0;
-
-    public function __construct(private readonly CatalogQueryResult $result)
-    {
-    }
-
-    public function search(string $kind, string $query = '', array $filterDsl = [], int $page = 1, int $perPage = 20): CatalogQueryResult
-    {
-        $this->lastKind = $kind;
-        $this->lastFilterDsl = $filterDsl;
-        $this->lastPerPage = $perPage;
-
-        return $this->result;
     }
 }


### PR DESCRIPTION
## AGENT-P2-02 — `aggregate_count` (Closes #1959)

**Stack:** bazuje na #2069 (P2-01, `CatalogQueryPort`). Merge po #2069, potem retarget na `main` zrobi się automatycznie.

### Co robi
- `AggregateCatalogTool` (kind=Read, `object.read`) — zlicza obiekty pasujące do filter DSL przez ten sam `Search\Contracts\CatalogQueryPort` co `search_catalog`. To narzędzie groundingowe: agent MUSI poznać „matched N" zanim zaproponuje bulk edit (UC2).
- Wspiera `filter_dsl` jawny albo aktywny widok z `AgentToolContext.viewContext`.
- `RecordingCatalogQueryPort` wydzielony do osobnego pliku PSR-4 w testach (quirk: klasa w pliku testu nie autoloaduje się z innego testu).

### Bramki
- PHPStan max ✅ · Deptrac 0 violations ✅ · PHPUnit unit/integration ✅ · cs-fixer ✅
- Bez klucza Anthropic (BYOK) — narzędzie deterministyczne, testowane bez LLM; LLM-live smoke pending BYOK key.

### Świadome odejścia
- Agregacja = count only (bez median/avg) — wystarcza dla UC2, rozszerzenie gdy pojawi się use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
