### PR TITLE
fix(infra): AWS_ASSETS_KEY/SECRET not wired to MINIO_ROOT_* — changing MinIO passwords per README breaks all uploads

### DIFF
--- a/apps/api/.env
+++ b/apps/api/.env
@@ -132,6 +132,9 @@ JWT_PASSPHRASE=__CHANGE_ME_jwt_private_key_passphrase__
 # AWS_ASSETS_ENDPOINT to s3.<region>.amazonaws.com and rotates credentials.
 AWS_ASSETS_ENDPOINT=http://minio:9000
 AWS_ASSETS_REGION=eu-central-1
+# In Docker these two are overridden by docker-compose (wired to
+# MINIO_ROOT_USER/PASSWORD, #2181) — the values below only apply when the
+# api runs outside the compose stack against a default-credentials MinIO.
 AWS_ASSETS_KEY=minioadmin
 AWS_ASSETS_SECRET=minioadmin
 AWS_ASSETS_BUCKET=pim-assets

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,6 +176,12 @@ services:
       MERCURE_JWT_SECRET: ${MERCURE_JWT_SECRET:-!ChangeMercureKeyAtLeast256BitsLong!}
       MEILI_URL: http://meilisearch:7700
       MEILI_KEY: ${MEILI_MASTER_KEY:-masterKeyPleaseChangeMe}
+      # GOLIVE #2181 (cold-start L10) — S3 credentials follow MINIO_ROOT_* like
+      # minio-init and pgBackRest already do. apps/api/.env hardcodes the
+      # minioadmin defaults, so changing the MinIO passwords per README used to
+      # break every upload (InvalidAccessKeyId) — compose env wins over .env.
+      AWS_ASSETS_KEY: ${MINIO_ROOT_USER:-minioadmin}
+      AWS_ASSETS_SECRET: ${MINIO_ROOT_PASSWORD:-minioadmin}
       TRUSTED_PROXIES: 127.0.0.1,REMOTE_ADDR
       TRUSTED_HOSTS: '^pim\.localhost$$|^localhost$$|^api$$'
       # CI sentinel — propagated from GitHub Actions so docker-entrypoint.sh
@@ -256,6 +262,12 @@ services:
       MERCURE_TOPIC_BASE: ${MERCURE_TOPIC_BASE:-https://pim.localhost}
       MEILI_URL: http://meilisearch:7700
       MEILI_KEY: ${MEILI_MASTER_KEY:-masterKeyPleaseChangeMe}
+      # GOLIVE #2181 (cold-start L10) — S3 credentials follow MINIO_ROOT_* like
+      # minio-init and pgBackRest already do. apps/api/.env hardcodes the
+      # minioadmin defaults, so changing the MinIO passwords per README used to
+      # break every upload (InvalidAccessKeyId) — compose env wins over .env.
+      AWS_ASSETS_KEY: ${MINIO_ROOT_USER:-minioadmin}
+      AWS_ASSETS_SECRET: ${MINIO_ROOT_PASSWORD:-minioadmin}
     volumes:
       - ./apps/api:/app
       - api_var:/app/var


### PR DESCRIPTION
## Summary

GOLIVE Blok A, finding **L10 (HIGH)** z cold-start #2119, trzeci z 4 blokerów dnia pierwszego. Świeży klon z podmienionymi hasłami MinIO (zgodnie z README krok 2) → każdy upload 500 `InvalidAccessKeyId`.

## Root cause

Compose propaguje `MINIO_ROOT_*` do minio, minio-init i pgBackRest — ale nie do api/workera, które czytają hardcodowane `minioadmin` z `apps/api/.env`. U operatora niewidoczne (MinIO na defaultach), w CI niewidoczne (własny tor środowiska).

## Backend/infra changes

- `docker-compose.yml` (api + worker): `AWS_ASSETS_KEY: ${MINIO_ROOT_USER:-minioadmin}` + `AWS_ASSETS_SECRET: ${MINIO_ROOT_PASSWORD:-minioadmin}` — compose env wygrywa z `.env`, spójnie z minio-init/pgBackRest.
- `apps/api/.env`: komentarz — hardcode zostaje jako fallback poza stackiem Dockera.

## Quality gates

- `docker compose config`: zmienna resolves na obu usługach; api+worker recreate → oba healthy; env w kontenerze potwierdzony (`AWS_ASSETS_KEY=minioadmin` na defaultach = zero zmiany zachowania u operatora).
- Zero zmian PHP/TS — CI pełny na PR.

## Smoke test plan

Zbiorczy fresh-clone live-proof blokerów dnia 1: klon z **niedomyślnymi** `MINIO_ROOT_*` → upload w kreatorze importu działa bez ręcznych kroków. Proof w komentarzu zamykającym #2181. Do tego czasu: wiring zweryfikowany na defaultach, wariant z podmienionymi hasłami nieprzetestowany.

## Świadome odejścia

- Prod (realny S3, rotacja credentiali) → #2138; prod overlay ustawia własne `AWS_ASSETS_*`.

Closes #2181

🤖 Generated with [Claude Code](https://claude.com/claude-code)