### PR TITLE
fix(i18n): 48 EN translation keys missing (mostly plural forms) — parity gap pl→en

### DIFF
--- a/.github/workflows/quality-frontend.yml
+++ b/.github/workflows/quality-frontend.yml
@@ -59,6 +59,13 @@ jobs:
       - name: Admin max-lines guard
         run: bash scripts/lint-admin-max-lines.sh
 
+      # GOLIVE #2188 — fallbackLng='pl' masks missing EN keys at runtime, so
+      # pl↔en parity is enforced by script (plural-aware: Polish _few/_many
+      # vs English _one/_other are not gaps). Pure python3 over two JSON
+      # files — no Node/pnpm needed, runs with the other cheap guards.
+      - name: i18n key-parity guard (pl ↔ en)
+        run: bash scripts/lint-i18n-parity.sh
+
       - uses: pnpm/action-setup@v4
         with:
           version: 10.33.2

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1395,6 +1395,25 @@
     },
     "actions": {
       "view": "View"
+    },
+    "picker": {
+      "empty": "No results.",
+      "error_generic": "Saving failed",
+      "no_primary_warning": "Mark a primary category (⭐) to save.",
+      "save": "Save",
+      "saving": "Saving…",
+      "search_placeholder": "Search categories…",
+      "selected_count": "Selected: {{count}}",
+      "title": "Select categories"
+    },
+    "products_card": {
+      "disabled": "disabled",
+      "empty": "No products in this category.",
+      "empty_hint": "Open a product and assign it to this category on its \"Categories\" tab.",
+      "enabled": "enabled",
+      "is_primary": "Primary category",
+      "page_indicator": "Page {{page}} of {{total}}",
+      "title": "Products in this category"
     }
   },
   "object_types": {
@@ -1684,7 +1703,8 @@
         "multimedia": "Media",
         "relations": "Relations",
         "history": "History",
-        "variants": "Variants"
+        "variants": "Variants",
+        "categories": "Categories"
       },
       "locale": {
         "label": "Language",
@@ -1776,7 +1796,23 @@
         "copy_to_others": "Copy to other variants · Source: {{provenance}}",
         "copy_to_others_aria": "Copy {{label}} to other variants",
         "copy_to_others.success": "Copied to {{count}} variants"
+      },
+      "categories": {
+        "add_button": "+ Assign categories",
+        "detach": "Detach category",
+        "edit_button": "+ Edit categories",
+        "empty": "No categories assigned",
+        "empty_hint": "Assign a category to activate inherited form fields.",
+        "is_primary": "Primary category",
+        "set_primary": "Set as primary",
+        "subtitle": "Category assignment determines the inherited form fields.",
+        "title": "Categories"
       }
+    },
+    "view_mode": {
+      "aria": "View mode",
+      "excel": "Excel",
+      "grid": "Cards"
     }
   },
   "api_configurator": {
@@ -2889,7 +2925,8 @@
         "columns_count_one": "{{count}} column",
         "locale": "Locale",
         "last_used": "last used: {{date}}",
-        "never_used": "never used"
+        "never_used": "never used",
+        "columns_count_other": "{{count}} columns"
       },
       "list": {
         "col_name": "Name · code",

--- a/scripts/lint-i18n-parity.sh
+++ b/scripts/lint-i18n-parity.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# GOLIVE #2188 — i18n key-parity guard (pl.json ↔ en.json).
+#
+# `fallbackLng='pl'` masks missing EN keys at runtime: an EN user silently
+# gets the Polish string, so gaps are invisible in manual testing (48 keys
+# had drifted before this guard). Parity must be checked by script, not by
+# eye — and it must be PLURAL-AWARE: Polish uses the `_few` / `_many` CLDR
+# categories that English never selects, so a `_few`/`_many` key is NOT a
+# gap as long as the EN side covers the same base key with `_one` + `_other`.
+#
+# Symmetric: keys present in en.json but absent from pl.json fail too.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+python3 - <<'PY'
+import json
+import re
+import sys
+
+def flat(d, prefix=''):
+    out = {}
+    for k, v in d.items():
+        key = f'{prefix}.{k}' if prefix else k
+        if isinstance(v, dict):
+            out.update(flat(v, key))
+        else:
+            out[key] = v
+    return out
+
+pl = flat(json.load(open('apps/admin/src/locales/pl.json')))
+en = flat(json.load(open('apps/admin/src/locales/en.json')))
+
+PLURAL = re.compile(r'_(zero|one|two|few|many|other)$')
+
+def gaps(source, target, target_name):
+    problems = []
+    for key in sorted(set(source) - set(target)):
+        m = PLURAL.search(key)
+        if m:
+            base = PLURAL.sub('', key)
+            # A plural category the target language never selects is fine as
+            # long as the target covers the same base key completely in ITS
+            # plural system: `one + other` (English-style) or
+            # `one + few + many` (Polish-style — `other` only fires for
+            # fractions, which count-based UI strings never produce).
+            en_style = f'{base}_one' in target and f'{base}_other' in target
+            pl_style = all(f'{base}_{c}' in target for c in ('one', 'few', 'many'))
+            if en_style or pl_style:
+                continue
+        problems.append(f'  {key} (missing in {target_name})')
+    return problems
+
+problems = gaps(pl, en, 'en.json') + gaps(en, pl, 'pl.json')
+if problems:
+    print(f'lint-i18n-parity: {len(problems)} translation key gap(s):', file=sys.stderr)
+    print('\n'.join(problems), file=sys.stderr)
+    print('Add the missing translations (plural gaps need _one + _other on the target side).', file=sys.stderr)
+    sys.exit(1)
+
+print(f'lint-i18n-parity: pl={len(pl)} keys, en={len(en)} keys — parity OK (plural-aware).')
+PY


### PR DESCRIPTION
## Summary

GOLIVE Blok A finding (#2126 i18n audit). `fallbackLng='pl'` maskuje braki EN w runtime — użytkownik EN dostaje polskie stringi bez żadnego błędu.

## Root cause / diagnoza

Z 48 raportowanych braków **29 realnych**: 28 nieprzetłumaczonych kluczy (categories.picker.*, categories.products_card.*, products.detail.categories.*, products.view_mode.*, tabs.categories) + `columns_count_other` (EN miał tylko `_one` → count>1 = polski fallback). **19 fałszywych**: polskie kategorie plural `_few`/`_many`, których angielski CLDR nie wybiera (EN pokrywa przez `_one`+`_other`) — checker parytetu musi być plural-aware.

## Changes

- `apps/admin/src/locales/en.json` — +29 tłumaczeń.
- `scripts/lint-i18n-parity.sh` — dwukierunkowy, plural-aware guard (baza pokryta = `one+other` LUB `one+few+many`); python3, zero zależności.
- `quality-frontend.yml` — guard w stage'u tanich bash-guardów.

## Quality gates

tsc ✓ · biome ✓ (4 warningi pre-existing) · vitest 120/120 ✓ · build ✓ · guard: `pl=3010 keys, en=2991 keys — parity OK`. Guard podczas developmentu złapał realny reverse-gap (dowód skuteczności).

## Smoke test plan

Po merge: przełącz język na EN (profil użytkownika) → karta produktu zakładka Categories + picker kategorii + toggle widoku pokazują angielskie stringi. Proof w komentarzu zamykającym.

Closes #2188

🤖 Generated with [Claude Code](https://claude.com/claude-code)