### PR TITLE
fix(agent): re-assert tenant RLS GUC przed zapisem stanu akceptacji

### DIFF
--- a/apps/api/src/Agent/Application/Approval/AgentApprovalService.php
+++ b/apps/api/src/Agent/Application/Approval/AgentApprovalService.php
@@ -17,6 +17,7 @@ use App\Import\Contracts\SchemaImportPort;
 use App\Shared\Application\TenantContext;
 use App\Shared\Contracts\Event\AgentRunCompleted;
 use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\RlsTenantGuard;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use LogicException;
@@ -49,7 +50,24 @@ final readonly class AgentApprovalService
         private AgentActionAuditor $auditor,
         private \Symfony\Component\Messenger\MessageBusInterface $eventBus,
         private TenantContext $tenantContext,
+        private RlsTenantGuard $rlsTenantGuard,
     ) {
+    }
+
+    /**
+     * #2156 — re-assert the tenant RLS GUC before an approval-state write.
+     * Under FrankenPHP worker mode the DBAL connection can silently
+     * reconnect mid-request, dropping the session-scoped app.current_tenant
+     * that RlsContextListener set on kernel.request; the terminal-status
+     * UPDATE would then hit 0 rows under FORCE RLS and the run would look
+     * stuck (a reject/cancel that reported success but never persisted).
+     */
+    private function reassertRls(): void
+    {
+        $tenant = $this->tenantContext->get();
+        if ($tenant instanceof Tenant) {
+            $this->rlsTenantGuard->reassert($tenant);
+        }
     }
 
     /**
@@ -103,6 +121,7 @@ final readonly class AgentApprovalService
 
         $isSchemaBatch = $this->isSchemaBatch($batchId);
 
+        $this->reassertRls();
         $run->markCommitting($approvedBy);
         $this->entityManager->flush();
         $this->publisher->status($run);
@@ -153,6 +172,9 @@ final readonly class AgentApprovalService
             throw ApprovalConflictException::nothingToCommit();
         }
 
+        // The commit above did heavy DB work — most likely to have triggered
+        // a reconnect, so re-assert before the final terminal write.
+        $this->reassertRls();
         $run->markDone($result->bulkSessionId);
         $this->entityManager->flush();
         $this->publisher->status($run);
@@ -198,6 +220,7 @@ final readonly class AgentApprovalService
             $this->pendingChanges->reject($batchId);
         }
 
+        $this->reassertRls();
         $run->markRejected();
         $this->entityManager->flush();
         $this->publisher->status($run);
@@ -236,6 +259,7 @@ final readonly class AgentApprovalService
             $this->pendingChanges->expire($batchId);
         }
 
+        $this->reassertRls();
         $run->markCancelled();
         $this->entityManager->flush();
         $this->publisher->status($run);
@@ -284,6 +308,7 @@ final readonly class AgentApprovalService
 
         // The rollback handler's per-chunk clear() detached the run.
         $run = $this->reload($runId);
+        $this->reassertRls();
         $run->markRolledBack();
         $this->entityManager->flush();
         $this->publisher->status($run);

--- a/apps/api/src/Shared/Infrastructure/Doctrine/RlsTenantGuard.php
+++ b/apps/api/src/Shared/Infrastructure/Doctrine/RlsTenantGuard.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Doctrine;
+
+use App\Shared\Domain\Tenant;
+use Doctrine\DBAL\Connection;
+
+/**
+ * #2156 — re-asserts the session-scoped Postgres GUC `app.current_tenant`
+ * that the RLS policies read.
+ *
+ * RlsContextListener (HTTP) and TenantRlsGucMiddleware (workers) set that
+ * GUC once, on entry. Under FrankenPHP worker mode the DBAL connection is
+ * long-lived and can be reused / silently reconnected mid-request; a
+ * session variable is per physical connection, so a reconnect drops it.
+ * Any RLS-protected WRITE issued afterwards then evaluates the policy with
+ * an empty tenant and, under FORCE ROW LEVEL SECURITY, silently affects
+ * ZERO rows (no error) — e.g. an agent run's terminal-status UPDATE that
+ * reported success but never persisted.
+ *
+ * Call {@see reassert()} immediately before such a write to guarantee the
+ * GUC is present on whatever connection the flush lands on. Idempotent: if
+ * the GUC was already correct this is a no-op set.
+ */
+final readonly class RlsTenantGuard
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    public function reassert(Tenant $tenant): void
+    {
+        // tenant-safe: infrastructure (re-establishes the tenant_id RLS policies read; this IS the tenant boundary, not a bypass)
+        $this->connection->executeStatement(
+            "SELECT set_config('app.current_tenant', :tenant_id, false)",
+            ['tenant_id' => $tenant->getId()->toRfc4122()],
+        );
+    }
+}

--- a/apps/api/tests/Integration/Shared/RlsTenantGuardTest.php
+++ b/apps/api/tests/Integration/Shared/RlsTenantGuardTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Shared;
+
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\RlsTenantGuard;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * #2156 — the guard re-establishes the `app.current_tenant` GUC that RLS
+ * policies read, so a write issued after a mid-request DBAL reconnect (which
+ * drops the session variable) still lands under FORCE RLS instead of
+ * silently affecting zero rows.
+ */
+final class RlsTenantGuardTest extends KernelTestCase
+{
+    #[Test]
+    public function reassertRestoresTheTenantGucOnTheConnection(): void
+    {
+        self::bootKernel();
+        $connection = $this->connection();
+        $tenant = new Tenant('alpha', 'Alpha Tenant');
+
+        // Simulate the drift: a reconnect leaves the session variable empty.
+        $connection->executeStatement("SELECT set_config('app.current_tenant', '', false)");
+        self::assertSame('', $connection->fetchOne("SELECT current_setting('app.current_tenant', true)"));
+
+        new RlsTenantGuard($connection)->reassert($tenant);
+
+        self::assertSame(
+            $tenant->getId()->toRfc4122(),
+            $connection->fetchOne("SELECT current_setting('app.current_tenant', true)"),
+            'reassert must set app.current_tenant so the next RLS-protected write sees the tenant',
+        );
+    }
+
+    private function connection(): Connection
+    {
+        return self::getContainer()->get('doctrine.dbal.default_connection');
+    }
+}


### PR DESCRIPTION
Closes #2156

## Problem
`reject`/`cancel` (i potencjalnie `approve`/`rollback`) potrafiły zwrócić **HTTP 200** ze statusem terminalnym, a mimo to zostawić run jako `awaiting_approval` w bazie — UPDATE cicho trafiał w **0 wierszy**. Objaw zaobserwowany na żywo: run smoke-testu utknął, blokował nowe rozmowy (patrz też #2155, które usuwa samą blokadę).

## Root cause (potwierdzony na żywo)
`RlsContextListener` (HTTP) i `TenantRlsGucMiddleware` (workery) ustawiają session-scope GUC `app.current_tenant` **raz, na wejściu**. Pod FrankenPHP worker mode połączenie DBAL jest długożyjące i bywa **reużyte/reconnectowane** w trakcie requestu; session var jest per fizyczne połączenie, więc reconnect je gubi. Kolejny RLS-chroniony **zapis** ewaluuje wtedy policy z pustym tenantem → pod FORCE ROW LEVEL SECURITY 0 wierszy, bez błędu. Dowód: ten sam UPDATE jako `pim_app` z ręcznie ustawionym GUC → `UPDATE 1`.

## Fix
Nowy `RlsTenantGuard` (Shared) + re-assert GUC **tuż przed** każdym zapisem stanu akceptacji (`reject` / `cancel` / `rollback` / `committing` / `done`) w `AgentApprovalService`. Idempotentny gdy GUC już poprawny. Zapis ląduje na dowolnym połączeniu, którego użyje flush.

To **celowany** fix ścieżki akceptacji agenta; szersza odporność na reconnect (re-aplikacja GUC przy każdym `connect()` DBAL — driver middleware) to osobne, wyżej-ryzykowne hardening infra (do rozważenia jeśli objaw wróci na innych write-path).

## Testy (kontener pim-api-1)
- `RlsTenantGuardTest::reassertRestoresTheTenantGucOnTheConnection` — po wyczyszczeniu GUC (symulacja driftu) reassert przywraca `app.current_tenant`. ✅
- Regresja: `AgentRejectCancelTest` + `AgentApprovalCommitTest` + `AgentRollbackTest` — 15 testów zielonych.
- PHPStan max, Deptrac 0 violations, php-cs-fixer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)