### PR TITLE
DP-07: feat(catalog): WAL-3 — walidacja krzyżowa pól + conditional required (ADR-0025)

### DIFF
--- a/apps/admin/e2e/dp-07-cross-field-rules.spec.ts
+++ b/apps/admin/e2e/dp-07-cross-field-rules.spec.ts
@@ -1,0 +1,142 @@
+import { expect, type Page, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * DP-07 (#2037, ADR-0025) — cross-field rules builder on the ObjectType
+ * detail page + enforcement on the product write path.
+ *
+ * Single test, one login. Seeds two numeric attributes on the Product
+ * ObjectType via the browser-side API, builds a `compare` rule through
+ * the new card, saves, verifies enforcement with a violating API write
+ * (422), then cleans everything up.
+ */
+
+async function browserApi(
+  page: Page,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: unknown }> {
+  return page.evaluate(
+    async (args: { method: string; path: string; body?: unknown }) => {
+      const refresh = await fetch('/api/auth/refresh', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { accept: 'application/json' },
+      });
+      const { token } = (await refresh.json()) as { token: string };
+      const res = await fetch(args.path, {
+        method: args.method,
+        headers: {
+          authorization: `Bearer ${token}`,
+          accept: 'application/json',
+          ...(args.body !== undefined
+            ? {
+                'content-type':
+                  args.method === 'PATCH' ? 'application/merge-patch+json' : 'application/ld+json',
+              }
+            : {}),
+        },
+        ...(args.body !== undefined ? { body: JSON.stringify(args.body) } : {}),
+      });
+      const text = await res.text();
+      let parsed: unknown = null;
+      try {
+        parsed = text === '' ? null : JSON.parse(text);
+      } catch {
+        parsed = text;
+      }
+      return { status: res.status, body: parsed };
+    },
+    { method, path, body },
+  );
+}
+
+test('DP-07 — operator builds a compare rule and the write path enforces it', async ({ page }) => {
+  await loginAsAdmin(page);
+
+  // Resolve the Product ObjectType.
+  const objectTypes = await browserApi(page, 'GET', '/api/object_types?itemsPerPage=50');
+  const productOt = (objectTypes.body as Array<{ id: string; kind: string }>).find(
+    (ot) => ot.kind === 'product',
+  );
+  expect(productOt).toBeTruthy();
+  const otId = productOt?.id ?? '';
+
+  const suffix = Date.now().toString(36);
+  const netCode = `dp07e2e_net_${suffix}`;
+  const grossCode = `dp07e2e_gross_${suffix}`;
+  const attrIds: string[] = [];
+
+  for (const code of [netCode, grossCode]) {
+    const created = await browserApi(page, 'POST', '/api/attributes', {
+      code,
+      type: 'number',
+      label: { pl: code },
+    });
+    expect(created.status, JSON.stringify(created.body)).toBe(201);
+    const attrId = (created.body as { id: string }).id;
+    attrIds.push(attrId);
+    const attached = await browserApi(
+      page,
+      'POST',
+      `/api/object_types/${otId}/attributes/${attrId}`,
+    );
+    expect(attached.status).toBe(204);
+  }
+
+  try {
+    // Build the rule through the card.
+    await page.goto(`/modeling/object-types/${otId}`);
+    const card = page
+      .getByText(/reguły walidacji \(między polami\)|validation rules/i)
+      .first()
+      .locator('..')
+      .locator('..');
+    await expect(card).toBeVisible();
+
+    await page.getByRole('button', { name: /porównanie pól/i }).click();
+    const selects = page.getByRole('combobox', { name: /atrybut/i });
+    await selects.nth(0).selectOption(netCode);
+    await selects.nth(1).selectOption(grossCode);
+    await page.getByRole('button', { name: /^(zapisz|save)$/i }).click();
+
+    // Persisted server-side.
+    await expect
+      .poll(async () => {
+        const fetched = await browserApi(page, 'GET', `/api/object_types/${otId}`);
+        return JSON.stringify(
+          (fetched.body as { validationRules?: unknown[] }).validationRules ?? [],
+        );
+      })
+      .toContain(netCode);
+
+    // Enforcement: violating write on a real product → 422.
+    const products = await browserApi(page, 'GET', '/api/products?itemsPerPage=1');
+    const productId = (products.body as Array<{ id: string }>)[0]?.id ?? '';
+    expect(productId).not.toBe('');
+
+    const violating = await browserApi(page, 'PATCH', `/api/objects/${productId}`, {
+      attributes: { [netCode]: 50, [grossCode]: 10 },
+    });
+    expect(violating.status).toBe(422);
+    expect(String((violating.body as { detail?: string }).detail)).toContain(netCode);
+
+    const valid = await browserApi(page, 'PATCH', `/api/objects/${productId}`, {
+      attributes: { [netCode]: 5, [grossCode]: 10 },
+    });
+    expect(valid.status).toBe(200);
+
+    // Tidy the product values.
+    await browserApi(page, 'PATCH', `/api/objects/${productId}`, {
+      attributes: { [netCode]: null, [grossCode]: null },
+    });
+  } finally {
+    await browserApi(page, 'PATCH', `/api/object_types/${otId}`, { validationRules: [] });
+    for (const attrId of attrIds) {
+      await browserApi(page, 'DELETE', `/api/object_types/${otId}/attributes/${attrId}`);
+      await browserApi(page, 'DELETE', `/api/attributes/${attrId}`);
+    }
+  }
+});

--- a/apps/admin/src/components/modeling/validation-rules-card.tsx
+++ b/apps/admin/src/components/modeling/validation-rules-card.tsx
@@ -1,0 +1,333 @@
+import { useQuery } from '@tanstack/react-query';
+import { Plus, Scale, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { jsonFetch } from '@/lib/http';
+
+/**
+ * DP-07 (#2037, ADR-0025) — builder for the ObjectType-level cross-field
+ * rules (`object_types.validation_rules`). Two rule kinds:
+ *   - compare:      [left attr] [op] [right attr] — numeric attributes only,
+ *   - require_when: Gdy [attr] równa się [value] → wymagaj [attr].
+ * State is local; one PATCH per explicit "Zapisz" via the page's
+ * handlePatch({ validationRules }). Attribute options come from the global
+ * library (tenant-wide validation contract — same source the backend guard
+ * checks against).
+ */
+
+export interface CrossFieldRuleShape {
+  type: string;
+  [key: string]: unknown;
+}
+
+interface AttributeOption {
+  id: string;
+  code: string;
+  type: string;
+  system?: boolean;
+}
+
+const COMPARE_OPS = [
+  { value: 'lt', label: '<' },
+  { value: 'lte', label: '≤' },
+  { value: 'gt', label: '>' },
+  { value: 'gte', label: '≥' },
+  { value: 'eq', label: '=' },
+  { value: 'neq', label: '≠' },
+] as const;
+
+const NUMERIC_TYPES = new Set(['number', 'metric', 'price']);
+
+export function ValidationRulesCard({
+  rules,
+  locked,
+  onSave,
+}: {
+  rules: CrossFieldRuleShape[];
+  locked?: boolean;
+  onSave: (rules: CrossFieldRuleShape[]) => Promise<boolean>;
+}) {
+  const { t } = useTranslation();
+  const [draft, setDraft] = useState<CrossFieldRuleShape[]>(rules);
+  const [saving, setSaving] = useState(false);
+
+  const attributesQuery = useQuery<AttributeOption[]>({
+    queryKey: ['validation-rules-card', 'attributes'],
+    queryFn: () =>
+      jsonFetch<AttributeOption[]>('/api/attributes?itemsPerPage=200', {
+        accept: 'application/json',
+      }),
+    staleTime: 60_000,
+  });
+  const attributes = (attributesQuery.data ?? []).filter((a) => a.system !== true);
+  const numericAttributes = attributes.filter((a) => NUMERIC_TYPES.has(a.type));
+
+  const dirty = JSON.stringify(draft) !== JSON.stringify(rules);
+
+  const updateRule = (index: number, patch: Record<string, unknown>) => {
+    setDraft((prev) => prev.map((rule, i) => (i === index ? { ...rule, ...patch } : rule)));
+  };
+
+  const removeRule = (index: number) => {
+    setDraft((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const save = async () => {
+    setSaving(true);
+    const ok = await onSave(draft);
+    setSaving(false);
+    if (!ok) return;
+  };
+
+  return (
+    <Card>
+      <CardContent className="space-y-3 p-6">
+        <div className="flex items-center gap-2">
+          <Scale className="size-4 text-zinc-500" aria-hidden />
+          <div className="text-[11px] font-medium uppercase tracking-wider text-zinc-500">
+            {t('object_types.validation_rules_section', {
+              defaultValue: 'Reguły walidacji (między polami)',
+            })}
+          </div>
+        </div>
+        <p className="text-[12px] text-muted-foreground">
+          {t('object_types.validation_rules_hint', {
+            defaultValue:
+              'Reguły egzekwowane przy każdym zapisie wartości (ręcznym, imporcie, agencie) — na poziomie całego obiektu, np. waga netto ≤ waga brutto albo pole wymagane warunkowo.',
+          })}
+        </p>
+
+        {draft.length === 0 ? (
+          <p className="rounded-xl border border-dashed border-zinc-200 px-4 py-5 text-center text-[12.5px] text-muted-foreground">
+            {t('object_types.validation_rules_empty', { defaultValue: 'Brak reguł.' })}
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {draft.map((rule, index) => (
+              <div
+                // biome-ignore lint/suspicious/noArrayIndexKey: rows are positional edits of a JSON list — no stable identity exists
+                key={`${rule.type}-${index}`}
+                className="flex flex-wrap items-center gap-2 rounded-xl border border-zinc-200 px-3 py-2"
+              >
+                {rule.type === 'compare' ? (
+                  <>
+                    <AttrSelect
+                      id={`rule-${index}-left`}
+                      value={String(rule.left ?? '')}
+                      options={numericAttributes}
+                      onChange={(v) => updateRule(index, { left: v })}
+                      disabled={locked}
+                    />
+                    <select
+                      aria-label={t('object_types.validation_rules_op', {
+                        defaultValue: 'Operator',
+                      })}
+                      value={String(rule.op ?? 'lte')}
+                      onChange={(e) => updateRule(index, { op: e.target.value })}
+                      disabled={locked}
+                      className="h-9 rounded-md border border-input bg-background px-2 font-mono text-sm"
+                    >
+                      {COMPARE_OPS.map((op) => (
+                        <option key={op.value} value={op.value}>
+                          {op.label}
+                        </option>
+                      ))}
+                    </select>
+                    <AttrSelect
+                      id={`rule-${index}-right`}
+                      value={String(rule.right ?? '')}
+                      options={numericAttributes}
+                      onChange={(v) => updateRule(index, { right: v })}
+                      disabled={locked}
+                    />
+                  </>
+                ) : (
+                  <RequireWhenRow
+                    rule={rule}
+                    attributes={attributes}
+                    disabled={locked}
+                    onChange={(patch) => updateRule(index, patch)}
+                  />
+                )}
+                <button
+                  type="button"
+                  onClick={() => removeRule(index)}
+                  disabled={locked}
+                  aria-label={t('app.remove', { defaultValue: 'Usuń' })}
+                  className="ml-auto grid size-7 place-items-center rounded-lg text-zinc-400 hover:bg-red-50 hover:text-red-600 disabled:opacity-40"
+                >
+                  <Trash2 className="size-3.5" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="flex flex-wrap items-center gap-2 pt-1">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={locked}
+            onClick={() =>
+              setDraft((prev) => [...prev, { type: 'compare', left: '', op: 'lte', right: '' }])
+            }
+            className="h-8 rounded-lg px-2.5 text-[12px]"
+          >
+            <Plus className="size-3.5" />
+            {t('object_types.validation_rules_add_compare', { defaultValue: 'Porównanie pól' })}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={locked}
+            onClick={() =>
+              setDraft((prev) => [
+                ...prev,
+                {
+                  type: 'require_when',
+                  if: { field: '', operator: 'equals', value: '' },
+                  // biome-ignore lint/suspicious/noThenProperty: `then` is the backend DSL key (ADR-0025), not a thenable
+                  then: { required: '' },
+                },
+              ])
+            }
+            className="h-8 rounded-lg px-2.5 text-[12px]"
+          >
+            <Plus className="size-3.5" />
+            {t('object_types.validation_rules_add_require', {
+              defaultValue: 'Wymagane warunkowo',
+            })}
+          </Button>
+          {dirty ? (
+            <Button
+              type="button"
+              size="sm"
+              disabled={saving || locked}
+              onClick={() => void save()}
+              className="ml-auto h-8 rounded-xl bg-zinc-900 px-3 text-[12px] hover:bg-zinc-800"
+            >
+              {t('app.save', { defaultValue: 'Zapisz' })}
+            </Button>
+          ) : null}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function AttrSelect({
+  id,
+  value,
+  options,
+  onChange,
+  disabled,
+  allTypes,
+}: {
+  id: string;
+  value: string;
+  options: AttributeOption[];
+  onChange: (v: string) => void;
+  disabled?: boolean;
+  allTypes?: boolean;
+}) {
+  const { t } = useTranslation();
+  return (
+    <select
+      id={id}
+      aria-label={t('object_types.validation_rules_attribute', { defaultValue: 'Atrybut' })}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
+      className="h-9 min-w-[150px] rounded-md border border-input bg-background px-2 font-mono text-sm"
+    >
+      <option value="">
+        {t('object_types.validation_rules_pick', { defaultValue: '— wybierz —' })}
+      </option>
+      {options.map((attr) => (
+        <option key={attr.id} value={attr.code}>
+          {attr.code}
+          {allTypes ? ` (${attr.type})` : ''}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function RequireWhenRow({
+  rule,
+  attributes,
+  disabled,
+  onChange,
+}: {
+  rule: CrossFieldRuleShape;
+  attributes: AttributeOption[];
+  disabled?: boolean;
+  onChange: (patch: Record<string, unknown>) => void;
+}) {
+  const { t } = useTranslation();
+  const condition = (rule.if ?? {}) as Record<string, unknown>;
+  const then = (rule.then ?? {}) as Record<string, unknown>;
+
+  const setCondition = (patch: Record<string, unknown>) =>
+    onChange({ if: { operator: 'equals', ...condition, ...patch } });
+
+  return (
+    <>
+      <span className="text-[12.5px] text-zinc-600">
+        {t('object_types.validation_rules_when', { defaultValue: 'Gdy' })}
+      </span>
+      <AttrSelect
+        id="rule-condition-field"
+        value={String(condition.field ?? '')}
+        options={attributes}
+        onChange={(v) => setCondition({ field: v })}
+        disabled={disabled}
+        allTypes
+      />
+      <span className="text-[12.5px] text-zinc-600">
+        {t('object_types.validation_rules_equals', { defaultValue: 'równa się' })}
+      </span>
+      <Input
+        aria-label={t('object_types.validation_rules_value', { defaultValue: 'Wartość' })}
+        value={valueToInput(condition.value)}
+        onChange={(e) => setCondition({ value: inputToValue(e.target.value) })}
+        disabled={disabled}
+        placeholder="np. true / 5 / bulb"
+        className="h-9 w-36 font-mono text-sm"
+      />
+      <span className="text-[12.5px] text-zinc-600">
+        {t('object_types.validation_rules_then_require', { defaultValue: '→ wymagaj' })}
+      </span>
+      <AttrSelect
+        id="rule-required-target"
+        value={String(then.required ?? '')}
+        options={attributes}
+        // biome-ignore lint/suspicious/noThenProperty: `then` is the backend DSL key (ADR-0025), not a thenable
+        onChange={(v) => onChange({ then: { required: v } })}
+        disabled={disabled}
+        allTypes
+      />
+    </>
+  );
+}
+
+function valueToInput(value: unknown): string {
+  if (value === undefined || value === null) return '';
+  if (typeof value === 'string') return value;
+  return JSON.stringify(value);
+}
+
+/** `true`/`false`/numbers get their JSON types back; everything else stays a string. */
+function inputToValue(raw: string): unknown {
+  const trimmed = raw.trim();
+  if (trimmed === 'true') return true;
+  if (trimmed === 'false') return false;
+  if (trimmed !== '' && !Number.isNaN(Number(trimmed))) return Number(trimmed);
+  return raw;
+}

--- a/apps/admin/src/features/catalog/object-types/show.tsx
+++ b/apps/admin/src/features/catalog/object-types/show.tsx
@@ -42,6 +42,10 @@ import { LocaleTabsField } from '@/components/modeling/locale-tabs-field';
 import { ObjectTypeIcon } from '@/components/modeling/object-type-icon';
 import { SettingToggleRow } from '@/components/modeling/setting-toggle-row';
 import { StatBox } from '@/components/modeling/stat-box';
+import {
+  type CrossFieldRuleShape,
+  ValidationRulesCard,
+} from '@/components/modeling/validation-rules-card';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { resolveLabel } from '@/features/catalog/attributes/list';
@@ -66,6 +70,7 @@ interface ObjectTypeDetail {
   abstract?: boolean;
   allowedParentTypeIds?: string[];
   completenessRules?: Record<string, unknown> | null;
+  validationRules?: CrossFieldRuleShape[] | null;
   exposeToMainMenu?: boolean;
   isCategorizable?: boolean;
   hasMultimedia?: boolean;
@@ -881,6 +886,15 @@ export function ObjectTypeShowPage() {
           </div>
         </CardContent>
       </Card>
+
+      {/* DP-07 (#2037, ADR-0025) — cross-field rules. Deliberately editable
+        on built-in ObjectTypes too: the rules constrain VALUES, not the
+        entity model (backend guard mirrors this). */}
+      <ValidationRulesCard
+        key={`validation-rules-${objectType.schemaVersion ?? 0}`}
+        rules={objectType.validationRules ?? []}
+        onSave={(rules) => handlePatch({ validationRules: rules })}
+      />
 
       <Card>
         <CardContent className="space-y-3 p-6">

--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -778,6 +778,12 @@ parameters:
         # status/enabled write — per-chunk category resolve + replace/append.
         App\Import\Application\Handler\ImportRunHandler:
             - App\Catalog\Application\BatchValueWriter
+            # DP-07 (#2037, ADR-0025) — cross-field rules: the prime pass loads
+            # rule-referenced attributes so compare-against-existing works when
+            # the counterpart column is absent from the mapping. Same burndown
+            # bucket as BatchValueWriter (#1466).
+            - App\Catalog\Application\CrossFieldRulesValidator
+            - App\Catalog\Domain\Repository\AttributeRepositoryInterface
             # IMP2-2.6 (#1482) bulk path — suppress the per-flush sync rebuild
             # via BulkContext and dispatch the async attributes_indexed rebuild;
             # part of the #1466 Import → Catalog_Internals burndown.

--- a/apps/api/migrations/Version20260703170000.php
+++ b/apps/api/migrations/Version20260703170000.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * DP-07 (#2037, ADR-0025) — ObjectType-level cross-field validation rules.
+ *
+ * List-shaped JSONB (`[]` default) holding `compare` and `require_when`
+ * rules; shape is guarded at the domain edge (CrossFieldRules::fromArray),
+ * the column itself stays schemaless like completeness_rules.
+ */
+final class Version20260703170000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add object_types.validation_rules JSONB (cross-field rules, ADR-0025)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE object_types ADD validation_rules JSONB DEFAULT '[]' NOT NULL");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE object_types DROP validation_rules');
+    }
+}

--- a/apps/api/src/Catalog/Application/BatchValueWriter.php
+++ b/apps/api/src/Catalog/Application/BatchValueWriter.php
@@ -33,9 +33,19 @@ final class BatchValueWriter
     /** @var array<string, true> "attributeId|value" of identifier values seen in this chunk (in-file duplicates) */
     private array $chunkIdentifiers = [];
 
+    /**
+     * DP-07 (#2037) — objectId => code => existing NON-EMPTY global envelope,
+     * built in the same primeChunk() row loop (zero extra queries). Feeds the
+     * cross-field pre-pass in writeMany().
+     *
+     * @var array<string, array<string, array<string, mixed>>>
+     */
+    private array $globalEnvelopeIndex = [];
+
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly ValueWriteCore $core,
+        private readonly CrossFieldRulesValidator $crossFieldRules,
     ) {
     }
 
@@ -51,6 +61,7 @@ final class BatchValueWriter
     {
         $this->scopeIndex = [];
         $this->chunkIdentifiers = [];
+        $this->globalEnvelopeIndex = [];
 
         if ([] === $objects || [] === $attributesByCode) {
             return;
@@ -74,6 +85,11 @@ final class BatchValueWriter
                 $row->getLocale(),
                 $row->getChannelId(),
             )] = $row;
+
+            if (null === $row->getLocale() && null === $row->getChannelId()
+                && !ValueWriteCore::isEmptyEnvelope($row->getValue())) {
+                $this->globalEnvelopeIndex[$row->getObject()->getId()->toRfc4122()][$row->getAttribute()->getCode()] = $row->getValue();
+            }
         }
     }
 
@@ -95,9 +111,49 @@ final class BatchValueWriter
         $issues = [];
         $changed = 0;
 
+        // Normalise + route once; the per-write loop below and the DP-07
+        // cross-field pre-pass share the prepared entries.
+        $prepared = [];
         foreach ($writes as $write) {
             $attribute = $write['attribute'];
-            $envelope = $this->core->normalise($attribute->getType(), $write['envelope']);
+            [$targetLocale, $targetChannel] = $tenant instanceof Tenant
+                ? $this->core->routeScope($attribute, $tenant, $write['locale'], $write['channelId'])
+                : [$write['locale'], $write['channelId']];
+            $prepared[] = [
+                'attribute' => $attribute,
+                'envelope' => $this->core->normalise($attribute->getType(), $write['envelope']),
+                'locale' => $targetLocale,
+                'channelId' => $targetChannel,
+            ];
+        }
+
+        // DP-07 (#2037, ADR-0025) — cross-field pre-pass: evaluate the rules
+        // against existing global envelopes (primeChunk index) overlaid with
+        // this row's writes. Broken `compare` skips the implicated incoming
+        // writes (invalid data must not land); `require_when` is report-only
+        // (the target is empty — there is nothing to skip).
+        $skipCodes = [];
+        $rules = $this->crossFieldRules->rulesFor($object->getObjectType());
+        if ([] !== $rules) {
+            $baseView = $this->globalEnvelopeIndex[$object->getId()->toRfc4122()] ?? [];
+            $view = $this->crossFieldRules->overlay($baseView, $prepared);
+            foreach ($this->crossFieldRules->evaluate($rules, $view) as $violation) {
+                $issues[] = ['attributeCode' => $violation->attributeCode, 'kind' => 'cross_field', 'message' => $violation->message];
+                if ('compare' === $violation->ruleType) {
+                    foreach ($violation->referencedCodes as $code) {
+                        $skipCodes[$code] = true;
+                    }
+                }
+            }
+        }
+
+        foreach ($prepared as $write) {
+            $attribute = $write['attribute'];
+            $envelope = $write['envelope'];
+
+            if (isset($skipCodes[$attribute->getCode()])) {
+                continue;
+            }
 
             $requiredViolation = $this->core->requiredViolation($attribute, $envelope);
             if (null !== $requiredViolation) {
@@ -135,9 +191,9 @@ final class BatchValueWriter
                 $this->chunkIdentifiers[$chunkKey] = true;
             }
 
-            [$targetLocale, $targetChannel] = $tenant instanceof Tenant
-                ? $this->core->routeScope($attribute, $tenant, $write['locale'], $write['channelId'])
-                : [$write['locale'], $write['channelId']];
+            // Scope already routed in the prepare pass.
+            $targetLocale = $write['locale'];
+            $targetChannel = $write['channelId'];
 
             $existing = $this->scopeIndex[$this->scopeKey($object->getId(), $attribute->getId(), $targetLocale, $targetChannel)] ?? null;
             if ($existing instanceof ObjectValue) {

--- a/apps/api/src/Catalog/Application/CrossFieldRulesValidator.php
+++ b/apps/api/src/Catalog/Application/CrossFieldRulesValidator.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application;
+
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use App\Catalog\Domain\Rule\CompareRule;
+use App\Catalog\Domain\Rule\CrossFieldRule;
+use App\Catalog\Domain\Rule\CrossFieldRules;
+use App\Catalog\Domain\Rule\CrossFieldViolation;
+use App\Catalog\Domain\Rule\RequireWhenRule;
+use App\Catalog\Domain\Rule\VisibleWhenRuleEvaluator;
+use InvalidArgumentException;
+use Symfony\Component\Uid\Uuid;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * DP-07 (#2037, ADR-0025) — evaluates ObjectType-level cross-field rules
+ * (`compare`, `require_when`) against the object's effective GLOBAL view:
+ * existing global-scope ObjectValue rows overlaid with the incoming writes.
+ *
+ * Deliberately NOT built on `attributes_indexed`: the rebuild listener
+ * skips bulk flows (BulkContext) and a freshly created object has an empty
+ * cache mid-flush — the canonical rows are the only source that is always
+ * fresh on both write paths. Evaluation is GLOBAL scope only (locale=null,
+ * channel=null), consistent with `attributes_indexed` and `visible_when`;
+ * locale/channel-routed writes are not overlaid.
+ *
+ * Contract (ADR-0025 semantics table):
+ *   - an empty incoming envelope REMOVES the code from the view
+ *     ("cleared" == "never set"),
+ *   - compare skips when either side is missing or non-numeric,
+ *   - require_when fires when the condition holds and the target is absent.
+ */
+final class CrossFieldRulesValidator
+{
+    /** @var array<string, list<CrossFieldRule>> parsed-rule memo keyed by "otId|schemaVersion" */
+    private array $ruleMemo = [];
+
+    public function __construct(
+        private readonly ObjectValueRepositoryInterface $values,
+        private readonly VisibleWhenRuleEvaluator $visibleWhen,
+    ) {
+    }
+
+    /**
+     * Parsed rules for the ObjectType, [] when none (or when stored JSONB
+     * is malformed — runtime is lenient, the PATCH edge is strict).
+     *
+     * @return list<CrossFieldRule>
+     */
+    public function rulesFor(ObjectType $objectType): array
+    {
+        $raw = $objectType->getValidationRules();
+        if ([] === $raw) {
+            return [];
+        }
+
+        $key = $objectType->getId()->toRfc4122().'|'.$objectType->getSchemaVersion();
+        if (!isset($this->ruleMemo[$key])) {
+            try {
+                $this->ruleMemo[$key] = CrossFieldRules::fromArray($raw);
+            } catch (InvalidArgumentException) {
+                // Stale/hand-edited JSONB must not brick every write.
+                $this->ruleMemo[$key] = [];
+            }
+        }
+
+        return $this->ruleMemo[$key];
+    }
+
+    /**
+     * Admin-path entry point: one query for the existing GLOBAL rows (only
+     * when the ObjectType has rules), overlay the prepared writes, evaluate.
+     *
+     * @param list<array{attribute: Attribute, envelope: array<string, mixed>, locale: ?string, channelId: ?Uuid}> $incoming
+     *
+     * @return list<CrossFieldViolation>
+     */
+    public function validateForUpsert(CatalogObject $object, array $incoming): array
+    {
+        $rules = $this->rulesFor($object->getObjectType());
+        if ([] === $rules) {
+            return [];
+        }
+
+        $view = [];
+        foreach ($this->values->findByObject($object) as $row) {
+            if (null === $row->getLocale() && null === $row->getChannelId()
+                && !ValueWriteCore::isEmptyEnvelope($row->getValue())) {
+                $view[$row->getAttribute()->getCode()] = $row->getValue();
+            }
+        }
+
+        return $this->evaluate($rules, $this->overlay($view, $incoming));
+    }
+
+    /**
+     * Apply global-routed incoming writes onto a base view. An empty
+     * envelope unsets the code — clearing behaves like never-set.
+     *
+     * @param array<string, array<string, mixed>>                                                                  $view
+     * @param list<array{attribute: Attribute, envelope: array<string, mixed>, locale: ?string, channelId: ?Uuid}> $incoming
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function overlay(array $view, array $incoming): array
+    {
+        foreach ($incoming as $write) {
+            if (null !== $write['locale'] || null !== $write['channelId']) {
+                continue;
+            }
+            $code = $write['attribute']->getCode();
+            if (ValueWriteCore::isEmptyEnvelope($write['envelope'])) {
+                unset($view[$code]);
+
+                continue;
+            }
+            $view[$code] = $write['envelope'];
+        }
+
+        return $view;
+    }
+
+    /**
+     * @param list<CrossFieldRule>                $rules
+     * @param array<string, array<string, mixed>> $view  code => NON-EMPTY global envelope
+     *
+     * @return list<CrossFieldViolation>
+     */
+    public function evaluate(array $rules, array $view): array
+    {
+        $violations = [];
+        foreach ($rules as $rule) {
+            $violation = match (true) {
+                $rule instanceof CompareRule => $this->evaluateCompare($rule, $view),
+                $rule instanceof RequireWhenRule => $this->evaluateRequireWhen($rule, $view),
+                default => null,
+            };
+            if (null !== $violation) {
+                $violations[] = $violation;
+            }
+        }
+
+        return $violations;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $view
+     */
+    private function evaluateCompare(CompareRule $rule, array $view): ?CrossFieldViolation
+    {
+        $left = $this->numericValue($view[$rule->left] ?? null);
+        $right = $this->numericValue($view[$rule->right] ?? null);
+        if (null === $left || null === $right) {
+            // Missing / non-numeric side => skip; required-ness is a
+            // separate dimension (ADR-0025 semantics).
+            return null;
+        }
+
+        // Float-normalise both sides so eq/neq do not split on int-vs-float
+        // representation of the same number (5 vs 5.0).
+        $left = (float) $left;
+        $right = (float) $right;
+
+        $holds = match ($rule->op) {
+            'lt' => $left < $right,
+            'lte' => $left <= $right,
+            'gt' => $left > $right,
+            'gte' => $left >= $right,
+            'eq' => $left === $right,
+            'neq' => $left !== $right,
+            default => true,
+        };
+        if ($holds) {
+            return null;
+        }
+
+        return new CrossFieldViolation(
+            attributeCode: $rule->left,
+            ruleType: CompareRule::TYPE,
+            message: \sprintf(
+                'Attribute "%s" must be %s attribute "%s" (%s vs %s).',
+                $rule->left,
+                self::OP_LABELS[$rule->op],
+                $rule->right,
+                var_export($left, true),
+                var_export($right, true),
+            ),
+            referencedCodes: $rule->referencedCodes(),
+        );
+    }
+
+    private const array OP_LABELS = [
+        'lt' => 'less than',
+        'lte' => 'less than or equal to',
+        'gt' => 'greater than',
+        'gte' => 'greater than or equal to',
+        'eq' => 'equal to',
+        'neq' => 'different from',
+    ];
+
+    /**
+     * @param array<string, array<string, mixed>> $view
+     */
+    private function evaluateRequireWhen(RequireWhenRule $rule, array $view): ?CrossFieldViolation
+    {
+        // The view carries envelope shapes exactly like attributes_indexed,
+        // so the visible_when evaluator's scalar extraction applies as-is.
+        if (!$this->visibleWhen->isVisible($rule->condition, $view)) {
+            return null;
+        }
+        if (isset($view[$rule->requiredCode])) {
+            return null;
+        }
+
+        return new CrossFieldViolation(
+            attributeCode: $rule->requiredCode,
+            ruleType: RequireWhenRule::TYPE,
+            message: \sprintf(
+                'Attribute "%s" is required when "%s" equals %s.',
+                $rule->requiredCode,
+                $rule->condition->field,
+                json_encode($rule->condition->value, JSON_THROW_ON_ERROR),
+            ),
+            referencedCodes: $rule->referencedCodes(),
+        );
+    }
+
+    /**
+     * Numeric extraction per envelope shape: number/metric carry `value`,
+     * price carries `amount`. Numeric strings cast to float; anything else
+     * yields null (=> compare skip).
+     */
+    private function numericValue(mixed $envelope): int|float|null
+    {
+        if (!\is_array($envelope)) {
+            return null;
+        }
+        $raw = $envelope['value'] ?? $envelope['amount'] ?? null;
+        if (\is_int($raw) || \is_float($raw)) {
+            return $raw;
+        }
+        if (\is_string($raw) && is_numeric($raw)) {
+            return (float) $raw;
+        }
+
+        return null;
+    }
+}

--- a/apps/api/src/Catalog/Application/ObjectAttributesUpserter.php
+++ b/apps/api/src/Catalog/Application/ObjectAttributesUpserter.php
@@ -39,6 +39,7 @@ final readonly class ObjectAttributesUpserter
         private ObjectValueRepositoryInterface $values,
         private ValueWriteCore $core,
         private AttributePermissionReader $attributePermissions,
+        private CrossFieldRulesValidator $crossFieldRules,
     ) {
     }
 
@@ -64,6 +65,13 @@ final readonly class ObjectAttributesUpserter
             // listener has already run by the time this service is called.
             return;
         }
+
+        // DP-07 (#2037, ADR-0025) — three phases: (1) the existing per-attribute
+        // validation collects prepared writes instead of saving, (2) the
+        // cross-field gate throws 422 BEFORE anything is saved, (3) persistence.
+        // Guarantees a cross-field violation never leaves a half-written object.
+        /** @var list<array{attribute: Attribute, envelope: array<string, mixed>, locale: ?string, channelId: ?Uuid}> $prepared */
+        $prepared = [];
 
         foreach ($payload as $code => $rawValue) {
             if ('' === $code) {
@@ -118,9 +126,30 @@ final readonly class ObjectAttributesUpserter
                 ));
             }
 
-            $existing = $this->values->findOneByScope($object, $attribute, $targetChannel, $targetLocale);
+            $prepared[] = [
+                'attribute' => $attribute,
+                'envelope' => $jsonbValue,
+                'locale' => $targetLocale,
+                'channelId' => $targetChannel,
+            ];
+        }
+
+        // Phase 2 — cross-field gate (ADR-0025): existing global rows
+        // overlaid with the prepared writes; a violation aborts the whole
+        // payload with 422 before the first save.
+        $violations = $this->crossFieldRules->validateForUpsert($object, $prepared);
+        if ([] !== $violations) {
+            throw new UnprocessableEntityHttpException(implode(
+                '; ',
+                array_map(static fn ($violation): string => $violation->message, $violations),
+            ));
+        }
+
+        // Phase 3 — persistence (unchanged semantics of the pre-DP-07 loop).
+        foreach ($prepared as $write) {
+            $existing = $this->values->findOneByScope($object, $write['attribute'], $write['channelId'], $write['locale']);
             if ($existing instanceof ObjectValue) {
-                $existing->updateValue($jsonbValue);
+                $existing->updateValue($write['envelope']);
                 $existing->changeProvenance($provenance);
                 $this->values->save($existing);
 
@@ -129,11 +158,11 @@ final readonly class ObjectAttributesUpserter
 
             $value = new ObjectValue(
                 object: $object,
-                attribute: $attribute,
-                value: $jsonbValue,
+                attribute: $write['attribute'],
+                value: $write['envelope'],
                 provenance: $provenance,
-                channelId: $targetChannel,
-                locale: $targetLocale,
+                channelId: $write['channelId'],
+                locale: $write['locale'],
             );
             $this->values->save($value);
         }

--- a/apps/api/src/Catalog/Application/ObjectTypeService.php
+++ b/apps/api/src/Catalog/Application/ObjectTypeService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Catalog\Application;
 
+use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
 use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\Entity\ObjectTypeAttribute;
@@ -12,7 +13,10 @@ use App\Catalog\Domain\Exception\DisabledFeatureException;
 use App\Catalog\Domain\Exception\ObjectTypeCodeConflictException;
 use App\Catalog\Domain\Exception\ObjectTypeHasInstancesException;
 use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectTypeAttributeRepositoryInterface;
+use App\Catalog\Domain\Rule\CompareRule;
+use App\Catalog\Domain\Rule\CrossFieldRules;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
@@ -48,6 +52,7 @@ final readonly class ObjectTypeService
     public function __construct(
         private EntityManagerInterface $em,
         private ObjectTypeAttributeRepositoryInterface $junctions,
+        private AttributeRepositoryInterface $attributes,
         private Connection $connection,
         private bool $enableCustomObjectTypes,
     ) {
@@ -112,9 +117,10 @@ final readonly class ObjectTypeService
      * (including empty list / map) to overwrite. The signature uses named
      * arguments so callers don't need to position-track the optionals.
      *
-     * @param array<string, string>|null $label
-     * @param list<string>|null          $allowedParentTypeIds
-     * @param array<string, mixed>|null  $completenessRules
+     * @param array<string, string>|null      $label
+     * @param list<string>|null               $allowedParentTypeIds
+     * @param array<string, mixed>|null       $completenessRules
+     * @param list<array<string, mixed>>|null $validationRules      DP-07 (#2037, ADR-0025) cross-field rules
      */
     public function update(
         ObjectType $objectType,
@@ -126,6 +132,7 @@ final readonly class ObjectTypeService
         ?bool $abstract = null,
         ?array $allowedParentTypeIds = null,
         ?array $completenessRules = null,
+        ?array $validationRules = null,
         ?bool $exposeToMainMenu = null,
         ?bool $isCategorizable = null,
         ?bool $hasMultimedia = null,
@@ -175,6 +182,17 @@ final readonly class ObjectTypeService
             }
             $objectType->updateCompletenessRules($completenessRules);
         }
+        if (null !== $validationRules) {
+            // DP-07 (#2037, ADR-0025) — deliberately editable on built-in
+            // ObjectTypes too: cross-field rules constrain VALUES, not the
+            // entity model, and the primary use case (weight_net <=
+            // weight_gross) lives on the built-in Product. Shape parsed
+            // strictly; referenced codes must exist tenant-wide; compare
+            // sides must be numeric attributes of the same type.
+            $parsed = CrossFieldRules::fromArray($validationRules);
+            $this->assertRuleReferences($objectType, $parsed);
+            $objectType->updateValidationRules(CrossFieldRules::toStoredArray($parsed));
+        }
         if (null !== $exposeToMainMenu) {
             // VIEW-08 (#427): Asset has its own /assets DAM page. Exposing it
             // as a generic menu candidate would route to /objects/asset which
@@ -223,6 +241,47 @@ final readonly class ObjectTypeService
         $this->em->flush();
 
         return $objectType;
+    }
+
+    /**
+     * DP-07 (#2037) — every code a rule references must exist tenant-wide
+     * (deliberately NOT the effective schema: group membership drifts
+     * independently of rules and a detach must not silently break them),
+     * and compare sides must be numeric attributes of the SAME type
+     * (no price-vs-metric comparisons; unit conversion is out of scope).
+     *
+     * @param list<\App\Catalog\Domain\Rule\CrossFieldRule> $rules
+     */
+    private function assertRuleReferences(ObjectType $objectType, array $rules): void
+    {
+        $tenant = $objectType->getTenant();
+        if (null === $tenant) {
+            throw new LogicException('ObjectType has no tenant — cannot validate rule references.');
+        }
+
+        $numericTypes = [AttributeType::Number, AttributeType::Metric, AttributeType::Price];
+
+        foreach ($rules as $rule) {
+            $resolved = [];
+            foreach ($rule->referencedCodes() as $code) {
+                $attribute = $this->attributes->findByCode($code, $tenant);
+                if (!$attribute instanceof Attribute) {
+                    throw new LogicException(\sprintf('validation_rules references unknown attribute "%s".', $code));
+                }
+                $resolved[$code] = $attribute;
+            }
+
+            if ($rule instanceof CompareRule) {
+                $left = $resolved[$rule->left];
+                $right = $resolved[$rule->right];
+                if (!\in_array($left->getType(), $numericTypes, true)) {
+                    throw new LogicException(\sprintf('compare.left "%s" must be a numeric attribute (number/metric/price), got "%s".', $rule->left, $left->getType()->value));
+                }
+                if ($left->getType() !== $right->getType()) {
+                    throw new LogicException(\sprintf('compare sides must share one attribute type — "%s" is %s, "%s" is %s.', $rule->left, $left->getType()->value, $rule->right, $right->getType()->value));
+                }
+            }
+        }
     }
 
     public function delete(ObjectType $objectType): void

--- a/apps/api/src/Catalog/Domain/Entity/ObjectType.php
+++ b/apps/api/src/Catalog/Domain/Entity/ObjectType.php
@@ -65,6 +65,15 @@ class ObjectType implements TenantScoped
      * @var array<string, mixed>
      */
     private array $completenessRules = [];
+
+    /**
+     * DP-07 (#2037, ADR-0025) — cross-field rules (`compare` / `require_when`)
+     * stored as a JSONB list; shape guarded by CrossFieldRules::fromArray at
+     * the write edge (ObjectTypeService), read by CrossFieldRulesValidator.
+     *
+     * @var list<array<string, mixed>>
+     */
+    private array $validationRules = [];
     private ?Attribute $labelAttribute = null;
     private ?Attribute $imageAttribute = null;
 
@@ -288,6 +297,23 @@ class ObjectType implements TenantScoped
     public function updateCompletenessRules(array $rules): void
     {
         $this->completenessRules = $rules;
+        $this->touch();
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function getValidationRules(): array
+    {
+        return $this->validationRules;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rules canonical stored shape (CrossFieldRules::toStoredArray)
+     */
+    public function updateValidationRules(array $rules): void
+    {
+        $this->validationRules = $rules;
         $this->touch();
     }
 

--- a/apps/api/src/Catalog/Domain/Rule/CompareRule.php
+++ b/apps/api/src/Catalog/Domain/Rule/CompareRule.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Domain\Rule;
+
+use InvalidArgumentException;
+
+/**
+ * DP-07 (#2037, ADR-0025) — `weight_net <= weight_gross`-style numeric
+ * comparison of two attributes. Both sides must be numeric attributes of
+ * the SAME AttributeType (guarded on rule save, not here — the VO only
+ * owns the shape). Evaluation skips when either side is missing or
+ * non-numeric: required-ness is a separate dimension.
+ */
+final readonly class CompareRule implements CrossFieldRule
+{
+    public const string TYPE = 'compare';
+
+    public const array OPERATORS = ['lt', 'lte', 'gt', 'gte', 'eq', 'neq'];
+
+    public function __construct(
+        public string $left,
+        public string $op,
+        public string $right,
+    ) {
+        if ('' === trim($this->left) || '' === trim($this->right)) {
+            throw new InvalidArgumentException('compare.left and compare.right must be non-empty attribute codes.');
+        }
+        if ($this->left === $this->right) {
+            throw new InvalidArgumentException('compare.left and compare.right must be different attributes.');
+        }
+        if (!\in_array($this->op, self::OPERATORS, true)) {
+            throw new InvalidArgumentException(\sprintf(
+                'Unsupported compare.op "%s" — supported: %s.',
+                $this->op,
+                implode(', ', self::OPERATORS),
+            ));
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        $left = $payload['left'] ?? null;
+        $op = $payload['op'] ?? null;
+        $right = $payload['right'] ?? null;
+        if (!\is_string($left) || !\is_string($op) || !\is_string($right)) {
+            throw new InvalidArgumentException('compare rule requires string `left`, `op` and `right`.');
+        }
+
+        return new self($left, $op, $right);
+    }
+
+    public function referencedCodes(): array
+    {
+        return [$this->left, $this->right];
+    }
+
+    public function toArray(): array
+    {
+        return ['type' => self::TYPE, 'left' => $this->left, 'op' => $this->op, 'right' => $this->right];
+    }
+}

--- a/apps/api/src/Catalog/Domain/Rule/CrossFieldRule.php
+++ b/apps/api/src/Catalog/Domain/Rule/CrossFieldRule.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Domain\Rule;
+
+/**
+ * DP-07 (#2037, ADR-0025) — one ObjectType-level cross-field rule.
+ * Implementations: {@see CompareRule}, {@see RequireWhenRule}.
+ */
+interface CrossFieldRule
+{
+    /**
+     * Attribute codes this rule reads — used to pre-load existing values
+     * (import prime) and to validate references on rule save.
+     *
+     * @return list<string>
+     */
+    public function referencedCodes(): array;
+
+    /**
+     * @return array<string, mixed> canonical stored JSONB shape
+     */
+    public function toArray(): array;
+}

--- a/apps/api/src/Catalog/Domain/Rule/CrossFieldRules.php
+++ b/apps/api/src/Catalog/Domain/Rule/CrossFieldRules.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Domain\Rule;
+
+use InvalidArgumentException;
+
+/**
+ * DP-07 (#2037, ADR-0025) — strict parser for the ObjectType-level
+ * `validation_rules` JSONB list. PATCH is the only writer and the column
+ * defaults to `[]`, so parsing is strict everywhere: any malformed entry
+ * throws at the domain edge and the JSONB never carries garbage
+ * (same philosophy as VisibleWhenRule).
+ */
+final class CrossFieldRules
+{
+    /**
+     * @param array<int|string, mixed> $raw
+     *
+     * @return list<CrossFieldRule>
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function fromArray(array $raw): array
+    {
+        if (!array_is_list($raw)) {
+            throw new InvalidArgumentException('validation_rules must be a JSON list of rule objects.');
+        }
+
+        $rules = [];
+        foreach ($raw as $index => $entry) {
+            if (!\is_array($entry)) {
+                throw new InvalidArgumentException(\sprintf('validation_rules[%d] must be an object.', $index));
+            }
+            /** @var array<string, mixed> $entry */
+            $type = $entry['type'] ?? null;
+            $rules[] = match ($type) {
+                CompareRule::TYPE => CompareRule::fromArray($entry),
+                RequireWhenRule::TYPE => RequireWhenRule::fromArray($entry),
+                default => throw new InvalidArgumentException(\sprintf(
+                    'validation_rules[%d].type must be one of: %s.',
+                    $index,
+                    implode(', ', [CompareRule::TYPE, RequireWhenRule::TYPE]),
+                )),
+            };
+        }
+
+        return $rules;
+    }
+
+    /**
+     * @param list<CrossFieldRule> $rules
+     *
+     * @return list<array<string, mixed>>
+     */
+    public static function toStoredArray(array $rules): array
+    {
+        return array_map(static fn (CrossFieldRule $rule): array => $rule->toArray(), $rules);
+    }
+}

--- a/apps/api/src/Catalog/Domain/Rule/CrossFieldViolation.php
+++ b/apps/api/src/Catalog/Domain/Rule/CrossFieldViolation.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Domain\Rule;
+
+/**
+ * DP-07 (#2037) — one broken cross-field rule, transport-agnostic
+ * (the admin path maps to 422, the import path to a `cross_field` issue).
+ */
+final readonly class CrossFieldViolation
+{
+    public function __construct(
+        public string $attributeCode,
+        public string $ruleType,
+        public string $message,
+        /** @var list<string> every attribute code the broken rule reads */
+        public array $referencedCodes = [],
+    ) {
+    }
+}

--- a/apps/api/src/Catalog/Domain/Rule/RequireWhenRule.php
+++ b/apps/api/src/Catalog/Domain/Rule/RequireWhenRule.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Domain\Rule;
+
+use InvalidArgumentException;
+
+/**
+ * DP-07 (#2037, ADR-0025) — conditional required: `max_sd_card_gb` is
+ * required when `expandable_storage equals true`. The condition reuses
+ * {@see VisibleWhenRule} so the whole system speaks one condition shape
+ * (conditional visibility on attribute_group_attributes uses the same VO);
+ * Faza 1 operator extensions inherit automatically.
+ */
+final readonly class RequireWhenRule implements CrossFieldRule
+{
+    public const string TYPE = 'require_when';
+
+    public function __construct(
+        public VisibleWhenRule $condition,
+        public string $requiredCode,
+    ) {
+        if ('' === trim($this->requiredCode)) {
+            throw new InvalidArgumentException('require_when.then.required must be a non-empty attribute code.');
+        }
+        if ($this->requiredCode === $this->condition->field) {
+            throw new InvalidArgumentException('require_when target must differ from the condition field.');
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        $if = $payload['if'] ?? null;
+        if (!\is_array($if)) {
+            throw new InvalidArgumentException('require_when rule requires an `if` condition object.');
+        }
+        /** @var array<string, mixed> $if */
+        $then = $payload['then'] ?? null;
+        $required = \is_array($then) ? ($then['required'] ?? null) : null;
+        if (!\is_string($required)) {
+            throw new InvalidArgumentException('require_when rule requires `then.required` (attribute code).');
+        }
+
+        return new self(VisibleWhenRule::fromArray($if), $required);
+    }
+
+    public function referencedCodes(): array
+    {
+        return [$this->condition->field, $this->requiredCode];
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'type' => self::TYPE,
+            'if' => $this->condition->toArray(),
+            'then' => ['required' => $this->requiredCode],
+        ];
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Listener/ObjectTypeSchemaVersionBumper.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Listener/ObjectTypeSchemaVersionBumper.php
@@ -41,6 +41,8 @@ final class ObjectTypeSchemaVersionBumper
         'abstract',
         'allowedParentTypeIds',
         'completenessRules',
+        // DP-07 (#2037, ADR-0025) — cross-field rules shape the form contract.
+        'validationRules',
     ];
 
     public function preUpdate(PreUpdateEventArgs $args): void

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectType.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectType.orm.xml
@@ -55,6 +55,12 @@
                 <option name="default">{}</option>
             </options>
         </field>
+        <field name="validationRules" type="json" column="validation_rules">
+            <options>
+                <option name="jsonb">true</option>
+                <option name="default">[]</option>
+            </options>
+        </field>
         <field name="hierarchical" type="boolean">
             <options>
                 <option name="default">false</option>

--- a/apps/api/src/Catalog/Infrastructure/Serializer/ObjectType.xml
+++ b/apps/api/src/Catalog/Infrastructure/Serializer/ObjectType.xml
@@ -45,6 +45,10 @@
             <group>admin:read</group>
             <group>admin:write</group>
         </attribute>
+        <attribute name="validationRules">
+            <group>admin:read</group>
+            <group>admin:write</group>
+        </attribute>
         <attribute name="hierarchical">
             <group>admin:read</group>
             <group>integration:read</group>

--- a/apps/api/src/Catalog/Presentation/Controller/UpdateObjectTypeController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/UpdateObjectTypeController.php
@@ -72,6 +72,7 @@ final class UpdateObjectTypeController
                 abstract: $this->boolOrNull($body['abstract'] ?? null),
                 allowedParentTypeIds: $this->idListOrNull($body['allowedParentTypeIds'] ?? null),
                 completenessRules: $this->mapOrNull($body['completenessRules'] ?? null),
+                validationRules: $this->ruleListOrNull($body['validationRules'] ?? null),
                 exposeToMainMenu: $this->boolOrNull($body['exposeToMainMenu'] ?? null),
                 isCategorizable: $this->boolOrNull($body['isCategorizable'] ?? null),
                 hasMultimedia: $this->boolOrNull($body['hasMultimedia'] ?? null),
@@ -95,6 +96,7 @@ final class UpdateObjectTypeController
             'abstract' => $objectType->isAbstract(),
             'allowedParentTypeIds' => $objectType->getAllowedParentTypeIds(),
             'completenessRules' => $objectType->getCompletenessRules(),
+            'validationRules' => $objectType->getValidationRules(),
             'exposeToMainMenu' => $objectType->isExposedToMainMenu(),
             'isCategorizable' => $objectType->isCategorizable(),
             'hasMultimedia' => $objectType->hasMultimedia(),
@@ -176,6 +178,31 @@ final class UpdateObjectTypeController
         }
 
         return array_values(array_unique($clean));
+    }
+
+    /**
+     * DP-07 (#2037) — validationRules must be a JSON list of objects; the
+     * deep shape (rule types, operators, referenced codes) is validated in
+     * ObjectTypeService via CrossFieldRules::fromArray.
+     *
+     * @return list<array<string, mixed>>|null
+     */
+    private function ruleListOrNull(mixed $raw): ?array
+    {
+        if (null === $raw) {
+            return null;
+        }
+        if (!\is_array($raw) || !array_is_list($raw)) {
+            throw new BadRequestHttpException('validationRules must be a JSON list.');
+        }
+        foreach ($raw as $entry) {
+            if (!\is_array($entry)) {
+                throw new BadRequestHttpException('validationRules entries must be objects.');
+            }
+        }
+
+        /* @var list<array<string, mixed>> $raw */
+        return $raw;
     }
 
     /**

--- a/apps/api/src/Catalog/Presentation/Controller/UpdateObjectTypeController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/UpdateObjectTypeController.php
@@ -195,14 +195,19 @@ final class UpdateObjectTypeController
         if (!\is_array($raw) || !array_is_list($raw)) {
             throw new BadRequestHttpException('validationRules must be a JSON list.');
         }
+        $clean = [];
         foreach ($raw as $entry) {
             if (!\is_array($entry)) {
                 throw new BadRequestHttpException('validationRules entries must be objects.');
             }
+            $ruleEntry = [];
+            foreach ($entry as $key => $value) {
+                $ruleEntry[(string) $key] = $value;
+            }
+            $clean[] = $ruleEntry;
         }
 
-        /* @var list<array<string, mixed>> $raw */
-        return $raw;
+        return $clean;
     }
 
     /**

--- a/apps/api/src/Import/Application/Handler/ImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImportRunHandler.php
@@ -152,6 +152,8 @@ final class ImportRunHandler extends AbstractBatchHandler
         private readonly ImportUndoLogger $undoLogger,
         private readonly ImportColumnGrammar $columnGrammar,
         private readonly \App\Catalog\Application\BatchValueWriter $valueWriter,
+        private readonly \App\Catalog\Application\CrossFieldRulesValidator $crossFieldRules,
+        private readonly \App\Catalog\Domain\Repository\AttributeRepositoryInterface $attributeRepository,
         private readonly \App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface $catalogObjects,
         private readonly \App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface $objectCategories,
         private readonly \App\Asset\Domain\Repository\AssetRepositoryInterface $assets,
@@ -282,7 +284,11 @@ final class ImportRunHandler extends AbstractBatchHandler
         $sourcePath = null;
         try {
             $columnMapping = $this->resolveColumnMapping($session);
-            $attributesByCode = $this->validator->loadAttributesByCode($tenant, $columnMapping);
+            $attributesByCode = $this->withCrossFieldRuleAttributes(
+                $this->validator->loadAttributesByCode($tenant, $columnMapping),
+                $session,
+                $tenant,
+            );
             $sourcePath = $this->stageSourceFile($session, $tenant);
 
             $skuSeenInFile = [];
@@ -347,7 +353,11 @@ final class ImportRunHandler extends AbstractBatchHandler
                     return;
                 }
 
-                $attributesByCode = $this->validator->loadAttributesByCode($tenant, $columnMapping);
+                $attributesByCode = $this->withCrossFieldRuleAttributes(
+                    $this->validator->loadAttributesByCode($tenant, $columnMapping),
+                    $session,
+                    $tenant,
+                );
                 // Throttled: at most one snapshot per ~1% of the file (force=false).
                 $this->publishProgress($session, $processed);
 
@@ -1265,6 +1275,43 @@ final class ImportRunHandler extends AbstractBatchHandler
      * Structural imports (attributes / attribute groups) carry no target and
      * never reach this handler, so a null here is a programming error.
      */
+    /**
+     * DP-07 (#2037, ADR-0025) — extend the primed attribute set with codes
+     * referenced by the target ObjectType's cross-field rules, so
+     * BatchValueWriter::primeChunk() loads existing counterpart values even
+     * when the rule's other side is absent from the import mapping. A code
+     * that stays unmapped only UNDER-enforces (compare skips, condition
+     * false) — never a false positive.
+     *
+     * @param array<string, Attribute> $attributesByCode
+     *
+     * @return array<string, Attribute>
+     */
+    private function withCrossFieldRuleAttributes(
+        array $attributesByCode,
+        ImportSession $session,
+        Tenant $tenant,
+    ): array {
+        $target = $session->getTargetObjectType();
+        if (!$target instanceof \App\Catalog\Domain\Entity\ObjectType) {
+            return $attributesByCode;
+        }
+
+        foreach ($this->crossFieldRules->rulesFor($target) as $rule) {
+            foreach ($rule->referencedCodes() as $code) {
+                if (isset($attributesByCode[$code])) {
+                    continue;
+                }
+                $attribute = $this->attributeRepository->findByCode($code, $tenant);
+                if ($attribute instanceof Attribute) {
+                    $attributesByCode[$code] = $attribute;
+                }
+            }
+        }
+
+        return $attributesByCode;
+    }
+
     private function requireTargetObjectType(ImportSession $session): \App\Catalog\Domain\Entity\ObjectType
     {
         $target = $session->getTargetObjectType();

--- a/apps/api/tests/Api/Catalog/CrossFieldValidationApiTest.php
+++ b/apps/api/tests/Api/Catalog/CrossFieldValidationApiTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\ObjectKind;
+use PHPUnit\Framework\Attributes\Test;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * DP-07 (#2037, ADR-0025) — ObjectType-level cross-field rules end to end:
+ * the PATCH pipeline that stores them (shape + reference guards) and the
+ * write path that enforces them (422 BEFORE anything is saved).
+ */
+final class CrossFieldValidationApiTest extends CatalogApiTestCase
+{
+    /**
+     * @return array{client: \ApiPlatform\Symfony\Bundle\Test\Client, productOt: string}
+     */
+    private function seedWeights(): array
+    {
+        $client = $this->authenticatedClient();
+        $productOt = $this->objectTypeIdFor(ObjectKind::Product);
+
+        foreach (['weight_net', 'weight_gross'] as $code) {
+            $response = $client->request('POST', '/api/attributes', [
+                'headers' => ['content-type' => 'application/ld+json', 'accept' => 'application/ld+json'],
+                'body' => json_encode([
+                    'code' => $code,
+                    'type' => 'number',
+                    'label' => ['pl' => $code, 'en' => $code],
+                ], JSON_THROW_ON_ERROR),
+            ]);
+            self::assertResponseStatusCodeSame(201);
+            $attrId = $response->toArray()['id'];
+            \assert(\is_string($attrId));
+            $client->request('POST', '/api/object_types/'.$productOt.'/attributes/'.$attrId);
+            self::assertResponseStatusCodeSame(204);
+        }
+
+        return ['client' => $client, 'productOt' => $productOt];
+    }
+
+    #[Test]
+    public function patchStoresRulesAndEchoesThem(): void
+    {
+        ['client' => $client, 'productOt' => $productOt] = $this->seedWeights();
+
+        $rules = [['type' => 'compare', 'left' => 'weight_net', 'op' => 'lte', 'right' => 'weight_gross']];
+        $response = $client->request('PATCH', '/api/object_types/'.$productOt, [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(['validationRules' => $rules], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(200);
+        self::assertSame($rules, $response->toArray()['validationRules']);
+    }
+
+    #[Test]
+    public function patchRejectsUnknownAttributeCode(): void
+    {
+        ['client' => $client, 'productOt' => $productOt] = $this->seedWeights();
+
+        $client->request('PATCH', '/api/object_types/'.$productOt, [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(['validationRules' => [
+                ['type' => 'compare', 'left' => 'weight_net', 'op' => 'lte', 'right' => 'ghost_attr'],
+            ]], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(422);
+    }
+
+    #[Test]
+    public function patchRejectsNonNumericAndMismatchedCompareSides(): void
+    {
+        ['client' => $client, 'productOt' => $productOt] = $this->seedWeights();
+
+        // `name` is the seeded text attribute — not numeric.
+        $client->request('PATCH', '/api/object_types/'.$productOt, [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(['validationRules' => [
+                ['type' => 'compare', 'left' => 'name', 'op' => 'lte', 'right' => 'weight_gross'],
+            ]], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(422);
+
+        // Metric vs number — numeric but mismatched types.
+        $metric = $client->request('POST', '/api/attributes', [
+            'headers' => ['content-type' => 'application/ld+json', 'accept' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'depth_metric',
+                'type' => 'metric',
+                'label' => ['pl' => 'Głębokość', 'en' => 'Depth'],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(201);
+        \assert(\is_string($metric->toArray()['id']));
+
+        $client->request('PATCH', '/api/object_types/'.$productOt, [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(['validationRules' => [
+                ['type' => 'compare', 'left' => 'depth_metric', 'op' => 'lte', 'right' => 'weight_gross'],
+            ]], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(422);
+    }
+
+    #[Test]
+    public function patchRejectsMalformedDsl(): void
+    {
+        ['client' => $client, 'productOt' => $productOt] = $this->seedWeights();
+
+        $client->request('PATCH', '/api/object_types/'.$productOt, [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(['validationRules' => [
+                ['type' => 'compare', 'left' => 'weight_net', 'op' => 'between', 'right' => 'weight_gross'],
+            ]], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(422);
+    }
+
+    #[Test]
+    public function compareViolationBlocksTheWholeWriteBeforeAnySave(): void
+    {
+        ['client' => $client, 'productOt' => $productOt] = $this->seedWeights();
+
+        $client->request('PATCH', '/api/object_types/'.$productOt, [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(['validationRules' => [
+                ['type' => 'compare', 'left' => 'weight_net', 'op' => 'lte', 'right' => 'weight_gross'],
+            ]], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(200);
+
+        // Valid product first.
+        $created = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'XF-1',
+                'objectTypeId' => $productOt,
+                'attributes' => ['name' => 'XF', 'weight_net' => 5, 'weight_gross' => 10],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(201);
+        $productId = $created->toArray()['id'];
+        \assert(\is_string($productId));
+
+        // Violating PATCH: net > gross. BOTH incoming values must be rejected
+        // atomically — the gross bump must not land either (phase-2 gate).
+        $client->request('PATCH', '/api/objects/'.$productId, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'body' => json_encode([
+                'attributes' => ['weight_net' => 50, 'weight_gross' => 20],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(422);
+
+        $fetched = $client->request('GET', '/api/objects/'.$productId, [
+            'headers' => ['accept' => 'application/json'],
+        ])->toArray();
+        /** @var array<string, array{value?: mixed}> $indexed */
+        $indexed = \is_array($fetched['attributesIndexed'] ?? null) ? $fetched['attributesIndexed'] : [];
+        self::assertSame(5, $indexed['weight_net']['value'] ?? null);
+        self::assertSame(10, $indexed['weight_gross']['value'] ?? null);
+    }
+
+    #[Test]
+    public function partialPayloadIsValidatedAgainstExistingValues(): void
+    {
+        ['client' => $client, 'productOt' => $productOt] = $this->seedWeights();
+
+        $client->request('PATCH', '/api/object_types/'.$productOt, [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(['validationRules' => [
+                ['type' => 'compare', 'left' => 'weight_net', 'op' => 'lte', 'right' => 'weight_gross'],
+            ]], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(200);
+
+        $created = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'XF-2',
+                'objectTypeId' => $productOt,
+                'attributes' => ['name' => 'XF2', 'weight_net' => 5, 'weight_gross' => 10],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(201);
+        $productId = $created->toArray()['id'];
+        \assert(\is_string($productId));
+
+        // Only weight_net in the payload — compared against the EXISTING gross.
+        $client->request('PATCH', '/api/objects/'.$productId, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'body' => json_encode(['attributes' => ['weight_net' => 50]], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(422);
+
+        // Satisfying value passes.
+        $client->request('PATCH', '/api/objects/'.$productId, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'body' => json_encode(['attributes' => ['weight_net' => 7]], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(200);
+    }
+
+    #[Test]
+    public function requireWhenFiresAndClearingConditionLiftsIt(): void
+    {
+        $client = $this->authenticatedClient();
+        $productOt = $this->objectTypeIdFor(ObjectKind::Product);
+
+        foreach ([['expandable_storage', 'boolean'], ['max_sd_card_gb', 'number']] as [$code, $type]) {
+            $response = $client->request('POST', '/api/attributes', [
+                'headers' => ['content-type' => 'application/ld+json', 'accept' => 'application/ld+json'],
+                'body' => json_encode([
+                    'code' => $code,
+                    'type' => $type,
+                    'label' => ['pl' => $code, 'en' => $code],
+                ], JSON_THROW_ON_ERROR),
+            ]);
+            self::assertResponseStatusCodeSame(201);
+            $attrId = $response->toArray()['id'];
+            \assert(\is_string($attrId));
+            $client->request('POST', '/api/object_types/'.$productOt.'/attributes/'.$attrId);
+            self::assertResponseStatusCodeSame(204);
+        }
+
+        $client->request('PATCH', '/api/object_types/'.$productOt, [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(['validationRules' => [
+                ['type' => 'require_when', 'if' => ['field' => 'expandable_storage', 'operator' => 'equals', 'value' => true], 'then' => ['required' => 'max_sd_card_gb']],
+            ]], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(200);
+
+        // Condition true + empty target => 422 already at create.
+        $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'RW-1',
+                'objectTypeId' => $productOt,
+                'attributes' => ['name' => 'RW', 'expandable_storage' => true],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(422);
+
+        // Target supplied alongside => 201.
+        $created = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'RW-2',
+                'objectTypeId' => $productOt,
+                'attributes' => ['name' => 'RW2', 'expandable_storage' => true, 'max_sd_card_gb' => 512],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(201);
+        $productId = $created->toArray()['id'];
+        \assert(\is_string($productId));
+
+        // Clearing the condition field lifts the requirement even when the
+        // target is cleared in the same payload.
+        $client->request('PATCH', '/api/objects/'.$productId, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'body' => json_encode([
+                'attributes' => ['expandable_storage' => null, 'max_sd_card_gb' => null],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(200);
+    }
+}

--- a/apps/api/tests/Api/Catalog/CustomKindFeatureFlagApiTest.php
+++ b/apps/api/tests/Api/Catalog/CustomKindFeatureFlagApiTest.php
@@ -147,6 +147,7 @@ final class CustomKindFeatureFlagApiTest extends CatalogApiTestCase
         return new ObjectTypeService(
             $this->em(),
             self::getContainer()->get(ObjectTypeAttributeRepositoryInterface::class),
+            self::getContainer()->get(\App\Catalog\Domain\Repository\AttributeRepositoryInterface::class),
             self::getContainer()->get(\Doctrine\DBAL\Connection::class),
             $flag,
         );

--- a/apps/api/tests/Api/Import/ImportPauseResumeTest.php
+++ b/apps/api/tests/Api/Import/ImportPauseResumeTest.php
@@ -310,6 +310,8 @@ final class ImportPauseResumeTest extends CatalogApiTestCase
             undoLogger: self::getContainer()->get(\App\Import\Application\Service\ImportUndoLogger::class),
             columnGrammar: self::getContainer()->get(\App\Import\Application\Service\ImportColumnGrammar::class),
             valueWriter: self::getContainer()->get(\App\Catalog\Application\BatchValueWriter::class),
+            crossFieldRules: self::getContainer()->get(\App\Catalog\Application\CrossFieldRulesValidator::class),
+            attributeRepository: self::getContainer()->get(\App\Catalog\Domain\Repository\AttributeRepositoryInterface::class),
             catalogObjects: self::getContainer()->get(\App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface::class),
             objectCategories: self::getContainer()->get(\App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface::class),
             assets: self::getContainer()->get(\App\Asset\Domain\Repository\AssetRepositoryInterface::class),

--- a/apps/api/tests/Api/Import/ImportRunHandlerRefreshTest.php
+++ b/apps/api/tests/Api/Import/ImportRunHandlerRefreshTest.php
@@ -145,6 +145,8 @@ final class ImportRunHandlerRefreshTest extends CatalogApiTestCase
             undoLogger: self::getContainer()->get(\App\Import\Application\Service\ImportUndoLogger::class),
             columnGrammar: self::getContainer()->get(\App\Import\Application\Service\ImportColumnGrammar::class),
             valueWriter: self::getContainer()->get(\App\Catalog\Application\BatchValueWriter::class),
+            crossFieldRules: self::getContainer()->get(\App\Catalog\Application\CrossFieldRulesValidator::class),
+            attributeRepository: self::getContainer()->get(\App\Catalog\Domain\Repository\AttributeRepositoryInterface::class),
             catalogObjects: self::getContainer()->get(\App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface::class),
             objectCategories: self::getContainer()->get(\App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface::class),
             assets: self::getContainer()->get(\App\Asset\Domain\Repository\AssetRepositoryInterface::class),

--- a/apps/api/tests/Integration/Catalog/ObjectTypeServiceTest.php
+++ b/apps/api/tests/Integration/Catalog/ObjectTypeServiceTest.php
@@ -258,6 +258,7 @@ final class ObjectTypeServiceTest extends KernelTestCase
         return new ObjectTypeService(
             $this->em(),
             self::getContainer()->get(ObjectTypeAttributeRepositoryInterface::class),
+            self::getContainer()->get(\App\Catalog\Domain\Repository\AttributeRepositoryInterface::class),
             self::getContainer()->get(\Doctrine\DBAL\Connection::class),
             $flag,
         );

--- a/apps/api/tests/Unit/Catalog/Application/CrossFieldRulesValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Application/CrossFieldRulesValidatorTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Application;
+
+use App\Catalog\Application\CrossFieldRulesValidator;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use App\Catalog\Domain\Rule\CompareRule;
+use App\Catalog\Domain\Rule\CrossFieldRules;
+use App\Catalog\Domain\Rule\VisibleWhenRuleEvaluator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * DP-07 (#2037, ADR-0025) — the semantics matrix for cross-field evaluation.
+ * The view passed to evaluate() is `code => NON-EMPTY global envelope`.
+ */
+final class CrossFieldRulesValidatorTest extends TestCase
+{
+    private CrossFieldRulesValidator $validator;
+
+    protected function setUp(): void
+    {
+        $values = $this->createStub(ObjectValueRepositoryInterface::class);
+        $this->validator = new CrossFieldRulesValidator($values, new VisibleWhenRuleEvaluator());
+    }
+
+    /**
+     * @return list<\App\Catalog\Domain\Rule\CrossFieldRule>
+     */
+    private function compare(string $op): array
+    {
+        return CrossFieldRules::fromArray([
+            ['type' => 'compare', 'left' => 'weight_net', 'op' => $op, 'right' => 'weight_gross'],
+        ]);
+    }
+
+    /**
+     * @return list<\App\Catalog\Domain\Rule\CrossFieldRule>
+     */
+    private function requireWhen(mixed $conditionValue = true): array
+    {
+        return CrossFieldRules::fromArray([
+            ['type' => 'require_when', 'if' => ['field' => 'expandable_storage', 'operator' => 'equals', 'value' => $conditionValue], 'then' => ['required' => 'max_sd_card_gb']],
+        ]);
+    }
+
+    #[Test]
+    public function compareViolatesWhenLeftExceedsRight(): void
+    {
+        $violations = $this->validator->evaluate($this->compare('lte'), [
+            'weight_net' => ['value' => 12.5],
+            'weight_gross' => ['value' => 10],
+        ]);
+
+        self::assertCount(1, $violations);
+        self::assertSame('weight_net', $violations[0]->attributeCode);
+        self::assertSame(CompareRule::TYPE, $violations[0]->ruleType);
+        self::assertStringContainsString('less than or equal to', $violations[0]->message);
+    }
+
+    #[Test]
+    public function compareHoldsWhenSatisfied(): void
+    {
+        self::assertSame([], $this->validator->evaluate($this->compare('lte'), [
+            'weight_net' => ['value' => 9],
+            'weight_gross' => ['value' => 10],
+        ]));
+    }
+
+    #[Test]
+    public function compareSkipsWhenEitherSideMissingOrNonNumeric(): void
+    {
+        self::assertSame([], $this->validator->evaluate($this->compare('lte'), [
+            'weight_net' => ['value' => 12.5],
+        ]));
+        self::assertSame([], $this->validator->evaluate($this->compare('lte'), [
+            'weight_net' => ['value' => 'heavy'],
+            'weight_gross' => ['value' => 10],
+        ]));
+        self::assertSame([], $this->validator->evaluate($this->compare('lte'), []));
+    }
+
+    #[Test]
+    public function compareReadsPriceAmountAndCastsNumericStrings(): void
+    {
+        $violations = $this->validator->evaluate($this->compare('lt'), [
+            'weight_net' => ['amount' => '15.5'],
+            'weight_gross' => ['value' => 10],
+        ]);
+
+        self::assertCount(1, $violations);
+    }
+
+    #[Test]
+    public function eqDoesNotSplitOnIntVsFloat(): void
+    {
+        self::assertSame([], $this->validator->evaluate($this->compare('eq'), [
+            'weight_net' => ['value' => 5],
+            'weight_gross' => ['value' => 5.0],
+        ]));
+    }
+
+    #[Test]
+    public function everyOperatorEvaluates(): void
+    {
+        $view = static fn (int|float $l, int|float $r): array => [
+            'weight_net' => ['value' => $l],
+            'weight_gross' => ['value' => $r],
+        ];
+
+        self::assertCount(1, $this->validator->evaluate($this->compare('lt'), $view(10, 10)));
+        self::assertSame([], $this->validator->evaluate($this->compare('lt'), $view(9, 10)));
+        self::assertCount(1, $this->validator->evaluate($this->compare('gt'), $view(10, 10)));
+        self::assertSame([], $this->validator->evaluate($this->compare('gte'), $view(10, 10)));
+        self::assertCount(1, $this->validator->evaluate($this->compare('neq'), $view(10, 10)));
+        self::assertSame([], $this->validator->evaluate($this->compare('neq'), $view(9, 10)));
+    }
+
+    #[Test]
+    public function requireWhenFiresOnConditionTrueAndMissingTarget(): void
+    {
+        $violations = $this->validator->evaluate($this->requireWhen(), [
+            'expandable_storage' => ['value' => true],
+        ]);
+
+        self::assertCount(1, $violations);
+        self::assertSame('max_sd_card_gb', $violations[0]->attributeCode);
+        self::assertStringContainsString('required when', $violations[0]->message);
+    }
+
+    #[Test]
+    public function requireWhenHoldsWhenTargetPresentOrConditionFalse(): void
+    {
+        self::assertSame([], $this->validator->evaluate($this->requireWhen(), [
+            'expandable_storage' => ['value' => true],
+            'max_sd_card_gb' => ['value' => 512],
+        ]));
+        self::assertSame([], $this->validator->evaluate($this->requireWhen(), [
+            'expandable_storage' => ['value' => false],
+        ]));
+        // Missing condition field => condition false (visible_when semantics).
+        self::assertSame([], $this->validator->evaluate($this->requireWhen(), []));
+    }
+
+    #[Test]
+    public function requireWhenMatchesSelectEnvelopeShape(): void
+    {
+        $rules = CrossFieldRules::fromArray([
+            ['type' => 'require_when', 'if' => ['field' => 'light_type', 'operator' => 'equals', 'value' => 'bulb'], 'then' => ['required' => 'socket_type']],
+        ]);
+
+        $violations = $this->validator->evaluate($rules, [
+            'light_type' => ['option_code' => 'bulb'],
+        ]);
+
+        self::assertCount(1, $violations);
+    }
+
+    #[Test]
+    public function overlayAppliesGlobalWritesAndClearsRemoveCodes(): void
+    {
+        $net = new Attribute('weight_net', ['en' => 'Net'], AttributeType::Number);
+        $gross = new Attribute('weight_gross', ['en' => 'Gross'], AttributeType::Number);
+
+        $base = [
+            'weight_net' => ['value' => 5],
+            'weight_gross' => ['value' => 10],
+        ];
+
+        $view = $this->validator->overlay($base, [
+            // Global write overrides.
+            ['attribute' => $net, 'envelope' => ['value' => 12], 'locale' => null, 'channelId' => null],
+            // Clearing removes the code — "cleared" == "never set".
+            ['attribute' => $gross, 'envelope' => ['value' => null], 'locale' => null, 'channelId' => null],
+        ]);
+
+        self::assertSame(['value' => 12], $view['weight_net']);
+        self::assertArrayNotHasKey('weight_gross', $view);
+    }
+
+    #[Test]
+    public function overlayIgnoresLocaleAndChannelRoutedWrites(): void
+    {
+        $net = new Attribute('weight_net', ['en' => 'Net'], AttributeType::Number);
+
+        $view = $this->validator->overlay([], [
+            ['attribute' => $net, 'envelope' => ['value' => 12], 'locale' => 'de', 'channelId' => null],
+            ['attribute' => $net, 'envelope' => ['value' => 13], 'locale' => null, 'channelId' => Uuid::v7()],
+        ]);
+
+        self::assertSame([], $view);
+    }
+}

--- a/apps/api/tests/Unit/Catalog/CrossFieldRulesTest.php
+++ b/apps/api/tests/Unit/Catalog/CrossFieldRulesTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog;
+
+use App\Catalog\Domain\Rule\CompareRule;
+use App\Catalog\Domain\Rule\CrossFieldRules;
+use App\Catalog\Domain\Rule\RequireWhenRule;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * DP-07 (#2037, ADR-0025) — strict parsing of the ObjectType-level
+ * validation_rules JSONB list.
+ */
+final class CrossFieldRulesTest extends TestCase
+{
+    #[Test]
+    public function parsesCompareAndRequireWhenAndRoundTrips(): void
+    {
+        $stored = [
+            ['type' => 'compare', 'left' => 'weight_net', 'op' => 'lte', 'right' => 'weight_gross'],
+            ['type' => 'require_when', 'if' => ['field' => 'expandable_storage', 'operator' => 'equals', 'value' => true], 'then' => ['required' => 'max_sd_card_gb']],
+        ];
+
+        $rules = CrossFieldRules::fromArray($stored);
+
+        self::assertCount(2, $rules);
+        self::assertInstanceOf(CompareRule::class, $rules[0]);
+        self::assertInstanceOf(RequireWhenRule::class, $rules[1]);
+        self::assertSame(['weight_net', 'weight_gross'], $rules[0]->referencedCodes());
+        self::assertSame(['expandable_storage', 'max_sd_card_gb'], $rules[1]->referencedCodes());
+        self::assertSame($stored, CrossFieldRules::toStoredArray($rules));
+    }
+
+    #[Test]
+    public function rejectsUnknownRuleType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/type must be one of/');
+        CrossFieldRules::fromArray([['type' => 'sum', 'left' => 'a', 'right' => 'b']]);
+    }
+
+    #[Test]
+    public function rejectsNonListPayload(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        CrossFieldRules::fromArray(['type' => 'compare']);
+    }
+
+    #[Test]
+    public function compareRejectsUnknownOperator(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/compare\.op/');
+        CompareRule::fromArray(['left' => 'a', 'op' => 'between', 'right' => 'b']);
+    }
+
+    #[Test]
+    public function compareRejectsSelfComparison(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        CompareRule::fromArray(['left' => 'a', 'op' => 'lte', 'right' => 'a']);
+    }
+
+    #[Test]
+    public function requireWhenRejectsMissingThenRequired(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/then\.required/');
+        RequireWhenRule::fromArray(['if' => ['field' => 'a', 'operator' => 'equals', 'value' => 1], 'then' => []]);
+    }
+
+    #[Test]
+    public function requireWhenRejectsBadConditionShape(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        RequireWhenRule::fromArray(['if' => ['field' => 'a', 'operator' => 'in', 'value' => [1]], 'then' => ['required' => 'b']]);
+    }
+
+    #[Test]
+    public function requireWhenRejectsSelfTarget(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        RequireWhenRule::fromArray(['if' => ['field' => 'a', 'operator' => 'equals', 'value' => 1], 'then' => ['required' => 'a']]);
+    }
+}

--- a/docs/adr/0025-object-type-cross-field-validation.md
+++ b/docs/adr/0025-object-type-cross-field-validation.md
@@ -1,0 +1,104 @@
+# ADR-0025: Walidacja krzyżowa pól + conditional required na poziomie ObjectType
+
+- **Status:** accepted
+- **Data:** 2026-07-03
+- **Kontekst:** epik DP (drobne poprawki), ticket DP-07 (#2037)
+- **Powiązane:** ADR-0019 (ValueWriteCore — wspólny write path), ADR-009 (ObjectType first-class), UI-08.8 #263 (VisibleWhenRule), `docs/api/jsonb-schemas.md`
+
+## Kontekst
+
+Silnik walidacji per-atrybut (`Attribute.validation_rules` + `TypeValidator/*`) nie mieści reguł
+odnoszących się do WIELU pól naraz:
+
+- **walidacja krzyżowa**: `weight_net ≤ weight_gross`, `threads ≥ cores`, `hdmi_2_1_ports ≤ hdmi_ports`,
+- **conditional required**: `max_sd_card_gb` wymagane, gdy `expandable_storage = true`.
+
+Takie reguły opisują kształt CAŁEGO obiektu, więc ich naturalnym właścicielem jest `ObjectType`
+(analogicznie do `completeness_rules`), nie pojedynczy atrybut.
+
+## Decyzja
+
+### Storage
+
+Nowa kolumna `object_types.validation_rules JSONB DEFAULT '[]' NOT NULL` — lista reguł.
+Wzorzec identyczny z `completeness_rules` (pole encji + jsonb w ORM + grupa `admin:read/write`
+w serializerze). Pole jest schema-shaping → dopisane do `ObjectTypeSchemaVersionBumper::SCHEMA_FIELDS`.
+
+### DSL — dwa rodzaje reguł
+
+```json
+{"type": "compare", "left": "weight_net", "op": "lte", "right": "weight_gross"}
+{"type": "require_when",
+ "if": {"field": "expandable_storage", "operator": "equals", "value": true},
+ "then": {"required": "max_sd_card_gb"}}
+```
+
+- `compare.op` ∈ `lt | lte | gt | gte | eq | neq`. Obie strony muszą być atrybutami numerycznymi
+  (`number` / `metric` / `price`) i **tego samego typu** (guard przy zapisie reguł; konwersja
+  jednostek/walut świadomie poza zakresem — patrz DP-09 #2038).
+- `require_when.if` **reużywa `VisibleWhenRule`** (`{field, operator: 'equals', value}`) — jeden
+  kształt warunku w całym systemie (spójność z conditional visibility na junction
+  `attribute_group_attributes.visible_when`). Rozszerzenia operatorów (not_equals/in/composites)
+  dziedziczą się automatycznie, gdy Faza 1 rozszerzy `VisibleWhenRule`.
+
+VO domenowe: `CrossFieldRule` (interfejs), `CompareRule`, `RequireWhenRule`, `CrossFieldViolation`,
+parser `CrossFieldRules::fromArray` (strict — złe kształty rzucają `InvalidArgumentException` na
+krawędzi domeny, JSONB nigdy nie niesie śmieci; wzorzec `VisibleWhenRule`).
+
+### Egzekwowanie
+
+Wspólny `CrossFieldRulesValidator` (Catalog\Application) wołany z OBU ścieżek zapisu wartości:
+
+- **Edycja ręczna** (`ObjectAttributesUpserter`): restrukturyzacja na 3 fazy —
+  (1) dotychczasowa walidacja per-atrybut zbiera przygotowane wpisy zamiast zapisywać,
+  (2) gate cross-field → `422` PRZED pierwszym save (żadna wartość nie ląduje przy violation),
+  (3) persystencja. Wszyscy konsumenci upserta (create/update/bulk/backfill) dostają enforcement.
+- **Import/bulk** (`BatchValueWriter`): `primeChunk()` buduje dodatkowo indeks globalnych kopert
+  (bez nowych zapytań), `writeMany()` robi pre-pass i emituje issues `kind: 'cross_field'`;
+  wpisy uwikłane w złamany `compare` są pomijane (nie lądują), `require_when` jest report-only.
+- **Agent (Faza 2)** dziedziczy przez te same seamy.
+
+### Semantyka (kontrakt)
+
+- Ewaluacja WYŁĄCZNIE na global scope (locale=null, channel=null) — spójnie z `attributes_indexed`
+  i `visible_when`; wpisy locale/channel-routed nie wchodzą do widoku.
+- Źródłem istniejących wartości są kanoniczne wiersze `ObjectValue`
+  (`findByObject` w upsercie / prime-index w imporcie) — **nie** `attributes_indexed`
+  (listener rebuildu pomija bulk, świeży obiekt ma pusty cache).
+- Widok = istniejące global rows nadpisane przychodzącymi kopertami; pusta koperta
+  (`ValueWriteCore::isEmptyEnvelope`) USUWA kod z widoku ("wyczyszczone" ≡ "nigdy nie ustawione").
+- `compare`: którakolwiek strona nieobecna/nienumeryczna → SKIP (brak violation; wymagalność to
+  osobny wymiar). Violation kotwiczona w lewym kodzie.
+- `require_when`: strzela gdy warunek prawdziwy ORAZ target nieobecny w widoku; wyczyszczenie pola
+  warunku zdejmuje wymóg; brak pola warunku = warunek fałszywy (semantyka ewaluatora visible_when).
+- Reguła wskazująca usunięty atrybut: runtime pobłażliwy (SKIP / warunek false), ale ponowny zapis
+  reguł przez PATCH odrzuca nieistniejące kody.
+
+### Zapis reguł
+
+`PATCH /api/object_types/{id}` przyjmuje `validationRules`; `ObjectTypeService::update()` parsuje
+przez `CrossFieldRules::fromArray`, sprawdza istnienie kodów **tenant-wide**
+(`AttributeRepositoryInterface::findByCode` — celowo nie effective-schema: grupy dryfują
+niezależnie od reguł) oraz guard numeryczno-typowy dla `compare`. Built-in ObjectTypes:
+`fieldLocked` jak przy `completenessRules`.
+
+## Konsekwencje
+
+- (+) reguły cross-field działają identycznie w edycji ręcznej, imporcie i (w Fazie 2) u agenta,
+- (+) zero nowych zapytań na ścieżce importu; w edycji ręcznej jedno dodatkowe zapytanie tylko
+  gdy ObjectType ma reguły,
+- (+) jeden kształt warunku (`VisibleWhenRule`) dla visibility i conditional required,
+- (−) global-scope-only: reguły nie widzą wartości per-locale/per-channel (świadome ograniczenie
+  MVP, spójne z resztą systemu; rozszerzenie wymaga decyzji o semantyce porównań cross-scope),
+- (−) `compare` bez konwersji jednostek (guard same-type minimalizuje ryzyko pomyłek; pełna
+  konwersja = DP-09, optional).
+
+## Odrzucone alternatywy
+
+- **Reguły w `Attribute.validation_rules`** — reguła dwustronna nie ma naturalnego właściciela
+  wśród atrybutów; duplikacja i dryf przy edycji jednej strony.
+- **Egzekwowanie w `ValueWriteCore.formatViolations`** — core waliduje pojedynczą kopertę i nie
+  zna obiektu; wciąganie kontekstu obiektu do niego złamałoby jego kontrakt (ADR-0019).
+- **Doctrine listener post-flush** — traci natychmiastowe 422 i gwarancję "nic nie zapisane".
+- **`attributes_indexed` jako źródło** — nieświeży w bulk (BulkContext) i pusty dla świeżych
+  obiektów w tym samym flushu.

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -24000,6 +24000,20 @@
                             ]
                         }
                     },
+                    "validationRules": {
+                        "readOnly": true,
+                        "description": "DP-07 (#2037, ADR-0025) \u2014 cross-field rules (`compare` / `require_when`)\nstored as a JSONB list; shape guarded by CrossFieldRules::fromArray at\nthe write edge (ObjectTypeService), read by CrossFieldRulesValidator.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
                     "labelAttribute": {
                         "anyOf": [
                             {
@@ -24149,6 +24163,20 @@
                                         "string",
                                         "null"
                                     ]
+                                }
+                            },
+                            "validationRules": {
+                                "readOnly": true,
+                                "description": "DP-07 (#2037, ADR-0025) \u2014 cross-field rules (`compare` / `require_when`)\nstored as a JSONB list; shape guarded by CrossFieldRules::fromArray at\nthe write edge (ObjectTypeService), read by CrossFieldRulesValidator.",
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
                                 }
                             },
                             "labelAttribute": {

--- a/docs/api/jsonb-schemas.md
+++ b/docs/api/jsonb-schemas.md
@@ -133,6 +133,33 @@ Schema unionowa — pole `validation_rules` jest interpretowane przez validator 
 
 ---
 
+## 2a. `object_types.validation_rules` — reguły cross-field (DP-07 #2037, ADR-0025)
+
+**Tabela**: `object_types.validation_rules JSONB DEFAULT '[]' NOT NULL`
+**Writer**: `ObjectTypeService::update()` (strict parse przez [`CrossFieldRules`](apps/api/src/Catalog/Domain/Rule/CrossFieldRules.php) — JSONB nigdy nie niesie śmieci)
+**Reader**: [`CrossFieldRulesValidator`](apps/api/src/Catalog/Application/CrossFieldRulesValidator.php) — egzekwowanie w OBU ścieżkach zapisu wartości (`ObjectAttributesUpserter` → 422 przed zapisem; `BatchValueWriter` → issue `kind: 'cross_field'`).
+
+### Shape
+
+Lista reguł dwóch rodzajów:
+
+```json
+[
+  { "type": "compare", "left": "weight_net", "op": "lte", "right": "weight_gross" },
+  { "type": "require_when",
+    "if": { "field": "expandable_storage", "operator": "equals", "value": true },
+    "then": { "required": "max_sd_card_gb" } }
+]
+```
+
+- `compare.op` ∈ `lt | lte | gt | gte | eq | neq`; `left`/`right` to kody atrybutów numerycznych
+  (`number`/`metric`/`price`) **tego samego typu** (guard przy PATCH; bez konwersji jednostek/walut).
+- `require_when.if` = kształt `VisibleWhenRule` (ten sam co `attribute_group_attributes.visible_when`).
+- Ewaluacja wyłącznie na global scope (locale=null, channel=null); brakująca/pusta strona `compare`
+  → SKIP; `require_when` strzela gdy warunek prawdziwy i target pusty. Pełna tabela semantyki: ADR-0025.
+
+---
+
 ## 3. `completeness` — denormalizowana kompletność
 
 **Tabela**: `objects.completeness JSONB DEFAULT '{}'` + redundant `objects.completeness_pct SMALLINT DEFAULT 0`


### PR DESCRIPTION
## Co i dlaczego

Reguły odnoszące się do WIELU pól (`weight_net ≤ weight_gross`, „`max_sd_card_gb` wymagane gdy `expandable_storage=true`") nie mieszczą się w per-atrybutowym `validation_rules`. Ten PR realizuje **ADR-0025** (w zestawie): reguły na poziomie ObjectType, egzekwowane identycznie w edycji ręcznej i imporcie. Plan zaakceptowany przez operatora w Plan Mode.

## Zakres

**ADR-0025** (`docs/adr/0025-object-type-cross-field-validation.md`) — storage, DSL, semantyka, odrzucone alternatywy.

**Storage + DSL:** kolumna `object_types.validation_rules JSONB DEFAULT '[]'` (wzór `completeness_rules`, schema-shaping → bump `schemaVersion`); VO `CompareRule` (lt/lte/gt/gte/eq/neq, pary numeryczne tego samego typu) i `RequireWhenRule` (**warunek reużywa `VisibleWhenRule`** — jeden kształt warunku w systemie); parser `CrossFieldRules::fromArray` strict na krawędzi domeny.

**Egzekwowanie (`CrossFieldRulesValidator`):**
- `ObjectAttributesUpserter` zrestrukturyzowany na 3 fazy: walidacja per-atrybut → **gate cross-field → 422 PRZED pierwszym save** (atomowość: violation nigdy nie zostawia w połowie zapisanego obiektu) → persystencja. Wszyscy 4 konsumenci upserta dostają enforcement.
- `BatchValueWriter`: pre-pass per obiekt, issues `kind: 'cross_field'`; wpisy uwikłane w złamany compare pomijane, require_when report-only. `primeChunk` buduje indeks globalnych kopert w tej samej pętli — **zero nowych zapytań** na ścieżce importu.
- Widok = istniejące global rows (`findByObject`) + overlay przychodzących kopert; **celowo nie `attributes_indexed`** (listener rebuildu pomija bulk; świeży obiekt ma pusty cache). Pusta koperta usuwa kod z widoku („wyczyszczone" ≡ „nigdy nie ustawione").
- `ImportRunHandler` domergowuje atrybuty z reguł do prime (compare-z-istniejącym działa nawet gdy druga strona nie jest w mappingu); wpisy deptrac w tym samym koszyku burndownu co BatchValueWriter (#1466).

**PATCH pipeline:** `validationRules` w `PATCH /api/object_types/{id}` + echo + ekspozycja w GET (serializer `admin:read/write`); guardy: strict shape → 422, kody tenant-wide, compare numeric same-type. **Świadomie edytowalne na built-in OT** (reguły ograniczają WARTOŚCI, nie model — główny use case żyje na Product).

**UI:** karta „Reguły walidacji (między polami)" na detail ObjectType — wiersze `[attr] [op] [attr]` i `Gdy [attr] równa się [wartość] → wymagaj [attr]`, zapis jednym PATCH.

**Kontrakty:** sekcja 2a w `docs/api/jsonb-schemas.md`, regeneracja `docs/api-spec/v0.json` + `shared-types`.

## Testy

- Unit: `CrossFieldRulesTest` (8) + `CrossFieldRulesValidatorTest` (11 — pełna macierz semantyki z ADR: skip-on-empty, wszystkie operatory, require_when fire/lift, overlay/clear, scope-routed ignorowane).
- Api: `CrossFieldValidationApiTest` (7 — PATCH/echo, nieznany kod 422, non-numeric/mismatch 422, malformed 422, **atomowość: po 422 wartości nietknięte**, partial payload vs existing, require_when przy create/clear).
- Aktualizacja 4 istniejących testów po zmianach konstruktorów (znana lekcja anonimowych fake'ów).
- E2E `dp-07-cross-field-rules.spec.ts`: builder → save → GET persisted → violating write 422 → valid 200 → cleanup.

## Smoke test (żywy stack, pim.localhost)

curl: reguła `dp07_net lte dp07_gross` na Product OT (PATCH 200 + echo) → zapis 5/10 **200** → zapis samego net=50 **422** `Attribute "dp07_net" must be less than or equal to attribute "dp07_gross" (50.0 vs 10.0)` → **GET potwierdza net=5, gross=10 (nic nie zapisane)** → cleanup 200/204. Bramki: PHPStan max ✅ CS-Fixer ✅ Deptrac 0 violations ✅ unit 1453 ✅ tsc/biome/vitest/build ✅. Migracja wykonana na dev DB.

## Świadome odejścia (per ADR)

- Global-scope only (spójnie z attributes_indexed/visible_when); konwersja jednostek poza zakresem (guard same-type); kompozyty AND/OR dziedziczą się z przyszłych rozszerzeń VisibleWhenRule.
- Gotcha: zmiana `Serializer/ObjectType.xml` wymaga `cache:clear` (metadata cache przeżywa restart workera) — złapane na żywym smoke'u.

Closes #2037

🤖 Generated with [Claude Code](https://claude.com/claude-code)