### PR TITLE
fix(identity): fresh clone cannot log in — JWT keypair generation missing from onboarding path

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -24,6 +24,21 @@ docker compose exec -T api bin/console pim:db:reset --with-fixtures   # canonica
 
 Open `https://pim.localhost` (Caddy will produce a self-signed cert — accept it once). Login with `admin@demo.localhost` / `changeme`. Navigate to **Products** — the demo dataset seeded by `App\DataFixtures\AppFixtures` should be visible.
 
+### JWT keys
+
+Login tokens are signed with an RSA keypair in `apps/api/config/jwt/` (gitignored). **In dev/test the api container generates it automatically on first boot** (`lexik:jwt:generate-keypair --skip-if-exists` in the entrypoint), using whatever `JWT_PASSPHRASE` resolves to — you don't need to do anything. To use your own passphrase, set `JWT_PASSPHRASE=<value>` in `apps/api/.env.local` **before** the first boot.
+
+Manual generation (production, or running outside Docker — never auto-generated when `APP_ENV=prod`):
+
+```bash
+docker compose exec -T api bin/console lexik:jwt:generate-keypair
+```
+
+Troubleshooting — `POST /api/auth/login` returns 500 `An error occurred while trying to encode the JWT token`:
+
+- **Keys missing** (e.g. wiped manually): restart the api container (regenerates) or run the command above.
+- **Passphrase changed after the keys were generated**: `docker compose exec -T api bin/console lexik:jwt:check-config` will fail; regenerate with `lexik:jwt:generate-keypair --overwrite` (invalidates all issued tokens — everyone logs in again).
+
 Verify your environment with the same gates CI runs:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ pnpm install
 cp .env.example .env
 
 # 3. Wystartuj cały stack (build kontenerów przy pierwszym uruchomieniu trwa kilka minut)
+#    Przy pierwszym boocie kontener api sam generuje parę kluczy JWT
+#    (config/jwt/*.pem, gitignored) — bez tego login zwracałby 500.
+#    Szczegóły + troubleshooting: ONBOARDING.md sekcja "JWT keys".
 pnpm dev          # foreground, Ctrl+C zatrzymuje
 # albo:
 pnpm stack:up     # detached, działa w tle

--- a/apps/api/.env
+++ b/apps/api/.env
@@ -118,6 +118,11 @@ JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
 JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem
 # AUD-005 — placeholder only in this committed template. Real passphrase lives
 # in untracked apps/api/.env.dev (or .env.local). Never commit a real value here.
+# Dev/test: the api entrypoint auto-generates config/jwt/*.pem on first boot
+# with whatever this resolves to (#2176) — set your own in .env.local BEFORE
+# first boot if you want a non-placeholder passphrase; changing it afterwards
+# requires `lexik:jwt:generate-keypair --overwrite` (invalidates issued tokens).
+# Prod: no auto-generation — provision keys explicitly with a real passphrase.
 JWT_PASSPHRASE=__CHANGE_ME_jwt_private_key_passphrase__
 ###< lexik/jwt-authentication-bundle ###
 

--- a/apps/api/docker-entrypoint.sh
+++ b/apps/api/docker-entrypoint.sh
@@ -53,6 +53,36 @@ if [ "${CI:-}" != "true" ] && [ "${APP_DEBUG:-}" = "0" ] \
     fi
 fi
 
+# Generate the JWT keypair on first boot when missing (dev/test only).
+#
+# A fresh clone has no config/jwt/*.pem (gitignored per the lexik bundle
+# recipe) and nothing in the onboarding path created them, so the very
+# first login on a new machine failed with a 500 ("An error occurred
+# while trying to encode the JWT token") — GOLIVE cold-start finding L4.
+# CI is unaffected (workflows generate keys themselves before boot) and
+# prod is skipped entirely: production keys are provisioned explicitly
+# with a real passphrase (secrets vault), never from an entrypoint hook.
+#
+# Gated on PIM_JWT_AUTOGEN, set by docker-compose ONLY on the api
+# service: the worker shares the same bind mount and entrypoint, and two
+# containers generating concurrently on first boot could interleave into
+# a mismatched pair. The worker never encodes JWTs, so it needs no keys.
+#
+# --skip-if-exists makes the step idempotent — existing keys are never
+# touched, so a restart cannot invalidate issued tokens. The follow-up
+# check-config is warn-only: it catches a passphrase changed AFTER the
+# keys were generated (keys load-fail) without blocking the boot.
+if [ "${CI:-}" != "true" ] && [ "${PIM_JWT_AUTOGEN:-}" = "1" ] \
+    && { [ "${APP_ENV:-dev}" = "dev" ] || [ "${APP_ENV:-dev}" = "test" ]; }; then
+    if [ -x /app/bin/console ]; then
+        echo "[entrypoint] Ensuring JWT keypair exists (lexik:jwt:generate-keypair --skip-if-exists)"
+        php /app/bin/console lexik:jwt:generate-keypair --skip-if-exists --no-interaction \
+            || echo "[entrypoint] WARN: JWT keypair generation failed; login will return 500 until keys exist. Run 'docker compose exec api bin/console lexik:jwt:generate-keypair' manually to diagnose."
+        php /app/bin/console lexik:jwt:check-config --no-interaction \
+            || echo "[entrypoint] WARN: JWT config check failed — likely JWT_PASSPHRASE no longer matches the existing keys. Regenerate with 'docker compose exec api bin/console lexik:jwt:generate-keypair --overwrite' (this invalidates all issued tokens)."
+    fi
+fi
+
 # Run the seed guard only on dev / test, and never in CI — Playwright's
 # workflow drives migrations + fixtures explicitly via `bin/console
 # doctrine:migrations:migrate` after the container is up, and the seed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,6 +182,12 @@ services:
       # can skip the dev seed guard (Playwright workflow drives migrations
       # itself, see apps/api/docker-entrypoint.sh).
       CI: ${CI:-}
+      # Dev/test-only JWT keypair auto-generation on boot (GOLIVE cold-start
+      # L4). Set ONLY here, not on the worker: both services share the
+      # ./apps/api bind mount, and two containers generating concurrently on
+      # first boot could interleave into a mismatched key pair. The worker
+      # never encodes JWTs, so it needs no keys of its own.
+      PIM_JWT_AUTOGEN: "1"
     expose:
       - "80"
     # Live-mount the source tree so iterating on PHP code does not require a


### PR DESCRIPTION
## Summary

Blok A GOLIVE, finding **L4 (CRITICAL)** z cold-start testu #2119 — pierwszy z 4 blokerów dnia pierwszego handoveru. Świeży klon nie mógł się zalogować: `config/jwt/*.pem` jest gitignored, entrypoint nie generował kluczy, README/ONBOARDING milczały → `POST /api/auth/login` 500. Fix realizuje oba warianty z ticketu: (a) auto-generacja w entrypoincie dev/test + (b) dokumentacja Day-1.

## Root cause

Klasa „works on my machine": klucze wygenerowane historycznie u operatora, nie re-derywowalne z repo. CI niewidzące problemu — workflow generuje klucze własnym torem (openssl).

## Backend/infra changes

- `apps/api/docker-entrypoint.sh` — nowy dev/test-only blok (wzorzec 1:1 z auto-seedem): `lexik:jwt:generate-keypair --skip-if-exists` (idempotentny, nigdy nie nadpisuje istniejących kluczy) + warn-only `lexik:jwt:check-config` (łapie mismatch passphrase↔klucz z komendą naprawczą w logu). Best-effort — fail kroku nie blokuje bootu. Gated: `CI != true` ∧ `APP_ENV ∈ {dev,test}` ∧ `PIM_JWT_AUTOGEN=1`.
- `docker-compose.yml` — `PIM_JWT_AUTOGEN: "1"` TYLKO na usłudze `api`. Worker celowo bez flagi: współdzieli bind-mount `./apps/api` i równoległa generacja przy pierwszym boocie mogłaby przeplести się w niesparowaną parę kluczy; worker nie enkoduje JWT.
- `apps/api/.env` — komentarz nad `JWT_PASSPHRASE` (dev autogen, własna passphrase w `.env.local` przed pierwszym bootem, prod = manual + vault).

## Docs changes

- `README.md` — notka w quickstart (krok 3) + link do ONBOARDING.
- `ONBOARDING.md` — sekcja „JWT keys": mechanizm autogen, manual generation (prod / poza Dockerem), troubleshooting login 500 (klucze brak / passphrase mismatch → `--overwrite`).

## Quality gates

- `sh -n` entrypoint: OK. `docker compose config`: flaga tylko na api (worker: absent).
- Zero zmian PHP/TS — PHPStan/Biome/PHPUnit/Playwright bez wpływu; CI pełny na PR.
- Smoke na żywym api: `--skip-if-exists` z istniejącymi kluczami → skip, mtime nietknięty, `check-config` OK; generacja od zera (temp dir przez env-override) → para powstaje, `check-config` OK.

## Smoke test plan (live-proof przed zamknięciem #2176)

Świeży klon w izolacji (`COMPOSE_PROJECT_NAME=pim2176`, świeże wolumeny, NIE-domyślne sekrety, wzorzec z lessons #2119):
1. Boot bez żadnego `.env.local` i bez `config/jwt/` → log entrypointa pokazuje generację, `config/jwt/` = 2 pliki.
2. `POST /api/auth/login` → **200 + `token` w JSON** (asercja kształtu, nie statusu).
3. Restart api → klucze niezmienione, login dalej 200.

**Status smoke:** ścieżka idempotentna + generacja od zera przetestowane na żywym stacku (wyniki wyżej); pełny fresh-clone end-to-end wykonywany PO merge (klon z main) — wynik trafi do komentarza zamykającego #2176. Do tego czasu: komponent gotowy, fresh-clone end-to-end nieprzetestowany.

## Świadome odejścia

- Prod provisioning kluczy (vault, fail-fast) → #2138 (Blok C); tu tylko wpis w docs.
- Placeholder passphrase w dev świadomie zaakceptowany (ta sama klasa co `changeme`).
- Bez automatycznych testów shella (brak harnessa bats w repo — nie wprowadzam nowego toolingu dla ~10 linii sh); AC weryfikowane live-proofem.

Closes #2176

🤖 Generated with [Claude Code](https://claude.com/claude-code)