### PR TITLE
feat(agent): praca w kontekście zaznaczenia + pytanie o zakres

### DIFF
--- a/apps/api/src/Agent/Application/Run/AgentSystemPromptBuilder.php
+++ b/apps/api/src/Agent/Application/Run/AgentSystemPromptBuilder.php
@@ -23,6 +23,8 @@ final readonly class AgentSystemPromptBuilder
             ? 'none'
             : json_encode($context, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
+        $scopeRule = $this->scopeRule($context);
+
         return <<<PROMPT
             You are the catalog agent of a PIM system, acting strictly within the permissions of the initiating user.
 
@@ -32,10 +34,37 @@ final readonly class AgentSystemPromptBuilder
             - Catalog writes happen ONLY through the provided write tools, which materialize proposals for human approval; you never commit changes yourself.
             - A "forbidden" tool result means the action is outside the user's permissions - do not retry it; tell the user instead.
             - HIGH-LEVEL intents (e.g. "prepare the DE launch for category X") are multi-step plans: break them into a sequence of tool calls in ONE run - ground first, then materialize each step. Later write-tool calls automatically append to the same proposal batch, so the operator approves ONE collective diff; keep the steps within the run's tool-call budget.
-            - When you are done (proposal materialized or question asked), reply with a short plain-text summary in the user's language: for multi-step plans list each step with its numbers.
+            - When you are done (proposal materialized or question asked), reply with a short plain-text summary in the user's language: for multi-step plans list each step with its numbers.{$scopeRule}
 
             View context of the initiating user (carry it into tool calls instead of asking for it):
             {$contextJson}
             PROMPT;
+    }
+
+    /**
+     * #2153 — when the operator has rows SELECTED in the list, the agent
+     * must act on that selection, not the whole view, and must ask before
+     * widening the scope. Returns an extra rule line (leading newline +
+     * indent to sit in the bullet list) or '' when there is no selection.
+     *
+     * @param array<string, mixed> $context
+     */
+    private function scopeRule(array $context): string
+    {
+        $selected = $context['selected_ids'] ?? null;
+        if (!\is_array($selected)) {
+            return '';
+        }
+        $count = \count(array_filter($selected, static fn (mixed $id): bool => \is_string($id) && '' !== $id));
+        if (0 === $count) {
+            return '';
+        }
+
+        $total = $context['total_matching'] ?? null;
+        $totalPhrase = \is_int($total) && $total > $count
+            ? \sprintf('all %d in the active view', $total)
+            : 'the whole list';
+
+        return "\n            - SELECTION SCOPE: the operator has {$count} object(s) SELECTED in the list. The write tools default to this selection when you omit object_ids and filter_dsl - use that default. Only target {$totalPhrase} if the intent CLEARLY says so (e.g. \"all\", \"every\", \"the whole list\"). If it is not clear whether they mean the {$count} selected or {$totalPhrase}, ask ONE clarifying question first and stop.";
     }
 }

--- a/apps/api/src/Agent/Application/Tool/AdjustNumericValuesTool.php
+++ b/apps/api/src/Agent/Application/Tool/AdjustNumericValuesTool.php
@@ -24,6 +24,8 @@ use Symfony\Component\Uid\Uuid;
  */
 final readonly class AdjustNumericValuesTool implements AgentToolInterface
 {
+    use ResolvesSelectionScope;
+
     public function __construct(
         private BulkEditValuesPort $bulkEdits,
         private PendingChangesPort $pendingChangesReader,
@@ -41,7 +43,9 @@ final readonly class AdjustNumericValuesTool implements AgentToolInterface
             .'multiply/add/subtract/divide/modulo by an operand, computed per object from its CURRENT value. '
             .'Use this instead of bulk_edit_values when the user asks to change a value RELATIVE to itself ("raise price by 10%%" -> operator "*", operand 1.1; "double the price" -> "*", 2). '
             .'Nothing is written - the proposal is materialized for human approval and you MUST report the returned counts. '
-            .'Objects whose current value is empty/non-numeric are skipped. Ground the selector with aggregate_count first; omit filter_dsl to use the active view.';
+            .'Objects whose current value is empty/non-numeric are skipped. Ground the selector with aggregate_count first. '
+            .'Selector precedence: explicit object_ids, else filter_dsl, else the operator\'s current SELECTION (selected_ids in the view context), else the active view. '
+            .'When the view context has a non-empty selected_ids and the user did not clearly ask for the whole list, act on the SELECTION (omit object_ids and filter_dsl).';
     }
 
     public function parametersSchema(): array
@@ -66,9 +70,14 @@ final readonly class AdjustNumericValuesTool implements AgentToolInterface
                     'type' => 'string',
                     'description' => 'ObjectType code (e.g. product). Default: product.',
                 ],
+                'object_ids' => [
+                    'type' => 'array',
+                    'items' => ['type' => 'string'],
+                    'description' => 'Selector (highest precedence): explicit object UUIDs to adjust, e.g. the operator\'s current selection. Omit to fall back to filter_dsl / the view selection.',
+                ],
                 'filter_dsl' => [
                     'type' => 'object',
-                    'description' => 'Selector: canonical filter DSL. Omit to use the active view filter. An empty selector targets EVERY object of the type - be sure that is what the user wants.',
+                    'description' => 'Selector: canonical filter DSL. Omit to use the current selection (selected_ids) or the active view filter. An empty selector targets EVERY object of the type - be sure that is what the user wants.',
                 ],
                 'pending_change_batch_id' => [
                     'type' => 'string',
@@ -107,13 +116,7 @@ final readonly class AdjustNumericValuesTool implements AgentToolInterface
 
         $objectTypeCode = \is_string($arguments['object_type_code'] ?? null) ? $arguments['object_type_code'] : 'product';
 
-        $filterDsl = \is_array($arguments['filter_dsl'] ?? null) ? $arguments['filter_dsl'] : null;
-        $viewFilter = $context->viewContext['filter_dsl'] ?? null;
-        if (null === $filterDsl && \is_array($viewFilter)) {
-            $filterDsl = $viewFilter;
-        }
-        /** @var array<string, mixed> $filterDslArray */
-        $filterDslArray = $filterDsl ?? [];
+        [$selectedIds, $filterDslArray] = $this->resolveScope($arguments, $context);
 
         [$batchId, $batchError] = $this->resolveBatch($arguments['pending_change_batch_id'] ?? null, PendingChangeType::Value);
         if (null === $batchId) {
@@ -128,6 +131,7 @@ final readonly class AdjustNumericValuesTool implements AgentToolInterface
             attrCode: $attrCode,
             operator: $operator,
             operand: $operand,
+            selectedIds: $selectedIds,
         );
 
         if (0 === $proposal->materializedChanges) {

--- a/apps/api/src/Agent/Application/Tool/AssignCategoriesTool.php
+++ b/apps/api/src/Agent/Application/Tool/AssignCategoriesTool.php
@@ -18,6 +18,8 @@ use Symfony\Component\Uid\Uuid;
  */
 final readonly class AssignCategoriesTool implements AgentToolInterface
 {
+    use ResolvesSelectionScope;
+
     public function __construct(
         private AssignCategoriesPort $assignments,
         private PendingChangesPort $pendingChangesReader,
@@ -31,8 +33,10 @@ final readonly class AssignCategoriesTool implements AgentToolInterface
 
     public function description(): string
     {
-        return 'Propose a bulk category assignment: add, remove or move every object matching a filter DSL to the given categories. '
+        return 'Propose a bulk category assignment: add, remove or move a set of objects to the given categories. '
             .'Nothing is written - the proposal is materialized for human approval and you MUST report the returned counts. '
+            .'Selector precedence: explicit object_ids, else filter_dsl, else the operator\'s current SELECTION (selected_ids in the view context), else the active view filter. '
+            .'When the view context has a non-empty selected_ids and the user did not clearly ask for the whole list, act on the SELECTION (omit object_ids and filter_dsl). '
             .'Ground the selector with aggregate_count first. Category ids must be UUIDs of category objects (search them first if you only know the name).';
     }
 
@@ -45,9 +49,14 @@ final readonly class AssignCategoriesTool implements AgentToolInterface
                     'type' => 'string',
                     'description' => 'ObjectType code (e.g. product). Default: product.',
                 ],
+                'object_ids' => [
+                    'type' => 'array',
+                    'items' => ['type' => 'string'],
+                    'description' => 'Selector (highest precedence): explicit object UUIDs, e.g. the operator\'s current selection. Omit to fall back to filter_dsl / the view selection.',
+                ],
                 'filter_dsl' => [
                     'type' => 'object',
-                    'description' => 'Selector: canonical filter DSL. Omit to use the active view filter. An empty selector targets EVERY object of the type.',
+                    'description' => 'Selector: canonical filter DSL. Omit to use the current selection (selected_ids) or the active view filter. An empty selector targets EVERY object of the type.',
                 ],
                 'category_ids' => [
                     'type' => 'array',
@@ -92,13 +101,7 @@ final readonly class AssignCategoriesTool implements AgentToolInterface
         $operationRaw = $arguments['operation'] ?? null;
         $operation = \in_array($operationRaw, ['add', 'remove', 'move'], true) ? $operationRaw : 'add';
 
-        $filterDsl = \is_array($arguments['filter_dsl'] ?? null) ? $arguments['filter_dsl'] : null;
-        $viewFilter = $context->viewContext['filter_dsl'] ?? null;
-        if (null === $filterDsl && \is_array($viewFilter)) {
-            $filterDsl = $viewFilter;
-        }
-        /** @var array<string, mixed> $filterDslArray */
-        $filterDslArray = $filterDsl ?? [];
+        [$selectedIds, $filterDslArray] = $this->resolveScope($arguments, $context);
 
         [$batchId, $batchError] = $this->resolveBatch($arguments['pending_change_batch_id'] ?? null, PendingChangeType::Category);
         if (null === $batchId) {
@@ -112,6 +115,7 @@ final readonly class AssignCategoriesTool implements AgentToolInterface
             filterDsl: $filterDslArray,
             categoryIds: $categoryIds,
             operation: $operation,
+            selectedIds: $selectedIds,
         );
 
         if (0 === $proposal->affectedObjects) {

--- a/apps/api/src/Agent/Application/Tool/BulkEditValuesTool.php
+++ b/apps/api/src/Agent/Application/Tool/BulkEditValuesTool.php
@@ -18,6 +18,8 @@ use Symfony\Component\Uid\Uuid;
  */
 final readonly class BulkEditValuesTool implements AgentToolInterface
 {
+    use ResolvesSelectionScope;
+
     public function __construct(
         private BulkEditValuesPort $bulkEdits,
         private PendingChangesPort $pendingChangesReader,
@@ -31,9 +33,11 @@ final readonly class BulkEditValuesTool implements AgentToolInterface
 
     public function description(): string
     {
-        return 'Propose a bulk value edit: set attribute values on every object matching a filter DSL. Nothing is written to the catalog - '
+        return 'Propose a bulk value edit: set attribute values on a set of objects. Nothing is written to the catalog - '
             .'the proposal is materialized for human approval and you MUST report the returned counts to the user. '
-            .'Ground the selector with aggregate_count first. If the user refers to the current view, omit filter_dsl.';
+            .'Selector precedence: explicit object_ids, else filter_dsl, else the operator\'s current SELECTION (selected_ids in the view context), else the active view filter. '
+            .'When the view context has a non-empty selected_ids and the user did not clearly ask for the whole list, act on the SELECTION (omit object_ids and filter_dsl). '
+            .'Ground the selector with aggregate_count first.';
     }
 
     public function parametersSchema(): array
@@ -45,9 +49,14 @@ final readonly class BulkEditValuesTool implements AgentToolInterface
                     'type' => 'string',
                     'description' => 'ObjectType code (e.g. product). Default: product.',
                 ],
+                'object_ids' => [
+                    'type' => 'array',
+                    'items' => ['type' => 'string'],
+                    'description' => 'Selector (highest precedence): explicit object UUIDs to edit, e.g. the operator\'s current selection. Omit to fall back to filter_dsl / the view selection.',
+                ],
                 'filter_dsl' => [
                     'type' => 'object',
-                    'description' => 'Selector: canonical filter DSL. Omit to use the active view filter. An empty selector targets EVERY object of the type - be sure that is what the user wants.',
+                    'description' => 'Selector: canonical filter DSL. Omit to use the current selection (selected_ids) or the active view filter. An empty selector targets EVERY object of the type - be sure that is what the user wants.',
                 ],
                 'changes' => [
                     'type' => 'object',
@@ -85,13 +94,7 @@ final readonly class BulkEditValuesTool implements AgentToolInterface
         $modeRaw = $arguments['mode'] ?? null;
         $mode = \in_array($modeRaw, ['overwrite', 'only_empty'], true) ? $modeRaw : 'only_empty';
 
-        $filterDsl = \is_array($arguments['filter_dsl'] ?? null) ? $arguments['filter_dsl'] : null;
-        $viewFilter = $context->viewContext['filter_dsl'] ?? null;
-        if (null === $filterDsl && \is_array($viewFilter)) {
-            $filterDsl = $viewFilter;
-        }
-        /** @var array<string, mixed> $filterDslArray */
-        $filterDslArray = $filterDsl ?? [];
+        [$selectedIds, $filterDslArray] = $this->resolveScope($arguments, $context);
 
         [$batchId, $batchError] = $this->resolveBatch($arguments['pending_change_batch_id'] ?? null, PendingChangeType::Value);
         if (null === $batchId) {
@@ -105,6 +108,7 @@ final readonly class BulkEditValuesTool implements AgentToolInterface
             filterDsl: $filterDslArray,
             changes: $changes,
             mode: $mode,
+            selectedIds: $selectedIds,
         );
 
         if (0 === $proposal->materializedChanges) {

--- a/apps/api/src/Agent/Application/Tool/ResolvesSelectionScope.php
+++ b/apps/api/src/Agent/Application/Tool/ResolvesSelectionScope.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Tool;
+
+/**
+ * #2153 — shared selector precedence for write tools. The operator works
+ * on a list with a SELECTION (checked rows) and/or an active view filter;
+ * the agent must act on what the operator means, not blindly on the whole
+ * view.
+ *
+ * Precedence (narrowest deliberate intent first):
+ *   1. explicit `object_ids` tool arg  — the model listed exact ids
+ *   2. explicit `filter_dsl` tool arg  — the model chose a broader scope
+ *   3. context `selected_ids`          — the operator's current selection
+ *   4. context `filter_dsl`            — the active view
+ *   5. nothing                         — every object of the type
+ *
+ * Returns [selectedIds, filterDsl]: at most one is "set" (selectedIds
+ * non-null XOR a non-empty filterDsl); the engine validates selectedIds
+ * against tenant + object type, so a stray id can never widen the scope.
+ */
+trait ResolvesSelectionScope
+{
+    /**
+     * @param array<string, mixed> $arguments
+     *
+     * @return array{0: list<string>|null, 1: array<string, mixed>} [selectedIds, filterDsl]
+     */
+    private function resolveScope(array $arguments, AgentToolContext $context): array
+    {
+        $argIds = $this->stringList($arguments['object_ids'] ?? null);
+        if (null !== $argIds) {
+            return [$argIds, []];
+        }
+
+        if (\is_array($arguments['filter_dsl'] ?? null)) {
+            /** @var array<string, mixed> $filter */
+            $filter = $arguments['filter_dsl'];
+
+            return [null, $filter];
+        }
+
+        $selection = $this->stringList($context->viewContext['selected_ids'] ?? null);
+        if (null !== $selection) {
+            return [$selection, []];
+        }
+
+        if (\is_array($context->viewContext['filter_dsl'] ?? null)) {
+            /** @var array<string, mixed> $viewFilter */
+            $viewFilter = $context->viewContext['filter_dsl'];
+
+            return [null, $viewFilter];
+        }
+
+        return [null, []];
+    }
+
+    /**
+     * Non-empty list of non-empty strings, or null when the input is not a
+     * usable id list (missing, empty, or all-invalid). Null means "no
+     * selection at this precedence level" so resolution falls through.
+     *
+     * @return list<string>|null
+     */
+    private function stringList(mixed $raw): ?array
+    {
+        if (!\is_array($raw)) {
+            return null;
+        }
+        $out = [];
+        foreach ($raw as $value) {
+            if (\is_string($value) && '' !== $value) {
+                $out[] = $value;
+            }
+        }
+
+        return [] === $out ? null : $out;
+    }
+}

--- a/apps/api/src/Catalog/Application/PendingChanges/AssignCategoriesMaterializer.php
+++ b/apps/api/src/Catalog/Application/PendingChanges/AssignCategoriesMaterializer.php
@@ -62,6 +62,7 @@ final readonly class AssignCategoriesMaterializer implements AssignCategoriesPor
         array $filterDsl,
         array $categoryIds,
         string $operation,
+        ?array $selectedIds = null,
     ): CategoryAssignProposal {
         if (!\in_array($operation, self::OPERATIONS, true)) {
             throw new InvalidArgumentException(\sprintf('Unknown operation "%s" (use add, remove or move).', $operation));
@@ -85,7 +86,7 @@ final readonly class AssignCategoriesMaterializer implements AssignCategoriesPor
 
         $objectIds = [];
         if ([] !== $validCategoryIds) {
-            $objectIds = $this->resolveObjectIds($tenant, $objectType, $filterDsl);
+            $objectIds = $this->resolveObjectIds($tenant, $objectType, $filterDsl, $selectedIds);
         }
 
         $affectedObjects = 0;
@@ -135,14 +136,39 @@ final readonly class AssignCategoriesMaterializer implements AssignCategoriesPor
     }
 
     /**
+     * When $selectedIds is given (the operator's current SELECTION, #2153)
+     * it is THE selector, validated against tenant + object type so a stray
+     * id can never widen the scope. Otherwise the filter DSL is the selector
+     * ([] = every object of the type).
+     *
      * @param array<string, mixed> $filterDsl
+     * @param list<mixed>|null     $selectedIds
      *
      * @return list<string>
      */
-    private function resolveObjectIds(Tenant $tenant, ObjectType $objectType, array $filterDsl): array
+    private function resolveObjectIds(Tenant $tenant, ObjectType $objectType, array $filterDsl, ?array $selectedIds = null): array
     {
+        $params = [
+            'tenant' => $tenant->getId()->toRfc4122(),
+            'otid' => $objectType->getId()->toRfc4122(),
+        ];
+        $types = [];
         $where = '';
-        if ([] !== $filterDsl) {
+
+        if (null !== $selectedIds) {
+            $clean = [];
+            foreach ($selectedIds as $id) {
+                if (\is_string($id) && Uuid::isValid($id)) {
+                    $clean[] = $id;
+                }
+            }
+            if ([] === $clean) {
+                return [];
+            }
+            $where = ' AND co.id IN (:ids)';
+            $params['ids'] = $clean;
+            $types['ids'] = ArrayParameterType::STRING;
+        } elseif ([] !== $filterDsl) {
             $this->filterResolver->validate($filterDsl);
             $fragment = $this->filterResolver->toCountSql($filterDsl);
             if (null === $fragment) {
@@ -155,10 +181,8 @@ final readonly class AssignCategoriesMaterializer implements AssignCategoriesPor
         // Doctrine TenantFilter); RLS is the backstop.
         $rows = $this->entityManager->getConnection()->fetchFirstColumn(
             'SELECT co.id FROM objects co WHERE co.tenant_id = :tenant AND co.object_type_id = :otid'.$where,
-            [
-                'tenant' => $tenant->getId()->toRfc4122(),
-                'otid' => $objectType->getId()->toRfc4122(),
-            ],
+            $params,
+            $types,
         );
 
         $ids = [];

--- a/apps/api/src/Catalog/Application/PendingChanges/BulkEditValuesMaterializer.php
+++ b/apps/api/src/Catalog/Application/PendingChanges/BulkEditValuesMaterializer.php
@@ -66,6 +66,7 @@ final readonly class BulkEditValuesMaterializer implements BulkEditValuesPort
         array $filterDsl,
         array $changes,
         string $mode,
+        ?array $selectedIds = null,
     ): ValueEditProposal {
         if (!\in_array($mode, ['overwrite', 'only_empty'], true)) {
             throw new InvalidArgumentException(\sprintf('Unknown mode "%s" (use overwrite or only_empty).', $mode));
@@ -87,7 +88,7 @@ final readonly class BulkEditValuesMaterializer implements BulkEditValuesPort
 
         [$validChanges, $rejected] = $this->screenChanges($tenant, $userId, $changes);
 
-        $objectIds = $this->resolveObjectIds($tenant, $objectType, $filterDsl);
+        $objectIds = $this->resolveObjectIds($tenant, $objectType, $filterDsl, $selectedIds);
 
         $affectedObjects = 0;
         $materialized = 0;
@@ -123,6 +124,7 @@ final readonly class BulkEditValuesMaterializer implements BulkEditValuesPort
         string $attrCode,
         string $operator,
         float $operand,
+        ?array $selectedIds = null,
     ): ValueEditProposal {
         if (!\in_array($operator, ['+', '-', '*', '/', '%'], true)) {
             throw new InvalidArgumentException(\sprintf('Unsupported operator "%s" (use + - * / %%).', $operator));
@@ -160,7 +162,7 @@ final readonly class BulkEditValuesMaterializer implements BulkEditValuesPort
         $skipped = 0;
 
         if ($attribute instanceof Attribute) {
-            $objectIds = $this->resolveObjectIds($tenant, $objectType, $filterDsl);
+            $objectIds = $this->resolveObjectIds($tenant, $objectType, $filterDsl, $selectedIds);
             if ([] !== $objectIds) {
                 $drafts = $this->arithmeticDraftGenerator(
                     $tenant,
@@ -235,14 +237,43 @@ final readonly class BulkEditValuesMaterializer implements BulkEditValuesPort
     }
 
     /**
+     * Resolve the objects a bulk operation targets. When $selectedIds is
+     * given (the operator's current SELECTION, #2153), the selector is that
+     * list — validated against tenant + object type so a stray/foreign id
+     * from the model or client can never widen the scope (RLS is the
+     * backstop; this is the explicit predicate). Otherwise the selector is
+     * the filter DSL ([] = every object of the type).
+     *
      * @param array<string, mixed> $filterDsl
+     * @param list<mixed>|null      $selectedIds explicit selection, or null to use the filter
      *
      * @return list<string>
      */
-    private function resolveObjectIds(Tenant $tenant, ObjectType $objectType, array $filterDsl): array
+    private function resolveObjectIds(Tenant $tenant, ObjectType $objectType, array $filterDsl, ?array $selectedIds = null): array
     {
+        $params = [
+            'tenant' => $tenant->getId()->toRfc4122(),
+            'otid' => $objectType->getId()->toRfc4122(),
+        ];
+        $types = [];
         $where = '';
-        if ([] !== $filterDsl) {
+
+        if (null !== $selectedIds) {
+            $clean = [];
+            foreach ($selectedIds as $id) {
+                if (\is_string($id) && Uuid::isValid($id)) {
+                    $clean[] = $id;
+                }
+            }
+            if ([] === $clean) {
+                return [];
+            }
+            // Intersect the selection with tenant + type — never trust the
+            // raw id list; a foreign/mistyped id simply yields no row.
+            $where = ' AND co.id IN (:ids)';
+            $params['ids'] = $clean;
+            $types['ids'] = \Doctrine\DBAL\ArrayParameterType::STRING;
+        } elseif ([] !== $filterDsl) {
             $this->filterResolver->validate($filterDsl);
             $fragment = $this->filterResolver->toCountSql($filterDsl);
             if (null === $fragment) {
@@ -256,10 +287,8 @@ final readonly class BulkEditValuesMaterializer implements BulkEditValuesPort
         // as the XMLF feed scope (ExportBuilderFeedValues).
         $rows = $this->entityManager->getConnection()->fetchFirstColumn(
             'SELECT co.id FROM objects co WHERE co.tenant_id = :tenant AND co.object_type_id = :otid'.$where,
-            [
-                'tenant' => $tenant->getId()->toRfc4122(),
-                'otid' => $objectType->getId()->toRfc4122(),
-            ],
+            $params,
+            $types,
         );
 
         $ids = [];

--- a/apps/api/src/Catalog/Application/PendingChanges/BulkEditValuesMaterializer.php
+++ b/apps/api/src/Catalog/Application/PendingChanges/BulkEditValuesMaterializer.php
@@ -245,7 +245,7 @@ final readonly class BulkEditValuesMaterializer implements BulkEditValuesPort
      * the filter DSL ([] = every object of the type).
      *
      * @param array<string, mixed> $filterDsl
-     * @param list<mixed>|null      $selectedIds explicit selection, or null to use the filter
+     * @param list<mixed>|null     $selectedIds explicit selection, or null to use the filter
      *
      * @return list<string>
      */

--- a/apps/api/src/Catalog/Contracts/Command/AssignCategoriesPort.php
+++ b/apps/api/src/Catalog/Contracts/Command/AssignCategoriesPort.php
@@ -24,6 +24,10 @@ interface AssignCategoriesPort
      * @param string               $operation   add|remove|move - runtime-validated (a literal
      *                                          union here makes the adapter's defensive guard
      *                                          "always true" for PHPStan)
+     * @param list<mixed>|null     $selectedIds the operator's current SELECTION (#2153): when
+     *                                          non-null it is THE selector (validated against
+     *                                          tenant + object type), taking precedence over
+     *                                          $filterDsl. null = fall back to $filterDsl.
      *
      * @throws InvalidArgumentException on unknown object type / invalid DSL / unknown operation
      */
@@ -34,5 +38,6 @@ interface AssignCategoriesPort
         array $filterDsl,
         array $categoryIds,
         string $operation,
+        ?array $selectedIds = null,
     ): CategoryAssignProposal;
 }

--- a/apps/api/src/Catalog/Contracts/Command/BulkEditValuesPort.php
+++ b/apps/api/src/Catalog/Contracts/Command/BulkEditValuesPort.php
@@ -27,7 +27,7 @@ interface BulkEditValuesPort
      * @param string               $mode        overwrite|only_empty - runtime-validated (a literal
      *                                          union here makes the adapter's defensive guard
      *                                          "always true" for PHPStan)
-     * @param list<mixed>|null      $selectedIds the operator's current SELECTION (#2153): when
+     * @param list<mixed>|null     $selectedIds the operator's current SELECTION (#2153): when
      *                                          non-null it is THE selector (validated against
      *                                          tenant + object type), taking precedence over
      *                                          $filterDsl. null = fall back to $filterDsl.
@@ -54,7 +54,7 @@ interface BulkEditValuesPort
      *
      * @param array<string, mixed> $filterDsl   selector ([] = every object of the type)
      * @param string               $operator    one of + - * / % (runtime-validated)
-     * @param list<mixed>|null      $selectedIds the operator's current SELECTION (#2153): when
+     * @param list<mixed>|null     $selectedIds the operator's current SELECTION (#2153): when
      *                                          non-null it is THE selector (validated against
      *                                          tenant + object type), taking precedence over
      *                                          $filterDsl. null = fall back to $filterDsl.

--- a/apps/api/src/Catalog/Contracts/Command/BulkEditValuesPort.php
+++ b/apps/api/src/Catalog/Contracts/Command/BulkEditValuesPort.php
@@ -22,11 +22,15 @@ use Symfony\Component\Uid\Uuid;
 interface BulkEditValuesPort
 {
     /**
-     * @param array<string, mixed> $filterDsl selector ([] = every object of the type)
-     * @param array<string, mixed> $changes   attribute code => raw value
-     * @param string               $mode      overwrite|only_empty - runtime-validated (a literal
-     *                                        union here makes the adapter's defensive guard
-     *                                        "always true" for PHPStan)
+     * @param array<string, mixed> $filterDsl   selector ([] = every object of the type)
+     * @param array<string, mixed> $changes     attribute code => raw value
+     * @param string               $mode        overwrite|only_empty - runtime-validated (a literal
+     *                                          union here makes the adapter's defensive guard
+     *                                          "always true" for PHPStan)
+     * @param list<mixed>|null      $selectedIds the operator's current SELECTION (#2153): when
+     *                                          non-null it is THE selector (validated against
+     *                                          tenant + object type), taking precedence over
+     *                                          $filterDsl. null = fall back to $filterDsl.
      *
      * @throws InvalidArgumentException on unknown object type / attribute / invalid DSL
      */
@@ -37,6 +41,7 @@ interface BulkEditValuesPort
         array $filterDsl,
         array $changes,
         string $mode,
+        ?array $selectedIds = null,
     ): ValueEditProposal;
 
     /**
@@ -47,8 +52,12 @@ interface BulkEditValuesPort
      * division-by-zero are skipped, never errored. Same approval path: the
      * result is a pending_changes batch, committed post-accept.
      *
-     * @param array<string, mixed> $filterDsl selector ([] = every object of the type)
-     * @param string               $operator  one of + - * / % (runtime-validated)
+     * @param array<string, mixed> $filterDsl   selector ([] = every object of the type)
+     * @param string               $operator    one of + - * / % (runtime-validated)
+     * @param list<mixed>|null      $selectedIds the operator's current SELECTION (#2153): when
+     *                                          non-null it is THE selector (validated against
+     *                                          tenant + object type), taking precedence over
+     *                                          $filterDsl. null = fall back to $filterDsl.
      *
      * @throws InvalidArgumentException on unknown object type / unsupported operator / invalid DSL
      */
@@ -60,5 +69,6 @@ interface BulkEditValuesPort
         string $attrCode,
         string $operator,
         float $operand,
+        ?array $selectedIds = null,
     ): ValueEditProposal;
 }

--- a/apps/api/tests/Integration/Agent/AssignCategoriesFlowTest.php
+++ b/apps/api/tests/Integration/Agent/AssignCategoriesFlowTest.php
@@ -125,6 +125,36 @@ final class AssignCategoriesFlowTest extends KernelTestCase
         self::assertSame('Unknown category.', $proposal->rejected[1]['reason']);
     }
 
+    #[Test]
+    public function selectionScopeTargetsOnlyTheSelectedObjects(): void
+    {
+        // #2153 — "add category Botki for the 2 selected products" must
+        // touch only those, not every product in the view.
+        [$em, $product, $category] = $this->fixture();
+
+        $productType = $product->getObjectType();
+        $other = new CatalogObject($productType, 'FESTO-2');
+        $em->persist($other);
+        $em->flush();
+
+        $batchId = Uuid::v7();
+        $proposal = $this->port()->materializeCategoryAssignments(
+            batchId: $batchId,
+            userId: Uuid::v7(),
+            objectTypeCode: 'product',
+            filterDsl: [],
+            categoryIds: [$category->getId()->toRfc4122()],
+            operation: 'add',
+            selectedIds: [$product->getId()->toRfc4122()],
+        );
+
+        self::assertSame(1, $proposal->affectedObjects, 'only the selected product, not FESTO-2');
+
+        $rows = $this->pendingChanges()->listBatch($batchId);
+        self::assertCount(1, $rows);
+        self::assertTrue($product->getId()->equals($rows[0]->targetObjectId ?? Uuid::v4()));
+    }
+
     /**
      * @return array{0: EntityManagerInterface, 1: CatalogObject, 2: CatalogObject}
      */

--- a/apps/api/tests/Integration/Agent/BulkEditValuesMaterializerTest.php
+++ b/apps/api/tests/Integration/Agent/BulkEditValuesMaterializerTest.php
@@ -308,6 +308,75 @@ final class BulkEditValuesMaterializerTest extends KernelTestCase
         self::assertSame('Attribute is outside your edit permissions.', $proposal->rejected[0]['reason']);
     }
 
+    #[Test]
+    public function selectionScopeTargetsOnlyTheSelectedObjectsAndIgnoresForeignIds(): void
+    {
+        // #2153 — when the operator has rows selected, the write targets
+        // exactly that selection (validated against tenant + type: a bogus
+        // id simply matches no row, it cannot widen the scope).
+        [, $em, $type] = $this->fixture();
+
+        $a = new CatalogObject($type, 'SEL-A');
+        $b = new CatalogObject($type, 'SEL-B');
+        $c = new CatalogObject($type, 'SEL-C');
+        foreach ([$a, $b, $c] as $obj) {
+            $em->persist($obj);
+        }
+        $em->flush();
+
+        $batchId = Uuid::v7();
+        $proposal = $this->port()->materializeValueEdits(
+            batchId: $batchId,
+            userId: Uuid::v7(),
+            objectTypeCode: 'product',
+            filterDsl: [],
+            changes: ['price' => 100],
+            mode: 'overwrite',
+            selectedIds: [$a->getId()->toRfc4122(), $c->getId()->toRfc4122(), Uuid::v7()->toRfc4122()],
+        );
+
+        self::assertSame(2, $proposal->affectedObjects, 'only the two real selected objects (foreign id ignored)');
+        self::assertSame(2, $proposal->materializedChanges);
+
+        $rows = $this->pendingChanges()->listBatch($batchId);
+        $ids = [];
+        foreach ($rows as $row) {
+            $ids[] = $row->targetObjectId?->toRfc4122();
+        }
+        sort($ids);
+        $expected = [$a->getId()->toRfc4122(), $c->getId()->toRfc4122()];
+        sort($expected);
+        self::assertSame($expected, $ids, 'SEL-B (not selected) must be untouched');
+    }
+
+    #[Test]
+    public function arithmeticSelectionScopeTargetsOnlyTheSelectedObjects(): void
+    {
+        [, $em, $type] = $this->fixture();
+
+        $a = new CatalogObject($type, 'ARSEL-A');
+        $a->updateAttributeIndex(['price' => ['value' => 100]]);
+        $b = new CatalogObject($type, 'ARSEL-B');
+        $b->updateAttributeIndex(['price' => ['value' => 200]]);
+        $em->persist($a);
+        $em->persist($b);
+        $em->flush();
+
+        $proposal = $this->port()->materializeArithmeticEdits(
+            batchId: Uuid::v7(),
+            userId: Uuid::v7(),
+            objectTypeCode: 'product',
+            filterDsl: [],
+            attrCode: 'price',
+            operator: '*',
+            operand: 2.0,
+            selectedIds: [$a->getId()->toRfc4122()],
+        );
+
+        self::assertSame(1, $proposal->affectedObjects, 'only the selected object is adjusted');
+        self::assertSame(1, $proposal->materializedChanges);
+    }
+
     /**
      * @return array{0: Tenant, 1: EntityManagerInterface, 2: ObjectType}
      */

--- a/apps/api/tests/Unit/Agent/AdjustNumericValuesToolTest.php
+++ b/apps/api/tests/Unit/Agent/AdjustNumericValuesToolTest.php
@@ -74,6 +74,82 @@ final class AdjustNumericValuesToolTest extends TestCase
         $tool->execute(['attr_code' => 'price', 'operator' => '+', 'operand' => 5], $context);
 
         self::assertSame(['field' => 'status', 'op' => 'eq', 'value' => 'draft'], $port->lastFilterDsl);
+        self::assertNull($port->lastSelectedIds);
+    }
+
+    #[Test]
+    public function usesTheContextSelectionOverTheViewFilter(): void
+    {
+        // #2153 — the operator has rows selected: default to the selection,
+        // not the whole view.
+        $port = $this->port(new ValueEditProposal(Uuid::v7(), 2, 2, 0, []));
+        $tool = new AdjustNumericValuesTool($port, $this->pendingChanges());
+
+        $context = new AgentToolContext(Uuid::v7(), new Tenant('alpha', 'Alpha'), [
+            'selected_ids' => ['id-1', 'id-2'],
+            'filter_dsl' => ['field' => 'status', 'op' => 'eq', 'value' => 'draft'],
+        ]);
+
+        $tool->execute(['attr_code' => 'price', 'operator' => '*', 'operand' => 1.2], $context);
+
+        self::assertSame(['id-1', 'id-2'], $port->lastSelectedIds, 'the selection is the selector');
+        self::assertSame([], $port->lastFilterDsl, 'the view filter is not applied when a selection exists');
+    }
+
+    #[Test]
+    public function explicitObjectIdsArgumentWinsOverTheSelection(): void
+    {
+        $port = $this->port(new ValueEditProposal(Uuid::v7(), 1, 1, 0, []));
+        $tool = new AdjustNumericValuesTool($port, $this->pendingChanges());
+
+        $context = new AgentToolContext(Uuid::v7(), new Tenant('alpha', 'Alpha'), [
+            'selected_ids' => ['id-1', 'id-2'],
+        ]);
+
+        $tool->execute([
+            'attr_code' => 'price', 'operator' => '*', 'operand' => 2,
+            'object_ids' => ['explicit-1'],
+        ], $context);
+
+        self::assertSame(['explicit-1'], $port->lastSelectedIds);
+    }
+
+    #[Test]
+    public function explicitFilterDslArgumentSuppressesTheSelection(): void
+    {
+        // Passing a filter is a deliberate broader-scope choice by the model
+        // (e.g. after the user confirmed "the whole list").
+        $port = $this->port(new ValueEditProposal(Uuid::v7(), 5, 5, 0, []));
+        $tool = new AdjustNumericValuesTool($port, $this->pendingChanges());
+
+        $context = new AgentToolContext(Uuid::v7(), new Tenant('alpha', 'Alpha'), [
+            'selected_ids' => ['id-1', 'id-2'],
+        ]);
+
+        $tool->execute([
+            'attr_code' => 'price', 'operator' => '*', 'operand' => 2,
+            'filter_dsl' => ['field' => 'brand', 'op' => 'eq', 'value' => 'Acme'],
+        ], $context);
+
+        self::assertNull($port->lastSelectedIds);
+        self::assertSame(['field' => 'brand', 'op' => 'eq', 'value' => 'Acme'], $port->lastFilterDsl);
+    }
+
+    #[Test]
+    public function anEmptyContextSelectionIsIgnored(): void
+    {
+        $port = $this->port(new ValueEditProposal(Uuid::v7(), 1, 1, 0, []));
+        $tool = new AdjustNumericValuesTool($port, $this->pendingChanges());
+
+        $context = new AgentToolContext(Uuid::v7(), new Tenant('alpha', 'Alpha'), [
+            'selected_ids' => [],
+            'filter_dsl' => ['field' => 'status', 'op' => 'eq', 'value' => 'draft'],
+        ]);
+
+        $tool->execute(['attr_code' => 'price', 'operator' => '+', 'operand' => 5], $context);
+
+        self::assertNull($port->lastSelectedIds, 'empty selection is not a selection');
+        self::assertSame(['field' => 'status', 'op' => 'eq', 'value' => 'draft'], $port->lastFilterDsl);
     }
 
     #[Test]
@@ -193,6 +269,8 @@ final class RecordingBulkEditValuesPort implements BulkEditValuesPort
     public ?string $lastObjectTypeCode = null;
     /** @var array<string, mixed>|null */
     public ?array $lastFilterDsl = null;
+    /** @var list<mixed>|null */
+    public ?array $lastSelectedIds = null;
 
     public function __construct(private readonly ValueEditProposal $proposal)
     {
@@ -205,8 +283,11 @@ final class RecordingBulkEditValuesPort implements BulkEditValuesPort
         array $filterDsl,
         array $changes,
         string $mode,
+        ?array $selectedIds = null,
     ): ValueEditProposal {
         $this->called = true;
+        $this->lastFilterDsl = $filterDsl;
+        $this->lastSelectedIds = $selectedIds;
 
         return $this->proposal;
     }
@@ -219,6 +300,7 @@ final class RecordingBulkEditValuesPort implements BulkEditValuesPort
         string $attrCode,
         string $operator,
         float $operand,
+        ?array $selectedIds = null,
     ): ValueEditProposal {
         $this->called = true;
         $this->lastAttrCode = $attrCode;
@@ -226,6 +308,7 @@ final class RecordingBulkEditValuesPort implements BulkEditValuesPort
         $this->lastOperand = $operand;
         $this->lastObjectTypeCode = $objectTypeCode;
         $this->lastFilterDsl = $filterDsl;
+        $this->lastSelectedIds = $selectedIds;
 
         return $this->proposal;
     }

--- a/apps/api/tests/Unit/Agent/AgentSystemPromptBuilderTest.php
+++ b/apps/api/tests/Unit/Agent/AgentSystemPromptBuilderTest.php
@@ -26,7 +26,7 @@ final class AgentSystemPromptBuilderTest extends TestCase
             'total_matching' => 95,
         ]);
 
-        $prompt = (new AgentSystemPromptBuilder())->build($run);
+        $prompt = new AgentSystemPromptBuilder()->build($run);
 
         self::assertStringContainsString('SELECTION SCOPE', $prompt);
         self::assertStringContainsString('1 object(s) SELECTED', $prompt);
@@ -41,7 +41,7 @@ final class AgentSystemPromptBuilderTest extends TestCase
             'filter_dsl' => ['field' => 'brand', 'op' => 'eq', 'value' => 'Acme'],
         ]);
 
-        $prompt = (new AgentSystemPromptBuilder())->build($run);
+        $prompt = new AgentSystemPromptBuilder()->build($run);
 
         self::assertStringNotContainsString('SELECTION SCOPE', $prompt);
     }
@@ -53,7 +53,7 @@ final class AgentSystemPromptBuilderTest extends TestCase
             'selected_ids' => [],
         ]);
 
-        $prompt = (new AgentSystemPromptBuilder())->build($run);
+        $prompt = new AgentSystemPromptBuilder()->build($run);
 
         self::assertStringNotContainsString('SELECTION SCOPE', $prompt);
     }

--- a/apps/api/tests/Unit/Agent/AgentSystemPromptBuilderTest.php
+++ b/apps/api/tests/Unit/Agent/AgentSystemPromptBuilderTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Agent;
+
+use App\Agent\Application\Run\AgentSystemPromptBuilder;
+use App\Agent\Domain\AgentRunSurface;
+use App\Agent\Domain\Entity\AgentRun;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * #2153 — the system prompt makes the agent act on the operator's
+ * SELECTION when the list has rows checked, and ask before widening the
+ * scope to the whole view.
+ */
+final class AgentSystemPromptBuilderTest extends TestCase
+{
+    #[Test]
+    public function addsSelectionScopeRuleWhenTheContextHasASelection(): void
+    {
+        $run = new AgentRun(Uuid::v7(), AgentRunSurface::CmdK, 'raise price 20%', [
+            'selected_ids' => ['id-1'],
+            'total_matching' => 95,
+        ]);
+
+        $prompt = (new AgentSystemPromptBuilder())->build($run);
+
+        self::assertStringContainsString('SELECTION SCOPE', $prompt);
+        self::assertStringContainsString('1 object(s) SELECTED', $prompt);
+        self::assertStringContainsString('all 95 in the active view', $prompt);
+        self::assertStringContainsString('ask ONE clarifying question', $prompt);
+    }
+
+    #[Test]
+    public function noSelectionRuleWhenNothingIsSelected(): void
+    {
+        $run = new AgentRun(Uuid::v7(), AgentRunSurface::Chat, 'raise price 20%', [
+            'filter_dsl' => ['field' => 'brand', 'op' => 'eq', 'value' => 'Acme'],
+        ]);
+
+        $prompt = (new AgentSystemPromptBuilder())->build($run);
+
+        self::assertStringNotContainsString('SELECTION SCOPE', $prompt);
+    }
+
+    #[Test]
+    public function anEmptySelectionAddsNoRule(): void
+    {
+        $run = new AgentRun(Uuid::v7(), AgentRunSurface::CmdK, 'do something', [
+            'selected_ids' => [],
+        ]);
+
+        $prompt = (new AgentSystemPromptBuilder())->build($run);
+
+        self::assertStringNotContainsString('SELECTION SCOPE', $prompt);
+    }
+}


### PR DESCRIPTION
Closes #2153

## Problem
User zaznaczył **1 produkt**, a agent zaproponował zmianę dla **wszystkich 95** w widoku. Narzędzia write widziały tylko `filter_dsl` aktywnego widoku — nie zaznaczenie (selection).

## Fix (backend-only — FE już wysyła `selected_ids` + `total_matching` w kontekście Cmd+K)
**Precedencja selektora** w `bulk_edit_values` i `adjust_numeric_values` (nowy trait `ResolvesSelectionScope`):
`object_ids` (jawny arg) → `filter_dsl` (jawny arg) → `selected_ids` (zaznaczenie z widoku) → `filter_dsl` widoku → wszystko.

**Silnik** (`BulkEditValuesMaterializer::resolveObjectIds`) waliduje przekazane ID względem **tenant + object type** — obcy/błędny ID nie może poszerzyć zakresu (RLS to backstop). Nowy opcjonalny param `?array $selectedIds` w `BulkEditValuesPort` (oba materialize\*).

**Prompt** (`AgentSystemPromptBuilder`): gdy kontekst ma niepuste `selected_ids`, dochodzi reguła **SELECTION SCOPE** — agent domyślnie działa na zaznaczeniu i **pyta ONE clarifying question** („{N} zaznaczonych czy wszystkie {M}?") gdy intencja nie mówi jasno o zakresie.

## Testy (kontener pim-api-1) — 25 testów, PHPStan max, Deptrac 0 violations
- Tool precedence: selection > view filter; explicit `object_ids` > selection; explicit `filter_dsl` suppresses selection; empty selection ignored.
- Materializer: selection scope targets tylko zaznaczone (obcy ID zignorowany, tenant/type-scoped); wariant arytmetyczny.
- Prompt: reguła SELECTION SCOPE pojawia się przy selekcji, znika bez / przy pustej.

## Smoke test na żywym stacku (pim.localhost)
Run z `selected_ids: [2 produkty]`, `total_matching: 95`, intent „podnieś price_gross o 10% dla zaznaczonych":
agent wywołał `adjust_numeric_values` z `object_ids: [2 zaznaczone]` → **affected_count = 2** (NIE 95), batch = dokładnie te 2 produkty (317.38→349.118, 306.95→337.645). Run odrzucony, dane nietknięte.

Refs #1961

🤖 Generated with [Claude Code](https://claude.com/claude-code)