### PR TITLE
fix(cmd-k): każda komenda przez agenta (akceptacja), koniec natychmiastowego 'Zastosuj'

### DIFF
--- a/apps/admin/e2e/1975-cmdk-agent-wire.spec.ts
+++ b/apps/admin/e2e/1975-cmdk-agent-wire.spec.ts
@@ -84,10 +84,10 @@ test('cmd+k sends a free-form command to the agent with view context', async ({ 
   const commandInput = dialog.getByRole('textbox');
   await expect(commandInput).toBeVisible();
 
-  // Free-form command → the local planner falls back → "send to agent".
+  // #2163 — every command goes straight to the agent on submit (the
+  // immediate quick-action "Zastosuj" path was removed).
   await commandInput.fill('przecen produkty festo o 10%');
   await commandInput.press('Enter');
-  await page.getByTestId('cmdk-list-ask-agent').click();
 
   await expect.poll(() => capturedBody).not.toBeNull();
   const body = capturedBody as unknown as {

--- a/apps/admin/src/components/agent/cmd-k-palette.tsx
+++ b/apps/admin/src/components/agent/cmd-k-palette.tsx
@@ -7,60 +7,31 @@ import { startAgentRun } from '@/features/agent/api';
 import { OPEN_AGENT_CHAT_EVENT } from '@/features/agent/chat/AgentChatSheet';
 import { AGENT_ENABLED } from '@/lib/features';
 import type { FilterDsl } from '@/lib/filters/filter-dsl';
-import { httpErrorDetail, jsonFetch } from '@/lib/http';
+import { httpErrorDetail } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
 /**
- * VIEW-19 (#550) — Cmd+K palette (USP demo gate).
+ * VIEW-19 / #2163 — Cmd+K palette.
  *
- * Keyboard shortcut `mod+k` opens the palette; the input dispatches a
- * POST `/api/agent/cmd-k` request to the deterministic planner. On a
- * matching intent the planner returns a `{action, payload, summary}`
- * triple, which we use to drive the same bulk endpoints that power the
- * manual wizard (consistency contract per CLAUDE.md §8.5).
+ * Every command goes to the PIM agent: it starts an agent run (LLM →
+ * plan → pending_changes) and hands off to the chat sheet, so nothing is
+ * written to the catalog without passing the approval inbox. The old
+ * deterministic quick-action path applied bulk changes IMMEDIATELY with
+ * no approval — inconsistent with the agent's safety model and surprising
+ * (a change landed with no confirmation and no feedback), so it was
+ * removed. The single rule now: agent = always approval.
  *
- * Anthropic SDK + tool-use + Mercure SSE streaming + BYOK rotation
- * land in VIEW-19.1 (epik 0.7 / Faza 2). The MVP slice keeps the
- * keyboard shortcut + selection context surface + 6 killer intents
- * demo-ready.
- *
- * Suggested phrasings (mockup `list-v2-overlays.jsx` l. 651-735):
- *   • „Ustaw brand na Festo"
- *   • „Pomnóż price przez 1.10"
- *   • „Skopiuj manufacturer do brand"
- *   • „Wyczyść description_en"
- *   • „Dodaj kategorię akcesoria"
- *   • „Publikuj na shopify"
+ * Suggested phrasings just pre-fill the input; the user still submits.
  */
-
-interface BulkActionResult {
-  session_id: string;
-  action: string;
-  target_count: number;
-  success_count: number;
-  skipped_count: number;
-  error_count: number;
-  rollback_available_until?: string;
-  completed_at?: string;
-}
 
 interface CmdKPaletteProps {
   open: boolean;
   onClose: () => void;
   selectedIds: string[];
   totalMatching: number;
-  onApplied: (result: BulkActionResult) => void;
   /** AGENT-P6-02 (#1975) — view context carried into agent runs. */
   objectTypeCode?: string;
   filterDsl?: FilterDsl | null;
-}
-
-interface CmdKPlan {
-  action: string | null;
-  payload: Record<string, unknown> | null;
-  summary: string | null;
-  fallback_hint?: string;
-  selection_context: { selected_ids: string[]; total_matching: number };
 }
 
 const SUGGESTIONS: string[] = [
@@ -77,21 +48,17 @@ export function CmdKPalette({
   onClose,
   selectedIds,
   totalMatching,
-  onApplied,
   objectTypeCode,
   filterDsl,
 }: CmdKPaletteProps) {
   const { t } = useTranslation();
   const [command, setCommand] = useState('');
-  const [plan, setPlan] = useState<CmdKPlan | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [recent, setRecent] = useState<string[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!open) {
       setCommand('');
-      setPlan(null);
     } else {
       window.requestAnimationFrame(() => inputRef.current?.focus());
     }
@@ -99,74 +66,23 @@ export function CmdKPalette({
 
   if (!open) return null;
 
-  const requestPlan = async (text: string): Promise<void> => {
-    setIsLoading(true);
-    try {
-      const response = await jsonFetch<CmdKPlan>('/api/agent/cmd-k', {
-        method: 'POST',
-        body: {
-          command: text,
-          selection_context: {
-            selected_ids: selectedIds,
-            total_matching: totalMatching,
-          },
-        },
-      });
-      setPlan(response);
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'plan failed');
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const applyPlan = async (): Promise<void> => {
-    if (!plan?.action || !plan.payload) return;
-    if (selectedIds.length === 0) {
+  const askAgent = async (raw: string): Promise<void> => {
+    const text = raw.trim();
+    if (text === '' || isLoading) return;
+    if (!AGENT_ENABLED) {
       toast.error(
-        t('agent.cmd_k.no_selection', {
-          defaultValue: 'Zaznacz produkty zanim wywołasz akcję zbiorczą',
+        t('agent.cmd_k.disabled', {
+          defaultValue: 'Agent PIM jest wyłączony — włącz go w Ustawieniach › AI.',
         }),
       );
       return;
     }
     setIsLoading(true);
     try {
-      const body: Record<string, unknown> = {
-        target_ids: selectedIds,
-        payload: plan.payload,
-      };
-      if (plan.action === 'delete') {
-        body.confirmation_count = selectedIds.length;
-      }
-      const result = await jsonFetch<BulkActionResult>(
-        `/api/products/bulk-actions/${plan.action}`,
-        { method: 'POST', body },
-      );
-      toast.success(
-        t('agent.cmd_k.applied', {
-          count: result.success_count,
-          defaultValue: `Zastosowano do ${result.success_count} produktów`,
-        }),
-      );
-      setRecent((prev) => [command, ...prev.filter((c) => c !== command)].slice(0, 5));
-      onApplied(result);
-      onClose();
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'apply failed');
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const askAgent = async (): Promise<void> => {
-    const text = command.trim();
-    if (text === '' || isLoading) return;
-    setIsLoading(true);
-    try {
-      // AGENT-P6-02 (#1975) — free-form intents leave the 6 canned bulk
-      // intents to the local planner and go to the REAL agent, carrying
-      // exactly what the user is looking at (PRD §5.1).
+      // #2163 — every command goes to the REAL agent, carrying exactly
+      // what the user is looking at (view + selection). The agent
+      // materializes changes into the approval inbox; nothing is applied
+      // without an explicit accept.
       const run = await startAgentRun(text, 'cmdk', {
         object_type_code: objectTypeCode,
         filter_dsl: filterDsl ?? null,
@@ -224,8 +140,7 @@ export function CmdKPalette({
           <form
             onSubmit={(e) => {
               e.preventDefault();
-              if (command.trim() === '') return;
-              void requestPlan(command);
+              void askAgent(command);
             }}
           >
             <input
@@ -240,111 +155,37 @@ export function CmdKPalette({
             />
           </form>
 
-          {plan ? (
-            <div className="rounded-2xl border border-zinc-200 bg-zinc-50/70 p-4 space-y-3">
-              <div className="text-[11px] uppercase tracking-wider font-semibold text-zinc-500">
-                {t('agent.cmd_k.plan_label', { defaultValue: 'Plan' })}
-              </div>
-              {plan.action ? (
-                <>
-                  <div className="text-[14px] font-medium text-zinc-900">{plan.summary}</div>
-                  <div className="text-[11.5px] font-mono text-zinc-500">
-                    {plan.action} · target={selectedIds.length}
-                  </div>
-                  <div className="flex items-center gap-2 pt-1">
-                    <button
-                      type="button"
-                      onClick={() => void applyPlan()}
-                      disabled={isLoading || selectedIds.length === 0}
-                      className="h-9 px-4 rounded-lg bg-orange-600 text-white text-[12.5px] font-medium hover:bg-orange-500 disabled:opacity-50"
-                    >
-                      {t('agent.cmd_k.apply', { defaultValue: 'Zastosuj' })}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setPlan(null)}
-                      className="h-9 px-4 rounded-lg border border-zinc-200 text-[12.5px] font-medium text-zinc-700 hover:bg-white"
-                    >
-                      {t('agent.cmd_k.reject', { defaultValue: 'Odrzuć plan' })}
-                    </button>
-                  </div>
-                </>
-              ) : (
-                <div className="space-y-2">
-                  <div className="text-[12.5px] text-zinc-700">
-                    {AGENT_ENABLED
-                      ? t('agent.cmd_k.fallback_agent', {
-                          defaultValue:
-                            'Komenda nie pasuje do szybkich akcji — wyślij ją do agenta PIM.',
-                        })
-                      : (plan.fallback_hint ??
-                        t('agent.cmd_k.fallback', {
-                          defaultValue: 'Komenda nie pasuje do MVP intentu.',
-                        }))}
-                  </div>
-                  {AGENT_ENABLED && (
-                    <button
-                      type="button"
-                      onClick={() => void askAgent()}
-                      disabled={isLoading}
-                      data-testid="cmdk-list-ask-agent"
-                      className="h-9 px-4 rounded-lg bg-orange-500 text-white text-[12.5px] font-medium hover:bg-orange-600 disabled:opacity-60"
-                    >
-                      {t('agent.cmd_k.ask_agent', { defaultValue: 'Wyślij do agenta PIM' })}
-                    </button>
-                  )}
-                </div>
-              )}
+          <div className="rounded-2xl border border-orange-100 bg-orange-50/50 px-4 py-2.5 text-[11.5px] text-zinc-600">
+            {t('agent.cmd_k.approval_hint', {
+              defaultValue:
+                'Komenda trafi do agenta PIM — przygotuje zmiany do akceptacji. Nic nie wchodzi bez Twojego „Akceptuj".',
+            })}
+          </div>
+
+          <div className="space-y-2">
+            <div className="text-[11px] uppercase tracking-wider font-semibold text-zinc-500">
+              {t('agent.cmd_k.suggestions_label', { defaultValue: 'Spróbuj' })}
             </div>
-          ) : (
-            <div className="space-y-2">
-              <div className="text-[11px] uppercase tracking-wider font-semibold text-zinc-500">
-                {t('agent.cmd_k.suggestions_label', { defaultValue: 'Spróbuj' })}
-              </div>
-              <ul className="space-y-1">
-                {SUGGESTIONS.map((s) => (
-                  <li key={s}>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setCommand(s);
-                        void requestPlan(s);
-                      }}
-                      className={cn(
-                        'w-full text-left px-3 py-2 rounded-lg text-[12.5px]',
-                        'hover:bg-zinc-50 text-zinc-700',
-                      )}
-                    >
-                      {s}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-              {recent.length > 0 ? (
-                <>
-                  <div className="text-[11px] uppercase tracking-wider font-semibold text-zinc-500 pt-2">
-                    {t('agent.cmd_k.recent_label', { defaultValue: 'Ostatnio' })}
-                  </div>
-                  <ul className="space-y-1">
-                    {recent.map((r) => (
-                      <li key={r}>
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setCommand(r);
-                            void requestPlan(r);
-                          }}
-                          className="w-full text-left px-3 py-2 rounded-lg text-[12.5px] text-zinc-600 hover:bg-zinc-50 font-mono"
-                        >
-                          {r}
-                        </button>
-                      </li>
-                    ))}
-                  </ul>
-                </>
-              ) : null}
-            </div>
-          )}
+            <ul className="space-y-1">
+              {SUGGESTIONS.map((s) => (
+                <li key={s}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setCommand(s);
+                      inputRef.current?.focus();
+                    }}
+                    className={cn(
+                      'w-full text-left px-3 py-2 rounded-lg text-[12.5px]',
+                      'hover:bg-zinc-50 text-zinc-700',
+                    )}
+                  >
+                    {s}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/admin/src/components/objects/universal-list-page.tsx
+++ b/apps/admin/src/components/objects/universal-list-page.tsx
@@ -1012,12 +1012,6 @@ export function UniversalListPage({
           totalMatching={
             crossPageSelection.active ? crossPageSelection.totalMatched : selected.size
           }
-          onApplied={(result) => {
-            setLastBulkSession(result);
-            setSelected(new Set());
-            setShowSelectedOnly(false);
-            refetch();
-          }}
         />
       </Suspense>
 


### PR DESCRIPTION
Closes #2163

## Problem
Paleta Cmd+K miała dwa silniki pod jednym brandem „Asystent": rozpoznana komenda → **bulk zmiana OD RAZU** (`/api/products/bulk-actions/...`, bez akceptacji, bez feedbacku), nierozpoznana → agent z `pending_changes` + skrzynką akceptacji. Ta sama intencja, różny poziom bezpieczeństwa. „Dodaj kategorię botki" weszło natychmiast, bez potwierdzenia — operator nie wiedział czy coś się stało.

## Decyzja operatora
**Każda komenda → agent → akceptacja.** Usunięto szybką ścieżkę „Zastosuj". Jedna reguła: agent = zawsze akceptacja (świadomy trade-off: LLM tokeny nawet dla prostych akcji).

## Zmiana (FE)
- `cmd-k-palette.tsx`: submit zawsze `startAgentRun(command, 'cmdk', {view+selection})` + otwarcie czatu. Usunięto plan preview, `Zastosuj`, `applyPlan`, wywołania bulk-actions. Podpowiedzi tylko pre-fillują input. Dodany hint „nic nie wchodzi bez Twojego Akceptuj". Guard gdy agent wyłączony.
- `universal-list-page.tsx`: usunięty nieużywany już prop `onApplied` z `CmdKPalette`.
- E2E `1975-cmdk-agent-wire`: Enter idzie prosto do agenta (bez pośredniego przycisku).

Backend `/api/agent/cmd-k` + `CmdKPlanner` zostają (martwe dla apply) — sprzątanie w osobnym tickecie.

## Smoke test
- **E2E `1975-cmdk-agent-wire`** (Playwright w CI) asertuje wiring: Cmd+K → Enter → `POST /api/agent/runs` z `surface=cmdk` + view/selection context (bez pośredniego „Zastosuj").
- **Zmiana FE wdrożona na dev-stack** (Vite HMR, app 200, brak błędów kompilacji) — manualny smoke w przeglądarce po Twojej stronie: Cmd+K „dodaj kategorię botki" z 1 zaznaczonym → otwiera czat agenta → plan → skrzynka akceptacji, nic nie wchodzi bez „Akceptuj".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
(uzupełnię — Cmd+K „dodaj kategorię botki" z 1 zaznaczonym → czat → plan → skrzynka akceptacji, nic nie wchodzi bez Akceptuj)

🤖 Generated with [Claude Code](https://claude.com/claude-code)