### PR TITLE
fix(agent): parked run (awaiting_approval/input) nie blokuje nowej rozmowy

### DIFF
--- a/apps/api/src/Agent/Application/Run/AgentRunStarter.php
+++ b/apps/api/src/Agent/Application/Run/AgentRunStarter.php
@@ -60,6 +60,17 @@ final readonly class AgentRunStarter
         return $run;
     }
 
+    /**
+     * "Active" means GENUINELY EXECUTING — planning (the async loop is
+     * calling the LLM) or committing (writing the approved batch). A run
+     * parked for the human — awaiting_input (waiting for a chat reply) or
+     * awaiting_approval (the autonomous stretch is done, the plan sits in
+     * the inbox) — costs nothing and MUST NOT block a new conversation:
+     * otherwise a parked (or stuck) run is a dead-end with no reliable
+     * escape. The parked run stays in the inbox/history for its own
+     * accept/reject/resume decision. Mirrors the partial unique index
+     * (Version20260703130000).
+     */
     private function hasActiveRun(Uuid $userId): bool
     {
         $count = $this->entityManager->createQueryBuilder()
@@ -70,8 +81,6 @@ final readonly class AgentRunStarter
             ->setParameter('user', $userId, 'uuid')
             ->setParameter('active', [
                 AgentRunStatus::Planning->value,
-                AgentRunStatus::AwaitingInput->value,
-                AgentRunStatus::AwaitingApproval->value,
                 AgentRunStatus::Committing->value,
             ])
             ->getQuery()

--- a/apps/api/src/Agent/Infrastructure/Migrations/Version20260703130000.php
+++ b/apps/api/src/Agent/Infrastructure/Migrations/Version20260703130000.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AgentMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * #2155 — narrow "1 active run per user" to the GENUINELY EXECUTING
+ * statuses. The original partial unique index (Version20260702170000)
+ * covered planning + awaiting_input + awaiting_approval + committing, so
+ * a run parked for the human (awaiting a chat reply, or a plan sitting in
+ * the approval inbox) occupied the single "active" slot and blocked a new
+ * conversation at the DB level — a dead-end when a parked run got stuck.
+ *
+ * Parked runs cost nothing (the LLM is not running) and live in the
+ * inbox/history for their own accept/reject/resume decision, so they no
+ * longer count as active. Only planning (loop running) and committing
+ * (writing the approved batch) block a concurrent start. Mirrors
+ * {@see \App\Agent\Application\Run\AgentRunStarter::hasActiveRun}.
+ */
+final class Version20260703130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '#2155: narrow "one active run per user" index to executing statuses (planning, committing)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX uniq_agent_runs_active_per_user');
+        $this->addSql(
+            'CREATE UNIQUE INDEX uniq_agent_runs_active_per_user ON agent_runs (tenant_id, user_id) '
+            ."WHERE status IN ('planning', 'committing')"
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX uniq_agent_runs_active_per_user');
+        $this->addSql(
+            'CREATE UNIQUE INDEX uniq_agent_runs_active_per_user ON agent_runs (tenant_id, user_id) '
+            ."WHERE status IN ('planning', 'awaiting_input', 'awaiting_approval', 'committing')"
+        );
+    }
+}

--- a/apps/api/tests/Integration/Agent/AgentRunStarterTest.php
+++ b/apps/api/tests/Integration/Agent/AgentRunStarterTest.php
@@ -52,6 +52,60 @@ final class AgentRunStarterTest extends KernelTestCase
     }
 
     #[Test]
+    public function parkedRunAwaitingApprovalDoesNotBlockANewConversation(): void
+    {
+        // #2155 — a plan sitting in the approval inbox is not "executing";
+        // it must never dead-end a new conversation.
+        [$tenant, $em] = $this->tenantFixture();
+        $starter = new AgentRunStarter($this->guard(true), $this->permissiveLimits($em), $em, $this->noopBus());
+        $userId = Uuid::v7();
+
+        $parked = new AgentRun($userId, AgentRunSurface::Chat, 'parked plan');
+        $parked->markAwaitingApproval(Uuid::v7(), 42);
+        $em->persist($parked);
+        $em->flush();
+
+        $fresh = $starter->start($tenant, $userId, AgentRunSurface::Chat, 'new conversation');
+        self::assertSame(AgentRunStatus::Planning, $fresh->getStatus());
+    }
+
+    #[Test]
+    public function runAwaitingInputDoesNotBlockANewConversation(): void
+    {
+        // #2155 — a run waiting for a chat reply is paused, not running.
+        [$tenant, $em] = $this->tenantFixture();
+        $starter = new AgentRunStarter($this->guard(true), $this->permissiveLimits($em), $em, $this->noopBus());
+        $userId = Uuid::v7();
+
+        $waiting = new AgentRun($userId, AgentRunSurface::Chat, 'waiting for reply');
+        $waiting->markAwaitingInput();
+        $em->persist($waiting);
+        $em->flush();
+
+        $fresh = $starter->start($tenant, $userId, AgentRunSurface::Chat, 'start fresh instead');
+        self::assertSame(AgentRunStatus::Planning, $fresh->getStatus());
+    }
+
+    #[Test]
+    public function committingRunStillBlocks(): void
+    {
+        // #2155 — genuinely executing states (committing / planning) still
+        // enforce one-at-a-time: a concurrent start is a 409.
+        [$tenant, $em] = $this->tenantFixture();
+        $starter = new AgentRunStarter($this->guard(true), $this->permissiveLimits($em), $em, $this->noopBus());
+        $userId = Uuid::v7();
+
+        $committing = new AgentRun($userId, AgentRunSurface::Chat, 'writing the batch');
+        $committing->markAwaitingApproval(Uuid::v7(), 1);
+        $committing->markCommitting(Uuid::v7());
+        $em->persist($committing);
+        $em->flush();
+
+        $this->expectException(ActiveRunConflictException::class);
+        $starter->start($tenant, $userId, AgentRunSurface::Chat, 'try to start during commit');
+    }
+
+    #[Test]
     public function guardRefusalPersistsNothing(): void
     {
         [$tenant, $em] = $this->tenantFixture();


### PR DESCRIPTION
Closes #2155

## Problem
Reguła „1 aktywny run per user" liczyła `awaiting_input` i `awaiting_approval` jako aktywne — i w guardzie aplikacji, i w partial unique index `uniq_agent_runs_active_per_user`. Run **zaparkowany na decyzję człowieka** (odpowiedź w czacie albo plan czekający w skrzynce akceptacji) nic nie kosztuje, a gdy utknie — staje się ślepą uliczką: „You already have an active agent run" bez pewnej drogi ucieczki.

Zaobserwowane na żywo: run smoke-testu utknął w `awaiting_approval` i blokował start nowej rozmowy (patrz też #2156 — reject/cancel cicho nie persystował przez bug RLS GUC).

## Fix
Zawężenie „aktywny" (blokujący) do stanów **realnie wykonujących się**: `planning` (pętla woła LLM) + `committing` (zapis zaakceptowanego batcha):
- `AgentRunStarter::hasActiveRun` → `{planning, committing}`.
- Migracja `Version20260703130000` → `uniq_agent_runs_active_per_user WHERE status IN ('planning','committing')`.

Run zaparkowany zostaje w skrzynce/historii do własnej decyzji accept/reject/resume; nową rozmowę można zawsze zacząć. Współbieżność realnie biegnącej pracy dalej jest jeden-na-raz.

## Testy (kontener pim-api-1)
- `parkedRunAwaitingApprovalDoesNotBlockANewConversation` ✅
- `runAwaitingInputDoesNotBlockANewConversation` ✅
- `committingRunStillBlocks` ✅ (409 dalej działa dla executing)
- PHPStan max ✅
- Uwaga: `realDispatchRunsWorkerInlineAndKeylessTenantEndsInError` failuje **lokalnie** (ten kontener nie odpala `AgentRunMessage` inline w APP_ENV=test) — potwierdzone pre-existing/środowiskowe: failuje też z oryginalnym 4-stanowym guardem. W CI (in-memory + drain) przechodzi.

## Smoke test na żywym stacku (pim.localhost)
Zaaplikowana migracja (narrow index) + przeładowany guard, admin z **parked run `awaiting_approval`**:
`POST /api/agent/runs` → **HTTP 201, status `planning`** (nie 409). Parked run nie blokuje nowej rozmowy. Runy smoke posprzątane.

Refs #1955

🤖 Generated with [Claude Code](https://claude.com/claude-code)