### PR TITLE
fix(admin): settings/users emits 401 console errors on load — auth bootstrap race

### DIFF
--- a/apps/admin/e2e/2199-auth-bootstrap-console-noise.spec.ts
+++ b/apps/admin/e2e/2199-auth-bootstrap-console-noise.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * #2199 — a hard reload of an authed page used to emit `401 GET /api/auth/me`
+ * console noise: the in-memory access token is empty right after a full
+ * navigation, and optimistic requests raced the in-flight refresh instead of
+ * waiting for it (the retry healed the data, not the console). Listeners are
+ * attached only AFTER login: the unauthenticated login screen legitimately
+ * probes `POST /api/auth/refresh` (HttpOnly cookie cannot be checked
+ * client-side), and that 401 is out of scope here.
+ */
+test('settings/users load emits no 401s after login (auth bootstrap race)', async ({ page }) => {
+  await loginAsAdmin(page);
+
+  const unauthorized: string[] = [];
+  page.on('response', (r) => {
+    if (r.status() === 401) unauthorized.push(`${r.request().method()} ${r.url()}`);
+  });
+
+  await page.goto('https://pim.localhost/settings/users');
+  await expect(page.getByRole('heading').first()).toBeVisible();
+  // Hard reload = fresh document with an empty in-memory token — the exact
+  // shape that used to race the refresh.
+  await page.reload();
+  await expect(page.getByRole('heading').first()).toBeVisible();
+  // Give late queries (roles catalogue, identity) time to settle.
+  await page.waitForTimeout(3000);
+
+  expect(unauthorized).toEqual([]);
+});

--- a/apps/admin/src/lib/http.ts
+++ b/apps/admin/src/lib/http.ts
@@ -87,6 +87,18 @@ export async function jsonFetch<T = unknown>(path: string, init: JsonRequestInit
 }
 
 async function fetchInternal<T>(path: string, init: InternalJsonRequestInit): Promise<T> {
+  if (!accessToken && refreshInFlight) {
+    // Auth bootstrap race (#2199): after a hard reload the in-memory token is
+    // empty while authProvider.check() is already refreshing it. An
+    // optimistic request fired now would go out without a Bearer, 401, and
+    // land in the console as noise even though the retry-after-refresh path
+    // heals it. Wait for the in-flight refresh instead of racing it.
+    await refreshInFlight.catch(() => {
+      // Refresh failed — proceed tokenless; the caller's 401/onError path
+      // owns the redirect to /login.
+    });
+  }
+
   const url = init.query ? appendQuery(path, init.query) : path;
   const headers = new Headers();
   headers.set('accept', init.accept ?? 'application/ld+json');


### PR DESCRIPTION
## Summary

Finding matrycy przeglądarek #2126 (GOLIVE Blok A). Po twardym reloadzie strony authed optymistyczne żądania (`GET /api/auth/me`) ścigały się z single-flight refreshem tokenu — wychodziły bez Bearera i logowały 401 w konsoli (dane healował retry, konsola zostawała brudna).

## Root cause

Reprodukcja Playwright z fazowaniem: 401-ki to NIE `useList` (hipoteza wstępna), tylko `GET /api/auth/me` w fazach post-login-goto i post-reload. `fetchInternal` nie czekał na `refreshInFlight` gdy token pusty.

## Frontend changes

- `src/lib/http.ts` — `fetchInternal` awaituje trwający refresh przy pustym tokenie (catch → tokenless fallthrough; redirect należy do onError). Fix globalny dla całej klasy stron.
- `e2e/2199-auth-bootstrap-console-noise.spec.ts` — regresja: login → goto + hard reload `/settings/users` → asercja zero odpowiedzi 401.

## Quality gates

tsc ✓ · biome (4 warningi pre-existing, poza zmienianymi plikami) ✓ · vitest 120/120 ✓ · vite build ✓ · nowy spec 1/1 zielony lokalnie na pim.localhost (przed fixem: 2× `401 GET /api/auth/me`).

## Smoke test plan

Po merge: hard reload `https://pim.localhost/settings/users` z otwartym DevTools → zero czerwonych 401. Proof w komentarzu zamykającym.

## Świadome odejścia

- `[pre-login] 401 POST /api/auth/refresh` na `/login` — sonda sesji (HttpOnly cookie niesprawdzalne client-side); poza scope ticketu (dotyczy tylko ekranu logowania).

Closes #2199

🤖 Generated with [Claude Code](https://claude.com/claude-code)