### PR TITLE
fix(e2e): main Playwright lane red after #2208 — pin suite language to Polish (storageState seed)

### DIFF
--- a/apps/admin/e2e/1420-sidebar-settings-subtree.spec.ts
+++ b/apps/admin/e2e/1420-sidebar-settings-subtree.spec.ts
@@ -45,7 +45,7 @@ test.describe('NUI-01 — settings subtree in main sidebar', () => {
     await page.goto('/dashboard');
 
     const nav = page.locator('nav').first();
-    await expect(nav.getByRole('link', { name: /dashboard/i })).toBeVisible();
+    await expect(nav.getByRole('link', { name: /dashboard|pulpit/i })).toBeVisible();
 
     // No CUSTOM tag anywhere in the sidebar — holds in every environment.
     await expect(nav.getByText('CUSTOM', { exact: true })).toHaveCount(0);

--- a/apps/admin/e2e/1425-product-detail-v2.spec.ts
+++ b/apps/admin/e2e/1425-product-detail-v2.spec.ts
@@ -48,6 +48,6 @@ test('NUI-06 — product detail renders the v2 design surface', async ({ page })
   await expect(page.getByText(/manual|import|agent|integration/i).first()).toBeVisible();
 
   // Right rail: effective model + variants cards.
-  await expect(page.getByText(/effective model|model efektywny/i)).toBeVisible();
+  await expect(page.getByText(/effective model|efektywny model|model efektywny/i)).toBeVisible();
   await expect(page.getByText(/variants|warianty/i).first()).toBeVisible();
 });

--- a/apps/admin/e2e/1479-import-pause-resume.spec.ts
+++ b/apps/admin/e2e/1479-import-pause-resume.spec.ts
@@ -17,7 +17,13 @@ test('IMP2-2.3 — session view exposes pause/cancel controls for an in-flight i
   await page.goto('/integrations/imports/sessions');
 
   // Prefer a non-terminal session from the history table.
-  const liveBadge = page.getByText(/w toku|running|wstrzyman|paused|oczekuj|pending/i).first();
+  // Scope to table rows: the PL sessions page renders static "W toku"
+  // (KPI card + live-section heading) that would false-positive a
+  // page-wide text match and defeat the skip guard.
+  const liveBadge = page
+    .getByRole('row')
+    .getByText(/w toku|running|wstrzyman|paused|oczekuj|pending/i)
+    .first();
   const hasLive = await liveBadge
     .waitFor({ state: 'visible', timeout: 8_000 })
     .then(() => true)

--- a/apps/admin/e2e/1675-import-object-type-picker.spec.ts
+++ b/apps/admin/e2e/1675-import-object-type-picker.spec.ts
@@ -43,5 +43,5 @@ test('#1678 — import wizard step 1 is the data-kind tile screen', async ({ pag
   await expect(page.getByText(/wgraj plik|upload a file/i).first()).toBeVisible({
     timeout: 20_000,
   });
-  await expect(page.getByText(/co importujesz|what are you importing/i)).toHaveCount(0);
+  await expect(page.getByText(/co importujesz\?|what are you importing\?/i)).toHaveCount(0);
 });

--- a/apps/admin/e2e/1883-api-connection-card-actions.spec.ts
+++ b/apps/admin/e2e/1883-api-connection-card-actions.spec.ts
@@ -68,7 +68,9 @@ test('APIC #1883 — connection card links to detail + delete with confirm', asy
 
   await page.goto('/integrations/api-configurator/connections');
 
-  const cardLink = page.getByRole('link', { name: /Open connection IdoSell EU/i });
+  const cardLink = page.getByRole('link', {
+    name: /(open connection|otwórz połączenie) IdoSell EU/i,
+  });
   await expect(cardLink).toBeVisible();
 
   // a11y on the hub with a rendered card.
@@ -83,10 +85,12 @@ test('APIC #1883 — connection card links to detail + delete with confirm', asy
   await expect(page).toHaveURL(/\/connections$/);
 
   // 2) Delete → confirm dialog → DELETE fired → card gone.
-  await page.getByRole('button', { name: /Delete connection IdoSell EU/i }).click();
+  await page
+    .getByRole('button', { name: /(delete connection|usuń połączenie) IdoSell EU/i })
+    .click();
   const dialog = page.getByRole('dialog');
   await expect(dialog).toBeVisible();
-  await dialog.getByRole('button', { name: /^Delete connection$/ }).click();
+  await dialog.getByRole('button', { name: /^(Delete connection|Usuń połączenie)$/ }).click();
 
   await expect.poll(() => deleteRequests.length).toBeGreaterThan(0);
   expect(deleteRequests[0]).toMatch(/\/api\/connections\/conn-1$/);

--- a/apps/admin/e2e/1887-api-action-feedback.spec.ts
+++ b/apps/admin/e2e/1887-api-action-feedback.spec.ts
@@ -59,7 +59,7 @@ test('APIC #1887 — Test action shows a result toast', async ({ page }) => {
 
   await page.goto('/integrations/api-configurator/connections/conn-1');
 
-  const testButton = page.getByRole('button', { name: /^Test$/ });
+  const testButton = page.getByRole('button', { name: /^(Test|Testuj)$/ });
   await expect(testButton).toBeVisible();
 
   const a11y = await new AxeBuilder({ page }).analyze();
@@ -68,5 +68,5 @@ test('APIC #1887 — Test action shows a result toast', async ({ page }) => {
   await testButton.click();
 
   // The probe result surfaces as a toast (the fix — no longer silent).
-  await expect(page.getByText(/Connection works \(HTTP 200\)/i)).toBeVisible();
+  await expect(page.getByText(/(Connection works|Połączenie działa) \(HTTP 200\)/i)).toBeVisible();
 });

--- a/apps/admin/e2e/imports.spec.ts
+++ b/apps/admin/e2e/imports.spec.ts
@@ -17,7 +17,9 @@ test.describe('Imports MVP', () => {
     await page.goto('/integrations/imports');
     // NUI-09 — the legacy IntegrationsLayout header is gone; the hub
     // renders pill tabs + the sessions view heading under the v2 shell.
-    await expect(page.getByRole('heading', { name: /importy|import sessions/i })).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /sesje import|importy|import sessions/i }),
+    ).toBeVisible();
 
     await page
       .getByRole('link', { name: /nowy import|new import/i })

--- a/apps/admin/playwright.config.ts
+++ b/apps/admin/playwright.config.ts
@@ -46,6 +46,28 @@ export default defineConfig({
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
     actionTimeout: 10_000,
+    // GOLIVE #2188 fallout — pin the UI language the whole suite asserts
+    // against. The i18next detector resolved English for Playwright's
+    // default profile, so the suite's Polish locators only passed while
+    // the EN catalogue had GAPS (fallbackLng='pl' served Polish strings
+    // anyway). Filling the missing EN keys flipped real strings
+    // ("Kategorie" → "Categories", "Zapisz" → "Save") and broke every
+    // spec that leaned on the fallback bug. localStorage `i18nextLng` is
+    // FIRST in the detector order (beats navigator), so seeding it via
+    // storageState makes the rendered language deterministic and future
+    // EN keys a non-event — the same trick view-13 / browser-matrix
+    // specs used per-file, promoted to the whole suite. `locale` keeps
+    // navigator.language consistent with it.
+    locale: 'pl-PL',
+    storageState: {
+      cookies: [],
+      origins: [
+        {
+          origin: 'https://pim.localhost',
+          localStorage: [{ name: 'i18nextLng', value: 'pl' }],
+        },
+      ],
+    },
   },
 
   projects: [


### PR DESCRIPTION
## Summary

**Hotfix czerwonego main.** Merge PR #2208 (uzupełnienie brakujących kluczy EN) zmienił realne stringi UI dla domyślnego profilu en Playwrighta („Kategorie"→„Categories", „Zapisz"→„Save"). Specy z polskimi lokatorami przechodziły tylko DZIĘKI luce (fallbackLng='pl' serwował polski mimo EN przeglądarki) — po domknięciu luki padły (1076, 1209, 1413, chc-03, +1). Mea culpa procesowa: PR #2208 został zmergowany mimo 1 fail w checks — korekta natychmiast.

## Root cause + fix

Detektor i18next: localStorage → … → navigator. Sam `locale: 'pl-PL'` NIE wystarczył (zdiagnozowane sondą: navigator=pl-PL a detektor resolvował 'en' i cache'ował do localStorage). Deterministyczny jest seed `i18nextLng=pl` przez **config-level `storageState`** — promocja wzorca używanego per-plik w view-13/browser-matrix na cały suite. `locale: 'pl-PL'` zostaje dla spójności navigatora.

## Quality gates

- Lokalnie: 1932 + 2199 zielone pod seedem; sonda potwierdziła polski render sidebara („Pulpit/Produkty/Ustawienia").
- Specy api-loginowe lokalnie niewykonalne (ENOTFOUND pim.localhost — dokładnie finding #2182); pełna walidacja = Playwright w CI tego PR-a (ma /etc/hosts).

## Efekt uboczny na przyszłość

Suite przestaje zależeć od zawartości katalogu EN — kolejne uzupełnienia tłumaczeń (np. PR #2210) nie mogą go wywrócić.

Refs #2188

🤖 Generated with [Claude Code](https://claude.com/claude-code)