### PR TITLE
ci: consolidate jobs under the Free 20-concurrent cap (25 -> 13)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -2,6 +2,10 @@ name: Security audit
 
 # composer audit + pnpm audit on every PR + nightly main.
 # Blocks merge on high/critical CVEs (failed audit returns non-zero).
+#
+# #2148 — composer + pnpm audit share one job (was two) so a single PR
+# run stays under the GitHub Free 20-concurrent-job cap. Both audits run
+# sequentially; each still fails the job independently.
 
 on:
   pull_request:
@@ -15,34 +19,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  composer-audit:
-    name: composer audit
+  dependency-audit:
+    name: Dependency audit (composer + pnpm)
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: apps/api
     steps:
       - uses: actions/checkout@v7
+
       - uses: shivammathur/setup-php@v2
         with:
           php-version: "8.4"
           extensions: ctype, iconv, intl
           tools: composer:v2
+
       - name: composer audit
+        working-directory: apps/api
         run: composer audit --no-dev --abandoned=fail --locked
 
-  pnpm-audit:
-    name: pnpm audit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v4
         with:
           version: 10.33.2
+
       - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
+
       - run: pnpm install --frozen-lockfile
+
       - name: pnpm audit
         run: pnpm audit --audit-level=high

--- a/.github/workflows/quality-frontend.yml
+++ b/.github/workflows/quality-frontend.yml
@@ -37,8 +37,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  guards:
-    name: Frontend lint guards
+  # #2148 — the five fast frontend gates (guards, biome, typecheck,
+  # vitest, build) run in ONE job so a single PR run stays under the
+  # GitHub Free 20-concurrent-job cap, and pnpm install runs once instead
+  # of four times. The two bash guards run first (fail in seconds, no
+  # Node needed); each remaining step still fails the job independently.
+  # Playwright E2E stays its own job (heavy docker stack, own timeout).
+  frontend-checks:
+    name: Frontend checks (guards + biome + tsc + vitest + build)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -46,18 +52,12 @@ jobs:
       # AUD-055 — block new jsonFetch+useEffect reads (stale-data anti-pattern,
       # ADR-0021). AUD-057 — block new admin source files growing past the
       # max-lines threshold (ADR-0021 sibling: readability). Both are pure
-      # bash guards over apps/admin/src — no Node/pnpm needed.
+      # bash guards over apps/admin/src — no Node/pnpm needed, run first.
       - name: jsonFetch + useEffect guard (ADR-0021)
         run: bash scripts/lint-jsonfetch-useeffect.sh
 
       - name: Admin max-lines guard
         run: bash scripts/lint-admin-max-lines.sh
-
-  biome:
-    name: Biome strict
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
 
       - uses: pnpm/action-setup@v4
         with:
@@ -74,65 +74,11 @@ jobs:
       - name: Biome check
         run: pnpm --filter @pim/admin lint
 
-  typecheck:
-    name: TypeScript noEmit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.33.2
-
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
       - name: TypeScript typecheck
         run: pnpm --filter @pim/admin typecheck
 
-  unit:
-    name: Vitest unit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.33.2
-
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
       - name: Vitest
         run: pnpm --filter @pim/admin test
-
-  build:
-    name: Vite build (smoke)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.33.2
-
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm --filter @pim/admin build

--- a/.github/workflows/quality-php.yml
+++ b/.github/workflows/quality-php.yml
@@ -49,11 +49,39 @@ defaults:
     working-directory: apps/api
 
 jobs:
-  phpstan:
-    name: PHPStan max
+  # #2148 — the fast PHP static gates share ONE job (was seven: phpstan,
+  # deptrac, php-cs-fixer, openapi-spec + three shell linters) so a single
+  # PR run stays under the GitHub Free 20-concurrent-job cap, and the
+  # checkout + PHP + composer-install setup runs once instead of four
+  # times. The three shell linters run first (fail in seconds, before
+  # composer install); each remaining step still fails the job
+  # independently. Heavy/isolated jobs stay separate below (semgrep pin,
+  # phpunit shards, benchmark, agent-removability).
+  static:
+    name: PHP static (phpstan + deptrac + cs-fixer + openapi + shell linters)
     runs-on: ubuntu-latest
     steps:
+      # fetch-depth:0 — tracked-secrets-lint needs the real tree on
+      # push-to-main (git ls-files), not a shallow clone.
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # HARD-07 — raw SQL bypassing TenantFilter. AUD-017/021 — pgBackRest
+      # backup cron wiring. AUD-005/010 — real secrets in tracked .env
+      # files. Pure shell, run before composer install so they fail in
+      # seconds. working-directory: . (repo root; job default is apps/api).
+      - name: Lint raw SQL escape hatches
+        working-directory: .
+        run: bash scripts/lint-raw-sql.sh
+
+      - name: Lint backup cron wiring
+        working-directory: .
+        run: bash scripts/lint-backup-cron.sh
+
+      - name: Lint tracked env files for real secrets
+        working-directory: .
+        run: bash scripts/lint-tracked-secrets.sh
 
       - name: Setup PHP 8.4
         uses: shivammathur/setup-php@v2
@@ -81,7 +109,7 @@ jobs:
           openssl genpkey -algorithm RSA -out config/jwt/private.pem -aes256 -pass pass:ci -pkeyopt rsa_keygen_bits:4096
           openssl pkey -in config/jwt/private.pem -passin pass:ci -pubout -out config/jwt/public.pem
 
-      - name: Warm up cache (PHPStan needs the dev container.xml)
+      - name: Warm up cache (PHPStan + OpenAPI export need the dev container.xml)
         run: php bin/console cache:clear --env=dev
         env:
           APP_ENV: dev
@@ -99,86 +127,32 @@ jobs:
           APP_ENV: dev
           JWT_PASSPHRASE: ci
 
-  deptrac:
-    name: Deptrac (architectural fitness)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Setup PHP 8.4
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "8.4"
-          extensions: ctype, iconv, intl
-          coverage: none
-          tools: composer:v2
-
-      - name: Cache Composer
-        uses: actions/cache@v6
-        with:
-          path: |
-            apps/api/vendor
-            ~/.composer/cache
-          key: ${{ runner.os }}-composer-${{ hashFiles('apps/api/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install dependencies
-        run: composer install --no-interaction --no-progress --prefer-dist
-
       - name: Deptrac analyse
         run: vendor/bin/deptrac analyse --no-progress --no-cache
 
-  raw-sql-lint:
-    # HARD-07 — guard-rail for raw SQL bypassing TenantFilter.
-    # Cheap shell job; runs before composer install so failures
-    # surface in seconds without burning CI minutes.
-    name: Raw SQL tenant-safe lint
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: .
-    steps:
-      - uses: actions/checkout@v7
+      - name: PHP-CS-Fixer
+        run: composer cs-check
 
-      - name: Lint raw SQL escape hatches
-        run: bash scripts/lint-raw-sql.sh
+      # Re-export the OpenAPI spec and compare against the snapshot at
+      # docs/api-spec/v0.json. Fails when a PR changes API surface without
+      # bumping the spec — same idea as a Doctrine schema drift check.
+      - name: Export OpenAPI spec
+        run: php bin/console api:openapi:export | python3 -m json.tool > /tmp/v0.expected.json
+        env:
+          APP_ENV: dev
+          APP_DEBUG: "0"
+          DATABASE_URL: postgresql://pim:ChangeMeInDev@127.0.0.1:5432/pim?serverVersion=16&charset=utf8
+          JWT_PASSPHRASE: ci
 
-  backup-cron-lint:
-    # AUD-017 / AUD-021 — guard-rail keeping the pgBackRest backup cron alive.
-    # Fails if start-pim.sh stops registering the postgres crontab via
-    # `crontab -u` (dcron silently ignores an unregistered per-user file —
-    # the bug that killed the cron for ~49 days) or if the Dockerfile schedule
-    # drops the full / diff / weekly restore-test entries. Cheap shell job.
-    name: Backup cron wiring lint
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: .
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Lint backup cron wiring
-        run: bash scripts/lint-backup-cron.sh
-
-  tracked-secrets-lint:
-    # AUD-005 / AUD-010 — guard-rail against real secrets committed to VCS.
-    # Fails if a non-template `.env.<env>` file is tracked, or if any tracked
-    # `.env*` file carries a real (high-entropy / credential-bearing) value.
-    # Cheap shell job; complements gitleaks/trufflehog (security-secrets.yml)
-    # with a deterministic repo-hygiene assertion. Needs full history so
-    # `git ls-files` sees the real tree on push-to-main, not a shallow clone.
-    name: Tracked secrets lint
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: .
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - name: Lint tracked env files for real secrets
-        run: bash scripts/lint-tracked-secrets.sh
+      - name: Compare against snapshot
+        working-directory: ${{ github.workspace }}
+        run: |
+          if ! diff -u docs/api-spec/v0.json /tmp/v0.expected.json; then
+            echo "::error::OpenAPI spec drift — re-export with"
+            echo "::error::    docker compose exec -T api php bin/console api:openapi:export | python3 -m json.tool > docs/api-spec/v0.json"
+            echo "::error::and commit the result."
+            exit 1
+          fi
 
   semgrep-cortex:
     # RBAC-P6-008 / #720 — Cortex-specific Semgrep rules (the static-
@@ -224,35 +198,6 @@ jobs:
             --error --no-rewrite-rule-ids \
             --severity ERROR --severity WARNING \
             apps/api/src apps/admin/src
-
-  php-cs-fixer:
-    name: PHP-CS-Fixer (dry-run)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Setup PHP 8.4
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "8.4"
-          extensions: ctype, iconv, intl
-          coverage: none
-          tools: composer:v2
-
-      - name: Cache Composer
-        uses: actions/cache@v6
-        with:
-          path: |
-            apps/api/vendor
-            ~/.composer/cache
-          key: ${{ runner.os }}-composer-${{ hashFiles('apps/api/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install dependencies
-        run: composer install --no-interaction --no-progress --prefer-dist
-
-      - name: PHP-CS-Fixer
-        run: composer cs-check
 
   phpunit:
     # AUD-083 — shard the suite across testsuites so `api` and `integration`
@@ -519,57 +464,3 @@ jobs:
         run: pnpm --filter @pim/admin build
         env:
           VITE_AGENT_ENABLED: "false"
-
-  openapi-spec:
-    name: OpenAPI spec drift
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Setup PHP 8.4
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "8.4"
-          extensions: ctype, iconv, intl, opcache, pdo_pgsql
-          coverage: none
-          tools: composer:v2
-
-      - name: Cache Composer
-        uses: actions/cache@v6
-        with:
-          path: |
-            apps/api/vendor
-            ~/.composer/cache
-          key: ${{ runner.os }}-composer-${{ hashFiles('apps/api/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install dependencies
-        run: composer install --no-interaction --no-progress --prefer-dist
-
-      - name: Generate JWT keypair (cache:warmup boots Lexik)
-        run: |
-          mkdir -p config/jwt
-          openssl genpkey -algorithm RSA -out config/jwt/private.pem -aes256 -pass pass:ci -pkeyopt rsa_keygen_bits:4096
-          openssl pkey -in config/jwt/private.pem -passin pass:ci -pubout -out config/jwt/public.pem
-
-      # Re-export the OpenAPI spec and compare against the snapshot
-      # at `docs/api-spec/v0.json`. The CI fails when a PR changes API
-      # surface without bumping the spec — same idea as a Doctrine
-      # schema drift check, applied to the contract integrators read.
-      - name: Export OpenAPI spec
-        run: php bin/console api:openapi:export | python3 -m json.tool > /tmp/v0.expected.json
-        env:
-          APP_ENV: dev
-          APP_DEBUG: "0"
-          DATABASE_URL: postgresql://pim:ChangeMeInDev@127.0.0.1:5432/pim?serverVersion=16&charset=utf8
-          JWT_PASSPHRASE: ci
-
-      - name: Compare against snapshot
-        working-directory: ${{ github.workspace }}
-        run: |
-          if ! diff -u docs/api-spec/v0.json /tmp/v0.expected.json; then
-            echo "::error::OpenAPI spec drift — re-export with"
-            echo "::error::    docker compose exec -T api php bin/console api:openapi:export | python3 -m json.tool > docs/api-spec/v0.json"
-            echo "::error::and commit the result."
-            exit 1
-          fi

--- a/.github/workflows/security-secrets.yml
+++ b/.github/workflows/security-secrets.yml
@@ -2,7 +2,9 @@ name: Security (secrets scan)
 
 # RBAC-P1-001 (#640) — secrets-leak guard rail.
 #
-# Two independent scanners run in parallel (defence in depth):
+# Two independent scanners run in ONE job (was two — #2148, to stay under
+# the GitHub Free 20-concurrent-job cap), sharing a single fetch-depth:0
+# checkout. Defence in depth is preserved — either step fails the job:
 #   - gitleaks: regex-based, catches predictable patterns (AWS keys,
 #     Stripe tokens, Anthropic keys, JWT secrets, RSA private keys).
 #   - trufflehog: high-entropy + verified-secret mode, catches keys
@@ -27,15 +29,14 @@ permissions:
   pull-requests: read
 
 jobs:
-  gitleaks:
-    name: Gitleaks (regex-based)
+  secret-scan:
+    name: Secret scan (gitleaks + trufflehog)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
         with:
-          # fetch-depth: 0 lets gitleaks scan the full diff against base.
-          # For push-to-main events, fetches the prior commit so the
-          # action can compare HEAD~1..HEAD.
+          # fetch-depth: 0 lets gitleaks scan the full diff against base
+          # and trufflehog resolve the PR base..head range (push: HEAD~1).
           fetch-depth: 0
 
       - name: Gitleaks scan
@@ -47,14 +48,6 @@ jobs:
           # but the action degrades gracefully (logs a notice, still runs
           # the open-source rule set).
           GITLEAKS_NOTIFY_USER_LIST: "@malipie"
-
-  trufflehog:
-    name: TruffleHog (entropy + verified)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
 
       - name: TruffleHog scan
         uses: trufflesecurity/trufflehog@main


### PR DESCRIPTION
Zamyka #2148.

## Dlaczego
Konto na **GitHub Free** = cap **20 równoległych jobów**. Repo publiczne (minuty darmowe), więc bottleneckiem jest współbieżność, nie minuty. Jeden przebieg PR miał **~25 job-instancji** → nie mieścił się w 20 → nawet pojedynczy PR kolejkował ~20 min.

## Co
Grupowanie szybkich bramek tak, żeby jeden przebieg zmieścił się w capie — **bez utraty pokrycia** i **bez whitelisty ścieżek** (antywzorzec AUD-061; `paths-ignore` blacklist zostaje).

| Plik | Było | Jest |
|---|---|---|
| audit.yml | composer-audit, pnpm-audit | **dependency-audit** (1) |
| security-secrets.yml | gitleaks, trufflehog | **secret-scan** (1, wspólny fetch-depth:0) |
| quality-frontend.yml | guards, biome, typecheck, unit, build, e2e | **frontend-checks** (1× pnpm install) + **e2e** (2) |
| quality-php.yml | phpstan, deptrac, 3× shell-lint, cs-fixer, openapi, semgrep, phpunit×5, benchmark, removability | **static** (7→1) + semgrep + phpunit×5 + benchmark + removability (9) |

**Razem: ~25 → 13 jobów.** Pojedynczy PR nie kolejkuje.

## Zachowane świadomie
- **phpunit sharding (5) nietknięty** — daje wall-clock (max ~12 min zamiast sumy ~40); przy 13 jobach total działa równolegle bez kolejki.
- **e2e / benchmark / agent-removability / semgrep** osobno — długie/izolowane/pinned.
- Zysk uboczny: współdzielony setup (checkout+PHP+composer / pnpm install raz zamiast N×) skraca też realny czas.

## Trade-off
Grupowane kroki są sekwencyjne — re-run grupy odpala wszystkie jej kroki. Koszt mały (linty sekundowe), zysk (brak kolejki) dominuje. **Każdy krok nadal failuje swój job niezależnie — nic nie jest pomijane.**

Ten PR dotyka tylko `.github/workflows/**`, więc **testuje sam siebie** — jeśli konsolidacja coś psuje, PR jest czerwony, main bezpieczny. Walidacja lokalna: actionlint czysty na wszystkich 4 plikach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
