### PR TITLE
DP-08: feat(admin): WAL-4 — zależności słownikowe (conditional visibility pól)

### DIFF
--- a/apps/admin/e2e/dp-08-conditional-visibility.spec.ts
+++ b/apps/admin/e2e/dp-08-conditional-visibility.spec.ts
@@ -78,9 +78,30 @@ test('DP-08 — visible_when hides and reveals a field without losing its value'
       }>;
     }
   ).effectiveGroups;
-  const group = groups.find((g) => g.display_mode === 'stacked' && !g.is_system_group);
-  expect(group, 'demo product needs a stacked non-system group').toBeTruthy();
-  const groupId = group?.id ?? '';
+  const existing = groups.find((g) => g.display_mode === 'stacked' && !g.is_system_group);
+
+  // CI fixtures ship no operator groups — create one and declare it on the
+  // product's ObjectType so the spec is self-sufficient in every environment.
+  let groupId = existing?.id ?? '';
+  let createdGroupId: string | null = null;
+  let groupLabel = '';
+  if (groupId === '') {
+    const objectTypeId = (schema.body as { objectType: { id: string } }).objectType.id;
+    groupLabel = `dp08 grp ${suffix}`;
+    const createdGroup = await browserApi(page, 'POST', '/api/attribute_groups', {
+      code: `dp08_grp_${suffix}`,
+      label: { pl: groupLabel },
+    });
+    expect(createdGroup.status, JSON.stringify(createdGroup.body)).toBe(201);
+    createdGroupId = (createdGroup.body as { id: string }).id;
+    groupId = createdGroupId;
+    const declared = await browserApi(
+      page,
+      'POST',
+      `/api/object_types/${objectTypeId}/groups/${groupId}`,
+    );
+    expect(declared.status, JSON.stringify(declared.body)).toBeLessThan(300);
+  }
 
   const attrIds: string[] = [];
   for (const code of [driverCode, depCode]) {
@@ -142,8 +163,19 @@ test('DP-08 — visible_when hides and reveals a field without losing its value'
       { productId, depCode },
     );
 
-    // Product form: driver empty → dependent hidden.
+    // Product form: driver empty → dependent hidden. A freshly created
+    // group may render as its own TAB — open it first (gating is identical
+    // on both paths, renderStackedGroup serves tab groups too).
     await page.goto(`/products/${productId}`);
+    const onDefaultTab = await page
+      .getByText(driverCode, { exact: true })
+      .first()
+      .waitFor({ state: 'visible', timeout: 5_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (!onDefaultTab && groupLabel !== '') {
+      await page.getByRole('tab', { name: new RegExp(groupLabel, 'i') }).click();
+    }
     const driverField = page.getByText(driverCode, { exact: true }).first();
     await expect(driverField).toBeVisible();
     await expect(page.getByText(depCode, { exact: true })).toHaveCount(0);
@@ -203,6 +235,16 @@ test('DP-08 — visible_when hides and reveals a field without losing its value'
     for (const attrId of attrIds) {
       await browserApi(page, 'DELETE', `/api/attribute_groups/${groupId}/attributes/${attrId}`);
       await browserApi(page, 'DELETE', `/api/attributes/${attrId}`);
+    }
+    if (createdGroupId !== null) {
+      // Spec-created group: undeclare from the ObjectType, then drop it.
+      const objectTypeId = (schema.body as { objectType: { id: string } }).objectType.id;
+      await browserApi(
+        page,
+        'DELETE',
+        `/api/object_types/${objectTypeId}/groups/${createdGroupId}`,
+      );
+      await browserApi(page, 'DELETE', `/api/attribute_groups/${createdGroupId}`);
     }
   }
 });

--- a/apps/admin/e2e/dp-08-conditional-visibility.spec.ts
+++ b/apps/admin/e2e/dp-08-conditional-visibility.spec.ts
@@ -1,0 +1,208 @@
+import { expect, type Page, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * DP-08 (#2039) — conditional visibility end to end.
+ *
+ * Single test, one login. Adds a driver + dependent text attribute to an
+ * existing stacked group of the demo product's form schema, sets a
+ * `visible_when` rule on the dependent through the group-detail dialog,
+ * then proves the product form hides/reveals the dependent as the driver
+ * value changes — and that the hidden value is NOT cleared. Cleans up.
+ */
+
+async function browserApi(
+  page: Page,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: unknown }> {
+  return page.evaluate(
+    async (args: { method: string; path: string; body?: unknown }) => {
+      const refresh = await fetch('/api/auth/refresh', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { accept: 'application/json' },
+      });
+      const { token } = (await refresh.json()) as { token: string };
+      const res = await fetch(args.path, {
+        method: args.method,
+        headers: {
+          authorization: `Bearer ${token}`,
+          accept: 'application/json',
+          ...(args.body !== undefined
+            ? {
+                'content-type':
+                  args.method === 'PATCH' ? 'application/json' : 'application/ld+json',
+              }
+            : {}),
+        },
+        ...(args.body !== undefined ? { body: JSON.stringify(args.body) } : {}),
+      });
+      const text = await res.text();
+      let parsed: unknown = null;
+      try {
+        parsed = text === '' ? null : JSON.parse(text);
+      } catch {
+        parsed = text;
+      }
+      return { status: res.status, body: parsed };
+    },
+    { method, path, body },
+  );
+}
+
+test('DP-08 — visible_when hides and reveals a field without losing its value', async ({
+  page,
+}) => {
+  await loginAsAdmin(page);
+
+  const suffix = Date.now().toString(36);
+  const driverCode = `dp08_driver_${suffix}`;
+  const depCode = `dp08_dep_${suffix}`;
+
+  // A stacked (non-system) group already on the demo product's form.
+  const products = await browserApi(page, 'GET', '/api/products?itemsPerPage=1');
+  const productId = (products.body as Array<{ id: string }>)[0]?.id ?? '';
+  expect(productId).not.toBe('');
+
+  const schema = await browserApi(page, 'GET', `/api/objects/${productId}/form-schema`);
+  const groups = (
+    schema.body as {
+      effectiveGroups: Array<{
+        id: string;
+        code: string;
+        display_mode: string;
+        is_system_group: boolean;
+      }>;
+    }
+  ).effectiveGroups;
+  const group = groups.find((g) => g.display_mode === 'stacked' && !g.is_system_group);
+  expect(group, 'demo product needs a stacked non-system group').toBeTruthy();
+  const groupId = group?.id ?? '';
+
+  const attrIds: string[] = [];
+  for (const code of [driverCode, depCode]) {
+    const created = await browserApi(page, 'POST', '/api/attributes', {
+      code,
+      type: 'text',
+      label: { pl: code },
+    });
+    expect(created.status, JSON.stringify(created.body)).toBe(201);
+    attrIds.push((created.body as { id: string }).id);
+  }
+  const attach = await browserApi(
+    page,
+    'POST',
+    `/api/attribute_groups/${groupId}/attributes/bulk-attach`,
+    {
+      attributeCodes: [driverCode, depCode],
+    },
+  );
+  expect(attach.status, JSON.stringify(attach.body)).toBe(200);
+
+  try {
+    // Set the rule through the group-detail dialog. The member rows are the
+    // grid-cols containers — scope to the ONE holding depCode (an unscoped
+    // div.filter matches every ancestor and .first() lands on the page root,
+    // whose first rule button belongs to a different row).
+    await page.goto(`/modeling/attribute-groups/${groupId}`);
+    const depRow = page
+      .locator('[class*="grid-cols-"]')
+      .filter({ has: page.getByText(depCode, { exact: true }) })
+      .last();
+    await depRow.getByRole('button', { name: /reguła widoczności/i }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel(/atrybut/i).selectOption(driverCode);
+    await dialog.getByLabel(/wartość|value/i).fill('bulb');
+    await dialog.getByRole('button', { name: /^(zapisz|save)$/i }).click();
+    await expect(page.getByText(`when ${driverCode}=bulb`).first()).toBeVisible();
+
+    // Seed a value on the dependent while it would be hidden — proves the
+    // value survives hiding (set via API, like legacy data).
+    await page.evaluate(
+      async (args: { productId: string; depCode: string }) => {
+        const refresh = await fetch('/api/auth/refresh', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { accept: 'application/json' },
+        });
+        const { token } = (await refresh.json()) as { token: string };
+        await fetch(`/api/objects/${args.productId}`, {
+          method: 'PATCH',
+          headers: {
+            authorization: `Bearer ${token}`,
+            'content-type': 'application/merge-patch+json',
+          },
+          body: JSON.stringify({ attributes: { [args.depCode]: 'przetrwam' } }),
+        });
+      },
+      { productId, depCode },
+    );
+
+    // Product form: driver empty → dependent hidden.
+    await page.goto(`/products/${productId}`);
+    const driverField = page.getByText(driverCode, { exact: true }).first();
+    await expect(driverField).toBeVisible();
+    await expect(page.getByText(depCode, { exact: true })).toHaveCount(0);
+
+    // Fill the driver with the matching value → dependent appears, and its
+    // previously-set value survived the hidden phase.
+    const driverInput = page
+      .locator(`[data-attr-code="${driverCode}"] input, [id*="${driverCode}"]`)
+      .first();
+    const row = page
+      .locator('div')
+      .filter({ has: page.getByText(driverCode, { exact: true }) })
+      .locator('input[type="text"]')
+      .first();
+    const input = (await driverInput.count()) > 0 ? driverInput : row;
+    await input.fill('bulb');
+
+    await expect(page.getByText(depCode, { exact: true }).first()).toBeVisible();
+    const depInput = page
+      .locator('div')
+      .filter({ has: page.getByText(depCode, { exact: true }) })
+      .locator('input[type="text"]')
+      .last();
+    await expect(depInput).toHaveValue('przetrwam');
+
+    // Flip the driver away → dependent hides again (value NOT cleared —
+    // asserted server-side below).
+    await input.fill('led');
+    await expect(page.getByText(depCode, { exact: true })).toHaveCount(0);
+
+    const check = await browserApi(page, 'GET', `/api/objects/${productId}`);
+    const indexed = (check.body as { attributesIndexed?: Record<string, { value?: unknown }> })
+      .attributesIndexed;
+    expect(indexed?.[depCode]?.value).toBe('przetrwam');
+  } finally {
+    await page.evaluate(
+      async (args: { productId: string; codes: string[] }) => {
+        const refresh = await fetch('/api/auth/refresh', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { accept: 'application/json' },
+        });
+        const { token } = (await refresh.json()) as { token: string };
+        await fetch(`/api/objects/${args.productId}`, {
+          method: 'PATCH',
+          headers: {
+            authorization: `Bearer ${token}`,
+            'content-type': 'application/merge-patch+json',
+          },
+          body: JSON.stringify({
+            attributes: Object.fromEntries(args.codes.map((c) => [c, null])),
+          }),
+        });
+      },
+      { productId, codes: [driverCode, depCode] },
+    );
+    for (const attrId of attrIds) {
+      await browserApi(page, 'DELETE', `/api/attribute_groups/${groupId}/attributes/${attrId}`);
+      await browserApi(page, 'DELETE', `/api/attributes/${attrId}`);
+    }
+  }
+});

--- a/apps/admin/e2e/dp-08-conditional-visibility.spec.ts
+++ b/apps/admin/e2e/dp-08-conditional-visibility.spec.ts
@@ -174,7 +174,10 @@ test('DP-08 — visible_when hides and reveals a field without losing its value'
       .then(() => true)
       .catch(() => false);
     if (!onDefaultTab && groupLabel !== '') {
-      await page.getByRole('tab', { name: new RegExp(groupLabel, 'i') }).click();
+      // Tab name is label[lang] ?? code — under the EN test locale a
+      // pl-only label falls back to the snake_case CODE, so match both
+      // shapes (`dp08 grp x` / `dp08_grp_x`).
+      await page.getByRole('tab', { name: new RegExp(`dp08[_ ]grp[_ ]${suffix}`, 'i') }).click();
     }
     const driverField = page.getByText(driverCode, { exact: true }).first();
     await expect(driverField).toBeVisible();

--- a/apps/admin/src/components/modeling/visible-when-rule-dialog.tsx
+++ b/apps/admin/src/components/modeling/visible-when-rule-dialog.tsx
@@ -1,0 +1,184 @@
+import { Eye } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { HttpError, httpErrorDetail, jsonFetch } from '@/lib/http';
+
+/**
+ * DP-08 (#2039) — editor for the per-group-member `visible_when` rule
+ * (UI-08.8 #263 substrate; the chip was display-only until now).
+ *
+ * MVP shape `{field, operator: 'equals', value}`; the backend enforces
+ * that the referenced field lives in the SAME group, so the field picker
+ * only offers sibling members. Saving PATCHes the junction
+ * (`/api/attribute_groups/{gid}/attributes/{aid}`), `null` clears.
+ * Callers mount the dialog only while open (fresh state per opening —
+ * ADR-0021 guard counts jsonFetch+useEffect co-occurrence).
+ */
+export function VisibleWhenRuleDialog({
+  groupId,
+  attributeId,
+  attributeCode,
+  siblingCodes,
+  initialRule,
+  onOpenChange,
+  onSaved,
+}: {
+  groupId: string;
+  attributeId: string;
+  attributeCode: string;
+  /** Codes of the OTHER members of this group (valid condition fields). */
+  siblingCodes: string[];
+  initialRule: { field: string; operator: string; value: unknown } | null;
+  onOpenChange: (open: boolean) => void;
+  onSaved: () => Promise<void> | void;
+}) {
+  const { t } = useTranslation();
+  const [field, setField] = useState(initialRule?.field ?? '');
+  const [rawValue, setRawValue] = useState(() => {
+    const value = initialRule?.value;
+    if (value === undefined || value === null) return '';
+    return typeof value === 'string' ? value : JSON.stringify(value);
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const persist = async (
+    visibleWhen: { field: string; operator: string; value: unknown } | null,
+  ) => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      await jsonFetch(`/api/attribute_groups/${groupId}/attributes/${attributeId}`, {
+        method: 'PATCH',
+        contentType: 'application/json',
+        accept: 'application/json',
+        body: { visibleWhen },
+      });
+      onOpenChange(false);
+      await onSaved();
+    } catch (err) {
+      setError(
+        (err instanceof HttpError ? httpErrorDetail(err) : null) ??
+          t('modeling.attributeGroups.rules_save_error', {
+            defaultValue: 'Nie udało się zapisać reguły.',
+          }),
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const save = () => {
+    if (field === '') return;
+    void persist({ field, operator: 'equals', value: parseValue(rawValue) });
+  };
+
+  return (
+    <Dialog open onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[460px] gap-0 p-0">
+        <div className="border-b border-zinc-100 px-6 pb-4 pt-5">
+          <div className="flex items-center gap-2">
+            <Eye className="size-4 text-zinc-500" />
+            <h2 className="text-[15px] font-semibold tracking-tight">
+              {t('modeling.attributeGroups.rules_dialog_title', {
+                defaultValue: 'Widoczność pola „{{code}}"',
+                code: attributeCode,
+              })}
+            </h2>
+          </div>
+          <p className="mt-1 text-[12.5px] text-zinc-500">
+            {t('modeling.attributeGroups.rules_dialog_hint', {
+              defaultValue:
+                'Pole będzie widoczne w formularzu tylko, gdy wskazany atrybut z tej samej grupy ma podaną wartość. Wartości ukrytych pól nie są czyszczone.',
+            })}
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 px-6 py-4">
+          <span className="text-[12.5px] text-zinc-600">
+            {t('modeling.attributeGroups.rules_dialog_when', { defaultValue: 'Widoczne gdy' })}
+          </span>
+          <div>
+            <Label className="sr-only" htmlFor="visible-when-field">
+              {t('modeling.attributeGroups.rules_dialog_field', { defaultValue: 'Atrybut' })}
+            </Label>
+            <select
+              id="visible-when-field"
+              value={field}
+              onChange={(e) => setField(e.target.value)}
+              className="h-9 min-w-[160px] rounded-md border border-input bg-background px-2 font-mono text-sm"
+            >
+              <option value="">
+                {t('modeling.attributeGroups.rules_dialog_pick', { defaultValue: '— wybierz —' })}
+              </option>
+              {siblingCodes.map((code) => (
+                <option key={code} value={code}>
+                  {code}
+                </option>
+              ))}
+            </select>
+          </div>
+          <span className="text-[12.5px] text-zinc-600">
+            {t('modeling.attributeGroups.rules_dialog_equals', { defaultValue: 'równa się' })}
+          </span>
+          <Input
+            aria-label={t('modeling.attributeGroups.rules_dialog_value', {
+              defaultValue: 'Wartość',
+            })}
+            value={rawValue}
+            onChange={(e) => setRawValue(e.target.value)}
+            placeholder="np. true / 5 / zarowka"
+            className="h-9 w-36 font-mono text-sm"
+          />
+        </div>
+
+        {error !== null ? (
+          <p className="mx-6 mb-2 rounded-md border border-destructive/50 bg-destructive/5 px-3 py-2 text-[12.5px] text-destructive">
+            {error}
+          </p>
+        ) : null}
+
+        <div className="flex items-center gap-2 border-t border-zinc-100 px-6 py-4">
+          {initialRule !== null ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={submitting}
+              onClick={() => void persist(null)}
+              className="text-red-600 hover:bg-red-50 hover:text-red-700"
+            >
+              {t('modeling.attributeGroups.rules_dialog_clear', { defaultValue: 'Usuń regułę' })}
+            </Button>
+          ) : null}
+          <div className="ml-auto flex items-center gap-2">
+            <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
+              {t('app.cancel', { defaultValue: 'Anuluj' })}
+            </Button>
+            <Button
+              size="sm"
+              disabled={field === '' || submitting}
+              onClick={save}
+              className="rounded-xl bg-zinc-900 hover:bg-zinc-800"
+            >
+              {t('app.save', { defaultValue: 'Zapisz' })}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** `true`/`false`/numbers regain their JSON types; anything else stays a string. */
+function parseValue(raw: string): unknown {
+  const trimmed = raw.trim();
+  if (trimmed === 'true') return true;
+  if (trimmed === 'false') return false;
+  if (trimmed !== '' && !Number.isNaN(Number(trimmed))) return Number(trimmed);
+  return raw;
+}

--- a/apps/admin/src/features/catalog/attribute-groups/show.tsx
+++ b/apps/admin/src/features/catalog/attribute-groups/show.tsx
@@ -28,6 +28,7 @@ import { BuiltInLockBadge } from '@/components/modeling/built-in-lock-badge';
 import { CreateAttributeInGroupDialog } from '@/components/modeling/create-attribute-in-group-dialog';
 import { DangerZoneCard } from '@/components/modeling/danger-zone-card';
 import { LocaleTabsField } from '@/components/modeling/locale-tabs-field';
+import { VisibleWhenRuleDialog } from '@/components/modeling/visible-when-rule-dialog';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -149,6 +150,8 @@ function Editor({
 
   const [pickerOpen, setPickerOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
+  // DP-08 (#2039) — which member's visible_when rule is being edited.
+  const [ruleTarget, setRuleTarget] = useState<MemberRow | null>(null);
 
   const isSystem = group.systemGroup === true;
   const isLegacyOptionalGroup = isLegacyOptionalSystemGroupCode(group.code);
@@ -557,6 +560,7 @@ function Editor({
                       onDetach={() => {
                         void detach(row.attribute.id);
                       }}
+                      onEditRule={() => setRuleTarget(row)}
                     />
                   ))}
                 </div>
@@ -589,11 +593,8 @@ function Editor({
                     </span>
                     <button
                       type="button"
-                      disabled
-                      title={t('modeling.attributeGroups.rules_edit_action_pending', {
-                        defaultValue: 'Edytor reguły — VIEW-03c',
-                      })}
-                      className="ml-auto inline-flex items-center gap-1 text-[11.5px] text-muted-foreground/60"
+                      onClick={() => setRuleTarget(m)}
+                      className="ml-auto inline-flex items-center gap-1 text-[11.5px] text-muted-foreground hover:text-foreground"
                     >
                       <Eye className="size-3.5" />
                       {t('modeling.attributeGroups.rules_edit_action', {
@@ -721,6 +722,23 @@ function Editor({
         </div>
       ) : null}
 
+      {/* DP-08 (#2039) — mounted only while open (fresh state per opening). */}
+      {ruleTarget !== null ? (
+        <VisibleWhenRuleDialog
+          groupId={group.id}
+          attributeId={ruleTarget.attribute.id}
+          attributeCode={ruleTarget.attribute.code}
+          siblingCodes={sortedMembers
+            .filter((m) => m.attribute.id !== ruleTarget.attribute.id)
+            .map((m) => m.attribute.code)}
+          initialRule={ruleTarget.visible_when}
+          onOpenChange={(open) => {
+            if (!open) setRuleTarget(null);
+          }}
+          onSaved={() => reload()}
+        />
+      ) : null}
+
       <AddAttributesFromLibraryDialog
         open={pickerOpen}
         onOpenChange={setPickerOpen}
@@ -784,11 +802,14 @@ function SortableMemberRow({
   locale,
   onToggleRequired,
   onDetach,
+  onEditRule,
 }: {
   row: MemberRow;
   locale: string;
   onToggleRequired: (next: boolean) => void;
   onDetach: () => void;
+  /** DP-08 (#2039) — opens the visible_when editor for this member. */
+  onEditRule: () => void;
 }) {
   const { t } = useTranslation();
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -827,15 +848,23 @@ function SortableMemberRow({
         {row.attribute.type}
       </span>
       {row.visible_when ? (
-        <span className="inline-flex items-center gap-1.5 rounded-lg bg-orange-50 px-2 py-1 font-mono text-[11px] text-orange-700">
+        <button
+          type="button"
+          onClick={onEditRule}
+          className="inline-flex items-center gap-1.5 rounded-lg bg-orange-50 px-2 py-1 text-left font-mono text-[11px] text-orange-700 transition hover:bg-orange-100"
+        >
           when {row.visible_when.field}={String(row.visible_when.value)}
-        </span>
+        </button>
       ) : (
-        <span className="text-[11px] text-zinc-300">
-          {t('modeling.attributeGroups.members_no_visibility_rule', {
-            defaultValue: 'brak reguły widoczności',
+        <button
+          type="button"
+          onClick={onEditRule}
+          className="text-left text-[11px] text-zinc-300 transition hover:text-zinc-600"
+        >
+          {t('modeling.attributeGroups.members_add_visibility_rule', {
+            defaultValue: '+ reguła widoczności',
           })}
-        </span>
+        </button>
       )}
       <label className="flex items-center gap-1.5 text-[11.5px] text-muted-foreground">
         <input

--- a/apps/admin/src/features/catalog/products/components/product-detail-content.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-content.tsx
@@ -1,6 +1,7 @@
 import { lazy } from 'react';
 
 import { isLegacyOptionalSystemGroupCode } from '@/lib/legacy-attribute-groups';
+import { isVisibleWhen } from '@/lib/visible-when';
 import { AttrGroupCard } from './attr-group-card';
 import { AttrRow } from './attr-row';
 import {
@@ -82,6 +83,13 @@ export function ProductDetailContent({
   onFieldChange,
   onToggleGroup,
 }: ProductDetailContentProps) {
+  // DP-08 (#2039) — conditional visibility: a member whose `visible_when`
+  // rule fails against the CURRENT form values is not rendered. Reactive by
+  // construction (fieldValue reads the live draft), and hidden values are
+  // deliberately NOT cleared — flipping the driver back reveals them intact.
+  const visibleAttributes = (group: GroupMeta) =>
+    group.attributes.filter((attr) => isVisibleWhen(attr.visible_when, fieldValue));
+
   const renderStackedGroup = (group: GroupMeta) => (
     <AttrGroupCard
       key={group.id}
@@ -94,7 +102,7 @@ export function ProductDetailContent({
       onToggle={() => onToggleGroup(group.id)}
       isSystem={isLegacyOptionalSystemGroupCode(group.code)}
     >
-      {group.attributes.map((attr) => (
+      {visibleAttributes(group).map((attr) => (
         <AttrRow
           key={attr.id}
           attribute={attr}

--- a/apps/admin/src/lib/visible-when.test.ts
+++ b/apps/admin/src/lib/visible-when.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { isVisibleWhen, parseVisibleWhen } from './visible-when';
+
+/**
+ * DP-08 (#2039) — 1:1 mirror of the backend VisibleWhenRuleEvaluator
+ * semantics (VisibleWhenRuleTest / UI-08.8 #263): missing field hides,
+ * scalars strict-equal, arrays deep-equal regardless of order, envelope
+ * shapes unwrap, malformed rules are lenient (always visible).
+ */
+describe('visible-when', () => {
+  const values = (map: Record<string, unknown>) => (code: string) => map[code];
+
+  it('no rule or malformed rule → always visible', () => {
+    expect(isVisibleWhen(null, values({}))).toBe(true);
+    expect(isVisibleWhen(undefined, values({}))).toBe(true);
+    expect(isVisibleWhen({ field: '' }, values({}))).toBe(true);
+    expect(isVisibleWhen('garbage', values({}))).toBe(true);
+    expect(parseVisibleWhen({ field: 'a', operator: 'equals' })).toBeNull(); // no value key
+  });
+
+  it('missing or empty driver value hides the field', () => {
+    const rule = { field: 'light_type', operator: 'equals', value: 'bulb' };
+    expect(isVisibleWhen(rule, values({}))).toBe(false);
+    expect(isVisibleWhen(rule, values({ light_type: null }))).toBe(false);
+    expect(isVisibleWhen(rule, values({ light_type: '' }))).toBe(false);
+  });
+
+  it('scalar equals compares strictly', () => {
+    const rule = { field: 'light_type', operator: 'equals', value: 'bulb' };
+    expect(isVisibleWhen(rule, values({ light_type: 'bulb' }))).toBe(true);
+    expect(isVisibleWhen(rule, values({ light_type: 'led' }))).toBe(false);
+
+    const boolRule = { field: 'expandable', operator: 'equals', value: true };
+    expect(isVisibleWhen(boolRule, values({ expandable: true }))).toBe(true);
+    expect(isVisibleWhen(boolRule, values({ expandable: false }))).toBe(false);
+  });
+
+  it('unwraps envelope shapes before comparing', () => {
+    const rule = { field: 'light_type', operator: 'equals', value: 'bulb' };
+    expect(isVisibleWhen(rule, values({ light_type: { value: 'bulb' } }))).toBe(true);
+    expect(isVisibleWhen(rule, values({ light_type: { option_code: 'bulb' } }))).toBe(true);
+
+    const multiRule = { field: 'tags', operator: 'equals', value: ['new', 'sale'] };
+    expect(isVisibleWhen(multiRule, values({ tags: { option_codes: ['sale', 'new'] } }))).toBe(
+      true,
+    );
+  });
+
+  it('arrays deep-equal regardless of order, length-sensitive', () => {
+    const rule = { field: 'tags', operator: 'equals', value: ['a', 'b'] };
+    expect(isVisibleWhen(rule, values({ tags: ['b', 'a'] }))).toBe(true);
+    expect(isVisibleWhen(rule, values({ tags: ['a'] }))).toBe(false);
+    expect(isVisibleWhen(rule, values({ tags: ['a', 'c'] }))).toBe(false);
+  });
+
+  it('unknown operators are lenient (forward-compat, mirrors BE)', () => {
+    const rule = { field: 'light_type', operator: 'not_equals', value: 'bulb' };
+    expect(isVisibleWhen(rule, values({ light_type: 'bulb' }))).toBe(true);
+  });
+});

--- a/apps/admin/src/lib/visible-when.ts
+++ b/apps/admin/src/lib/visible-when.ts
@@ -1,0 +1,68 @@
+/**
+ * DP-08 (#2039) — client-side mirror of the backend
+ * `VisibleWhenRuleEvaluator` (UI-08.8 #263): evaluates the MVP
+ * `{field, operator: 'equals', value}` rule against current form values.
+ *
+ * Semantics kept 1:1 with PHP:
+ *   - missing/empty field value → NOT visible (the dependent attribute
+ *     stays hidden until its driver has a value),
+ *   - scalars compared strictly, arrays deep-equal regardless of order,
+ *   - envelope shapes ({value}|{option_code}|{option_codes}) unwrap to
+ *     their canonical scalar before comparing,
+ *   - unknown operators → visible (forward-compat lenience, same as BE).
+ */
+
+export interface VisibleWhenRule {
+  field: string;
+  operator: string;
+  value: unknown;
+}
+
+export function parseVisibleWhen(raw: unknown): VisibleWhenRule | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const rule = raw as Record<string, unknown>;
+  if (typeof rule.field !== 'string' || rule.field === '') return null;
+  if (typeof rule.operator !== 'string') return null;
+  if (!('value' in rule)) return null;
+  return { field: rule.field, operator: rule.operator, value: rule.value };
+}
+
+/**
+ * @param raw           the junction's `visible_when` payload (or null/undefined)
+ * @param resolveField  reads the CURRENT value of an attribute code (form draft)
+ */
+export function isVisibleWhen(raw: unknown, resolveField: (code: string) => unknown): boolean {
+  const rule = parseVisibleWhen(raw);
+  if (rule === null) return true; // no (or malformed) rule → always visible
+
+  const current = extractScalar(resolveField(rule.field));
+  if (current === undefined || current === null || current === '') return false;
+
+  if (rule.operator === 'equals') {
+    return deepEquals(current, rule.value);
+  }
+
+  // Faza 1+ operators land here; until then unknown operators are lenient.
+  return true;
+}
+
+function extractScalar(payload: unknown): unknown {
+  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+    return payload;
+  }
+  const envelope = payload as Record<string, unknown>;
+  if ('value' in envelope) return envelope.value;
+  if ('option_code' in envelope) return envelope.option_code;
+  if ('option_codes' in envelope) return envelope.option_codes;
+  return payload;
+}
+
+function deepEquals(left: unknown, right: unknown): boolean {
+  if (Array.isArray(left) && Array.isArray(right)) {
+    if (left.length !== right.length) return false;
+    const l = [...left].sort();
+    const r = [...right].sort();
+    return l.every((entry, i) => deepEquals(entry, r[i]));
+  }
+  return left === right;
+}


### PR DESCRIPTION
## Co i dlaczego

`socket_type` widoczne tylko gdy `light_type = żarówka`. **Świadome odejście od treści ticketu** (zaakceptowane w plan mode): zamiast reużywać DSL z DP-07, DP-08 konsumuje **istniejący, kompletny substrat backendu** (UI-08.8 #263) — `AttributeGroupAttribute.visibleWhen` + `VisibleWhenRule` + PATCH junction + `visible_when` w każdym payloadzie formularza. Backend był gotowy od miesięcy; nic go nie konsumowało. Ten PR jest w 100% frontendowy.

## Zakres

- **`lib/visible-when.ts`** — lustro 1:1 backendowego `VisibleWhenRuleEvaluator`: brak wartości drivera → ukryte; skalar strict-equal; tablice deep-equal niezależnie od kolejności; koperty `{value}|{option_code}|{option_codes}` rozpakowywane; nieznane operatory pobłażliwe (forward-compat). **Vitest = macierz lustrzana do suity PHP** (6 testów).
- **Gating w formularzu produktu** (`product-detail-content.tsx`): członkowie grup filtrowani względem ŻYWEGO draftu formularza — pole zależne znika/pojawia się reaktywnie przy zmianie pola sterującego. **Wartości ukrytych pól NIE są czyszczone.**
- **Edytor reguły** (`visible-when-rule-dialog.tsx`): chip `when x=y` i nowa afordancja „+ reguła widoczności" na wierszu członka grupy otwierają dialog „Widoczne gdy [atrybut] równa się [wartość]" + „Usuń regułę"; picker pól ograniczony do członków TEJ SAMEJ grupy (lustro guardu BE); martwy przycisk „Edit rule — VIEW-03c pending" ożywiony.

## Smoke test (żywy stack, pim.localhost)

Playwright E2E (`dp-08-conditional-visibility.spec.ts`), jeden login, pełny flow na realnym produkcie demo: atrybuty driver+dependent dołączone do grupy `idosell_content` → reguła ustawiona przez dialog (chip `when driver=bulb`) → wartość „przetrwam" zapisana na ukrytym polu → formularz: pole ukryte przy pustym driverze → driver=„bulb" → pole **pojawia się z zachowaną wartością** → driver=„led" → znika → **GET potwierdza wartość nietkniętą** → pełny cleanup. Bramki: tsc ✅ biome ✅ vitest 120 ✅ build ✅ guard ADR-0021 „61 at baseline" ✅.

## Świadome odejścia

- Reuse istniejącego `visible_when` zamiast DSL z DP-07 (ADR-0025 świadomie zostawia visibility przy junction; oba mechanizmy dzielą kształt warunku `VisibleWhenRule`, więc rozszerzenia operatorów w Fazie 1 obejmą oba).
- MVP: operator `equals`, pole z tej samej grupy, jeden poziom (bez kaskad) — ograniczenia egzekwuje już backend.
- Grid Excel-like poza zakresem (warunkowość w formularzu detail, per plan).

## Debug-nota

Pierwsza wersja speca fałszywie wskazywała, że gating nie działa — winny był niejednoznaczny locator Playwrighta (`div.filter(has: text).first()` łapie NAJBARDZIEJ ZEWNĘTRZNY kontener → dialog otwierał się dla złego wiersza). Zawężony do kontenera wiersza (grid-cols). Gating działał od początku (potwierdzone izolowaną sondą).

Closes #2039

🤖 Generated with [Claude Code](https://claude.com/claude-code)