### PR TITLE
fix(admin): SetPasswordModal bez reset-effectu — guard ADR-0021 wrócił do baseline

### DIFF
--- a/.github/workflows/quality-frontend.yml
+++ b/.github/workflows/quality-frontend.yml
@@ -86,7 +86,10 @@ jobs:
   e2e:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # 20 got outgrown by the suite (~16.5m tests + ~4m stack setup): the job
+    # died as "canceled" AFTER "15x passed", masquerading as merge-ref flake.
+    # Keep headroom; revisit when the suite gets sharded.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
 

--- a/apps/admin/src/features/settings/users/SetPasswordModal.tsx
+++ b/apps/admin/src/features/settings/users/SetPasswordModal.tsx
@@ -1,5 +1,5 @@
 import { KeyRound } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
@@ -31,18 +31,13 @@ export function SetPasswordModal({
   onDone?: () => void;
 }) {
   const { t } = useTranslation();
+  // No reset effect by design (ADR-0021 guard counts jsonFetch+useEffect
+  // co-occurrence): the caller mounts the modal only while open, so every
+  // opening starts from fresh state.
   const [password, setPassword] = useState('');
   const [forceChange, setForceChange] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (open) {
-      setPassword('');
-      setForceChange(true);
-      setError(null);
-    }
-  }, [open]);
 
   const submit = async () => {
     if (password.length < 12 || submitting) return;

--- a/apps/admin/src/features/settings/users/UserDetailPage.tsx
+++ b/apps/admin/src/features/settings/users/UserDetailPage.tsx
@@ -697,7 +697,11 @@ export function UserDetailPage() {
         </div>
       </div>
 
-      <SetPasswordModal user={user} open={setPasswordOpen} onOpenChange={setSetPasswordOpen} />
+      {/* Mounted only while open so each opening starts from fresh state
+        (the modal has no reset effect by design — ADR-0021 guard). */}
+      {setPasswordOpen ? (
+        <SetPasswordModal user={user} open={setPasswordOpen} onOpenChange={setSetPasswordOpen} />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Co i dlaczego

Po równoległych merge'ach DP-01/DP-02 main wylądował na **62 plikach** mieszających `jsonFetch`+`useEffect` przy zamrożonym baseline **61** guardu `lint-jsonfetch-useeffect` — każdy kolejny PR dostawał czerwone Frontend checks (w tym #2169). Ofiarą wyścigu merge-refów był `SetPasswordModal` z DP-02.

## Fix

Ten sam wzorzec co w MoveCategoryDialog (DP-01): modal montowany tylko gdy otwarty (`{setPasswordOpen ? <SetPasswordModal .../> : null}`), reset-effect usunięty — świeży stan przy każdym otwarciu bez `useEffect`.

Guard lokalnie: **61 — at baseline. No regression.** Playwright `dp-02-admin-set-password.spec.ts` zielony na żywym stacku (po drodze naprawiona znana korupcja cache dev FrankenPHP — nuke `var/cache/dev`, nie regresja).

Refs #2032

🤖 Generated with [Claude Code](https://claude.com/claude-code)