### PR TITLE
docs(security): system-wide STRIDE threat model + review checklist (#2123, A3)

### DIFF
--- a/docs/security/security-checklist.md
+++ b/docs/security/security-checklist.md
@@ -1,0 +1,98 @@
+# Security review checklist — PR-y dotykające auth / permissions / danych
+
+> GOLIVE A3 (#2123). Checklist code-review dla każdego PR-a dotykającego
+> uwierzytelniania, autoryzacji, izolacji tenantów, sekretów lub parsowania
+> nieufnego wejścia. Wiele pozycji jest egzekwowanych maszynowo (Semgrep
+> `.semgrep/cortex-rbac.yml`, PHPStan rules, Deptrac, gitleaks) — checklist
+> pokrywa to, co wymaga ludzkiej oceny. Model zagrożeń: `threat-model.md`.
+> Warstwa agenta ma własną sekcję na końcu `threat-model.md`.
+
+## Nowy endpoint (`#[Route]` / API Resource)
+
+- [ ] Ma `#[RequiresPermission(module, action)]` **albo** jawne
+      `#[NoPermissionRequired]` z uzasadnieniem (Semgrep
+      `cortex-requires-permission-attribute-missing` to wymusza — nie obchodź).
+- [ ] Kod uprawnienia istnieje w macierzy (`src/Identity/Domain/Rbac/RbacMatrix.php`,
+      `docs/rbac.md`).
+- [ ] Błędy w formacie RFC 7807 (problem+json), bez stack-trace w prod.
+- [ ] Scoping własności: cudzy zasób → **404, nie 403** (nie ujawniaj istnienia).
+- [ ] Jeśli `PUBLIC_ACCESS`: udokumentowane *dlaczego* + podpięty rate-limiter
+      (patrz niżej) + brak side-effectów poza zamierzoną akcją.
+
+## Nowy voter
+
+- [ ] Sprawdza uprawnienie przez `isGranted(permission, subject)`, **nie**
+      hardkodowany string roli (`hasRole('admin')` zbanowany —
+      Semgrep `cortex-no-direct-role-string-check`).
+- [ ] Row-level: weryfikuje tenant + scope (kategoria/locale/channel) subjectu.
+- [ ] `abstain` vs `deny` przemyślane — brak głosu ≠ dostęp (fail-closed).
+- [ ] Test: pozytyw + negatyw + cross-tenant (0 wyników).
+
+## Nowa encja / migracja (izolacja tenantów)
+
+- [ ] Encja implementuje `TenantScoped` (`getTenant()`/`assignTenant()`) —
+      Semgrep `cortex-entity-missing-tenant-id`.
+- [ ] Migracja: `tenant_id UUID NOT NULL` + FK + `ENABLE`/`FORCE ROW LEVEL
+      SECURITY` + `CREATE POLICY tenant_isolation_*`.
+- [ ] Polityka RLS używa `NULLIF(current_setting('app.current_tenant', true), '')::uuid`
+      (nie bare `::uuid`; GUC to `app.current_tenant`, nie `pim.current_tenant_id`).
+- [ ] Tabele auth (users/refresh_tokens): polityka „pre-context-safe" (dopuszcza
+      brak GUC dla ścieżki logowania).
+- [ ] `TenantAssignmentListener` stempluje na `prePersist` (test:
+      `TenantAssignmentListenerTest`).
+- [ ] Test izolacji: `ForceRlsTenantIsolationTest` cross-tenant read = 0 wierszy.
+
+## Raw SQL / bulk / async
+
+- [ ] Raw SQL: jawny predykat `tenant_id` + komentarz `// tenant-safe:`
+      (Semgrep `cortex-raw-sql-missing-tenant-filter`; break-glass wyjątek tylko
+      w plikach `SuperAdmin*`).
+- [ ] Bulk DQL UPDATE/DELETE: pamiętaj że SQLFilter działa tylko na SELECT —
+      dołóż jawny `tenant` predykat, RLS = backstop.
+- [ ] Handler async: kontekst tenanta odtworzony (`TenantContextRebindingMiddleware`
+      + `TenantRlsGucMiddleware` ustawia GUC); po `em->clear()` reattach
+      run/tenant przed persistem (lekcja AUD-002 / agent P9-01).
+- [ ] `flush()` w pętli batch ma `clear()` (PHPStan `FlushWithoutClearInLoopRule`).
+
+## Token / sekret
+
+- [ ] Sekret nigdy w response (klucze BYOK/integracji — tylko prefix do
+      wyświetlenia) ani w logach.
+- [ ] Sekret w Vault / env (nie w trackowanym pliku) — guard
+      `lint-tracked-secrets` + gitleaks/trufflehog CI.
+- [ ] JWT: algorytm pinowany (brak `alg:none`); refresh HttpOnly + rotujący +
+      single-use (check-then-reset odporny na wyścig).
+- [ ] Access token po stronie FE tylko w pamięci — **nie** `localStorage`.
+- [ ] Nowy klucz API / webhook secret: przechowywany jako hash / zaszyfrowany;
+      podpis weryfikowany timing-safe.
+
+## Rate limiter (nowa powierzchnia publiczna)
+
+- [ ] Endpoint `PUBLIC_ACCESS` konsumuje limiter (albo jawnie udokumentowany brak).
+- [ ] Klucz limitera poprawny: per-IP (login), per-email (reset), per-key
+      (api_key), per-feed (feed_pull), per-tenant (import/backup).
+- [ ] 429 = problem+json + `Retry-After`; limit liczony PRZED kosztowną operacją.
+- [ ] Endpoint zawsze-200 (np. password-reset) limituje ścieżkę sukcesu **i**
+      porażki (brak timing oracle).
+
+## Field-level (atrybuty)
+
+- [ ] Read: `FieldRestrictionFilter` usuwa ograniczone atrybuty z serializacji.
+- [ ] Write: `canEditAttribute()` przed akceptacją PATCH.
+- [ ] Export: policy atrybutowa zastosowana przed listą kolumn (AUD-008).
+- [ ] Schema route nie wycieka definicji ograniczonych atrybutów.
+
+## Parsowanie nieufnego wejścia (import/webhook)
+
+- [ ] XML: parser bez rozwijania external entities (XXE); XLSX: `XlsxArchiveGuard`
+      (zip-bomb central-dir); ścieżki: `FolderPathGuard` (traversal).
+- [ ] Eksport CSV/XLSX: neutralizacja formuł (`=`,`+`,`-`,`@` prefix).
+- [ ] URL zewnętrzny (media/webhook): `NoPrivateNetworkHttpClient` (SSRF +
+      redirect rebinding).
+- [ ] Limity rozmiaru pliku + memory workera (bounded decompression).
+
+## Agent (jeśli PR dotyka warstwy agenta)
+
+Patrz osobna sekcja „Security review checklist (PRs touching auth / agent)"
+w `threat-model.md` — narrowest `requiredPermission`, write przez
+`pending_changes`, removability (`agent-removability` CI), audyt każdej tranzycji.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -70,3 +70,65 @@
 - [ ] Removability: agent DI stays in `services_agent.yaml`; no `App\Agent`
       reference leaks into core `src`/`config`/`tests` (CI `agent-removability`).
 - [ ] Secrets: no plaintext key in responses/logs; BYOK stays encrypted.
+
+---
+
+# Threat model — system-wide (STRIDE)
+
+> GOLIVE A3 (#2123). Rozszerza powyższy model agenta na całość systemu przed
+> go-live. Konsoliduje wektory z audytu półrocznego (`docs/audit/2026-06/`,
+> 81 findings, 5/5 CRITICAL naprawione Wave 0–3) jako punkty odniesienia.
+> Fundament obrony udokumentowany osobno: `docs/multi-tenancy.md` (TenantFilter
+> + RLS + GUC), `docs/rbac.md` (macierz uprawnień + voters). Aktualizować po
+> każdym red-teamie (Blok B #2129/#2130) i nowym wektorze.
+
+## Granice zaufania (trust boundaries)
+
+1. **Nieuwierzytelniony HTTP** — 15 tras `PUBLIC_ACCESS` (login, refresh, 2FA,
+   password-reset request/confirm, invitation accept/verify, SSO callback,
+   asset preview HMAC, publiczny feed-pull token, docs/contexts/metrics/root).
+2. **Uwierzytelniony HTTP** — powierzchnia zasobowa API Platform + custom
+   `#[Route]`; granica = tenant + RBAC.
+3. **Async / tło** — Messenger (`sync`/`async`/`import`/`failed`), webhooki
+   wychodzące.
+4. **Agent LLM** — powierzchnia narzędzi (osobny model powyżej).
+5. **Parsowanie plików** — import CSV/XML/JSON/XLSX/ZIP.
+6. **App → Postgres** — TenantFilter + RLS (FORCE, rola `pim_app` NOBYPASSRLS).
+
+## Assets (poza agentem)
+
+- **Dane katalogu wszystkich tenantów** — integralność + izolacja.
+- **Sekrety** — JWT keypair, BYOK master key, credentiale integracji (AES-GCM),
+  webhook secrets, feed tokeny (192-bit).
+- **Konta / sesje** — JWT (15 min) + refresh (HttpOnly, rotujący), MFA.
+- **Dostępność** — worker pool (FrankenPHP), pojemność DB pod 50k+ SKU.
+
+## STRIDE — powierzchnia systemowa
+
+| Category | Vector | Mitigation | Ref / residual |
+|----------|--------|------------|----------------|
+| **Spoofing** | Podszycie pod tenanta przez sfałszowany JWT (alg-confusion `alg:none`) | Lexik RS256, algorytm pinowany; brak akceptacji `none` | red-team B3 #2129 |
+| **Spoofing** | Brute-force logowania / enumeracja kont | Limiter `auth_login` 5/IP/15min; password-reset zawsze-200 (`password_reset_email` 5/15min + `password_reset_ip` 10/15min) | — |
+| **Spoofing** | Enumeracja/brute tokenu zaproszenia lub feedu | Token 192-bit + limiter `invitation_accept` 10/15min, `feed_pull` 120/h/feed; 404-not-403 | AUD-030 (fixed) |
+| **Tampering** | Cross-tenant write przez DQL/native omijający TenantFilter | RLS FORCE backstop (`pim_app` NOBYPASSRLS) + `// tenant-safe:` raw SQL + Semgrep `cortex-raw-sql-missing-tenant-filter` | AUD-002 (fixed W1-1) |
+| **Tampering** | CSV/formula injection w eksporcie, XXE/zip-bomb w imporcie | `neutraliseFormula` (XlsxStreamWriter), `XlsxArchiveGuard` central-dir, limity rozmiaru + memory workera | AUD-051 IMP2-2.8 (fixed) |
+| **Tampering** | SSRF przez URL webhooka / media z URL | `NoPrivateNetworkHttpClient` (blokuje RFC1918 + redirect rebinding) | IMP2-1.12 review (fixed) |
+| **Repudiation** | „Nie ja to zrobiłem" | DH Auditor append-only na encjach audytowanych + `audit_logs`; break-glass loguje `cross_tenant_access=true` | — |
+| **Information disclosure** | Cross-tenant SSE (Mercure) / cross-tenant read przez filtr Meili | Topiki tenant-prefixed + `private:true`; whitelist `filterableAttributes` Meili | AUD-001/004 (fixed W0) |
+| **Information disclosure** | Sekret w response/logach/trackowanym `.env` | Sekrety w Vault/env (nie w gitcie), guard `lint-tracked-secrets`, gitleaks/trufflehog CI; klucze nigdy w API (tylko prefix) | AUD-005 (fixed W0-7) |
+| **Information disclosure** | Cross-tenant asset przez zgadnięty preview URL | Podpis HMAC-SHA256 + TTL (AssetPreviewUrlSigner) | AUD-006 (fixed W0-4) |
+| **Information disclosure** | Field-level: atrybut ograniczony wyciekający w read/PATCH/export | `FieldRestrictionFilter` (read) + `canEditAttribute` (write) + policy w export builderze | AUD-008 (fixed W0-6) |
+| **Denial of service** | OOM workera na bulk (50k) — flush-bez-clear | PHPStan `FlushWithoutClearInLoopRule` + limit pamięci kontenera + alert Prometheus 256 MiB | AUD-011/012 (fixed W1-8) |
+| **Denial of service** | Zalew publicznych endpointów / kosztów agenta | Limitery per-bucket (login/reset/invite/feed/import/api_key/agent_run); §8.5 budżety agenta | — |
+| **Elevation of privilege** | Endpoint bez `#[RequiresPermission]` (domyślnie dostępny) | Semgrep `cortex-requires-permission-attribute-missing` + PHPStan rule; voters + `AbstractPrdVoter` | Phase 6 retrofit (done) |
+| **Elevation of privilege** | Hardkodowany `hasRole('admin')` omijający macierz | Semgrep `cortex-no-direct-role-string-check`; wszystkie decyzje przez `isGranted(permission)` | — |
+| **Elevation of privilege** | Nadużycie break-glass / platform-operator jako tenant super_admin | Rozdział platform-operator ≠ tenant super_admin; break-glass audytowany + runbook | AUD-003 (fixed W0-3) |
+
+## Ryzyko rezydualne
+
+- **Brak zewnętrznego pentestu** przed pierwszym pilotem — kompensowane B3
+  (15-punktowy red-team) + B3+ (wiel-agentowy deep audit); zewnętrzny do fazy
+  SaaS. Zapisane w `06-sprint-0-findings.md`.
+- **Timing-safe compare podpisu webhooka** — do jawnej weryfikacji w B3.
+- **Prompt classifier / tool sandbox** (agent) — hook §13.5 jeśli wektor
+  kiedykolwiek pokona approval.


### PR DESCRIPTION
## Co

Dwa dokumenty bezpieczeństwa przed go-live (A3):

- **`docs/security/threat-model.md`** — rozszerzenie istniejącego STRIDE agenta na **cały system**: granice zaufania (15 tras PUBLIC_ACCESS, uwierzytelniony HTTP, async, agent, parsowanie plików, App→Postgres), tabela STRIDE per kategoria z mitygacjami skrzyżowanymi z naprawionymi findingami audytu 2026-06 (5/5 CRITICAL), ryzyko rezydualne. Sekcja agenta zachowana verbatim.
- **`docs/security/security-checklist.md`** (nowy) — checklist code-review dla PR-ów dotykających auth/permissions/tenant-isolation/sekretów/parsowania: nowy endpoint, voter, encja/migracja RLS, raw-SQL/async, token/sekret, rate-limiter, field-level, parsowanie wejścia. Pokrywa ocenę ludzką; część maszynową (Semgrep `cortex-*`, PHPStan, gitleaks) tylko referuje.

## Weryfikacja

Wszystkie mechanizmy i ścieżki zweryfikowane w kodzie (security.yaml 15× PUBLIC_ACCESS, 8 reguł Semgrep, 10 limiterów w framework.yaml, voters, TenantFilter/RLS). Docs-only.

Refs #2123