### PR TITLE
test(golive): k6 load-test scenarios + seeder 50k (#2124, A4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ docker-compose.override.yml
 
 # Audyt 2026-06 — surowe outputy skanerów (regenerowalne, entropia myli secret-scan)
 docs/audit/2026-06/raw/
+scripts/load/results/

--- a/agent/lessons.md
+++ b/agent/lessons.md
@@ -2891,3 +2891,14 @@ M4 (P4-01..08) + M5 Hardening (P5-01..05) — wszystkie zmergowane. Epik APIC ko
 ### Env quirks (cold-start)
 - `pim.localhost` na macOS: przeglądarka rozwiązuje sama, **Node (`page.request`) nie** — bez `/etc/hosts` 80/122 speców E2E pada na `ENOTFOUND` (#2182). CI ma wpis, dlatego zielone.
 - Świeży klon wymaga: `JWT_PASSPHRASE` w `apps/api/.env.local` + `lexik:jwt:generate-keypair` (#2176) — bez tego login 500.
+
+## Lessons z GOLIVE #2124 (2026-07-04, k6 load prep + seed 50k)
+
+### Patterns to Follow
+- **Seeder kanoniczny, projekcje realnym pathem.** `pim:load:seed` pisze WYŁĄCZNIE `object_values` (envelope `{value}`), a `attributes_indexed` + Meili buduje się osobno przez `pim:catalog:detect-attributes-drift --reconcile` + `pim:search:reindex`. Zero drugiego kompozytora slotu (lekcja z drift-detektora) i darmowy re-użytek jako ćwiczenie fresh-install rebuild (#2125). Zmierzone: 300 prod × 200 atrybutów = 10082 wierszy wartości, peak 58 MiB.
+- **Komendy CLI utrzymaniowe = owner connection.** Konsola łączy się jako `pim_app` (FORCE RLS, brak request-scoped GUC) i widzi 0 wierszy → seed/reconcile/reindex owijać `DATABASE_URL="$DATABASE_URL_OWNER"` (jak entrypoint `pim:dev:ensure-seeded`). Bez tego `pim:load:seed` twierdził „Built-in product ObjectType missing".
+
+### Patterns to Avoid
+- **`K6_VUS`/`K6_DURATION` to NATYWNE opcje k6** — dla skryptu z własnym blokiem `scenarios`/`iterations` (feed-pull, auth-login, import-start) k6 NADPISUJE definicję i leci z natywną skalą. Feed-pull dostał 13k req/min i wysycił limiter 120/h. Wzorzec: rate-limited smoki pinują kształt w skrypcie, orkiestrator NIE przekazuje im native-override (case per scenariusz w wrapperze); własne progi env nazywać BEZ prefiksu `K6_`.
+- **`set -u` + pusta tablica bash** (`ARR=(); "${ARR[@]}"`) = „unbound variable" na bash < 4.4 (macOS) — nieszkodliwy placeholder element zamiast pustej tablicy.
+- **Limiter `feed_pull` siedzi w puli filesystem `cache.rate_limiter`, nie w Redis** — restart api/redis go NIE czyści; reset przez `cache:pool:clear cache.rate_limiter`. (Redis DBSIZE=0 mimo aktywnego limitera to nie bug — to inny backend.)

--- a/apps/api/src/Benchmark/LoadTestSeedCommand.php
+++ b/apps/api/src/Benchmark/LoadTestSeedCommand.php
@@ -1,0 +1,342 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Benchmark;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Provenance;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Repository\DoctrineTenantRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Load-test catalog seeder (GOLIVE A4, #2124).
+ *
+ * Seeds the MVP-scale dataset the load session in Blok B measures against:
+ * N products x M schema attributes x L locales, written as CANONICAL
+ * `object_values` rows (envelope `{value: ...}` per docs/api/jsonb-schemas.md).
+ * The denormalised projection and the search index are deliberately NOT
+ * written here — build them with the real production paths afterwards:
+ *
+ *   bin/console pim:catalog:detect-attributes-drift --reconcile --tenant=<code>
+ *   bin/console pim:search:reindex
+ *
+ * That split keeps the seeder honest (no second projection composer — see
+ * lessons on the drift detector) and doubles as the fresh-install rebuild
+ * exercise (#2125).
+ *
+ * Unlike {@see BulkImportBenchmarkCommand} (identity-map memory gate), this
+ * command optimises for realistic data shape: attributes are attached to the
+ * built-in product ObjectType, ~1/3 are localizable (one value row per
+ * locale), types rotate text/number/boolean. Batching mirrors the
+ * AbstractBatchHandler contract: flush() + clear() every --batch-size
+ * products, then re-find the tenant + type so listeners see managed
+ * instances.
+ *
+ * Attribute codes (`load_attr_NNNN`) are deterministic and reused across
+ * runs; product SKUs get a random per-run prefix so parallel/repeated seeds
+ * never collide and `--purge` can clean up exactly what load runs created.
+ */
+#[AsCommand(
+    name: 'pim:load:seed',
+    description: 'Seed N products x M attributes x L locales with canonical object_values for the load-test session (#2124).',
+)]
+final class LoadTestSeedCommand extends Command
+{
+    private const string ATTRIBUTE_CODE_FORMAT = 'load_attr_%04d';
+    private const string SKU_PREFIX_FORMAT = 'load-%s-';
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly DoctrineTenantRepository $tenantRepository,
+        private readonly ObjectTypeRepositoryInterface $objectTypeRepository,
+        private readonly TenantContext $tenantContext,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('products', 'p', InputOption::VALUE_REQUIRED, 'Number of products to insert', '50000')
+            ->addOption('attributes', 'a', InputOption::VALUE_REQUIRED, 'Number of schema attributes to ensure', '200')
+            ->addOption('locales', 'l', InputOption::VALUE_REQUIRED, 'Comma-separated locales for localizable values', 'pl,en,de')
+            ->addOption('values-per-product', null, InputOption::VALUE_REQUIRED, 'Distinct attributes filled per product (localizable ones fan out per locale)', '24')
+            ->addOption('batch-size', 'b', InputOption::VALUE_REQUIRED, 'Products per flush + clear cycle', '100')
+            ->addOption('tenant', 't', InputOption::VALUE_REQUIRED, 'Tenant code to seed into', 'demo')
+            ->addOption('purge', null, InputOption::VALUE_NONE, 'Delete products from previous load seeds (code LIKE "load-%") instead of seeding');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $products = (int) $input->getOption('products');
+        $attributeCount = (int) $input->getOption('attributes');
+        $valuesPerProduct = (int) $input->getOption('values-per-product');
+        $batchSize = (int) $input->getOption('batch-size');
+        /** @var string $tenantCode */
+        $tenantCode = $input->getOption('tenant');
+        /** @var string $localesRaw */
+        $localesRaw = $input->getOption('locales');
+        $locales = \array_values(\array_filter(
+            \array_map(trim(...), \explode(',', $localesRaw)),
+            static fn (string $locale): bool => '' !== $locale,
+        ));
+
+        if ($products < 1 || $attributeCount < 1 || $batchSize < 1 || [] === $locales) {
+            $io->error('--products, --attributes, --batch-size must be >= 1 and --locales non-empty.');
+
+            return Command::INVALID;
+        }
+        if ($valuesPerProduct < 1 || $valuesPerProduct > $attributeCount) {
+            $io->error('--values-per-product must be between 1 and --attributes.');
+
+            return Command::INVALID;
+        }
+
+        $tenant = $this->tenantRepository->findOneBy(['code' => $tenantCode]);
+        if (!$tenant instanceof Tenant) {
+            $io->error(\sprintf('Tenant "%s" not found. Run `doctrine:fixtures:load` first.', $tenantCode));
+
+            return Command::FAILURE;
+        }
+        $tenantId = $tenant->getId()->toRfc4122();
+        $this->tenantContext->set($tenant);
+
+        if (true === $input->getOption('purge')) {
+            return $this->purge($io, $tenantId);
+        }
+
+        $productType = $this->objectTypeRepository->findBuiltInByKind(ObjectKind::Product, $tenant);
+        if (!$productType instanceof ObjectType) {
+            $io->error(\sprintf('Built-in product ObjectType missing for tenant "%s".', $tenantCode));
+
+            return Command::FAILURE;
+        }
+        $productTypeId = $productType->getId()->toRfc4122();
+
+        $attributeIds = $this->ensureAttributes($io, $productType, $attributeCount, $locales);
+
+        // Re-anchor after ensureAttributes() cleared the unit of work.
+        $this->rebind($tenantId);
+        $productType = $this->entityManager->find(ObjectType::class, $productTypeId);
+        \assert($productType instanceof ObjectType);
+
+        $skuPrefix = \sprintf(self::SKU_PREFIX_FORMAT, \dechex(\random_int(0x100000, 0xFFFFFF)));
+        $io->section(\sprintf(
+            'Seeding %d products (values/product=%d, locales=%s, batch=%d) for tenant "%s", SKU prefix "%s"',
+            $products,
+            $valuesPerProduct,
+            \implode(',', $locales),
+            $batchSize,
+            $tenantCode,
+            $skuPrefix,
+        ));
+
+        $startedAt = \microtime(true);
+        $valueRows = 0;
+        $attributeTotal = \count($attributeIds);
+        $progress = $io->createProgressBar($products);
+
+        for ($i = 1; $i <= $products; ++$i) {
+            $sku = \sprintf('%s%06d', $skuPrefix, $i);
+            $object = new CatalogObject($productType, $sku);
+            $object->transitionTo(CatalogObject::STATUS_PUBLISHED);
+            $this->entityManager->persist($object);
+
+            // Deterministic, evenly-rotating attribute window per product so
+            // every attribute ends up with a comparable value population.
+            $offset = ($i * 7) % $attributeTotal;
+            for ($k = 0; $k < $valuesPerProduct; ++$k) {
+                $attributeId = $attributeIds[($offset + $k) % $attributeTotal];
+                $attribute = $this->entityManager->find(Attribute::class, $attributeId);
+                \assert($attribute instanceof Attribute);
+
+                foreach ($this->valueRowsFor($attribute, $i, $locales) as [$envelope, $locale]) {
+                    $this->entityManager->persist(new ObjectValue(
+                        $object,
+                        $attribute,
+                        $envelope,
+                        Provenance::Import,
+                        null,
+                        $locale,
+                    ));
+                    ++$valueRows;
+                }
+            }
+
+            if (0 === $i % $batchSize) {
+                $this->entityManager->flush();
+                $this->entityManager->clear();
+                $this->rebind($tenantId);
+                $productType = $this->entityManager->find(ObjectType::class, $productTypeId);
+                \assert($productType instanceof ObjectType);
+                $progress->advance($batchSize);
+            }
+        }
+
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+        $progress->finish();
+        $io->newLine(2);
+
+        $duration = \microtime(true) - $startedAt;
+        $peak = \memory_get_peak_usage(true);
+        $io->table(
+            ['Metric', 'Value'],
+            [
+                ['products', (string) $products],
+                ['schema_attributes', (string) $attributeTotal],
+                ['object_value_rows', (string) $valueRows],
+                ['duration_seconds', \sprintf('%.1f', $duration)],
+                ['products_per_second', \sprintf('%.1f', $products / \max($duration, 0.001))],
+                ['peak_memory_mib', \sprintf('%.1f', $peak / 1024 / 1024)],
+                ['sku_prefix', $skuPrefix],
+            ],
+        );
+
+        $io->note([
+            'Canonical values only — build the projections with the real paths:',
+            \sprintf('bin/console pim:catalog:detect-attributes-drift --reconcile --tenant=%s', $tenantCode),
+            'bin/console pim:search:reindex',
+        ]);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Ensures `load_attr_NNNN` attributes exist and are attached to the
+     * product ObjectType. Deterministic codes make re-runs idempotent; the
+     * type/localizable mix rotates so 1 in 3 attributes fans out per locale.
+     *
+     * @param list<string> $locales
+     *
+     * @return list<string> attribute ids (RFC 4122), ordered by code
+     */
+    private function ensureAttributes(SymfonyStyle $io, ObjectType $productType, int $count, array $locales): array
+    {
+        $existing = $this->entityManager->createQuery(
+            'SELECT a.code AS code, a.id AS id FROM '.Attribute::class." a WHERE a.code LIKE 'load_attr_%'",
+        )->getArrayResult();
+        /** @var array<string, string> $byCode */
+        $byCode = [];
+        foreach ($existing as $row) {
+            \assert(\is_array($row) && \is_string($row['code']));
+            $id = $row['id'];
+            \assert($id instanceof Uuid || \is_string($id));
+            $byCode[$row['code']] = $id instanceof Uuid ? $id->toRfc4122() : $id;
+        }
+
+        $attached = $this->entityManager->createQuery(
+            'SELECT a.code FROM '.ObjectTypeAttribute::class.' j JOIN j.attribute a WHERE j.objectType = :type',
+        )->setParameter('type', $productType)->getSingleColumnResult();
+        $attachedCodes = [];
+        foreach ($attached as $attachedCode) {
+            \assert(\is_string($attachedCode));
+            $attachedCodes[$attachedCode] = true;
+        }
+
+        $created = 0;
+        $ids = [];
+        for ($n = 1; $n <= $count; ++$n) {
+            $code = \sprintf(self::ATTRIBUTE_CODE_FORMAT, $n);
+            if (isset($byCode[$code])) {
+                if (!isset($attachedCodes[$code])) {
+                    $reused = $this->entityManager->find(Attribute::class, $byCode[$code]);
+                    \assert($reused instanceof Attribute);
+                    $this->entityManager->persist(new ObjectTypeAttribute($productType, $reused, false, 1000 + $n));
+                }
+                $ids[] = $byCode[$code];
+                continue;
+            }
+
+            $type = match ($n % 5) {
+                0 => AttributeType::Number,
+                4 => AttributeType::Boolean,
+                default => AttributeType::Text,
+            };
+            $attribute = new Attribute($code, ['pl' => 'Atrybut load '.$n, 'en' => 'Load attribute '.$n], $type);
+            if (0 === $n % 3 && AttributeType::Text === $type) {
+                $attribute->changeLocalizable(true);
+            }
+            $this->entityManager->persist($attribute);
+            if (!isset($attachedCodes[$code])) {
+                $this->entityManager->persist(new ObjectTypeAttribute($productType, $attribute, false, 1000 + $n));
+            }
+            $ids[] = $attribute->getId()->toRfc4122();
+            ++$created;
+        }
+
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $io->writeln(\sprintf('Schema: %d load attributes ensured (%d created, %d reused), locales: %s.', $count, $created, $count - $created, \implode(',', $locales)));
+
+        return $ids;
+    }
+
+    /**
+     * @param list<string> $locales
+     *
+     * @return list<array{0: array<string, mixed>, 1: ?string}> envelope + locale pairs
+     */
+    private function valueRowsFor(Attribute $attribute, int $productIndex, array $locales): array
+    {
+        $code = $attribute->getCode();
+        $scalar = match ($attribute->getType()) {
+            AttributeType::Number => ($productIndex % 997) + 0.5,
+            AttributeType::Boolean => 0 === $productIndex % 2,
+            default => \sprintf('Value %s #%06d', $code, $productIndex),
+        };
+
+        if (!$attribute->isLocalizable()) {
+            return [[['value' => $scalar], null]];
+        }
+
+        $rows = [];
+        foreach ($locales as $locale) {
+            $rows[] = [['value' => \sprintf('%s [%s]', \is_string($scalar) ? $scalar : (string) $productIndex, $locale)], $locale];
+        }
+
+        return $rows;
+    }
+
+    private function rebind(string $tenantId): void
+    {
+        $tenant = $this->tenantRepository->find($tenantId);
+        \assert($tenant instanceof Tenant);
+        $this->tenantContext->set($tenant);
+    }
+
+    private function purge(SymfonyStyle $io, string $tenantId): int
+    {
+        // tenant-safe: infrastructure (admin-only load-test CLI). Scoped to
+        // the resolved tenant id AND the load-test SKU prefix; object_values
+        // cascade via the object_values_object_fk ON DELETE CASCADE.
+        $deleted = (int) $this->entityManager->getConnection()->executeStatement(
+            "DELETE FROM objects WHERE kind = 'product' AND code LIKE 'load-%' AND tenant_id = :tenant",
+            ['tenant' => $tenantId],
+        );
+        $io->success(\sprintf('Purged %d load-test products (canonical values cascade).', $deleted));
+        $io->note('Schema attributes load_attr_* are kept for reuse. Run pim:search:reindex to drop their documents.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -492,6 +492,8 @@ services:
     network_mode: "service:caddy"
     volumes:
       - ./tools/perf:/scripts:ro
+      # GOLIVE #2124 — load-session scenarios + writable summary exports.
+      - ./scripts/load:/load
     entrypoint: ["k6"]
 
   # ─── Mailpit (dev mail catcher) ───────────────────────────────────────────

--- a/scripts/load/README.md
+++ b/scripts/load/README.md
@@ -1,0 +1,70 @@
+# Load testing (GOLIVE A4, #2124)
+
+Przygotowanie do jednorazowej sesji load z Bloku B (#2128): skrypty k6 + seed 50k SKU.
+Gate z planu testów: **p95 < 300 ms per endpoint** przy 50k SKU (lokalnie = proxy;
+bezwzględny wynik potwierdzamy na prod-podobnym sprzęcie).
+
+## Wymagania
+
+- Działający stack (`pnpm stack:up`), świeży token nie jest potrzebny — orkiestrator mintuje sam.
+- Serwis `k6` w composie (profil `perf`, nie startuje z `stack:up`); skrypty montowane jako `/load`.
+
+## Seed 50k (jednorazowo przed sesją)
+
+```bash
+scripts/load/run-load-session.sh --seed 50000
+```
+
+Robi po kolei: `pim:load:seed` (50k produktów × 200 atrybutów schematu × wartości
+w 3 locale, **kanoniczne `object_values`**, provenance=import, SKU `load-<hex>-NNNNNN`)
+→ `pim:catalog:detect-attributes-drift --reconcile` (projekcja `attributes_indexed`
+realnym rebuilerem) → `pim:search:reindex` (Meili). Seed 50k trwa kilkanaście–kilkadziesiąt
+minut; parametry (`--products`, `--attributes`, `--locales`, `--values-per-product`)
+— patrz `bin/console pim:load:seed --help`. Sprzątanie: `pim:load:seed --purge`.
+
+> Seed pisze do bazy dev tenanta `demo`. Przed sesją na danych operatora zrób
+> backup (`pnpm backup:run`) — patrz OSTRZEŻENIE o `pim:db:reset` w README.
+
+## Scenariusze
+
+| Skrypt | Endpoint | Charakter |
+|---|---|---|
+| `products-list.k6.js` | `GET /api/products` (keyset walk) | load |
+| `search-products.k6.js` | `GET /api/search/products?q=` | load (Meili) |
+| `export-preflight.k6.js` | `POST /api/exports/preflight` (scope=all) | load (COUNT 50k + RBAC) |
+| `bulk-preview.k6.js` | `POST /api/products/bulk-actions/preview` | load (diff bez mutacji) |
+| `mixed-endurance.k6.js` | mix 55/30/10/5 powyższych | endurance 2–4h (B2/B7) |
+| `feed-pull.k6.js` | publiczny URL feedu XML | capped (limiter 120/h/feed) |
+| `auth-login.k6.js` | `POST /api/auth/login` | smoke ×4 (limiter 5/IP/15min) |
+| `import-start.k6.js` | `POST /api/import-sessions` (3-wierszowy CSV) | smoke ×1 (limiter 20/h/tenant) |
+
+Świadome decyzje: apply bulk-edita, pełny eksport i duży import **nie są** młócone
+k6 (mutują dane / MinIO / kolejkę) — B2 mierzy je pojedynczym realnym przebiegiem,
+a k6 w tym czasie utrzymuje tło `mixed-endurance`. Login/import/feed są ograniczone
+limiterami — scenariusze celowo asertują brak 429 zamiast go wywoływać.
+
+## Uruchomienie
+
+```bash
+# domyślny zestaw read-heavy (list, search, preflight, bulk-preview)
+scripts/load/run-load-session.sh
+
+# pojedynczy scenariusz, własna skala
+scripts/load/run-load-session.sh --scenario products-list --vus 50 --duration 120s
+
+# endurance (obserwuj frankenphp_worker_memory_bytes w Prometheusie)
+scripts/load/run-load-session.sh --scenario mixed-endurance --vus 10 --duration 3h
+
+# feed pull (URL z ekranu szczegółów feedu)
+FEED_PULL_URL='https://pim.localhost/api/feeds/pull/<tenant>/<token>.xml' \
+  scripts/load/run-load-session.sh --scenario feed-pull
+```
+
+Wyniki (`--summary-export`) lądują w `scripts/load/results/*.json` (gitignore).
+Raport sesji B2 → `docs/perf/` (wzór: `docs/perf/sync-engine-benchmark.md`).
+
+## Znane pułapki
+
+- Po serii loginów/refreshy limiter potrafi blokować kolejne minty: `docker compose restart redis`.
+- `mixed-endurance` z dev-profilerem kłamie o pamięci — worker w dev jest pinowany do `APP_DEBUG=0`, ale komendy seed odpalaj z `APP_ENV=prod APP_DEBUG=0` (jak orkiestrator).
+- k6 działa w sieci Caddy (`network_mode: service:caddy`) — `https://pim.localhost` z self-signed certem, stąd `insecureSkipTLSVerify`.

--- a/scripts/load/auth-login.k6.js
+++ b/scripts/load/auth-login.k6.js
@@ -1,0 +1,38 @@
+// GOLIVE #2124 — login smoke under the auth_login limiter.
+//
+// The limiter is 5 attempts / IP / 15 min (fixed window) — a login "load
+// test" is therefore a SMOKE by design: 4 sequential iterations, asserting
+// 200 + token and that the limiter never fires. Hammering this endpoint
+// harder only measures the 429 path. K6_LOGIN_EMAIL/PASSWORD default to the
+// dev fixtures admin.
+
+import { check, sleep } from 'k6';
+import http from 'k6/http';
+import { baseUrl, hosts } from './lib.js';
+
+export const options = {
+  insecureSkipTLSVerify: true,
+  hosts,
+  vus: 1,
+  iterations: parseInt(__ENV.K6_LOGIN_ITERATIONS || '4', 10),
+  thresholds: {
+    http_req_duration: [`p(95)<${parseInt(__ENV.K6_P95_MS || '300', 10)}`],
+    checks: ['rate==1.0'],
+  },
+};
+
+const body = JSON.stringify({
+  email: __ENV.K6_LOGIN_EMAIL || 'admin@demo.localhost',
+  password: __ENV.K6_LOGIN_PASSWORD || 'changeme',
+});
+
+export default function () {
+  const res = http.post(`${baseUrl}/api/auth/login`, body, {
+    headers: { 'Content-Type': 'application/json' },
+  });
+  check(res, {
+    'status is 200 (limiter not hit)': (r) => r.status === 200,
+    'body has token': (r) => typeof r.body === 'string' && r.body.includes('"token"'),
+  });
+  sleep(1);
+}

--- a/scripts/load/bulk-preview.k6.js
+++ b/scripts/load/bulk-preview.k6.js
@@ -1,0 +1,47 @@
+// GOLIVE #2124 — bulk-edit preview under load.
+//
+// POST /api/products/bulk-actions/preview computes a non-mutating diff for a
+// sample of the selection — the hot read path behind the "edycja masowa"
+// modal. setup() grabs real object ids once; each iteration previews a
+// set_attribute over them. The APPLY path is deliberately not hammered here
+// (it mutates data and dispatches Messenger jobs) — B2 measures a single
+// real apply separately.
+
+import { check, group } from 'k6';
+import http from 'k6/http';
+import { baseUrl, bearerHeaders, defaultOptions } from './lib.js';
+
+export const options = defaultOptions();
+
+const headers = bearerHeaders({ 'Content-Type': 'application/json' });
+
+export function setup() {
+  const res = http.get(`${baseUrl}/api/products`, {
+    headers: bearerHeaders(),
+    // setup() runs outside the default TLS option context in some k6
+    // versions — repeat the insecure flag per request to be safe.
+    insecureSkipTLSVerify: true,
+  });
+  const doc = JSON.parse(res.body);
+  const members = doc['hydra:member'] || doc.member || [];
+  const ids = members.map((m) => (m['@id'] || '').split('/').pop()).filter(Boolean);
+  if (!ids.length) {
+    throw new Error('No products found — run pim:load:seed first.');
+  }
+  return { ids };
+}
+
+export default function (data) {
+  group('POST /api/products/bulk-actions/preview', () => {
+    const body = JSON.stringify({
+      action: 'set_attribute',
+      target_ids: data.ids,
+      payload: { attr: 'load_attr_0001', value: 'k6 preview probe' },
+    });
+    const res = http.post(`${baseUrl}/api/products/bulk-actions/preview`, body, { headers });
+    check(res, {
+      'status is 200': (r) => r.status === 200,
+      'has sample diff': (r) => typeof r.body === 'string' && r.body.includes('sample'),
+    });
+  });
+}

--- a/scripts/load/export-preflight.k6.js
+++ b/scripts/load/export-preflight.k6.js
@@ -1,0 +1,29 @@
+// GOLIVE #2124 — export preflight (row count + sync/async routing) under load.
+//
+// POST /api/exports/preflight with target_scope=all is the cheapest
+// representative slice of the export path: it authorises (RBAC exports:run),
+// resolves the entity type and COUNTs the 50k-row scope. Full export runs
+// mutate MinIO and the export tables — B2 triggers those once, manually.
+
+import { check, group } from 'k6';
+import http from 'k6/http';
+import { baseUrl, bearerHeaders, defaultOptions } from './lib.js';
+
+export const options = defaultOptions();
+
+const headers = bearerHeaders({ 'Content-Type': 'application/json' });
+const body = JSON.stringify({
+  entity_type: __ENV.K6_EXPORT_ENTITY || 'product',
+  target_scope: 'all',
+});
+
+export default function () {
+  group('POST /api/exports/preflight', () => {
+    const res = http.post(`${baseUrl}/api/exports/preflight`, body, { headers });
+    check(res, {
+      'status is 200': (r) => r.status === 200,
+      'returns count + mode': (r) =>
+        typeof r.body === 'string' && r.body.includes('"count"') && r.body.includes('"mode"'),
+    });
+  });
+}

--- a/scripts/load/feed-pull.k6.js
+++ b/scripts/load/feed-pull.k6.js
@@ -1,0 +1,45 @@
+// GOLIVE #2124 — public XML feed pull (token URL, no session).
+//
+// GET /api/feeds/pull/{tenantId}/{token}.xml serves the cached artifact via
+// StreamedResponse. The endpoint is rate-limited 120/h per feed
+// (framework.yaml `feed_pull`), so this scenario is CAPPED by design:
+// constant-arrival-rate well under the limiter, asserting 200s and that the
+// limiter is NOT hit. Pass the full public URL via FEED_PULL_URL (copy it
+// from the feed detail screen).
+
+import { check } from 'k6';
+import http from 'k6/http';
+
+const url = __ENV.FEED_PULL_URL;
+if (!url) {
+  throw new Error('FEED_PULL_URL env var is required (public feed URL with token).');
+}
+
+// NOTE: env vars here deliberately avoid the K6_ prefix — k6 treats K6_VUS /
+// K6_DURATION as native CLI-option overrides which would REPLACE the
+// scenarios block below and hammer the limiter (observed: 13k reqs/min).
+export const options = {
+  insecureSkipTLSVerify: true,
+  hosts: { 'pim.localhost': __ENV.K6_TARGET_IP || '127.0.0.1' },
+  scenarios: {
+    capped_pulls: {
+      executor: 'constant-arrival-rate',
+      rate: parseInt(__ENV.FEED_RATE_PER_MINUTE || '1', 10),
+      timeUnit: '1m',
+      duration: __ENV.FEED_PULL_DURATION || '5m',
+      preAllocatedVUs: 2,
+    },
+  },
+  thresholds: {
+    http_req_duration: [`p(95)<${parseInt(__ENV.LOAD_P95_MS || '300', 10)}`],
+    http_req_failed: ['rate<0.01'],
+  },
+};
+
+export default function () {
+  const res = http.get(url);
+  check(res, {
+    'status is 200 (not 429 — stay under feed_pull limiter)': (r) => r.status === 200,
+    'XML payload': (r) => typeof r.body === 'string' && r.body.startsWith('<?xml'),
+  });
+}

--- a/scripts/load/import-start.k6.js
+++ b/scripts/load/import-start.k6.js
@@ -1,0 +1,43 @@
+// GOLIVE #2124 — import start smoke (rate-limited path).
+//
+// POST /api/import-sessions is limited to 20/h per tenant (import_trigger),
+// so this is a SMOKE: a single multipart import of a 3-row CSV (<50 rows =
+// inline sync path), asserting 200/201 and a session id. Big-file import
+// timing is measured once, manually, in the B2 session — not via k6.
+//
+// Requires TARGET_OBJECT_TYPE_ID (built-in product ObjectType UUID); the
+// run-load-session.sh wrapper resolves it automatically.
+
+import { check } from 'k6';
+import http from 'k6/http';
+import { baseUrl, bearerHeaders, hosts } from './lib.js';
+
+const targetTypeId = __ENV.TARGET_OBJECT_TYPE_ID;
+if (!targetTypeId) {
+  throw new Error('TARGET_OBJECT_TYPE_ID env var is required (product ObjectType UUID).');
+}
+
+export const options = {
+  insecureSkipTLSVerify: true,
+  hosts,
+  vus: 1,
+  iterations: 1,
+  thresholds: { checks: ['rate==1.0'] },
+};
+
+const csv =
+  'sku,name\nk6-smoke-001,K6 smoke product 1\nk6-smoke-002,K6 smoke product 2\nk6-smoke-003,K6 smoke product 3\n';
+
+export default function () {
+  const payload = {
+    file: http.file(csv, 'k6-smoke.csv', 'text/csv'),
+    target_object_type_id: targetTypeId,
+    mapping: JSON.stringify({ sku: 'sku', name: 'name' }),
+    mode: 'upsert',
+  };
+  const res = http.post(`${baseUrl}/api/import-sessions`, payload, { headers: bearerHeaders() });
+  check(res, {
+    'status is 200/201/202': (r) => [200, 201, 202].includes(r.status),
+    'session id returned': (r) => typeof r.body === 'string' && r.body.includes('id'),
+  });
+}

--- a/scripts/load/lib.js
+++ b/scripts/load/lib.js
@@ -1,0 +1,44 @@
+// Shared helpers for the GOLIVE load-test scenarios (#2124).
+//
+// Every scenario reads the same env contract:
+//   API_TOKEN    — JWT bearer minted via POST /api/auth/login (required unless the scenario says otherwise)
+//   K6_BASE_URL  — defaults to https://pim.localhost
+//   K6_VUS / K6_DURATION — scenario size (each script has its own defaults)
+//   K6_P95_MS    — latency gate, defaults to 300 (GOLIVE plan: p95 < 300 ms per endpoint)
+
+export const baseUrl = __ENV.K6_BASE_URL || 'https://pim.localhost';
+
+// k6 shares the caddy container's network namespace (network_mode:
+// service:caddy) but keeps its OWN /etc/hosts, and Docker's embedded DNS
+// only resolves service names — pim.localhost must be pinned to the
+// loopback where caddy listens. Override with K6_TARGET_IP when pointing
+// at a remote (prod-like) host.
+export const hosts = { 'pim.localhost': __ENV.K6_TARGET_IP || '127.0.0.1' };
+
+export function bearerHeaders(extra = {}) {
+  const token = __ENV.API_TOKEN;
+  if (!token) {
+    throw new Error('API_TOKEN env var is required (mint via POST /api/auth/login).');
+  }
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/ld+json',
+    ...extra,
+  };
+}
+
+export function defaultOptions(overrides = {}) {
+  const p95 = parseInt(__ENV.K6_P95_MS || '300', 10);
+  return {
+    // Self-signed Caddy local CA cert — accepted inside the perf profile only.
+    insecureSkipTLSVerify: true,
+    hosts,
+    vus: parseInt(__ENV.K6_VUS || '20', 10),
+    duration: __ENV.K6_DURATION || '60s',
+    thresholds: {
+      http_req_duration: [`p(95)<${p95}`, `p(99)<${p95 * 2}`],
+      http_req_failed: ['rate<0.01'],
+    },
+    ...overrides,
+  };
+}

--- a/scripts/load/mixed-endurance.k6.js
+++ b/scripts/load/mixed-endurance.k6.js
@@ -1,0 +1,56 @@
+// GOLIVE #2124 — mixed-traffic endurance run (B2: 2-4h, worker-memory watch).
+//
+// Weighted read-mostly mix approximating admin + integrator traffic:
+//   55% product list (keyset walk)  ·  30% Meili search
+//   10% export preflight            ·   5% bulk preview
+// Run for hours while watching `frankenphp_worker_memory_bytes` — the
+// Identity-Map leak class only shows up on long mixed runs, not on
+// single-endpoint bursts.
+
+import { check } from 'k6';
+import http from 'k6/http';
+import { baseUrl, bearerHeaders, defaultOptions } from './lib.js';
+
+export const options = defaultOptions({
+  vus: parseInt(__ENV.K6_VUS || '10', 10),
+  duration: __ENV.K6_DURATION || '2h',
+});
+
+const headers = bearerHeaders();
+const jsonHeaders = bearerHeaders({ 'Content-Type': 'application/json' });
+const terms = ['value', 'load', 'product', '0042'];
+
+export function setup() {
+  const res = http.get(`${baseUrl}/api/products`, { headers });
+  const doc = JSON.parse(res.body);
+  const members = doc['hydra:member'] || doc.member || [];
+  return { ids: members.map((m) => (m['@id'] || '').split('/').pop()).filter(Boolean) };
+}
+
+export default function (data) {
+  const dice = Math.random();
+  let res;
+  if (dice < 0.55) {
+    res = http.get(`${baseUrl}/api/products?order[id]=desc`, { headers });
+  } else if (dice < 0.85) {
+    const term = terms[Math.floor(Math.random() * terms.length)];
+    res = http.get(`${baseUrl}/api/search/products?q=${term}`, { headers });
+  } else if (dice < 0.95) {
+    res = http.post(
+      `${baseUrl}/api/exports/preflight`,
+      JSON.stringify({ entity_type: 'product', target_scope: 'all' }),
+      { headers: jsonHeaders },
+    );
+  } else {
+    res = http.post(
+      `${baseUrl}/api/products/bulk-actions/preview`,
+      JSON.stringify({
+        action: 'set_attribute',
+        target_ids: data.ids,
+        payload: { attr: 'load_attr_0001', value: 'endurance probe' },
+      }),
+      { headers: jsonHeaders },
+    );
+  }
+  check(res, { 'status is 200': (r) => r.status === 200 });
+}

--- a/scripts/load/products-list.k6.js
+++ b/scripts/load/products-list.k6.js
@@ -1,0 +1,44 @@
+// GOLIVE #2124 — cursor-paginated product list under load.
+//
+// Each iteration walks K6_PAGES pages (default 3) of GET /api/products using
+// keyset pagination (`id[lt]=<last id>`), the way the admin grid and API
+// integrators read the catalog at 50k SKU.
+
+import { check, group } from 'k6';
+import http from 'k6/http';
+import { baseUrl, bearerHeaders, defaultOptions } from './lib.js';
+
+export const options = defaultOptions();
+
+const headers = bearerHeaders();
+const pages = parseInt(__ENV.K6_PAGES || '3', 10);
+
+function lastMemberId(body) {
+  try {
+    const doc = JSON.parse(body);
+    const members = doc['hydra:member'] || doc.member || [];
+    if (!members.length) return null;
+    const iri = members[members.length - 1]['@id'] || '';
+    return iri.split('/').pop() || null;
+  } catch {
+    return null;
+  }
+}
+
+export default function () {
+  group('GET /api/products keyset walk', () => {
+    let cursor = null;
+    for (let p = 0; p < pages; p++) {
+      const url = cursor
+        ? `${baseUrl}/api/products?order[id]=desc&id[lt]=${cursor}`
+        : `${baseUrl}/api/products?order[id]=desc`;
+      const res = http.get(url, { headers });
+      check(res, {
+        'status is 200': (r) => r.status === 200,
+        'JSON-LD collection': (r) => typeof r.body === 'string' && r.body.includes('"@type"'),
+      });
+      cursor = res.status === 200 ? lastMemberId(res.body) : null;
+      if (!cursor) break;
+    }
+  });
+}

--- a/scripts/load/run-load-session.sh
+++ b/scripts/load/run-load-session.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# GOLIVE #2124 — load-session orchestrator.
+#
+# Mints a JWT, resolves the product ObjectType id, and runs the selected k6
+# scenarios from scripts/load/ against the running stack. Seeding is a
+# separate, explicit step (see --seed) because 50k x 24 values is a
+# multi-minute write. Summaries land in scripts/load/results/ (gitignored).
+#
+# Usage:
+#   scripts/load/run-load-session.sh [--seed N] [--scenario NAME ...] [--vus N] [--duration D]
+#
+# Examples:
+#   scripts/load/run-load-session.sh --seed 50000            # seed only
+#   scripts/load/run-load-session.sh                          # all default scenarios
+#   scripts/load/run-load-session.sh --scenario products-list --vus 50 --duration 120s
+#   FEED_PULL_URL=https://pim.localhost/api/feeds/pull/<t>/<token>.xml \
+#     scripts/load/run-load-session.sh --scenario feed-pull
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+BASE_URL="${K6_BASE_URL:-https://pim.localhost}"
+EMAIL="${K6_LOGIN_EMAIL:-admin@demo.localhost}"
+PASSWORD="${K6_LOGIN_PASSWORD:-changeme}"
+TENANT="${LOAD_TENANT:-demo}"
+VUS="${K6_VUS:-20}"
+DURATION="${K6_DURATION:-60s}"
+SEED=""
+SCENARIOS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --seed) SEED="$2"; shift 2 ;;
+    --scenario) SCENARIOS+=("$2"); shift 2 ;;
+    --vus) VUS="$2"; shift 2 ;;
+    --duration) DURATION="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -n "$SEED" ]]; then
+  # Console runs connect as pim_app (FORCE RLS, no request-scoped GUC) and see
+  # zero rows — maintenance writes go through the owner connection, the same
+  # pattern the api entrypoint uses for pim:dev:ensure-seeded.
+  echo "== Seeding $SEED products for tenant $TENANT (canonical values) =="
+  docker compose exec -T -e APP_ENV=prod -e APP_DEBUG=0 api \
+    sh -c "DATABASE_URL=\"\$DATABASE_URL_OWNER\" php bin/console pim:load:seed --products=$SEED --tenant=$TENANT"
+  echo "== Rebuilding attributes_indexed from canonical values =="
+  docker compose exec -T -e APP_ENV=prod -e APP_DEBUG=0 api \
+    sh -c "DATABASE_URL=\"\$DATABASE_URL_OWNER\" php bin/console pim:catalog:detect-attributes-drift --reconcile --tenant=$TENANT --kind=product"
+  echo "== Reindexing Meilisearch =="
+  docker compose exec -T -e APP_ENV=prod -e APP_DEBUG=0 api \
+    sh -c "DATABASE_URL=\"\$DATABASE_URL_OWNER\" php bin/console pim:search:reindex"
+  exit 0
+fi
+
+if [[ ${#SCENARIOS[@]} -eq 0 ]]; then
+  # Default read-heavy set. Rate-limited smokes (auth-login, import-start)
+  # and feed-pull (needs FEED_PULL_URL) run only when named explicitly.
+  SCENARIOS=(products-list search-products export-preflight bulk-preview)
+fi
+
+echo "== Minting JWT for $EMAIL =="
+TOKEN=$(curl -sk -X POST "$BASE_URL/api/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')
+
+TARGET_OBJECT_TYPE_ID=""
+if [[ " ${SCENARIOS[*]} " == *" import-start "* ]]; then
+  TARGET_OBJECT_TYPE_ID=$(curl -sk "$BASE_URL/api/object_types?kind=product" -H "Authorization: Bearer $TOKEN" \
+    | python3 -c 'import json,sys; d=json.load(sys.stdin); m=d.get("hydra:member") or d.get("member") or []; print(m[0]["@id"].split("/")[-1] if m else "")')
+fi
+
+mkdir -p scripts/load/results
+STAMP=$(date +%Y%m%d-%H%M%S)
+
+for name in "${SCENARIOS[@]}"; do
+  echo "== k6: $name (vus=$VUS duration=$DURATION) =="
+  # K6_VUS / K6_DURATION are NATIVE k6 option overrides — they must reach ONLY
+  # the load scenarios. The rate-limited smokes (auth-login, import-start,
+  # feed-pull) pin their own fixed shape (iterations / arrival-rate); passing
+  # the native overrides would replace it and blast through the limiter.
+  case "$name" in
+    feed-pull)
+      SIZE_ARGS=(-e "FEED_PULL_DURATION=${FEED_PULL_DURATION:-5m}" -e "FEED_RATE_PER_MINUTE=${FEED_RATE_PER_MINUTE:-1}") ;;
+    auth-login|import-start)
+      # Fixed iteration/vus shape lives in the script; pass a harmless marker
+      # so the array is never empty (set -u + bash < 4.4 unbound-var guard).
+      SIZE_ARGS=(-e "LOAD_SMOKE=1") ;;
+    *)
+      SIZE_ARGS=(-e "K6_VUS=$VUS" -e "K6_DURATION=$DURATION") ;;
+  esac
+  docker compose --profile perf run --rm \
+    -e API_TOKEN="$TOKEN" \
+    -e K6_BASE_URL="$BASE_URL" \
+    "${SIZE_ARGS[@]}" \
+    -e K6_P95_MS="${K6_P95_MS:-300}" \
+    -e LOAD_P95_MS="${K6_P95_MS:-300}" \
+    -e FEED_PULL_URL="${FEED_PULL_URL:-}" \
+    -e TARGET_OBJECT_TYPE_ID="$TARGET_OBJECT_TYPE_ID" \
+    k6 run "--summary-export=/load/results/${STAMP}-${name}.json" "/load/${name}.k6.js" \
+    || echo "!! scenario $name FAILED (thresholds or errors) — see summary above"
+done
+
+echo "== Summaries in scripts/load/results/${STAMP}-*.json =="

--- a/scripts/load/search-products.k6.js
+++ b/scripts/load/search-products.k6.js
@@ -1,0 +1,26 @@
+// GOLIVE #2124 — Meilisearch-backed product search under load.
+//
+// Rotates realistic query terms over GET /api/search/products so Meili (not
+// Postgres) carries the read; terms match the pim:load:seed value shape.
+
+import { check, group } from 'k6';
+import http from 'k6/http';
+import { baseUrl, bearerHeaders, defaultOptions } from './lib.js';
+
+export const options = defaultOptions();
+
+const headers = bearerHeaders();
+const terms = (__ENV.K6_SEARCH_TERMS || 'value,load,0001,product,benchmark').split(',');
+
+export default function () {
+  const term = terms[Math.floor(Math.random() * terms.length)];
+  group('GET /api/search/products', () => {
+    const res = http.get(`${baseUrl}/api/search/products?q=${encodeURIComponent(term)}`, {
+      headers,
+    });
+    check(res, {
+      'status is 200': (r) => r.status === 200,
+      'JSON body': (r) => typeof r.body === 'string' && r.body.startsWith('{'),
+    });
+  });
+}


### PR DESCRIPTION
## Co

Substrat pod jednorazową sesję load z Bloku B (#2128): seeder skali MVP + zestaw scenariuszy k6.

- **`pim:load:seed`** (`apps/api/src/Benchmark/LoadTestSeedCommand.php`) — N produktów × M atrybutów schematu × L locale jako **kanoniczne `object_values`** (envelope `{value}`, provenance=import). Projekcje (`attributes_indexed`, Meili) buduje się osobno realnymi komendami (`pim:catalog:detect-attributes-drift --reconcile` + `pim:search:reindex`) — zero drugiego kompozytora slotu, przy okazji ćwiczenie fresh-install rebuild (#2125). `--purge` sprząta.
- **8 scenariuszy k6** w `scripts/load/`: products-list (keyset), search (Meili), export-preflight, bulk-preview, mixed-endurance (2–4h, watch pamięci workera) + capped smoki dla endpointów pod limiterami (feed-pull 120/h, auth-login 5/15min, import-start 20/h).
- **`run-load-session.sh`** — mint JWT + resolve ObjectType + seed + uruchomienie scenariuszy; `--summary-export` do `scripts/load/results/` (gitignore). Serwis k6 dostał mount `./scripts/load:/load`.
- **`scripts/load/README.md`** — instrukcja seeda + odpalenia + świadome decyzje (apply/eksport/duży import mierzone pojedynczo w B2, nie młócone k6).

## Smoke (live stack, pim.localhost)

Wszystkie 8 scenariuszy zielone. p95 z krótkiego przebiegu (5 VU / 10s, 300 load-produktów): products-list 276 ms · search 76 ms · export-preflight 60 ms · bulk-preview 56 ms (gate p95<300 ms). Rate-limited smoki potwierdzają brak 429 przy zaplanowanym rytmie (i wyłapały limiter feed_pull, gdy scenariusz był źle skonfigurowany — teraz naprawione). Seeder: 300 prod × 200 atrybutów = 10082 wiersze wartości, peak 58 MiB; reconcile + reindex spójne (0 pustych `attributes_indexed`). Dane testowe posprzątane (`--purge`, feed usunięty, reindex).

## Bramki

PHPStan max ✅ · CS-Fixer 0/1688 ✅ · Deptrac 0 ✅ · Biome (scripts/load) ✅. Skrypty k6 to standalone (runtime k6/Goja), poza TS buildem admina.

Refs #2124