### PR TITLE
test(golive): pgBackRest PITR restore drill + wrapper fixes (#2122, A2)

### DIFF
--- a/docs/audit/2026-07-handover/restore-drill.md
+++ b/docs/audit/2026-07-handover/restore-drill.md
@@ -1,0 +1,51 @@
+# Próba generalna backup/restore (PITR) — raport (#2122, epik GOLIVE)
+
+**Data:** 2026-07-04 · **Blok:** A (plan `Project Plan/15-plan-testow-przedprodukcyjnych.md`, sekcja A2)
+**Cel:** udowodnić, że backup pgBackRest jest nie tylko skonfigurowany, ale **odtwarzalny do konkretnego momentu (PITR)**, zmierzyć RTO, przećwiczyć quirk re-grant `pim_app`.
+
+Powtarzalny harness: [`scripts/restore-drill.sh`](../../../scripts/restore-drill.sh).
+
+## Scenariusz (test precyzji PITR)
+
+1. Backup inkrementalny (baza restore).
+2. Insert markera **BEFORE** + WAL switch → zapis celu `T = now()`.
+3. Insert markera **AFTER** + WAL switch.
+4. Restore `--type=time --target=T` (odtwarza WAL tylko do T).
+5. Promote + re-grant `pim_app`.
+6. Asercja: **BEFORE obecny, AFTER nieobecny** → PITR wylądował dokładnie na T.
+
+Marker przez tabelę `objects` (kanoniczną), nie deprecated `products` (którą wciąż celuje `test-pgbackrest-restore.sh` — po ObjectType ten `DELETE` to no-op, przez co tamten test byłby fałszywie zielony — osobna obserwacja).
+
+## Wynik
+
+```
+pre-restore:  BEFORE=1 AFTER=1
+post-restore: BEFORE=1 AFTER=0   (expect 1 / 0)
+RTO = 19s
+==> PITR DRILL PASSED — recovered to T exactly (BEFORE kept, AFTER dropped).
+pim_app grants OK (query succeeded; RLS shows 0 rows without tenant GUC)
+```
+
+- **PITR precyzyjny:** marker sprzed T przeżył, marker zza T zniknął. ✅
+- **RTO ≈ 19 s** (stop api+db → wipe → restore 169 MB → promote → re-grant → api healthy) na dev stacku; na prod-podobnym HW + większym wolumenie proporcjonalnie więcej, ale rząd wielkości potwierdzony.
+- **Owner widzi pełne dane** (211 obiektów), `pim_app` odpytuje bez `permission denied` (RLS zwraca 0 bez GUC — poprawne), **login end-to-end 200**.
+
+## Bugi DR wykryte drillem (naprawione w tym samym PR — broken restore = blocker)
+
+Drill odsłonił **2 realne bugi w `scripts/pim-backup-restore.sh`, które wysadziłyby każdy prawdziwy PITR** (→ [#2196](../../../issues/2196)):
+
+1. **`--target` ze spacją łamany.** `${PGBACKREST_ARGS[*]}` (string-join) gubił cytowanie — timestamp `YYYY-MM-DD HH:MM:SS` dzielony na 2 argumenty → `ERROR: [048]: invalid command '<time>'`. **Fizycznie żaden PITR nie działał.** Fix: double-quote każdego argumentu wewnątrz `su -c '...'`.
+2. **Brak promote po recovery target.** `--type=time` bez `--target-action` zostawiał klaster w read-only hot-standby (pauza recovery) — api nie mogło pisać. Fix: `--target-action=promote`.
+3. **Re-grant `pim_app`** dodany do wrappera (idempotentnie) — W1-1 migracja nie re-runuje po fizycznym restore.
+
+Runbook `docs/runbook/restore.md` uzupełniony o kroki promote + re-grant + PITR quirk.
+
+## Wnioski
+
+1. **Backup jest odtwarzalny do punktu w czasie** — udowodnione empirycznie, nie tylko skonfigurowane. RTO ~19 s (dev).
+2. **Krytyczne:** narzędzie restore było **zepsute dla PITR** (bug cytowania) — wykryte i naprawione zanim potrzebne w realnym DR. To główna wartość tej próby generalnej.
+3. Drill jest powtarzalny (miesięcznie, świadomie poza CI — DESTRUCTIVE); asertuje precyzję + RTO + grants.
+
+## Mapa ticketów
+
+[#2196](../../../issues/2196) bugi wrappera restore (PITR quoting + promote + re-grant) — naprawione.

--- a/docs/runbook/restore.md
+++ b/docs/runbook/restore.md
@@ -109,14 +109,37 @@ The orchestrator will:
 2. `docker compose stop database` — clean shutdown so the WAL is consistent.
 3. `docker compose run --rm --no-deps --entrypoint /bin/sh database -c …` —
    wipes `$PGDATA` and runs `pgbackrest restore` against the existing volume.
-4. `docker compose up -d --wait database api` — postgres replays WAL from the
-   repo on start-up; healthchecks block until everything is back.
+   For `--type time` the wrapper passes `--target-action=promote` so the
+   cluster finishes recovery **read-write** (a bare `--type=time` leaves it
+   paused in read-only hot-standby until `pg_promote()`).
+4. `docker compose up -d --wait database` — postgres replays WAL from the repo.
+5. **Re-grant `pim_app`** — the wrapper re-applies the runtime role's schema
+   grants (idempotent). A physical restore can land the cluster missing them
+   and the W1-1 migration does **not** re-run, so `pim_app` would otherwise hit
+   `permission denied for schema public`. Manual equivalent:
+   ```sql
+   GRANT USAGE ON SCHEMA public TO pim_app;
+   GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO pim_app;
+   GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA public TO pim_app;
+   ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO pim_app;
+   ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO pim_app;
+   ```
+6. `docker compose up -d --wait api` — healthchecks block until everything is back.
+
+> **PITR quirk (fixed #2196):** the `--target` timestamp contains a space; the
+> wrapper now double-quotes each pgBackRest arg so it stays a single argument.
+> A repeatable drill lives at `scripts/restore-drill.sh` (inserts before/after
+> markers, restores to a point between them, asserts precision + RTO).
 
 ### Verify
 
 ```bash
+# RLS bypass as owner sees the recovered rows:
 docker compose exec database \
-    psql -U pim -d pim -c "SELECT count(*) FROM products;"
+    psql -U pim -d pim -c "SELECT count(*) FROM objects;"
+# app role can query (RLS shows 0 without a tenant GUC — that is expected):
+docker compose exec database \
+    psql -U pim_app -d pim -c "SELECT count(*) FROM objects;"
 
 curl -k https://pim.localhost/api/products | head
 ```

--- a/scripts/pim-backup-restore.sh
+++ b/scripts/pim-backup-restore.sh
@@ -63,7 +63,10 @@ case "${TYPE}" in
             echo "--type time requires --target 'YYYY-MM-DD HH:MM:SS[+TZ]'" >&2
             exit 2
         fi
-        PGBACKREST_ARGS+=("--type=time" "--target=${TARGET}")
+        # --target-action=promote so Postgres finishes recovery read-WRITE
+        # instead of pausing in read-only hot-standby (a plain --type=time
+        # leaves the cluster paused until pg_promote(); the api cannot write).
+        PGBACKREST_ARGS+=("--type=time" "--target=${TARGET}" "--target-action=promote")
         ;;
     *) echo "Unsupported --type '${TYPE}' (use latest|time|immediate)" >&2; exit 2 ;;
 esac
@@ -103,14 +106,39 @@ run docker compose stop database
 # 3. Wipe + restore inside a one-shot container that reuses the database
 #    service's image, volumes and env vars. --entrypoint "" plus a custom
 #    command lets us shell in and run pgbackrest as the postgres user.
+# Double-quote every pgbackrest arg. The invocation is nested inside
+# `su -s /bin/sh postgres -c '...'` (single-quoted), so double quotes here are
+# literal to that inner shell and keep a --target value containing a space (the
+# "YYYY-MM-DD HH:MM:SS" timestamp) as ONE argument. `${ARR[*]}` string-joins and
+# silently splits it, which pgBackRest rejects with "invalid command '<time>'".
+QUOTED_ARGS=""
+for arg in "${PGBACKREST_ARGS[@]}"; do
+    QUOTED_ARGS+=" \"${arg}\""
+done
 RESTORE_CMD="rm -rf /var/lib/postgresql/data/* /var/lib/postgresql/data/.[!.]* 2>/dev/null; "
-RESTORE_CMD+="exec su -s /bin/sh postgres -c 'pgbackrest ${PGBACKREST_ARGS[*]}'"
+RESTORE_CMD+="exec su -s /bin/sh postgres -c 'pgbackrest${QUOTED_ARGS}'"
 
 run docker compose run --rm --no-deps --entrypoint /bin/sh database -c "${RESTORE_CMD}"
 
-# 4+5. Bring postgres + api back. archive_command resumes as soon as postgres
-# starts. The --wait flag blocks until healthchecks pass.
+# 4. Bring postgres back. archive_command resumes as soon as postgres starts.
 run docker compose up -d --wait database
+
+# 4b. Re-grant the runtime role. A physical restore can land the cluster with
+# the pre-W1-1 grant state (or the app role's schema grants otherwise dropped);
+# the W1-1 migration does NOT re-run on a restore, so `pim_app` would hit
+# "permission denied for schema public". Idempotent — safe on every restore.
+if ! ${DRY_RUN}; then
+    echo "==> Re-granting pim_app (post-restore quirk)"
+    docker compose exec -T database psql -U "${POSTGRES_USER:-pim}" -d "${POSTGRES_DB:-pim}" <<'SQL' || true
+GRANT USAGE ON SCHEMA public TO pim_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO pim_app;
+GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA public TO pim_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO pim_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO pim_app;
+SQL
+fi
+
+# 5. Bring api back. The --wait flag blocks until healthchecks pass.
 run docker compose up -d --wait api
 
 cat <<EOF

--- a/scripts/restore-drill.sh
+++ b/scripts/restore-drill.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# GOLIVE A2 (#2122) — pgBackRest point-in-time recovery (PITR) drill.
+#
+# Proves the backup is not just configured but RESTORABLE to a precise instant,
+# measures RTO, and exercises the post-restore `pim_app` re-grant quirk
+# (memory: db-restore-regrant-pim-app — after a physical restore the runtime
+# role can lose schema grants; the W1-1 migration does NOT re-run).
+#
+# PITR precision test:
+#   1. Take a backup (the restore base).
+#   2. Insert a BEFORE marker; force a WAL switch; record T = now().
+#   3. Insert an AFTER marker; force a WAL switch.
+#   4. Restore --type=time --target=T (replays WAL up to T only).
+#   5. Re-grant pim_app defensively.
+#   6. Assert BEFORE marker present AND AFTER marker absent → PITR landed
+#      exactly at T. Report RTO (restore wall-clock).
+#
+# Uses the canonical `objects` table (NOT the deprecated `products` table the
+# Sprint-0 test-pgbackrest-restore.sh still targets — post-ObjectType that
+# DELETE is a no-op, making that test falsely green).
+#
+# DESTRUCTIVE: wipes + restores the Postgres data dir. Everything committed
+# AFTER T is intentionally lost (here: only the AFTER marker). Run on a dev DB.
+#
+# Usage: scripts/restore-drill.sh [--force]   (--force skips the confirmation)
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+FORCE=0
+[[ "${1:-}" == "--force" ]] && FORCE=1
+
+PGUSER="${POSTGRES_USER:-pim}"
+PGDB="${POSTGRES_DB:-pim}"
+STAMP=$(date -u +%s)
+BEFORE="drill-before-${STAMP}"
+AFTER="drill-after-${STAMP}"
+
+psql_owner() {
+  docker compose exec -T database psql -U "$PGUSER" -d "$PGDB" -tA -c "$1"
+}
+
+if [[ "$FORCE" != "1" ]]; then
+  echo "This runs a DESTRUCTIVE PITR restore of the dev database. Type 'drill' to continue:"
+  read -r ack
+  [[ "$ack" == "drill" ]] || { echo "Aborted."; exit 1; }
+fi
+
+# Resolve the built-in product ObjectType id + a tenant to attach markers to.
+OTID=$(psql_owner "SELECT id FROM object_types WHERE kind='product' AND is_built_in=true LIMIT 1;")
+TENANT_ID=$(psql_owner "SELECT tenant_id FROM object_types WHERE id='${OTID}';")
+[[ -n "$OTID" && -n "$TENANT_ID" ]] || { echo "No built-in product ObjectType found." >&2; exit 1; }
+
+insert_marker() {
+  local code="$1"
+  # tenant-safe: drill-only marker, explicit tenant_id + object_type_id.
+  psql_owner "INSERT INTO objects (id, tenant_id, object_type_id, kind, code, status, attributes_indexed, created_at, updated_at)
+    VALUES (gen_random_uuid(), '${TENANT_ID}', '${OTID}', 'product', '${code}', 'draft', '{}', now(), now());" >/dev/null
+}
+count_marker() { psql_owner "SELECT count(*) FROM objects WHERE code='${1}';"; }
+
+echo "==> [1/6] Baseline backup (restore base)"
+docker compose exec -T database su -s /bin/sh postgres -c "pgbackrest --stanza=pim --type=incr backup" 2>&1 | tail -1
+
+echo "==> [2/6] Insert BEFORE marker + WAL switch, then record PITR target T"
+insert_marker "$BEFORE"
+psql_owner "SELECT pg_switch_wal();" >/dev/null
+sleep 1
+TARGET=$(psql_owner "SELECT now();")
+echo "    T = ${TARGET}"
+sleep 2
+
+echo "==> [3/6] Insert AFTER marker (must NOT survive PITR to T) + WAL switch"
+insert_marker "$AFTER"
+psql_owner "SELECT pg_switch_wal();" >/dev/null
+# Give pgBackRest's async archiver a moment to ship the segments.
+sleep 3
+
+echo "    pre-restore: BEFORE=$(count_marker "$BEFORE") AFTER=$(count_marker "$AFTER") (expect 1 / 1)"
+
+echo "==> [4/6] PITR restore to T (measuring RTO)"
+# The wrapper restores read-write (--target-action=promote) and re-grants
+# pim_app itself; RTO = full stop -> wipe -> restore -> re-grant -> api-up.
+RESTORE_START=$(date +%s)
+./scripts/pim-backup-restore.sh --type time --target "${TARGET}" --no-confirm
+RESTORE_END=$(date +%s)
+RTO=$((RESTORE_END - RESTORE_START))
+
+echo "==> [5/6] (promote + re-grant handled by the restore wrapper)"
+
+echo "==> [6/6] Verify PITR precision"
+B=$(count_marker "$BEFORE")
+A=$(count_marker "$AFTER")
+echo "    post-restore: BEFORE=${B} AFTER=${A} (expect 1 / 0)"
+echo "    RTO = ${RTO}s"
+
+# Confirm the app role can QUERY through the restored grants. Under FORCE RLS
+# with no request-scoped tenant GUC, pim_app legitimately sees 0 rows — so the
+# check is "query succeeds" (a missing grant would be 'permission denied for
+# table objects'), NOT "a row comes back".
+APP_READ=$(docker compose exec -T database psql -U pim_app -d "$PGDB" -tA -c "SELECT count(*) FROM objects;" 2>&1 || true)
+
+RC=0
+if [[ "$B" == "1" && "$A" == "0" ]]; then
+  echo "==> PITR DRILL PASSED — recovered to T exactly (BEFORE kept, AFTER dropped)."
+else
+  echo "==> PITR DRILL FAILED — expected BEFORE=1/AFTER=0, got ${B}/${A}." >&2; RC=1
+fi
+if [[ "$APP_READ" =~ ^[0-9]+$ ]]; then
+  echo "    pim_app grants OK after re-grant (query succeeded; RLS shows ${APP_READ} rows without a tenant GUC)."
+else
+  echo "    WARNING: pim_app query failed after re-grant: ${APP_READ}" >&2; RC=1
+fi
+
+# Clean up the surviving BEFORE marker so the drill leaves no residue.
+psql_owner "DELETE FROM objects WHERE code IN ('${BEFORE}','${AFTER}');" >/dev/null 2>&1 || true
+
+exit $RC


### PR DESCRIPTION
## Co

Próba generalna backup/restore z PITR (A2). `scripts/restore-drill.sh` + naprawy narzędzia DR + raport.

## Wynik drillu

**PITR precyzyjny** — marker sprzed T przeżył, marker zza T zniknął (`BEFORE=1 AFTER=0`). **RTO ≈ 19s** (stop→wipe→restore 169MB→promote→re-grant→api healthy). Login end-to-end 200. Owner widzi 211 obiektów, `pim_app` odpytuje bez permission-denied.

## Bugi DR wykryte i naprawione (broken restore = blocker)

Drill odsłonił **2 realne bugi w `pim-backup-restore.sh`, które wysadziłyby każdy prawdziwy PITR** ([#2196](../../../issues/2196)):
1. **`--target` ze spacją** → `${ARR[*]}` join dzielił timestamp na 2 argumenty → `invalid command`. **Żaden PITR fizycznie nie działał.** Fix: double-quote argumentów.
2. **Brak promote** → klaster zostawał read-only po recovery target. Fix: `--target-action=promote` + re-grant `pim_app` w wrapperze.

Runbook `docs/runbook/restore.md` uzupełniony (promote + re-grant + PITR quirk).

## Weryfikacja

Drill uruchomiony 2× na żywym stacku (raz odkrył bugi, raz zielony po fixie); pełny proof w `docs/audit/2026-07-handover/restore-drill.md`. Stack odzyskany, login 200.

Refs #2122