### PR TITLE
fix(catalog): attributes-drift detector reports non-converging false-positive on select-type values

### DIFF
--- a/apps/api/src/Catalog/Presentation/Command/DetectAttributesDriftCommand.php
+++ b/apps/api/src/Catalog/Presentation/Command/DetectAttributesDriftCommand.php
@@ -320,7 +320,7 @@ final class DetectAttributesDriftCommand extends Command
                 $orphaned[] = $code;
                 continue;
             }
-            if ($canon[$code] !== $cachedValue) {
+            if ($this->normalised($canon[$code]) !== $this->normalised($cachedValue)) {
                 $mismatched[] = $code;
             }
         }
@@ -337,6 +337,38 @@ final class DetectAttributesDriftCommand extends Command
         sort($mismatched);
 
         return ['orphaned' => $orphaned, 'missing' => $missing, 'mismatched' => $mismatched];
+    }
+
+    /**
+     * Recursively sorts associative keys so the comparison ignores key order
+     * (list 0..n order is preserved — element order in multiselects is
+     * meaningful).
+     *
+     * GOLIVE #2186 — Postgres jsonb canonicalises object keys on write
+     * (length, then bytes), while globalSlot() appends `provenance` after the
+     * value envelope. For envelopes whose key sorts AFTER "provenance"
+     * (`option_code` = 11 chars vs 10) the two orders diverge, and the strict
+     * `!==` reported an eternal false mismatch: select/multiselect values
+     * never converged no matter how many times --reconcile rewrote the cache
+     * (the rewrite itself round-trips through jsonb and reorders again).
+     * Text-style `{value}` envelopes sorted BEFORE "provenance" by accident,
+     * which is why only select-type attributes were affected.
+     */
+    private function normalised(mixed $value): mixed
+    {
+        if (!\is_array($value)) {
+            return $value;
+        }
+
+        $out = [];
+        foreach ($value as $key => $item) {
+            $out[$key] = $this->normalised($item);
+        }
+        if (!array_is_list($out)) {
+            ksort($out);
+        }
+
+        return $out;
     }
 
     /**

--- a/apps/api/tests/Api/Catalog/DetectAttributesDriftCommandTest.php
+++ b/apps/api/tests/Api/Catalog/DetectAttributesDriftCommandTest.php
@@ -4,7 +4,15 @@ declare(strict_types=1);
 
 namespace App\Tests\Api\Catalog;
 
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\AttributeOption;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
 use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -117,6 +125,73 @@ final class DetectAttributesDriftCommandTest extends CatalogApiTestCase
         $exitCode = $tester->execute(['--tenant' => self::TENANT_CODE, '--kind' => 'product']);
         self::assertSame(Command::SUCCESS, $exitCode, $tester->getDisplay());
         self::assertStringContainsString('No drift', $tester->getDisplay());
+    }
+
+    /**
+     * GOLIVE #2186 — select values written through the REAL path (API write →
+     * sync listener → globalSlot → jsonb) must NOT drift: Postgres jsonb
+     * reorders object keys (`provenance` sorts before `option_code`), so the
+     * old strict key-order-sensitive comparison reported an eternal false
+     * mismatch that no --reconcile could clear.
+     */
+    #[Test]
+    public function selectValueWrittenThroughRealPathReportsNoDrift(): void
+    {
+        $this->seedSelectWithOptions('drift_color', ['red', 'green']);
+        $this->seedSelectWithOptions('drift_tags', ['new', 'sale'], AttributeType::Multiselect);
+        $client = $this->authenticatedClient();
+        $productOt = $this->objectTypeIdFor(ObjectKind::Product);
+
+        $response = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'DRIFT-SEL-1',
+                'objectTypeId' => $productOt,
+                'attributes' => [
+                    'drift_color' => ['option_code' => 'green'],
+                    'drift_tags' => ['option_codes' => ['new', 'sale']],
+                ],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(201);
+
+        $tester = $this->commandTester();
+        $exitCode = $tester->execute(['--tenant' => self::TENANT_CODE, '--kind' => 'product']);
+        self::assertSame(Command::SUCCESS, $exitCode, $tester->getDisplay());
+        self::assertStringContainsString('No drift', $tester->getDisplay());
+    }
+
+    /**
+     * @param list<string> $optionCodes
+     */
+    private function seedSelectWithOptions(
+        string $code,
+        array $optionCodes,
+        AttributeType $type = AttributeType::Select,
+    ): void {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $product = self::getContainer()
+            ->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($product instanceof ObjectType);
+
+        $attribute = new Attribute($code, ['pl' => $code, 'en' => $code], $type);
+        $em->persist($attribute);
+        $position = 0;
+        foreach ($optionCodes as $optionCode) {
+            $em->persist(new AttributeOption(
+                attribute: $attribute,
+                code: $optionCode,
+                label: ['pl' => ucfirst($optionCode), 'en' => ucfirst($optionCode)],
+                position: $position++,
+            ));
+        }
+        $em->persist(new ObjectTypeAttribute($product, $attribute, false, 1));
+        $em->flush();
     }
 
     private function createTextAttribute(


### PR DESCRIPTION
## Summary

GOLIVE Blok A finding (#2125 fresh-install). Detektor dryfu `attributes_indexed` nigdy nie konwergował dla select/multiselect: po `--reconcile` kolejny scan znowu raportował mismatch (dev: 200/236 obiektów, `color,size,tags`).

## Root cause

Nie kompozycja slotu (po `b7c87828` obie strony idą przez `globalSlot()`), tylko porównanie: strict `!==` na tablicach jest wrażliwy na kolejność kluczy, a Postgres jsonb kanonicalizuje klucze przy zapisie (długość→bajty), podczas gdy `globalSlot()` dokleja `provenance` na końcu. `option_code`(11) sortuje się PO `provenance`(10) → jsonb odwraca kolejność → wieczny false-mismatch; `{value}`(5) przypadkiem sortuje się PRZED → dlatego text konwergował. `--reconcile` sam round-tripuje przez jsonb i odtwarza rozjazd — stąd brak konwergencji.

## Backend changes

- `DetectAttributesDriftCommand::normalised()` — rekurencyjny `ksort` map po obu stronach porównania (kolejność list 0..n zachowana — w multiselect znacząca).
- Regresja w `DetectAttributesDriftCommandTest`: select + multiselect zapisane realnym write-pathem (API → listener → globalSlot → jsonb) → `No drift`.

## Quality gates

- PHPStan max 0 · cs-fixer 0 · PHPUnit Api w CI.
- **Live proof (dev stack, 236 obiektów):** przed fixem `--reconcile` → re-detect = 200 drifted; po fixie re-detect = `No drift. 236 object(s) scanned`.

## Smoke test plan

Po merge: `pim:catalog:detect-attributes-drift` (owner DSN) na danych z selectami → `No drift`. Proof w komentarzu zamykającym.

Closes #2186

🤖 Generated with [Claude Code](https://claude.com/claude-code)