### PR TITLE
fix(infra): pim:db:reset + audit:schema:update + fixtures fail under pim_app role split — use owner connection + document sequence

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -14,12 +14,14 @@ pnpm stack:up                 # docker compose up -d (api + admin + caddy + post
 docker compose exec -T api bin/console pim:db:reset --with-fixtures   # canonical one-shot: drop+create+migrate+audit:schema:update+fixtures
 ```
 
-> The manual equivalent is **three** steps, not two — `audit:schema:update` is required: audit tables live outside the Doctrine migration pipeline, so without it any INSERT into an audited entity 500s with `relation "*_audit" does not exist`:
+> `pim:db:reset` re-runs itself on the owner connection (`DATABASE_URL_OWNER`) automatically — since the W1-1 role split the runtime role `pim_app` has no DDL/BYPASSRLS, so the raw sub-commands fail under it (#2178). The drop uses `DROP DATABASE … WITH (FORCE)`, so api/worker sessions are terminated atomically — no need to stop containers first.
+>
+> The manual equivalent is **three** steps, not two — `audit:schema:update` is required: audit tables live outside the Doctrine migration pipeline, so without it any INSERT into an audited entity 500s with `relation "*_audit" does not exist`. Two of them need the owner DSN swap (`migrations:migrate` has its own owner connection in config):
 >
 > ```bash
 > docker compose exec -T api bin/console doctrine:migrations:migrate --no-interaction
-> docker compose exec -T api bin/console audit:schema:update --force
-> docker compose exec -T api bin/console doctrine:fixtures:load --no-interaction
+> docker compose exec -T api sh -c 'DATABASE_URL="$DATABASE_URL_OWNER" bin/console audit:schema:update --force'
+> docker compose exec -T api sh -c 'DATABASE_URL="$DATABASE_URL_OWNER" bin/console doctrine:fixtures:load --no-interaction'
 > ```
 
 Open `https://pim.localhost` (Caddy will produce a self-signed cert — accept it once). Login with `admin@demo.localhost` / `changeme`. Navigate to **Products** — the demo dataset seeded by `App\DataFixtures\AppFixtures` should be visible.

--- a/README.md
+++ b/README.md
@@ -71,10 +71,13 @@ pnpm stack:logs   # tail logów
 docker compose exec -T api php bin/console pim:db:reset --with-fixtures --force
 #    Manualny odpowiednik to TRZY kroki (audit:schema:update jest wymagany —
 #    tabele *_audit są poza pipeline'em migracji; bez tego INSERT do audytowanej
-#    encji wywala 500 "relation '*_audit' does not exist"):
+#    encji wywala 500 "relation '*_audit' does not exist").
+#    UWAGA (#2178): po splicie ról W1-1 audit:schema:update i fixtures:load
+#    wymagają roli owner — stąd swap DATABASE_URL (migrate ma własne połączenie
+#    owner w konfiguracji; pim:db:reset robi ten swap sam):
 #      docker compose exec -T api php bin/console doctrine:migrations:migrate --no-interaction
-#      docker compose exec -T api php bin/console audit:schema:update --force
-#      docker compose exec -T api php bin/console doctrine:fixtures:load --no-interaction
+#      docker compose exec -T api sh -c 'DATABASE_URL="$DATABASE_URL_OWNER" php bin/console audit:schema:update --force'
+#      docker compose exec -T api sh -c 'DATABASE_URL="$DATABASE_URL_OWNER" php bin/console doctrine:fixtures:load --no-interaction'
 
 # 5. Sprawdź single-origin i zaloguj się (admin@demo.localhost / changeme)
 curl -sk https://pim.localhost/api/docs.jsonld | head  # Hydra/JSON-LD API documentation
@@ -116,12 +119,17 @@ Robi po kolei: `doctrine:database:drop` → `create` → `migrations:migrate` �
 `--force` (pomiń pytanie potwierdzające), `--force-prod` (dopuść `APP_ENV=prod` —
 domyślnie odmawia). Używaj **tylko na bazie deweloperskiej**.
 
+Komenda **sama przełącza się na połączenie owner** (`DATABASE_URL_OWNER`,
+rola `pim`) — po splicie ról W1-1 runtime'owa rola `pim_app` nie ma DDL ani
+BYPASSRLS, więc drop/create/audit/fixtures pod nią padają (#2178). Nie trzeba
+(i nie należy) ręcznie podmieniać env-varów. Drop wykonuje się jako
+`DROP DATABASE … WITH (FORCE)` — sesje trzymane przez api/worker są zrywane
+atomowo, **nie trzeba zatrzymywać kontenerów** przed resetem.
+
 > **OSTRZEŻENIE — wipe stanu manualnego.** `pim:db:reset` (i `pnpm stack:reset`)
 > kasują bazę i ładują od nowa tylko fixtures. **Nie odtwarzają** custom
 > ObjectType / grup atrybutów / danych utworzonych ręcznie przez UI — ten stan
 > przepada. Zrób smoke-test/eksport zanim zresetujesz, albo uprzedź operatora.
-> (Jeśli worker api działa, najpierw `docker compose stop api`, żeby FrankenPHP
-> zwolnił połączenie.)
 
 ### `exec` vs `exec -T`
 

--- a/apps/api/src/Shared/Infrastructure/Maintenance/DatabaseResetCommand.php
+++ b/apps/api/src/Shared/Infrastructure/Maintenance/DatabaseResetCommand.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Maintenance;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -11,16 +14,22 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Process\Process;
+use Throwable;
+
+use const PHP_BINARY;
 
 /**
  * Drop + create + migrate + (optional) load fixtures, in a single command.
  *
  * The Sprint-0 dance was three separate `bin/console` calls plus stopping the
  * api container so FrankenPHP would release its persistent connection. This
- * command bundles the SQL side of that workflow — the operator still has to
- * `docker compose stop api` first if the api worker is up. The runtime check
- * tells them so explicitly instead of failing on a confusing "database in use"
- * error from Postgres.
+ * command bundles the SQL side of that workflow; since GOLIVE #2178 the drop
+ * uses DROP DATABASE … WITH (FORCE), so lingering api/worker sessions no
+ * longer require stopping containers first, and the whole run self-elevates
+ * to the owner connection (see execute()) so it works under the W1-1
+ * runtime role without env-var tricks.
  *
  * Designed for development databases. In production a refusal trips on
  * APP_ENV=prod unless `--force-prod` is passed, so a stray invocation does not
@@ -32,6 +41,24 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 final class DatabaseResetCommand extends Command
 {
+    public function __construct(
+        #[Autowire(param: 'kernel.project_dir')]
+        private readonly string $projectDir,
+        // Only getParams() is read (never connects) — the drop itself runs on
+        // a throwaway maintenance-DB connection derived from these params.
+        #[Autowire(service: 'doctrine.dbal.owner_connection')]
+        private readonly Connection $ownerConnection,
+        // Closed right after the FORCE drop: a console-boot listener may have
+        // already opened it, and a session killed by DROP … WITH (FORCE)
+        // surfaces as "terminating connection due to administrator command"
+        // on next reuse (observed on the chained audit:schema:update step).
+        // close() discards the dead socket; DBAL reconnects lazily.
+        #[Autowire(service: 'doctrine.dbal.default_connection')]
+        private readonly Connection $defaultConnection,
+    ) {
+        parent::__construct();
+    }
+
     protected function configure(): void
     {
         $this
@@ -70,8 +97,75 @@ final class DatabaseResetCommand extends Command
 
         // VALUE_NONE options are typed as bool by phpstan-symfony — no cast.
         $loadFixtures = $input->getOption('with-fixtures');
+
+        // GOLIVE #2178 (cold-start L5/L6/L8) — since the W1-1 role split the
+        // default connection is `pim_app` (non-owner, NOBYPASSRLS): database
+        // drop/create and audit:schema:update need the table-owner role, and
+        // fixtures/reindex need BYPASSRLS (a CLI run never sets the per-request
+        // tenant GUC, so FORCE RLS would deny every insert / hide every row).
+        // The entrypoint seed already works around this by swapping
+        // DATABASE_URL to DATABASE_URL_OWNER; formalise the same swap here by
+        // re-executing this command in a child process on the owner DSN, so
+        // the documented `pim:db:reset` invocation works without tribal
+        // env-var knowledge. Single-role setups (owner fallback equals the
+        // runtime DSN — see .env) skip the hop entirely.
+        $ownerDsnRaw = $_SERVER['DATABASE_URL_OWNER'] ?? $_ENV['DATABASE_URL_OWNER'] ?? null;
+        $currentDsnRaw = $_SERVER['DATABASE_URL'] ?? $_ENV['DATABASE_URL'] ?? null;
+        $ownerDsn = \is_string($ownerDsnRaw) ? $ownerDsnRaw : '';
+        $currentDsn = \is_string($currentDsnRaw) ? $currentDsnRaw : '';
+        $elevated = '1' === ($_SERVER['PIM_DB_RESET_ELEVATED'] ?? $_ENV['PIM_DB_RESET_ELEVATED'] ?? '');
+
+        if (!$elevated && '' !== $ownerDsn && $ownerDsn !== $currentDsn) {
+            $io->note('Re-running on the owner connection (DATABASE_URL_OWNER): DDL steps need the table-owner role and the seed path bypasses FORCE RLS, exactly like the entrypoint auto-seed.');
+
+            // Confirmation already happened above — the child must not prompt
+            // again (and has no TTY to prompt on), so --force is always passed.
+            $childCommand = [PHP_BINARY, $this->projectDir.'/bin/console', 'pim:db:reset', '--force'];
+            if (true === $loadFixtures) {
+                $childCommand[] = '--with-fixtures';
+            }
+            if (true === $input->getOption('force-prod')) {
+                $childCommand[] = '--force-prod';
+            }
+
+            $process = new Process(
+                $childCommand,
+                $this->projectDir,
+                ['DATABASE_URL' => $ownerDsn, 'PIM_DB_RESET_ELEVATED' => '1'],
+                null,
+                // No timeout: migrate + fixtures + full reindex on a large
+                // catalog legitimately runs for minutes.
+                null,
+            );
+            $process->run(static function (string $type, string $buffer) use ($output): void {
+                $output->write($buffer);
+            });
+
+            return $process->isSuccessful() ? Command::SUCCESS : Command::FAILURE;
+        }
+
+        // GOLIVE #2178 — drop via raw `DROP DATABASE … WITH (FORCE)` (PG 13+)
+        // on a maintenance-DB connection instead of doctrine:database:drop.
+        // FrankenPHP (api) and the Messenger consumer (worker) re-open pooled
+        // connections within ~1 s, so the documented "terminate sessions, then
+        // reset" dance loses the race as often as it wins; FORCE terminates
+        // the sessions atomically inside the drop. Runs on the owner
+        // connection (`pim`), which holds the required privileges in every
+        // compose-provisioned environment.
+        $io->section('→ DROP DATABASE … WITH (FORCE)');
+        try {
+            $this->dropDatabaseWithForce();
+        } catch (Throwable $e) {
+            $io->error(sprintf('Dropping the database failed: %s', $e->getMessage()));
+
+            return Command::FAILURE;
+        }
+        // Discard sessions the FORCE drop just killed (see constructor note);
+        // every chained step below reconnects lazily against the new database.
+        $this->defaultConnection->close();
+        $this->ownerConnection->close();
+
         $steps = [
-            ['doctrine:database:drop', ['--force' => true, '--if-exists' => true]],
             ['doctrine:database:create', ['--if-not-exists' => true]],
             ['doctrine:migrations:migrate', ['--no-interaction' => true, '--allow-no-migration' => true]],
             // dh_auditor creates *_audit tables outside the regular Doctrine
@@ -150,5 +244,33 @@ final class DatabaseResetCommand extends Command
         ));
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * DROP DATABASE <target> WITH (FORCE) on a throwaway connection to the
+     * `postgres` maintenance database (a database cannot be dropped from a
+     * connection to itself). FORCE terminates lingering api/worker sessions
+     * atomically — no terminate-then-drop race.
+     */
+    private function dropDatabaseWithForce(): void
+    {
+        /** @var array{dbname?: string, url?: string} $params */
+        $params = $this->ownerConnection->getParams();
+        $dbname = $params['dbname'] ?? '';
+        if ('' === $dbname) {
+            throw new RuntimeException('Cannot resolve the database name from the owner connection params.');
+        }
+
+        $params['dbname'] = 'postgres';
+        // `url` (when present) would win over the overridden dbname.
+        unset($params['url']);
+
+        $maintenance = DriverManager::getConnection($params);
+        try {
+            $quoted = $maintenance->getDatabasePlatform()->quoteSingleIdentifier($dbname);
+            $maintenance->executeStatement(sprintf('DROP DATABASE IF EXISTS %s WITH (FORCE)', $quoted));
+        } finally {
+            $maintenance->close();
+        }
     }
 }

--- a/apps/api/src/Shared/Infrastructure/Maintenance/DatabaseResetCommand.php
+++ b/apps/api/src/Shared/Infrastructure/Maintenance/DatabaseResetCommand.php
@@ -268,6 +268,7 @@ final class DatabaseResetCommand extends Command
         $maintenance = DriverManager::getConnection($params);
         try {
             $quoted = $maintenance->getDatabasePlatform()->quoteSingleIdentifier($dbname);
+            // tenant-safe: infrastructure (dev-only whole-database drop on the maintenance DB; no tenant-scoped rows are queried)
             $maintenance->executeStatement(sprintf('DROP DATABASE IF EXISTS %s WITH (FORCE)', $quoted));
         } finally {
             $maintenance->close();


### PR DESCRIPTION
## Summary

GOLIVE Blok A, findingi **L5/L6/L8 (HIGH, wspólny root cause)** z cold-start #2119, czwarty bloker dnia pierwszego. Wszystkie dokumentowane komendy utrzymaniowe DB padały na świeżej instalacji pod rolą `pim_app`; działający wzorzec (swap na `DATABASE_URL_OWNER`) żył tylko w entrypoincie.

## Root cause

Chainowane sub-komendy na default connection (`pim_app`: non-owner, NOBYPASSRLS). Dodatkowo dokumentowana sekwencja resetu i tak przegrywała wyścig: FrankenPHP/worker reconnectują w ~1 s po `pg_terminate_backend` (zmierzone podczas implementacji).

## Backend changes (`DatabaseResetCommand`)

- **Self-elevation**: re-exec w procesie potomnym z `DATABASE_URL=DATABASE_URL_OWNER` (+ guard `PIM_DB_RESET_ELEVATED`), formalizując wzorzec entrypointa; single-role setupy pomijają hop (equal-DSN skip — dotyczy też env testowego/CI).
- **`DROP DATABASE … WITH (FORCE)`** na jednorazowym połączeniu do maintenance-DB zamiast `doctrine:database:drop` — sesje api/workera zrywane atomowo; koniec „stop api przed resetem".
- **`close()` default+owner po dropie** — killed-session z pre-drop connectu listenera wybuchał dopiero na chainowanym `audit:schema:update` (zaobserwowane: „terminating connection due to administrator command"); close wymusza lazy reconnect.

## Docs changes

- README: sekcja `pim:db:reset` (self-elevation + FORCE, bez zatrzymywania kontenerów) + manual 3-step z jawnym swapem owner dla `audit:schema:update`/`fixtures:load`.
- ONBOARDING Day-1: to samo (EN).

## Quality gates

- PHPStan max: 0 (deprecated `quoteIdentifier` → `quoteSingleIdentifier`). cs-fixer: 0.
- **Smoke na żywym stacku**: `pim:db:reset --with-fixtures --force` przy DZIAŁAJĄCYM api+worker, bez env-swapa, bez terminate → pełen cykl drop→create→migrate→audit→fixtures→reindex exit=0; login 200 po resecie.

## Smoke test plan

Zbiorczy fresh-clone live-proof blokerów dnia 1: reset wg docs na świeżym klonie bez wiedzy plemiennej. Proof w komentarzu zamykającym #2178.

## Świadome odejścia

- Entrypoint zostawia swój swap (redundantny, nieszkodliwy — equal-DSN skip).
- Obserwacja z developmentu: po resecie na branchu bez migracji z PR #2202 worker odtworzył crashloop #2177 (brak `messenger_messages` + `auto_setup=1` pod `pim_app`) — wyleczony workaroundem z ticketu; potwierdza diagnozę #2177.

Closes #2178

🤖 Generated with [Claude Code](https://claude.com/claude-code)