### PR TITLE
fix(infra): worker entrypoint cache:clear races the running reset — wait on the lifecycle lock

### DIFF
--- a/apps/api/docker-entrypoint.sh
+++ b/apps/api/docker-entrypoint.sh
@@ -47,6 +47,14 @@ fi
 if [ "${CI:-}" != "true" ] && [ "${APP_DEBUG:-}" = "0" ] \
     && { [ "${APP_ENV:-dev}" = "dev" ] || [ "${APP_ENV:-dev}" = "test" ]; }; then
     if [ -x /app/bin/console ]; then
+        # GOLIVE #2178 — a pim:db:reset FORCE drop kills this worker's DB
+        # session, which restarts the container and lands us right here while
+        # the reset CLI is still running. cache:clear on the SHARED /app/var
+        # volume would delete the compiled DI container out from under it
+        # (getXxxService.php "Failed to open stream" on the reset's final
+        # steps). Wait for the reset's advisory lock to clear first.
+        php /app/bin/console pim:dev:await-lifecycle-lock --no-interaction \
+            || echo "[entrypoint] WARN: lifecycle-lock wait failed; continuing."
         echo "[entrypoint] Rebuilding DI container (APP_DEBUG=0 skips freshness checks; ensures new handlers register)"
         php /app/bin/console cache:clear --no-interaction \
             || echo "[entrypoint] WARN: cache:clear failed; worker will start on the existing (possibly stale) container."

--- a/apps/api/src/Shared/Infrastructure/Maintenance/AwaitLifecycleLockCommand.php
+++ b/apps/api/src/Shared/Infrastructure/Maintenance/AwaitLifecycleLockCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Maintenance;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
+
+/**
+ * Blocks until no database lifecycle operation (pim:db:reset) is in flight,
+ * then exits. Container entrypoints call this BEFORE mutating shared state
+ * that a running reset depends on.
+ *
+ * GOLIVE #2178 (fresh-clone proof, round 2) — the reset's FORCE drop kills
+ * the worker's Messenger session; the restarted worker's entrypoint used to
+ * run `cache:clear` on the SHARED /app/var volume immediately, deleting the
+ * compiled DI container out from under the still-running reset CLI
+ * ("getXxxService.php: Failed to open stream" on its final steps). Waiting
+ * on the same cluster-wide advisory lock the reset holds for its entire run
+ * serialises the two: the cache rebuild starts only after the reset is done.
+ *
+ * Best-effort by design: any failure (DB briefly unreachable during a boot
+ * race) exits 0 with a warning — an entrypoint must never wedge the boot.
+ */
+#[AsCommand(
+    name: 'pim:dev:await-lifecycle-lock',
+    description: 'Wait until any in-flight database lifecycle operation (pim:db:reset) completes.',
+)]
+final class AwaitLifecycleLockCommand extends Command
+{
+    public function __construct(private readonly Connection $connection)
+    {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $maintenance = MaintenanceConnectionFactory::fromConnection($this->connection);
+            try {
+                // tenant-safe: infrastructure (cluster-wide advisory lock on the maintenance DB; no tenant-scoped data)
+                $maintenance->fetchOne(\sprintf('SELECT pg_advisory_lock(%d)', MaintenanceConnectionFactory::LIFECYCLE_LOCK_KEY));
+            } finally {
+                // Closing the session releases the lock — we only needed to
+                // WAIT for the holder, not to hold it ourselves.
+                $maintenance->close();
+            }
+        } catch (Throwable $e) {
+            $io->warning(\sprintf('Could not check the lifecycle lock (%s) — continuing anyway.', $e->getMessage()));
+        }
+
+        return Command::SUCCESS;
+    }
+}


### PR DESCRIPTION
## Summary

Drugi follow-up #2178, z rundy 2 fresh-clone proofa. Advisory lock z PR #2205 zserializował SAME resety, ale nie skutek uboczny na współdzielonym wolumenie: worker restartujący się po FORCE drop odpalał w entrypoincie `cache:clear` na `/app/var` i kasował skompilowany kontener DI spod wciąż działającego resetu → `getXxxService.php: Failed to open stream` na ostatnich krokach (`pim:search:reindex`).

## Changes

- **`pim:dev:await-lifecycle-lock`** (nowa komenda, Maintenance) — blokująco czeka na cluster-wide lifecycle lock (ten sam, który reset trzyma przez cały przebieg), zwalnia i kończy. Best-effort: każdy błąd = warning + kontynuacja (boot nigdy się nie wiesza).
- **`docker-entrypoint.sh`** — worker (gałąź APP_DEBUG=0) woła await PRZED `cache:clear`.

## Quality gates

- PHPStan max 0 (po `cache:warmup` — phpstan-symfony wymaga debug-container.xml) · cs-fixer 0 · lint-raw-sql clean · `sh -n` OK.
- **Test race'u na klonie** (fix wkopiowany + rebuild): 2× `pim:db:reset --with-fixtures --force` przy działającym workerze → oba **exit=0 z pełnym łańcuchem включając reindex** (przed fixem: pad na reindex); worker healthy; `pim:dev:await-lifecycle-lock` wykonywalny w workerze; login 200.

## Znane ograniczenie (nie dotyczy post-merge)

Jajko-kura PIERWSZEGO bootu po dodaniu komendy: await idzie ze SKOMPILOWANEGO kontenera sprzed rebuild'u → „Command not defined" → `||` kontynuuje (zachowanie sprzed fixa). Po merge nie występuje — komenda jest w źródłach od pierwszego builda, każdy kompilowany kontener ją zawiera.

## Smoke test plan

Finalny pristine fresh-clone proof #2178 po merge (klon z main): reset wg docs → exit 0 → worker healthy → login 200. Proof w komentarzu zamykającym.

Refs #2178

🤖 Generated with [Claude Code](https://claude.com/claude-code)