### PR TITLE
fix(cmd-k): resolucja kategorii po kodzie lub nazwie ('dodaj kategorię X' → działa)

### DIFF
--- a/apps/api/src/Catalog/Presentation/Controller/BulkActionsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/BulkActionsController.php
@@ -403,21 +403,125 @@ final class BulkActionsController
      */
     private function extractCategoryIds(array $payload): array
     {
-        $raw = $payload['category_ids'] ?? null;
-        if (!\is_array($raw) || [] === $raw) {
-            throw new BadRequestHttpException('payload.category_ids must be a non-empty array.');
-        }
-        $out = [];
-        foreach ($raw as $id) {
-            if (\is_string($id) && '' !== $id) {
-                $out[] = $id;
+        $rawIds = $payload['category_ids'] ?? null;
+        if (\is_array($rawIds) && [] !== $rawIds) {
+            $out = [];
+            foreach ($rawIds as $id) {
+                if (\is_string($id) && '' !== $id) {
+                    $out[] = $id;
+                }
+            }
+            if ([] !== $out) {
+                return $out;
             }
         }
-        if ([] === $out) {
-            throw new BadRequestHttpException('payload.category_ids has no valid entries.');
+
+        // #2161 — the Cmd+K planner emits human-friendly category_codes
+        // ("dodaj kategorię botki"), not UUIDs. Resolve each token to a
+        // category object id by CODE or display NAME (case-insensitive), so
+        // the quick action actually applies instead of returning a 400.
+        $rawCodes = $payload['category_codes'] ?? null;
+        if (\is_array($rawCodes) && [] !== $rawCodes) {
+            $codes = [];
+            foreach ($rawCodes as $code) {
+                if (\is_string($code) && '' !== trim($code)) {
+                    $codes[] = trim($code);
+                }
+            }
+            if ([] !== $codes) {
+                return $this->resolveCategoryRefs($codes);
+            }
         }
 
-        return $out;
+        throw new BadRequestHttpException('payload.category_ids (or category_codes) must be a non-empty array.');
+    }
+
+    /**
+     * Resolve category references (code or display name, case-insensitive)
+     * to category object ids within the current tenant. Unknown references
+     * are a clear 404 naming them, never a silent drop.
+     *
+     * @param list<string> $refs
+     *
+     * @return list<string>
+     */
+    private function resolveCategoryRefs(array $refs): array
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new BadRequestHttpException('No tenant context.');
+        }
+
+        $lowered = array_values(array_unique(array_map('mb_strtolower', $refs)));
+
+        // tenant-safe: explicit tenant_id predicate; RLS is the backstop.
+        // Match code OR name (scalar envelope value + pl/en localized value).
+        $rows = $this->em->getConnection()->fetchAllAssociative(
+            "SELECT co.id, co.code, co.attributes_indexed->'name' AS name
+             FROM objects co
+             JOIN object_types ot ON ot.id = co.object_type_id
+             WHERE co.tenant_id = :tenant AND ot.kind = 'category'",
+            ['tenant' => $tenant->getId()->toRfc4122()],
+        );
+
+        $byRef = [];
+        foreach ($rows as $row) {
+            $id = $row['id'] ?? null;
+            if (!\is_string($id)) {
+                continue;
+            }
+            foreach ($this->categoryRefKeys($row) as $key) {
+                // First match wins; codes/names are expected unique per tenant.
+                $byRef[$key] ??= $id;
+            }
+        }
+
+        $ids = [];
+        $missing = [];
+        foreach ($lowered as $ref) {
+            if (isset($byRef[$ref])) {
+                $ids[] = $byRef[$ref];
+            } else {
+                $missing[] = $ref;
+            }
+        }
+        if ([] !== $missing) {
+            throw new NotFoundHttpException(\sprintf('Nie znaleziono kategorii: %s.', implode(', ', $missing)));
+        }
+
+        return array_values(array_unique($ids));
+    }
+
+    /**
+     * Lower-cased lookup keys for a category row: its code and every display
+     * name shape (scalar envelope value, and pl/en of a localized value).
+     *
+     * @param array<string, mixed> $row
+     *
+     * @return list<string>
+     */
+    private function categoryRefKeys(array $row): array
+    {
+        $keys = [];
+        $code = $row['code'] ?? null;
+        if (\is_string($code) && '' !== $code) {
+            $keys[] = mb_strtolower($code);
+        }
+
+        $nameRaw = $row['name'] ?? null;
+        $name = \is_string($nameRaw) ? json_decode($nameRaw, true) : $nameRaw;
+        $value = \is_array($name) ? ($name['value'] ?? null) : $name;
+        if (\is_string($value) && '' !== $value) {
+            $keys[] = mb_strtolower($value);
+        } elseif (\is_array($value)) {
+            foreach ($value as $localized) {
+                if (\is_string($localized) && '' !== $localized) {
+                    $keys[] = mb_strtolower($localized);
+                }
+            }
+        }
+
+        return $keys;
     }
 
     /**

--- a/apps/api/tests/Api/Catalog/BulkActionsCategoryRefApiTest.php
+++ b/apps/api/tests/Api/Catalog/BulkActionsCategoryRefApiTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * #2161 — the Cmd+K planner emits human-friendly category_codes
+ * ("dodaj kategorię botki"), not UUIDs. The bulk-actions add_category
+ * endpoint resolves each reference by code OR display name (so the quick
+ * action actually applies), and an unknown reference is a clear 404 rather
+ * than the old cryptic "category_ids must be a non-empty array" 400.
+ */
+final class BulkActionsCategoryRefApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function addCategoryResolvesCategoryCodesByDisplayName(): void
+    {
+        $product = $this->seedObject(ObjectKind::Product, 'PROD-CATREF-1', []);
+        // Category whose CODE is "buty" but whose NAME is "Botki" — the user
+        // types the name, the planner passes it through as a code.
+        $this->seedObject(ObjectKind::Category, 'buty', ['name' => ['value' => 'Botki']]);
+
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/products/bulk-actions/add_category', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode([
+                'target_ids' => [$product],
+                'payload' => ['category_codes' => ['botki']],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseIsSuccessful();
+    }
+
+    #[Test]
+    public function addCategoryResolvesByCode(): void
+    {
+        $product = $this->seedObject(ObjectKind::Product, 'PROD-CATREF-2', []);
+        $this->seedObject(ObjectKind::Category, 'CAT-FOOTWEAR', ['name' => ['value' => 'Obuwie']]);
+
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/products/bulk-actions/add_category', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode([
+                'target_ids' => [$product],
+                'payload' => ['category_codes' => ['cat-footwear']],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseIsSuccessful();
+    }
+
+    #[Test]
+    public function addCategoryWithUnknownReferenceIsA404(): void
+    {
+        $product = $this->seedObject(ObjectKind::Product, 'PROD-CATREF-3', []);
+
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/products/bulk-actions/add_category', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode([
+                'target_ids' => [$product],
+                'payload' => ['category_codes' => ['nieistniejaca-kategoria']],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * @param array<string, mixed> $indexed
+     */
+    private function seedObject(ObjectKind $kind, string $code, array $indexed): string
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)->findBuiltInByKind($kind, $tenant);
+        \assert(null !== $type);
+
+        $object = new CatalogObject($type, $code);
+        if ([] !== $indexed) {
+            $object->updateAttributeIndex($indexed);
+        }
+        $em->persist($object);
+        $em->flush();
+
+        return $object->getId()->toRfc4122();
+    }
+}


### PR DESCRIPTION
Closes #2161

## Problem
Cmd+K „dodaj kategorię botki" → plan `add_category · target=1` → **Zastosuj → HTTP 400** (`payload.category_ids must be a non-empty array`).

Dwa błędy: (1) `CmdKPlanner` emituje `payload.category_codes`, a endpoint bulk-actions czytał tylko `category_ids` (UUID) → cmd-k add_category **nigdy** nie działał; (2) user pisze **nazwę** kategorii („Botki"), a w bazie kategoria ma kod `buty` — więc nawet po naprawie kontraktu sam kod by nie zmatchował.

## Fix
`extractCategoryIds` (BulkActionsController) akceptuje `category_codes` i resolvuje każdy token do UUID kategorii **po kodzie LUB nazwie** (case-insensitive; nazwa scalar/localized z envelope), w obrębie tenanta. Nierozwiązane tokeny → czytelny **404** „Nie znaleziono kategorii: X" zamiast cryptic 400. Dotyczy add/remove/move_category (preview + apply). Planner zostaje DB-less (bez zmian) — resolucja jest po stronie zapisu.

## Testy (kontener pim-api-1)
- `BulkActionsCategoryRefApiTest`: resolucja po **nazwie** („botki" → kategoria `buty`/Botki), po **kodzie** (`cat-footwear`), nieznany token → **404**. ✅
- PHPStan max, Deptrac 0 violations, php-cs-fixer.

## Smoke test na żywym stacku (pim.localhost)
- `POST /api/agent/cmd-k {"command":"dodaj kategorię botki"}` → `action=add_category`, `payload={category_codes:["botki"]}`.
- `POST /api/products/bulk-actions/add_category {target_ids:[prod], payload:{category_codes:["botki"]}}` (Zastosuj) → **HTTP 200, success_count: 1** (było 400). Produkt przypisany do kategorii `buty` (nazwa „Botki") — resolucja po nazwie potwierdzona w DB. Assignment posprzątany.

🤖 Generated with [Claude Code](https://claude.com/claude-code)