### PR TITLE
feat(agent): SKU + nazwa produktu w diffie skrzynki akceptacji

### DIFF
--- a/apps/admin/src/features/agent/api.ts
+++ b/apps/admin/src/features/agent/api.ts
@@ -135,6 +135,8 @@ export interface AgentPlanRow {
   change_type: 'value' | 'schema' | 'category';
   status: string;
   target_object_id: string | null;
+  target_object_code: string | null;
+  target_object_name: string | null;
   attribute_code: string | null;
   scope_locale: string | null;
   scope_channel: string | null;

--- a/apps/admin/src/features/agent/inbox/AgentInboxPage.tsx
+++ b/apps/admin/src/features/agent/inbox/AgentInboxPage.tsx
@@ -27,11 +27,33 @@ function planLine(
         : t('agent.inbox.schema_attribute', { defaultValue: 'atrybut' });
     return `+ ${kind} ${row.attribute_code ?? '?'}`;
   }
+  // #2154 — lead with the product identity (SKU · name) so the operator
+  // can tell WHICH product each diff row touches, not just the raw delta.
+  const identity = objectIdentity(row);
   if (row.change_type === 'category') {
     const op = typeof row.after?.operation === 'string' ? row.after.operation : '?';
-    return `${row.target_object_id ?? '?'} · ${t('agent.inbox.categories', { defaultValue: 'kategorie' })}: ${op}`;
+    return `${identity} · ${t('agent.inbox.categories', { defaultValue: 'kategorie' })}: ${op}`;
   }
-  return `${row.attribute_code ?? '?'}: ${beforeValue} → ${afterValue}`;
+  return `${identity} · ${row.attribute_code ?? '?'}: ${beforeValue} → ${afterValue}`;
+}
+
+/**
+ * "SKU · Name", falling back to whatever identity we have (#2154). The
+ * backend fills target_object_code/name on list reads; a bare id is the
+ * last resort.
+ */
+function objectIdentity(row: AgentPlanRow): string {
+  const parts: string[] = [];
+  if (row.target_object_code) {
+    parts.push(row.target_object_code);
+  }
+  if (row.target_object_name) {
+    parts.push(row.target_object_name);
+  }
+  if (parts.length > 0) {
+    return parts.join(' · ');
+  }
+  return row.target_object_id ?? '?';
 }
 
 /**

--- a/apps/api/src/Agent/Presentation/Controller/AgentRunController.php
+++ b/apps/api/src/Agent/Presentation/Controller/AgentRunController.php
@@ -214,6 +214,8 @@ final readonly class AgentRunController
                 'change_type' => $row->changeType->value,
                 'status' => $row->status->value,
                 'target_object_id' => $row->targetObjectId?->toRfc4122(),
+                'target_object_code' => $row->targetObjectCode,
+                'target_object_name' => $row->targetObjectName,
                 'attribute_code' => $row->attributeCode,
                 'scope_locale' => $row->scopeLocale,
                 'scope_channel' => $row->scopeChannel,

--- a/apps/api/src/Catalog/Application/PendingChanges/PendingChangesService.php
+++ b/apps/api/src/Catalog/Application/PendingChanges/PendingChangesService.php
@@ -98,7 +98,84 @@ final class PendingChangesService implements PendingChangesPort
             ->getQuery()
             ->getResult();
 
-        return array_map($this->toView(...), $rows);
+        // #2154 — enrich the list view with each target object's SKU + name
+        // in ONE extra query (no N+1), so the approval diff shows product
+        // identity, not a bare attribute delta.
+        $identities = $this->loadObjectIdentities($rows);
+
+        return array_map(fn (PendingChange $change): PendingChangeView => $this->toView($change, $identities), $rows);
+    }
+
+    /**
+     * @param list<PendingChange> $rows
+     *
+     * @return array<string, array{code: string, name: ?string}> keyed by object id
+     */
+    private function loadObjectIdentities(array $rows): array
+    {
+        $ids = [];
+        foreach ($rows as $row) {
+            $objectId = $row->getTargetObjectId();
+            if ($objectId instanceof Uuid) {
+                $ids[$objectId->toRfc4122()] = true;
+            }
+        }
+        if ([] === $ids) {
+            return [];
+        }
+
+        // tenant-safe: RLS scopes `objects` to the current tenant; the ids
+        // come from this tenant's batch. Single IN () query, no N+1.
+        $result = $this->entityManager->getConnection()->fetchAllAssociative(
+            "SELECT co.id, co.code, co.attributes_indexed->'name' AS name FROM objects co WHERE co.id IN (:ids)",
+            ['ids' => array_keys($ids)],
+            ['ids' => \Doctrine\DBAL\ArrayParameterType::STRING],
+        );
+
+        $identities = [];
+        foreach ($result as $objectRow) {
+            $id = $objectRow['id'] ?? null;
+            $code = $objectRow['code'] ?? null;
+            if (!\is_string($id) || !\is_string($code)) {
+                continue;
+            }
+            $nameRaw = $objectRow['name'] ?? null;
+            $nameSlot = \is_string($nameRaw) ? json_decode($nameRaw, true) : $nameRaw;
+            $identities[$id] = ['code' => $code, 'name' => $this->extractDisplayName($nameSlot)];
+        }
+
+        return $identities;
+    }
+
+    /**
+     * Best-effort display name from the attributes_indexed `name` slot,
+     * which may be an envelope ({value: ...}), a localized map
+     * ({pl: ..., en: ...}), or a bare scalar. Prefer PL, then EN, then any.
+     */
+    private function extractDisplayName(mixed $slot): ?string
+    {
+        if (\is_string($slot)) {
+            return '' === $slot ? null : $slot;
+        }
+        if (!\is_array($slot)) {
+            return null;
+        }
+        if (\array_key_exists('value', $slot)) {
+            return $this->extractDisplayName($slot['value']);
+        }
+        foreach (['pl', 'en'] as $locale) {
+            $candidate = $slot[$locale] ?? null;
+            if (\is_string($candidate) && '' !== $candidate) {
+                return $candidate;
+            }
+        }
+        foreach ($slot as $candidate) {
+            if (\is_string($candidate) && '' !== $candidate) {
+                return $candidate;
+            }
+        }
+
+        return null;
     }
 
     public function iterateBatch(Uuid $batchId): iterable
@@ -213,8 +290,14 @@ final class PendingChangesService implements PendingChangesPort
         }
     }
 
-    private function toView(PendingChange $change): PendingChangeView
+    /**
+     * @param array<string, array{code: string, name: ?string}> $identities object id => SKU/name (#2154)
+     */
+    private function toView(PendingChange $change, array $identities = []): PendingChangeView
     {
+        $objectId = $change->getTargetObjectId();
+        $identity = null !== $objectId ? ($identities[$objectId->toRfc4122()] ?? null) : null;
+
         return new PendingChangeView(
             id: $change->getId(),
             batchId: $change->getBatchId(),
@@ -230,6 +313,8 @@ final class PendingChangesService implements PendingChangesPort
             meta: $change->getMeta(),
             createdAt: $change->getCreatedAt(),
             decidedAt: $change->getDecidedAt(),
+            targetObjectCode: $identity['code'] ?? null,
+            targetObjectName: $identity['name'] ?? null,
         );
     }
 }

--- a/apps/api/src/Catalog/Contracts/PendingChanges/PendingChangeView.php
+++ b/apps/api/src/Catalog/Contracts/PendingChanges/PendingChangeView.php
@@ -34,6 +34,12 @@ final readonly class PendingChangeView
         public ?array $meta,
         public DateTimeImmutable $createdAt,
         public ?DateTimeImmutable $decidedAt,
+        // #2154 — the target object's SKU + display name, so the approval
+        // diff reads "SKU · Name · attr: before -> after" instead of a bare
+        // number. Populated by list reads (the inbox); null on the streaming
+        // commit path, which does not need them.
+        public ?string $targetObjectCode = null,
+        public ?string $targetObjectName = null,
     ) {
     }
 }

--- a/apps/api/tests/Integration/Catalog/PendingChangesPortTest.php
+++ b/apps/api/tests/Integration/Catalog/PendingChangesPortTest.php
@@ -8,6 +8,9 @@ use App\Catalog\Contracts\PendingChanges\PendingChangeDraft;
 use App\Catalog\Contracts\PendingChanges\PendingChangesPort;
 use App\Catalog\Contracts\PendingChanges\PendingChangeStatus;
 use App\Catalog\Contracts\PendingChanges\PendingChangeType;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
 use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
@@ -187,6 +190,40 @@ final class PendingChangesPortTest extends KernelTestCase
         self::assertSame(450, $port->materialize($batchId, 'agent', $drafts));
         self::assertSame(450, $port->countBatch($batchId));
         self::assertSame(450, $port->accept($batchId));
+    }
+
+    #[Test]
+    public function listBatchEnrichesRowsWithTargetObjectCodeAndName(): void
+    {
+        // #2154 — the approval diff must identify the product (SKU + name),
+        // not just show a bare attribute delta. listBatch resolves both in
+        // one extra query from the target object's row.
+        $tenant = $this->createTenant('alpha');
+        $this->activateTenantFilter($tenant);
+
+        $em = $this->em();
+        $type = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $em->persist($type);
+        $object = new CatalogObject($type, 'SKU-ENRICH-1');
+        $object->updateAttributeIndex(['name' => ['value' => ['pl' => 'Torebka Monnari', 'en' => 'Monnari Bag']]]);
+        $em->persist($object);
+        $em->flush();
+
+        $batchId = Uuid::v7();
+        $this->port()->materialize($batchId, 'agent', [
+            new PendingChangeDraft(
+                changeType: PendingChangeType::Value,
+                targetObjectId: $object->getId(),
+                attributeCode: 'price_gross',
+                before: ['value' => 100],
+                after: ['value' => 120],
+            ),
+        ]);
+
+        $rows = $this->port()->listBatch($batchId);
+        self::assertCount(1, $rows);
+        self::assertSame('SKU-ENRICH-1', $rows[0]->targetObjectCode);
+        self::assertSame('Torebka Monnari', $rows[0]->targetObjectName, 'PL-preferred name from the envelope');
     }
 
     /**


### PR DESCRIPTION
Closes #2154

## Problem
Modal akceptacji pokazywał surowe wiersze `price_gross: 129.99 → 155.988` — bez informacji **który produkt**. Przy 95 pozycjach nie da się zweryfikować zmiany.

## Fix (BE + FE)
- **BE**: `PendingChangesService::listBatch` wzbogaca każdy `PendingChangeView` o `targetObjectCode` (SKU) + `targetObjectName` w **jednym dodatkowym query** (IN (), bez N+1). Endpoint `/api/agent/runs/{id}/plan` serializuje `target_object_code` + `target_object_name`. Ekstrakcja nazwy obsługuje kształty `attributes_indexed.name`: envelope `{value:...}`, localized map `{pl,en}`, scalar (PL-preferred). Ścieżka streamująca commit (`iterateBatch`) nietknięta — pola null.
- **FE**: `AgentInboxPage.planLine` renderuje `SKU · Nazwa · attr: before → after`; typ `AgentPlanRow` + 2 pola.

## Testy
- `PendingChangesPortTest::listBatchEnrichesRowsWithTargetObjectCodeAndName` ✅ (realny obiekt, PL-preferred nazwa z envelope).
- PHPStan max, php-cs-fixer, biome, tsc — zielone.

## Smoke test na żywym stacku (pim.localhost)
Endpoint `/api/agent/runs/{id}/plan` po zmaterializowaniu batcha zwraca teraz:
```
BD-BELONA-NS-SR-NITKA · Czółenka asymetryczne brokatowe srebrne Butdam Belona · price_gross: 317.38 → 200
BD-BTK-ZAMSZ-TAUPE · Sztyblety skórzane zamszowe klasyczne taupe, beżowe Butdam · price_gross: 306.95 → 200
```
SKU + pełna nazwa produktu obecne. Run posprzątany.

🤖 Generated with [Claude Code](https://claude.com/claude-code)