### PR TITLE
fix(infra): serialise database lifecycle (reset vs ensure-seeded) with a cluster-wide advisory lock

### DIFF
--- a/apps/api/src/Shared/Infrastructure/Maintenance/DatabaseResetCommand.php
+++ b/apps/api/src/Shared/Infrastructure/Maintenance/DatabaseResetCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Shared\Infrastructure\Maintenance;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\DriverManager;
 use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -152,19 +151,51 @@ final class DatabaseResetCommand extends Command
         // the sessions atomically inside the drop. Runs on the owner
         // connection (`pim`), which holds the required privileges in every
         // compose-provisioned environment.
-        $io->section('→ DROP DATABASE … WITH (FORCE)');
         try {
-            $this->dropDatabaseWithForce();
+            $maintenance = MaintenanceConnectionFactory::fromConnection($this->ownerConnection);
         } catch (Throwable $e) {
-            $io->error(sprintf('Dropping the database failed: %s', $e->getMessage()));
+            $io->error(sprintf('Cannot open the maintenance connection: %s', $e->getMessage()));
 
             return Command::FAILURE;
         }
-        // Discard sessions the FORCE drop just killed (see constructor note);
-        // every chained step below reconnects lazily against the new database.
-        $this->defaultConnection->close();
-        $this->ownerConnection->close();
 
+        try {
+            // GOLIVE #2178 follow-up — serialise database lifecycle actors.
+            // The FORCE drop below kills the worker's Messenger session; the
+            // restarted worker's entrypoint re-runs ensure-seeded, which sees
+            // a half-reset (empty) database and chains ANOTHER reset — two
+            // unserialised resets then kill each other mid-fixtures (observed:
+            // "terminating connection due to administrator command" during
+            // fixtures:load on a fresh clone). The advisory lock is
+            // cluster-wide and held on the maintenance DB, so it survives the
+            // drop; concurrent actors block here until this run completes.
+            $io->section('→ acquire lifecycle advisory lock');
+            // tenant-safe: infrastructure (cluster-wide advisory lock on the maintenance DB; no tenant-scoped data)
+            $maintenance->fetchOne(sprintf('SELECT pg_advisory_lock(%d)', MaintenanceConnectionFactory::LIFECYCLE_LOCK_KEY));
+
+            $io->section('→ DROP DATABASE … WITH (FORCE)');
+            try {
+                $this->dropDatabaseWithForce($maintenance);
+            } catch (Throwable $e) {
+                $io->error(sprintf('Dropping the database failed: %s', $e->getMessage()));
+
+                return Command::FAILURE;
+            }
+            // Discard sessions the FORCE drop just killed (see constructor
+            // note); every chained step reconnects lazily against the new
+            // database.
+            $this->defaultConnection->close();
+            $this->ownerConnection->close();
+
+            return $this->runResetSteps($io, $output, true === $loadFixtures, $env);
+        } finally {
+            // Closing the session releases the advisory lock.
+            $maintenance->close();
+        }
+    }
+
+    private function runResetSteps(SymfonyStyle $io, OutputInterface $output, bool $loadFixtures, string $env): int
+    {
         $steps = [
             ['doctrine:database:create', ['--if-not-exists' => true]],
             ['doctrine:migrations:migrate', ['--no-interaction' => true, '--allow-no-migration' => true]],
@@ -247,31 +278,22 @@ final class DatabaseResetCommand extends Command
     }
 
     /**
-     * DROP DATABASE <target> WITH (FORCE) on a throwaway connection to the
-     * `postgres` maintenance database (a database cannot be dropped from a
-     * connection to itself). FORCE terminates lingering api/worker sessions
-     * atomically — no terminate-then-drop race.
+     * DROP DATABASE <target> WITH (FORCE) on the maintenance-DB connection
+     * (a database cannot be dropped from a connection to itself). FORCE
+     * terminates lingering api/worker sessions atomically — no
+     * terminate-then-drop race.
      */
-    private function dropDatabaseWithForce(): void
+    private function dropDatabaseWithForce(Connection $maintenance): void
     {
-        /** @var array{dbname?: string, url?: string} $params */
+        /** @var array{dbname?: string} $params */
         $params = $this->ownerConnection->getParams();
         $dbname = $params['dbname'] ?? '';
         if ('' === $dbname) {
             throw new RuntimeException('Cannot resolve the database name from the owner connection params.');
         }
 
-        $params['dbname'] = 'postgres';
-        // `url` (when present) would win over the overridden dbname.
-        unset($params['url']);
-
-        $maintenance = DriverManager::getConnection($params);
-        try {
-            $quoted = $maintenance->getDatabasePlatform()->quoteSingleIdentifier($dbname);
-            // tenant-safe: infrastructure (dev-only whole-database drop on the maintenance DB; no tenant-scoped rows are queried)
-            $maintenance->executeStatement(sprintf('DROP DATABASE IF EXISTS %s WITH (FORCE)', $quoted));
-        } finally {
-            $maintenance->close();
-        }
+        $quoted = $maintenance->getDatabasePlatform()->quoteSingleIdentifier($dbname);
+        // tenant-safe: infrastructure (dev-only whole-database drop on the maintenance DB; no tenant-scoped rows are queried)
+        $maintenance->executeStatement(sprintf('DROP DATABASE IF EXISTS %s WITH (FORCE)', $quoted));
     }
 }

--- a/apps/api/src/Shared/Infrastructure/Maintenance/EnsureSeededCommand.php
+++ b/apps/api/src/Shared/Infrastructure/Maintenance/EnsureSeededCommand.php
@@ -108,10 +108,48 @@ final class EnsureSeededCommand extends Command
             return Command::SUCCESS;
         }
 
+        // GOLIVE #2178 follow-up — before resetting, wait for any concurrent
+        // lifecycle operation to finish. `pim:db:reset` FORCE-drops the
+        // database, which kills this container's Messenger consumer; the
+        // restart re-runs this command, which would otherwise see the
+        // half-reset (empty) database and chain a SECOND reset that kills the
+        // first one's fixtures load. The advisory lock lives on the
+        // maintenance DB (cluster-wide, survives the drop): block until the
+        // concurrent reset completes, then re-check — if it just seeded the
+        // database, there is nothing left to do.
+        try {
+            $maintenance = MaintenanceConnectionFactory::fromConnection($this->connection);
+            try {
+                // tenant-safe: infrastructure (cluster-wide advisory lock on the maintenance DB; no tenant-scoped data)
+                $maintenance->fetchOne(\sprintf('SELECT pg_advisory_lock(%d)', MaintenanceConnectionFactory::LIFECYCLE_LOCK_KEY));
+            } finally {
+                // Closing the session releases the lock immediately — we only
+                // needed to WAIT, not to hold it (the chained reset below
+                // re-acquires it on its own session; holding ours would
+                // deadlock the child).
+                $maintenance->close();
+            }
+        } catch (DbalException) {
+            // Lock acquisition is best-effort: without it we simply fall back
+            // to the pre-lock behaviour (re-check + reset).
+        }
+
+        // A session opened before a concurrent FORCE drop is dead — discard
+        // it so the re-check below connects fresh against the new database.
+        $this->connection->close();
+
+        if ($this->tableExists('users') && $this->userCount() > 0 && $this->adminUserExists()) {
+            if (!$quiet) {
+                $io->success('Database was seeded by a concurrent reset while we waited — nothing to do.');
+            }
+
+            return Command::SUCCESS;
+        }
+
         $io->section('Empty database — running pim:db:reset --with-fixtures');
 
-        // Release our DBAL connection so 'doctrine:database:drop' (chained
-        // by pim:db:reset) is not blocked by our own session in postgres.
+        // Release our DBAL connection so the drop chained by pim:db:reset is
+        // not blocked by our own session in postgres.
         $this->connection->close();
 
         $resetInput = new ArrayInput([

--- a/apps/api/src/Shared/Infrastructure/Maintenance/MaintenanceConnectionFactory.php
+++ b/apps/api/src/Shared/Infrastructure/Maintenance/MaintenanceConnectionFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Maintenance;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use RuntimeException;
+
+/**
+ * Builds throwaway connections to the `postgres` maintenance database from an
+ * application connection's params (a database cannot be dropped from a
+ * connection to itself, and advisory-lock holders must survive the drop).
+ *
+ * GOLIVE #2178 — also owns the advisory-lock key that serialises dev database
+ * lifecycle operations: `pim:db:reset` FORCE-drops the database, which kills
+ * the worker's Messenger session; the restarted worker's entrypoint re-runs
+ * `pim:dev:ensure-seeded`, which sees a half-reset (empty) database and
+ * chains its own reset — two unserialised resets then kill each other's
+ * connections mid-fixtures. Postgres advisory locks are cluster-wide (not
+ * per-database), so a lock taken on the maintenance DB survives the drop of
+ * the application database and correctly serialises every lifecycle actor.
+ */
+final class MaintenanceConnectionFactory
+{
+    /**
+     * Arbitrary-but-stable bigint key for pg_advisory_lock. Shared by
+     * DatabaseResetCommand (holds it for the whole reset) and
+     * EnsureSeededCommand (waits on it, then re-checks whether a concurrent
+     * reset already seeded the database).
+     */
+    public const int LIFECYCLE_LOCK_KEY = 727968273;
+
+    public static function fromConnection(Connection $connection): Connection
+    {
+        /** @var array{dbname?: string, url?: string} $params */
+        $params = $connection->getParams();
+        if ('' === ($params['dbname'] ?? '')) {
+            throw new RuntimeException('Cannot resolve the database name from the connection params.');
+        }
+
+        $params['dbname'] = 'postgres';
+        // `url` (when present) would win over the overridden dbname.
+        unset($params['url']);
+
+        return DriverManager::getConnection($params);
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up do #2178 (reopened) po zbiorczym live-proofie blokerów dnia 1. FORCE drop z PR #2204 uzbroił istniejący wyścig lifecycle: drop zabija sesję konsumenta workera → worker restartuje → jego entrypoint `ensure-seeded` widzi pustą (w połowie zresetowaną) bazę → chainuje WŁASNY `pim:db:reset` → dwa nieserializowane resety zabijają sobie nawzajem połączenia w trakcie `fixtures:load`.

**Dowód buga (świeży klon):** worker `RestartCount=3`, 3× „Empty database — running pim:db:reset", ręczny reset ubity `terminating connection due to administrator command` w kroku fixtures.

## Backend changes

- **`MaintenanceConnectionFactory`** (nowy) — buduje jednorazowe połączenia do maintenance-DB `postgres` + właściciel klucza `LIFECYCLE_LOCK_KEY`. Advisory locki Postgresa są cluster-wide (nie per-database), więc holder przeżywa drop bazy aplikacyjnej.
- **`DatabaseResetCommand`** — `pg_advisory_lock` na maintenance-sesji PRZED dropem, trzymany przez CAŁY przebieg (drop→create→migrate→audit→fixtures→reindex); zwolnienie przez zamknięcie sesji w `finally`. Drop refaktor na przekazane połączenie.
- **`EnsureSeededCommand`** — przed decyzją o seedzie blokująco czeka na tym samym locku (na własnej maintenance-sesji, zwalnianej od razu — trzymanie jej zadeadlockowałoby chainowany reset), potem re-check na ŚWIEŻEJ sesji (pre-dropowa jest martwa): baza zasiana przez równoległy reset = cichy noop.

## Quality gates

- PHPStan max: 0 · cs-fixer: 0 · lint-raw-sql: clean (markery tenant-safe).
- **Smoke na żywym stacku (scenariusz wyścigu):** 2× `pim:db:reset --with-fixtures --force` z DZIAŁAJĄCYM workerem — oba exit=0 z `reset complete`, worker po 1 restarcie konsumenta (oczekiwane) wraca healthy, jego ensure-seeded czeka na locku i robi noop; login 200 po każdym resecie. Przed fixem identyczny scenariusz padał na kroku fixtures.

## Smoke test plan

Finalny pełny fresh-clone proof (po merge, klon z main): reset wg docs → exit 0 → worker healthy → login. Proof w komentarzu zamykającym #2178.

## Świadome odejścia

- Zaobserwowany osobno w logu workera po dropie: `RunMaintenanceCommand carries no tenant context` (wiadomość schedulera w locie w momencie dropu, usunięta z transportu po 0 retries) — klasa pre-existing, poza scope; do oceny przy chaos-testach #2137.

Refs #2178

🤖 Generated with [Claude Code](https://claude.com/claude-code)