### PR TITLE
test(golive): fresh-install from-zero rebuild drill (#2125, A5)

### DIFF
--- a/agent/lessons.md
+++ b/agent/lessons.md
@@ -2902,3 +2902,12 @@ M4 (P4-01..08) + M5 Hardening (P5-01..05) — wszystkie zmergowane. Epik APIC ko
 - **`K6_VUS`/`K6_DURATION` to NATYWNE opcje k6** — dla skryptu z własnym blokiem `scenarios`/`iterations` (feed-pull, auth-login, import-start) k6 NADPISUJE definicję i leci z natywną skalą. Feed-pull dostał 13k req/min i wysycił limiter 120/h. Wzorzec: rate-limited smoki pinują kształt w skrypcie, orkiestrator NIE przekazuje im native-override (case per scenariusz w wrapperze); własne progi env nazywać BEZ prefiksu `K6_`.
 - **`set -u` + pusta tablica bash** (`ARR=(); "${ARR[@]}"`) = „unbound variable" na bash < 4.4 (macOS) — nieszkodliwy placeholder element zamiast pustej tablicy.
 - **Limiter `feed_pull` siedzi w puli filesystem `cache.rate_limiter`, nie w Redis** — restart api/redis go NIE czyści; reset przez `cache:pool:clear cache.rate_limiter`. (Redis DBSIZE=0 mimo aktywnego limitera to nie bug — to inny backend.)
+
+## Lessons z GOLIVE #2125 (2026-07-04, fresh-install / from-zero rebuild)
+
+### Patterns to Follow
+- **Reindex-od-zera = `--purge`, inaczej sieroty.** `pim:search:reindex` bez `--purge` tylko upsertuje z Postgresa i NIE usuwa dokumentów-widm po wierszach skasowanych w PG (obserwacja: 646 docs Meili vs 211 obiektów PG = 435 sierot po cyklach seed/purge). Spójność (`meili numberOfDocuments == count(objects)`) osiągalna tylko po `--purge`. Harness: `scripts/fresh-install-verify.sh`.
+- **Consistency-check bez niszczenia danych**: reindex --purge + detect-attributes-drift --reconcile przebudowują TYLKO projekcje z kanonu (`object_values` nietknięte) → można je odpalić na żywym dev/prod bez drop-a bazy. Pełny drop+migrate za `--with-migrations --force`.
+
+### Patterns to Avoid
+- **`attributes_indexed` reconcile NIE konwerguje dla atrybutów `select`** — detektor dryfu daje false-positive na envelope `{option_code: X}` bo `globalSlot()` wzbogaca slot o `provenance` a porównanie kształtu `{option_code}` się rozjeżdża (kształt `{value}` konwerguje). Dane są POPRAWNE (option_code zgodny) — to bug detektora, nie korupcja. Nie da się zaasertować „zero drift" po rebuildzie dopóki niezałatane (#2186). Wariant lekcji z AGENT-P6-05 (#1978) który wrócił dla innego kształtu envelope'u.

--- a/docs/audit/2026-07-handover/fresh-install.md
+++ b/docs/audit/2026-07-handover/fresh-install.md
@@ -1,0 +1,54 @@
+# Fresh-install / from-zero rebuild — raport (#2125, epik GOLIVE)
+
+**Data:** 2026-07-04 · **Blok:** A (plan `Project Plan/15-plan-testow-przedprodukcyjnych.md`, sekcja A5)
+**Cel:** zweryfikować trzy ścieżki „od zera", które prod deploy i zewnętrzny software house wykonują pierwszego dnia, oraz spójność między magazynami (Postgres ↔ Meili ↔ `attributes_indexed`).
+
+Powtarzalny harness: [`scripts/fresh-install-verify.sh`](../../../scripts/fresh-install-verify.sh).
+
+## 1. Migracje od pustej bazy
+
+Zweryfikowane w ramach cold-start testu #2119 (raport [`cold-start.md`](cold-start.md)): entrypoint api na świeżym klonie z pustą bazą uruchomił **122 migracje od zera** bez błędu (`doctrine:migrations:migrate` → `Successfully migrated to Version20260703170000`, 1362 zapytania SQL), po czym `audit:schema:update` + fixtures + reindex. Pełna historia migracji jest wykonywalna od zera. ✅
+
+> Uwaga: kanoniczna ścieżka init to entrypoint auto-seed (`pim:dev:ensure-seeded`), NIE dokumentowane komendy ręczne — te padają na roli `pim_app` (luki L5/L6 z #2119 → #2178). Prod deploy musi używać owner-connection dla DDL. `--with-migrations --force` w skrypcie weryfikującym wymusza pełny drop+migrate przez owner url.
+
+## 2. Reindex Meilisearch od zera (`--purge`)
+
+`pim:search:reindex --purge` czyści indeks i buduje go wyłącznie z Postgresa (source of truth).
+
+| Metryka | Przed | Po |
+|---|---|---|
+| `objects` docs w Meili | **646** | **211** |
+| obiekty w Postgres | 211 | 211 |
+
+**Wynik: 646 → 211 = 211 PG.** ✅ Reindex-od-zera zbieżny. Przed purge indeks miał **435 dokumentów-sierot** — pozostałości po operacjach purgujących wiersze Postgresa bez czyszczenia indeksu (m.in. seed/purge load-testowy #2124, wcześniejsze dane XMLF/APIC). To potwierdza, że **`reindex` bez `--purge` tylko upsertuje i nie usuwa sierot** — prod deploy / odtworzenie indeksu MUSI używać `--purge` dla spójności. Wzorzec udokumentowany w harnessie i w `scripts/load/README.md`.
+
+## 3. Rebuild `attributes_indexed` od zera (`--reconcile`)
+
+`pim:catalog:detect-attributes-drift --reconcile` przepisuje denormalizowaną projekcję `attributes_indexed` z kanonicznych `object_values` realnym `AttributesIndexedRebuilder`.
+
+- Pierwszy przebieg: **297/422 obiektów zreconcyliowanych** (cache przepisany z kanonu).
+- Po rebuildzie 1 obiekt ma pusty `attributes_indexed` — obiekt bez wartości globalnych (asset/kategoria bez atrybutów global-scope); benign.
+- **Ponowny `detect` (bez reconcile) nie pokazuje 0 dryfu — zostaje 188/422 `mismatched=currency_code`.** To **false-positive detektora na atrybutach typu `select`**, NIE korupcja danych: `object_values.value = {"option_code":"PLN"}` vs `attributes_indexed = {"provenance":"import","option_code":"PLN"}` — wartość merytoryczna (`option_code=PLN`) zgodna po obu stronach; różni się porównanie wzbogaconego envelope'u. Zgłoszone jako **[#2186](../../../issues/2186)**.
+
+Projekcja jest **poprawna** (wartości zgodne z kanonem, `{value}`-envelope'y konwergują — większość obiektów `drifted=0`). Niekonwergujący jest tylko detektor spójności dla kształtu `{option_code}`.
+
+## 4. Wynik zbiorczy (przebieg `fresh-install-verify.sh`, dev stack)
+
+```
+meili_documents = 211
+postgres_objects = 211
+empty_attributes_indexed = 1
+PASS: Meili index count matches Postgres (reindex-from-zero consistent).
+residual_drift_after_reconcile = 188 drifted (known false-positive on select values — #2186)
+```
+
+## Wnioski
+
+1. **Migracje od zera i reindex Meili od zera: zdrowe.** Pełna historia migracji przechodzi na pustej bazie; reindex `--purge` daje idealną zgodność z Postgresem.
+2. **Sieroty w Meili to realne ryzyko operacyjne** — każda operacja kasująca wiersze bez `--purge` zostawia dokumenty-widma (tu: 435). Prod/rebuild MUSI purge'ować. Rozważyć okresowy `reindex --purge` w harmonogramie (poza scope tego ticketu).
+3. **Rebuild `attributes_indexed` produkuje poprawne dane, ale detektor spójności daje false-positive na `select`** (#2186) — do naprawy zanim „zero drift" stanie się wiarygodną bramką operatora.
+4. Harness `scripts/fresh-install-verify.sh` jest powtarzalny (miesięcznie / przed deployem), bezpieczny domyślnie (przebudowuje tylko projekcje), z opcją `--with-migrations --force` dla pełnego drop+migrate.
+
+## Mapa ticketów
+
+[#2186](../../../issues/2186) select-type drift false-positive · (migracje-od-zera / role: [#2178](../../../issues/2178) z #2119) · (messenger_messages fresh-install: [#2177](../../../issues/2177))

--- a/scripts/fresh-install-verify.sh
+++ b/scripts/fresh-install-verify.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# GOLIVE A5 (#2125) — fresh-install / from-zero rebuild consistency check.
+#
+# Verifies the three "from zero" rebuild paths a prod deploy or an external
+# software house exercises on day one, and asserts cross-store consistency:
+#
+#   1. (--with-migrations) migrate an EMPTY database through the full history
+#   2. Meilisearch reindex --purge  → index rebuilt only from Postgres
+#   3. attributes_indexed reconcile → projection rebuilt from canonical values
+#
+# Then asserts: Meili numberOfDocuments == Postgres object count, and reports
+# the residual attributes-drift count (known false-positive on select-type
+# values — see #2186).
+#
+# Maintenance commands connect through the OWNER url (pim_app sees zero rows
+# under FORCE RLS without a request GUC) — same pattern as the api entrypoint.
+#
+# SAFE by default: reindex --purge and reconcile rebuild PROJECTIONS from the
+# canonical Postgres source; they never mutate object_values. --with-migrations
+# DROPS the database and is gated behind an explicit flag + confirmation.
+#
+# Usage:
+#   scripts/fresh-install-verify.sh                 # reindex + reconcile + assert
+#   scripts/fresh-install-verify.sh --with-migrations --force   # full drop+migrate first (DESTRUCTIVE)
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+TENANT_FLAG=""
+WITH_MIGRATIONS=0
+FORCE=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --with-migrations) WITH_MIGRATIONS=1; shift ;;
+    --force) FORCE=1; shift ;;
+    --tenant) TENANT_FLAG="--tenant=$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+owner() { docker compose exec -T -e APP_ENV=prod -e APP_DEBUG=0 api sh -c "DATABASE_URL=\"\$DATABASE_URL_OWNER\" $1"; }
+psql_q() { docker compose exec -T database psql -U "${POSTGRES_USER:-pim}" -d "${POSTGRES_DB:-pim}" -tA -c "$1"; }
+
+if [[ "$WITH_MIGRATIONS" == "1" ]]; then
+  if [[ "$FORCE" != "1" ]]; then
+    echo "Refusing to drop the database without --force. This is DESTRUCTIVE." >&2
+    exit 1
+  fi
+  echo "== [1/3] Fresh migrations from empty database =="
+  docker compose stop api >/dev/null
+  owner "php bin/console pim:db:reset --with-fixtures --force"
+  docker compose start api >/dev/null
+  sleep 8
+fi
+
+echo "== [2/3] Meilisearch reindex from zero (--purge) =="
+owner "php bin/console pim:search:reindex --purge" | tail -2
+sleep 3
+
+echo "== [3/3] attributes_indexed rebuild from canonical values (--reconcile) =="
+owner "php bin/console pim:catalog:detect-attributes-drift --reconcile ${TENANT_FLAG}" | tail -2
+
+echo
+echo "== Consistency assertions =="
+MKEY=$(grep '^MEILI_MASTER_KEY=' .env | cut -d= -f2)
+MEILI_DOCS=$(docker compose exec -T meilisearch curl -s "http://localhost:7700/indexes/objects/stats" \
+  -H "Authorization: Bearer $MKEY" | python3 -c 'import json,sys; print(json.load(sys.stdin)["numberOfDocuments"])')
+PG_OBJECTS=$(psql_q "SELECT count(*) FROM objects;" | tr -d '[:space:]')
+EMPTY_IDX=$(psql_q "SELECT count(*) FROM objects WHERE attributes_indexed IS NULL OR attributes_indexed='{}';" | tr -d '[:space:]')
+
+echo "meili_documents = $MEILI_DOCS"
+echo "postgres_objects = $PG_OBJECTS"
+echo "empty_attributes_indexed = $EMPTY_IDX"
+
+RC=0
+if [[ "$MEILI_DOCS" == "$PG_OBJECTS" ]]; then
+  echo "PASS: Meili index count matches Postgres (reindex-from-zero consistent)."
+else
+  echo "FAIL: Meili=$MEILI_DOCS != Postgres=$PG_OBJECTS — stale/missing documents."; RC=1
+fi
+
+# Residual drift after reconcile is a known select-type false-positive (#2186);
+# report it but do not fail the run on it (the projection VALUES are correct).
+DRIFT=$(owner "php bin/console pim:catalog:detect-attributes-drift ${TENANT_FLAG}" 2>/dev/null | grep -oE '[0-9]+ drifted' | head -1 || true)
+echo "residual_drift_after_reconcile = ${DRIFT:-0 drifted} (known false-positive on select values — #2186)"
+
+exit $RC


### PR DESCRIPTION
## Co

Weryfikacja trzech ścieżek „od zera" (prod deploy / handover dnia pierwszego) + spójność Postgres ↔ Meili ↔ `attributes_indexed`.

- `scripts/fresh-install-verify.sh` — powtarzalny, **bezpieczny domyślnie** harness (przebudowuje tylko projekcje z kanonu; `--with-migrations --force` = pełny drop+migrate).
- `docs/audit/2026-07-handover/fresh-install.md` — raport z dowodami + mapa ticketów.

## Wyniki

- **Migracje od zera:** 122 migracje przechodzą na pustej bazie (zweryfikowane w cold-start #2119).
- **Meili reindex `--purge`:** 646 dokumentów → **211 = 211 obiektów PG** (zbieżne). Odkryto **435 sierot** — dowód, że `reindex` bez `--purge` nie usuwa dokumentów-widm po skasowanych wierszach; prod/rebuild musi purge'ować.
- **Rebuild `attributes_indexed`:** projekcja poprawna (wartości zgodne z kanonem), ale detektor spójności daje **niekonwergujący false-positive na atrybutach `select`** (`{option_code}` envelope) → zgłoszone [#2186](../../../issues/2186). Nie da się zaasertować „zero drift" dopóki niezałatane.

## Bramka

Zmiana: skrypt bash + raport + lessons (docs/infra-only, zero kodu aplikacji). Wszystkie kroki wykonane na żywym stacku (proof w raporcie).

Refs #2125