### PR TITLE
DP-04: feat(catalog): filtr atrybutów po grupie atrybutów na liście

### DIFF
--- a/apps/admin/e2e/dp-04-attributes-group-filter.spec.ts
+++ b/apps/admin/e2e/dp-04-attributes-group-filter.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * DP-04 (#2034) — attributes list filters by AttributeGroup.
+ *
+ * Single test, one login (rate-limiter budget). The dropdown drives the
+ * server-side `?attributeGroup=` filter (AttributeGroupFilter) and keeps
+ * its state in the URL (`?group=`), so refresh preserves the narrowed view.
+ */
+test('DP-04 — attributes list narrows by attribute group and keeps state in URL', async ({
+  page,
+}) => {
+  await loginAsAdmin(page);
+  await page.goto('/modeling/attributes');
+
+  // Baseline: caption reports the full library size (digit prefix keeps the
+  // locator away from the digit-less "Atrybuty"/"Attributes" headings).
+  const caption = page.getByText(/^\d+\s+(atrybutów|attributes)/i).first();
+  await expect(caption).toBeVisible();
+  const readCount = async (): Promise<number> => {
+    const text = (await caption.textContent()) ?? '';
+    return Number.parseInt(text.replace(/\D/g, ''), 10);
+  };
+  await expect.poll(readCount).toBeGreaterThan(0);
+  const before = await readCount();
+
+  // Pick a group in the combobox (custom component: trigger button showing
+  // the placeholder + a dropdown of option buttons). Demo DB seeds several
+  // groups; if the environment has none the dropdown reports empty — bail.
+  const trigger = page.getByRole('button', { name: /grupa atrybutów|attribute group/i });
+  await expect(trigger).toBeVisible();
+  await trigger.click();
+  const options = page.locator('.max-h-60 > button');
+  const optionCount = await options
+    .first()
+    .waitFor({ state: 'visible', timeout: 10_000 })
+    .then(() => options.count())
+    .catch(() => 0);
+  test.skip(optionCount === 0, 'No attribute groups in this environment seed');
+
+  await options.first().click();
+
+  // URL carries the group id; the list narrows server-side.
+  await expect(page).toHaveURL(/group=[0-9a-f-]{36}/);
+  await expect.poll(readCount).toBeLessThan(before);
+
+  // Refresh keeps the filter (URL is the source of truth).
+  await page.reload();
+  await expect.poll(readCount).toBeLessThan(before);
+});

--- a/apps/admin/src/features/catalog/attributes/list.tsx
+++ b/apps/admin/src/features/catalog/attributes/list.tsx
@@ -3,10 +3,11 @@ import { useQueries } from '@tanstack/react-query';
 import { ChevronRight, Layers, Plus, Search, Shield, Zap } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router';
+import { Link, useSearchParams } from 'react-router';
 
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import { Combobox } from '@/components/ui/combobox';
 import { jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
@@ -68,10 +69,17 @@ export function AttributesListPage() {
   const { t, i18n } = useTranslation();
   const [filter, setFilter] = useState<TypeFilter>('all');
   const [query, setQuery] = useState('');
+  // DP-04 (#2034) — group filter lives in the URL (`?group=<uuid>`) so a
+  // refresh / back-navigation keeps the narrowed view. Filtering happens
+  // server-side via `?attributeGroup=` (AttributeGroupFilter, BE).
+  const [searchParams, setSearchParams] = useSearchParams();
+  const groupFilter = searchParams.get('group') ?? '';
 
   const { result, query: listQuery } = useList<AttributeRow>({
     resource: 'attributes',
     pagination: { mode: 'off' },
+    filters:
+      groupFilter !== '' ? [{ field: 'attributeGroup', operator: 'eq', value: groupFilter }] : [],
     // Always refetch on mount + window focus so the list never serves a
     // stale snapshot after the operator creates / edits an attribute on
     // a sibling page (new.tsx, show.tsx, values.tsx) and clicks back.
@@ -79,6 +87,21 @@ export function AttributesListPage() {
     // CRUD flows where one tab can change data the other tab caches.
     queryOptions: { refetchOnMount: 'always', refetchOnWindowFocus: true, staleTime: 0 },
   });
+
+  const { result: groupsResult } = useList<{
+    id: string;
+    code: string;
+    label: Record<string, string> | string | null;
+  }>({
+    resource: 'attribute_groups',
+    pagination: { mode: 'off' },
+    queryOptions: { staleTime: 60_000 },
+  });
+  const groupOptions = groupsResult.data.map((group) => ({
+    value: group.id,
+    label: resolveLabel(group.label, i18n.language),
+    description: group.code,
+  }));
 
   const attributes = result.data;
   const isLoading = listQuery.isLoading;
@@ -152,6 +175,31 @@ export function AttributesListPage() {
             })}
             className="flex-1 min-w-[180px] bg-transparent text-[13.5px] outline-none placeholder:text-muted-foreground"
           />
+          <div className="w-56">
+            <Combobox
+              options={groupOptions}
+              value={groupFilter === '' ? null : groupFilter}
+              onChange={(value) => {
+                setSearchParams(
+                  (prev) => {
+                    const next = new URLSearchParams(prev);
+                    if (value === null) {
+                      next.delete('group');
+                    } else {
+                      next.set('group', value);
+                    }
+                    return next;
+                  },
+                  { replace: true },
+                );
+              }}
+              placeholder={t('attributes.filter.group', { defaultValue: 'Grupa atrybutów' })}
+              searchPlaceholder={t('attributes.filter.group_search', {
+                defaultValue: 'Szukaj grupy…',
+              })}
+              emptyText={t('attributes.filter.group_empty', { defaultValue: 'Brak grup' })}
+            />
+          </div>
           <div className="flex flex-wrap items-center gap-1">
             {TYPE_FILTERS.map((opt) => (
               <button

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1024,6 +1024,13 @@
     "back": "Back to attributes",
     "filter_type": "Type",
     "filter_all": "All",
+    "filter": {
+      "all": "all",
+      "system": "system",
+      "group": "Attribute group",
+      "group_search": "Search groups…",
+      "group_empty": "No groups"
+    },
     "empty": "No attributes for the current tenant.",
     "write_deferred_note": "Manual create / edit / drag-and-drop is deferred to the schema-add agent flow (Faza 2). The seeder ships the MVP attribute set.",
     "fields": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1034,6 +1034,13 @@
     "back": "Wróć do atrybutów",
     "filter_type": "Typ",
     "filter_all": "Wszystkie",
+    "filter": {
+      "all": "wszystkie",
+      "system": "system",
+      "group": "Grupa atrybutów",
+      "group_search": "Szukaj grupy…",
+      "group_empty": "Brak grup"
+    },
     "empty": "Brak atrybutów dla aktualnego najemcy.",
     "write_deferred_note": "Ręczne tworzenie / edycja / drag-and-drop są odroczone do agentowego flow schema-add (Faza 2). Seeder dostarcza MVP zestaw atrybutów.",
     "fields": {

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Filter/AttributeGroupFilter.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Filter/AttributeGroupFilter.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\ApiPlatform\Filter;
+
+use ApiPlatform\Doctrine\Orm\Filter\FilterInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use App\Catalog\Domain\Entity\AttributeGroupAttribute;
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * DP-04 (#2034) — `?attributeGroup=<uuid>` scopes `/api/attributes` to
+ * attributes assigned to a specific AttributeGroup.
+ *
+ * Membership is dual-path during the UI-08 transition (ADR-012): the
+ * authoritative M:N `attribute_group_attributes` junction OR the legacy
+ * `attributes.group_id` FK (ADR-009) still written by pre-migration data.
+ * The filter ORs both so pre-junction rows keep showing up until the data
+ * migration lands.
+ *
+ * Empty / non-UUID values are skipped — a stale FE param must not blow up
+ * the collection. Tenant scoping still applies via
+ * {@see \App\Shared\Infrastructure\Doctrine\Filter\TenantFilter}.
+ */
+final class AttributeGroupFilter implements FilterInterface
+{
+    private const string PARAMETER = 'attributeGroup';
+
+    public function apply(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $filters = $context['filters'] ?? [];
+        if (!\is_array($filters)) {
+            return;
+        }
+
+        $value = $filters[self::PARAMETER] ?? null;
+        if (!\is_string($value) || !Uuid::isValid($value)) {
+            return;
+        }
+
+        $alias = $queryBuilder->getRootAliases()[0] ?? null;
+        if (null === $alias) {
+            return;
+        }
+
+        $parameter = $queryNameGenerator->generateParameterName('attributeGroupId');
+        $junctionAlias = $queryNameGenerator->generateJoinAlias('aga');
+
+        $queryBuilder
+            ->andWhere(\sprintf(
+                'EXISTS (SELECT 1 FROM %s %s WHERE IDENTITY(%s.attribute) = %s.id AND IDENTITY(%s.attributeGroup) = :%s) OR IDENTITY(%s.group) = :%s',
+                AttributeGroupAttribute::class,
+                $junctionAlias,
+                $junctionAlias,
+                $alias,
+                $junctionAlias,
+                $parameter,
+                $alias,
+                $parameter,
+            ))
+            ->setParameter($parameter, $value);
+    }
+
+    /**
+     * @param class-string $resourceClass
+     *
+     * @return array<string, array{property?: string, type?: string, required?: bool, description?: string, strategy?: string, is_collection?: bool}>
+     */
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            self::PARAMETER => [
+                'property' => 'group',
+                'type' => 'string',
+                'required' => false,
+                'description' => 'Scope the collection to attributes assigned to the given AttributeGroup (UUID). Matches both the attribute_group_attributes junction (ADR-012) and the legacy attributes.group_id FK (ADR-009).',
+                'strategy' => 'exact',
+            ],
+        ];
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/Attribute.xml
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/Attribute.xml
@@ -17,6 +17,16 @@
             </values>
         </normalizationContext>
 
+        <!--
+            DP-04 (#2034): `?attributeGroup={uuid}` narrows /api/attributes to
+            attributes assigned to one group — junction (ADR-012) OR legacy
+            group_id FK (ADR-009). Tag'd `api_platform.filter` via _instanceof
+            in services.yaml; AP4 picks it up by FQCN here.
+        -->
+        <filters>
+            <filter>App\Catalog\Infrastructure\ApiPlatform\Filter\AttributeGroupFilter</filter>
+        </filters>
+
         <operations>
             <operation class="ApiPlatform\Metadata\GetCollection"
                        uriTemplate="/attributes{._format}"

--- a/apps/api/tests/Api/Catalog/AttributeGroupFilterApiTest.php
+++ b/apps/api/tests/Api/Catalog/AttributeGroupFilterApiTest.php
@@ -95,7 +95,7 @@ final class AttributeGroupFilterApiTest extends CatalogApiTestCase
         /** @var list<array{code?: string}> $rows */
         $rows = $response->toArray();
 
-        return array_values(array_map(static fn (array $row): string => $row['code'] ?? '', $rows));
+        return array_map(static fn (array $row): string => $row['code'] ?? '', $rows);
     }
 
     private function createGroup(\ApiPlatform\Symfony\Bundle\Test\Client $client, string $code): string

--- a/apps/api/tests/Api/Catalog/AttributeGroupFilterApiTest.php
+++ b/apps/api/tests/Api/Catalog/AttributeGroupFilterApiTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * DP-04 (#2034) — `GET /api/attributes?attributeGroup={uuid}` narrows the
+ * list to attributes assigned to one AttributeGroup. Membership is
+ * dual-path during the UI-08 transition: the M:N junction (ADR-012) OR the
+ * legacy `attributes.group_id` FK (ADR-009) — the filter must match both.
+ */
+final class AttributeGroupFilterApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function filtersByJunctionMembership(): void
+    {
+        $client = $this->authenticatedClient();
+        $this->seedAttribute('brand');
+        $this->seedAttribute('warranty_months');
+
+        $groupId = $this->createGroup($client, 'marketing');
+        $client->request('POST', '/api/attribute_groups/'.$groupId.'/attributes/bulk-attach', [
+            'json' => ['attributeCodes' => ['brand']],
+        ]);
+
+        $codes = $this->listCodes($client, '/api/attributes?attributeGroup='.$groupId);
+
+        self::assertContains('brand', $codes);
+        self::assertNotContains('warranty_months', $codes);
+    }
+
+    #[Test]
+    public function filtersByLegacyGroupFk(): void
+    {
+        $client = $this->authenticatedClient();
+        $this->seedAttribute('color');
+
+        $groupId = $this->createGroup($client, 'logistics');
+
+        // Wire membership through the pre-ADR-012 FK only — no junction row.
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $attribute = $em->getRepository(Attribute::class)->findOneBy(['code' => 'color', 'tenant' => $tenant]);
+        \assert($attribute instanceof Attribute);
+        $group = $em->getRepository(\App\Catalog\Domain\Entity\AttributeGroup::class)->find(Uuid::fromString($groupId));
+        \assert(null !== $group);
+        $attribute->assignToGroup($group);
+        $em->flush();
+
+        $codes = $this->listCodes($client, '/api/attributes?attributeGroup='.$groupId);
+
+        self::assertContains('color', $codes);
+    }
+
+    #[Test]
+    public function unknownGroupUuidYieldsEmptyList(): void
+    {
+        $client = $this->authenticatedClient();
+        $this->seedAttribute('size');
+
+        $codes = $this->listCodes($client, '/api/attributes?attributeGroup='.Uuid::v7()->toRfc4122());
+
+        self::assertSame([], $codes);
+    }
+
+    #[Test]
+    public function malformedParamIsIgnored(): void
+    {
+        $client = $this->authenticatedClient();
+        $this->seedAttribute('weight');
+
+        $codes = $this->listCodes($client, '/api/attributes?attributeGroup=not-a-uuid');
+
+        self::assertContains('weight', $codes);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function listCodes(\ApiPlatform\Symfony\Bundle\Test\Client $client, string $url): array
+    {
+        $response = $client->request('GET', $url, ['headers' => ['Accept' => 'application/json']]);
+        self::assertSame(200, $response->getStatusCode());
+
+        /** @var list<array{code?: string}> $rows */
+        $rows = $response->toArray();
+
+        return array_values(array_map(static fn (array $row): string => $row['code'] ?? '', $rows));
+    }
+
+    private function createGroup(\ApiPlatform\Symfony\Bundle\Test\Client $client, string $code): string
+    {
+        $created = $client->request('POST', '/api/attribute_groups', [
+            'json' => ['code' => $code, 'label' => ['pl' => $code]],
+        ]);
+        $groupId = $created->toArray()['id'] ?? null;
+        \assert(\is_string($groupId));
+
+        return $groupId;
+    }
+
+    private function seedAttribute(string $code): void
+    {
+        $ctx = self::getContainer()->get(TenantContext::class);
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $ctx->set($tenant);
+
+        $attribute = new Attribute($code, ['en' => $code], AttributeType::Text);
+        self::getContainer()->get(AttributeRepositoryInterface::class)->save($attribute);
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -920,6 +920,18 @@
                         },
                         "style": "form",
                         "explode": true
+                    },
+                    {
+                        "name": "attributeGroup",
+                        "in": "query",
+                        "description": "Scope the collection to attributes assigned to the given AttributeGroup (UUID). Matches both the attribute_group_attributes junction (ADR-012) and the legacy attributes.group_id FK (ADR-009).",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
                     }
                 ],
                 "x-cortex-permission": "attribute.read"


### PR DESCRIPTION
## Co i dlaczego

Lista atrybutów miała tylko wyszukiwarkę i chipy typu. Dochodzi filtr po grupie atrybutów — server-side, z utrwaleniem w URL.

## Zakres

**Backend:**
- `AttributeGroupFilter` (`?attributeGroup=<uuid>`) na `GET /api/attributes` — wzorzec `ObjectTypeFilter`
- Dwutorowe dopasowanie (okres przejściowy UI-08): `EXISTS` na junction `attribute_group_attributes` (ADR-012) **OR** legacy FK `attributes.group_id` (ADR-009)
- Zły/nieznany param degraduje bezpiecznie (no-op / pusta lista); tenant scoping przez TenantFilter bez zmian
- Rejestracja w `Attribute.xml` + **regeneracja `docs/api-spec/v0.json`** (nowy query param widoczny w OpenAPI)
- `AttributeGroupFilterApiTest` (4 testy: junction, legacy FK, unknown UUID → pusta lista, malformed → ignorowany)

**Frontend:**
- Searchable `Combobox` grup obok chipów typu w `attributes/list.tsx` (dane z zasobu `attribute_groups`)
- Filtr idzie server-side przez `useList` filters → data provider forwarduje jako `?attributeGroup=`
- Wybór w URL (`?group=<uuid>`) — refresh/back zachowuje zawężenie
- i18n pl/en, nowy spec E2E `dp-04-attributes-group-filter.spec.ts`

## Smoke test (żywy stack, pim.localhost)

- curl: `GET /api/attributes` → 125 wyników; `?attributeGroup=<uuid grupy "import">` → **37**; `?attributeGroup=not-a-uuid` → 125 (ignorowany). Wszystko HTTP 200.
- Playwright na żywym stacku zielony: login → lista → wybór grupy w combobox → URL `?group=` → licznik spada → reload zachowuje filtr.
- Bramki: PHPStan max ✅ CS-Fixer ✅ Deptrac ✅ PHPUnit unit 1429 ✅ tsc ✅ biome ✅ vitest 114 ✅ build ✅ (Api testy = CI).

Closes #2034

🤖 Generated with [Claude Code](https://claude.com/claude-code)