### PR TITLE
docs(onboarding): close cold-start documentation gaps (L1/L2/L3/L9/L11/L12)

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -11,7 +11,7 @@ git clone https://github.com/malipie/PIM.git
 cd PIM
 pnpm install
 pnpm stack:up                 # docker compose up -d (api + admin + caddy + postgres + redis + meilisearch + minio + mercure)
-docker compose exec -T api bin/console pim:db:reset --with-fixtures   # canonical one-shot: drop+create+migrate+audit:schema:update+fixtures
+docker compose exec -T api bin/console pim:db:reset --with-fixtures --force   # canonical one-shot: drop+create+migrate+audit:schema:update+fixtures
 ```
 
 > `pim:db:reset` re-runs itself on the owner connection (`DATABASE_URL_OWNER`) automatically — since the W1-1 role split the runtime role `pim_app` has no DDL/BYPASSRLS, so the raw sub-commands fail under it (#2178). The drop uses `DROP DATABASE … WITH (FORCE)`, so api/worker sessions are terminated atomically — no need to stop containers first.
@@ -47,7 +47,7 @@ Verify your environment with the same gates CI runs:
 docker compose exec -T api composer phpstan
 docker compose exec -T api composer cs-check
 docker compose exec -T api composer deptrac
-docker compose exec -T api php bin/phpunit --testsuite=unit
+docker compose exec -T api php bin/phpunit --testsuite=unit   # kernel/Api suites: CI-only (see docs/testing/local-kernel-suites.md)
 pnpm --filter @pim/admin lint
 pnpm --filter @pim/admin typecheck
 pnpm --filter @pim/admin build
@@ -76,4 +76,4 @@ Read the architecture in this order:
 
 Then pick a BC, follow its `Domain/Application/Infrastructure/Contracts` ring, and add the use case. New aggregates extend `Shared\Domain\AggregateRoot` and emit events; subscribers live next to the BC that reacts. Cross-BC reads go through `<BC>\Contracts\Query\*` DTOs; cross-BC writes go through events.
 
-When in doubt: re-run the audit at `Zrodla/Zalecana_struktura_kodu/Audyt/AUDIT-CHECKLIST.md` and look at the latest report under `docs/audits/`.
+When in doubt: look at the latest audit report under `docs/audits/` and the domain reports in `docs/audit/` (the old `Zrodla/...` checklist path is gitignored and does not exist in a fresh clone).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Agentic-first PIM platform. Konkurent PIMcore/Akeneo.
 
-**Status:** Sprint 0 zamknięty 2026-04-28 (gate decision GREEN, 13/13 ticketów). Aktualnie: MVP-Alpha — patrz [`agent/current_status.md`](agent/current_status.md).
+**Status:** aktualna sub-faza, epik i blokery — zawsze w [`agent/current_status.md`](agent/current_status.md) (ten plik celowo nie hardcoduje fazy, żeby nie dryfował).
 
 ## Stack (MVP)
 
@@ -17,7 +17,7 @@ PHP 8.4 + Symfony 7.4 LTS + API Platform 4 + FrankenPHP 2.x worker mode · Postg
 - **`CHANGELOG.md`** — release history per epic
 - **`Project Plan/01-architektura-pim.md`** — pełna architektura, ADR, model danych
 - **`Project Plan/02-plan-projektu-pim.md`** — fazy, milestones, backlog, ryzyka
-- **`docs/adr/`** — Architecture Decision Records (ADR-0000..0016)
+- **`docs/adr/`** — Architecture Decision Records (najnowszy numer = `ls docs/adr/`)
 - **`docs/runbook/restore.md`** — pgBackRest PITR walkthrough
 - **`docs/runbook/disaster-recovery.md`** — incident-response playbook (key rotation, breach forensics, async drift)
 - **`docs/multi-tenancy.md`** + **`docs/rbac.md`** — security model deep-dive
@@ -164,14 +164,27 @@ pnpm build        # build production wszystkich workspace'ów
 # PHP gates (w kontenerze api)
 docker compose exec api composer phpstan        # PHPStan max
 docker compose exec api composer cs-check       # PHP-CS-Fixer (dry-run)
-docker compose exec -e APP_ENV=test api php bin/phpunit
+docker compose exec -e APP_ENV=test api php bin/phpunit --testsuite=unit
 ```
+
+> **PHPUnit lokalnie = TYLKO `--testsuite=unit`** (przechodzi na świeżym klonie).
+> Suity kernel/Api wymagają test-env (klucze JWT + `.env.test.local` + baza
+> testowa) i pełny run ginie na limicie pamięci 256M — lokalna procedura dla
+> kernel-suitów: [`docs/testing/local-kernel-suites.md`](docs/testing/local-kernel-suites.md);
+> default = CI (#2183).
 
 CI: GitHub Actions na PR + push do main — `quality-php.yml`, `quality-frontend.yml` (Biome / typecheck / Vite build / **Playwright E2E**), `audit.yml` (composer + pnpm audit).
 
 ## Running E2E tests (Playwright)
 
-E2E używa Chromium przeciwko full stackowi (`https://pim.localhost`). Przed pierwszym uruchomieniem:
+E2E używa Chromium przeciwko full stackowi (`https://pim.localhost`).
+
+> **macOS też wymaga wpisu w `/etc/hosts`** (`127.0.0.1 pim.localhost`), mimo że
+> przeglądarka rozwiązuje `*.localhost` sama (RFC 6761): helpery `apiLogin` /
+> `page.request` działają w **Node**, który tego nie robi — bez wpisu ~80/122
+> speców pada środowiskowo na `getaddrinfo ENOTFOUND pim.localhost` (#2182).
+
+Przed pierwszym uruchomieniem:
 
 ```bash
 pnpm stack:up                                       # Caddy + Postgres + API + admin Vite
@@ -187,6 +200,20 @@ pnpm --filter @pim/admin e2e:ui       # tryb interaktywny (debug)
 ```
 
 Artefakty failure (screenshot / video / trace) lądują w `apps/admin/test-results/`. Reportowy HTML w `apps/admin/playwright-report/`. CI uploads obie ścieżki przez `actions/upload-artifact` przy failure.
+
+## Troubleshooting (dzień pierwszy)
+
+Znane quirki środowiska dev — symptom → heal (#2179; źródło: `agent/lessons.md`):
+
+| Symptom | Przyczyna | Heal |
+|---|---|---|
+| `/api/*` zwraca **HTTP 200 z HTML** `Fatal error: … getXxxService.php: No such file` (np. login), znika menu po zalogowaniu | Korupcja dev-cache FrankenPHP — `var/cache/dev` przebudowany pod działającym workerem (zdarza się też na świeżym klonie przy pierwszym boocie) | `docker compose exec api rm -rf /app/var/cache/dev && docker compose exec api php bin/console cache:warmup && docker compose restart api worker` |
+| Uploady padają 500 `SlowDownWrite` / `inconsistent drive` | MinIO w stanie degraded | `docker compose restart minio` — sprawdź storage ZANIM obwinisz kod |
+| Login utyka / `429 Too Many Requests` po serii prób (curl/Playwright) | Rate-limiter `auth_login` 5/IP/15min (dev override 50) wyczerpany skumulowanymi próbami | `docker compose exec api php bin/console cache:pool:clear cache.rate_limiter` (suita E2E robi to sama w global-setup) |
+| Toast „Nieprawidłowy e-mail lub hasło" na świeżej bazie | Baza pusta (po `down -v` / reset) — a NIE złe hasło | odczekaj boot api: entrypoint auto-seeduje (`pim:dev:ensure-seeded`); log `docker compose logs api \| grep seed` |
+| `database "pim" is being accessed by other users` przy operacjach na bazie | Sesje trzymają api ORAZ worker (FrankenPHP + konsument Messengera) | `pim:db:reset` radzi sobie sam (`DROP … WITH (FORCE)`); dla innych operacji: `docker compose stop api worker` na czas zabiegu |
+
+Uwaga do pierwszego symptomu: **HTTP 200 ≠ sukces** — smoke-testy muszą asertować kształt odpowiedzi (JSON z `token`), nie sam status.
 
 ## Stack components
 

--- a/docs/testing/local-kernel-suites.md
+++ b/docs/testing/local-kernel-suites.md
@@ -1,0 +1,70 @@
+# PHPUnit lokalnie — suity kernel (Integration / Api)
+
+> GOLIVE #2183 — README „Quality gates" dokumentował pełny `bin/phpunit`, który
+> na świeżym klonie sypie setkami błędów (brak test-env) i ginie na limicie
+> pamięci. Ten dokument przenosi działający wzorzec z wiedzy plemiennej
+> (`agent/lessons.md`) do trackowanych docs.
+
+## TL;DR
+
+| Suita | Lokalnie | Jak |
+|---|---|---|
+| `--testsuite=unit` (+ `architecture`) | ✅ | `docker compose exec -e APP_ENV=test api php bin/phpunit --testsuite=unit` — działa na świeżym klonie |
+| `integration`, `api-*` (kernel) | ⚠️ wymaga setupu | procedura niżej; default = CI (matrix-shard w `quality-php.yml`) |
+| pełny `bin/phpunit` jednym strzałem | ❌ | ginie na `memory_limit=256M` (suita architecture); CI dzieli na shardy |
+
+## Dlaczego kernel-suity nie działają „z pudełka"
+
+1. **Test-env JWT** — `APP_ENV=test` wymaga własnych kluczy (`config/jwt/*.pem`,
+   gitignored) + `JWT_PASSPHRASE` w `.env.test.local`; bez nich każdy test Api
+   pada na `JWTEncodeFailureException`.
+2. **Baza testowa** — Foundry `ResetDatabase` robi drop/create schematu, co
+   wymaga roli OWNER (`pim`), i koliduje z bazą dev, jeśli wskażesz tę samą.
+3. **Pamięć** — pełny run przekracza 256M (`FlushWithoutClearInLoopRuleTest`).
+
+## Procedura: kernel-suity w izolowanym kontenerze
+
+Uruchamia suity na dowolnym drzewie (main checkout albo `git worktree`) w
+JEDNORAZOWYM kontenerze — bez ruszania działającego stacka:
+
+```bash
+# 0. Jednorazowo: test-env w drzewie roboczym (gitignored, więc świeży klon/worktree ich nie ma)
+#    - config/jwt/*.pem — skopiuj z działającego stacka albo wygeneruj:
+docker compose exec api php bin/console lexik:jwt:generate-keypair --skip-if-exists
+#    - apps/api/.env.test.local z JWT_PASSPHRASE zgodnym z kluczami
+
+# 1. Run (przykład: suita integration; TREE = ścieżka do apps/api testowanego drzewa)
+TREE=$PWD/apps/api
+docker run --rm --entrypoint sh \
+  -v "$TREE":/app -v pim_api_vendor:/app/vendor \
+  --network pim_default \
+  -e APP_ENV=test -e APP_DEBUG=0 \
+  -e "DATABASE_URL=postgresql://pim:<POSTGRES_PASSWORD>@database:5432/pim_localtest?serverVersion=16&charset=utf8" \
+  -e "DATABASE_URL_OWNER=postgresql://pim:<POSTGRES_PASSWORD>@database:5432/pim_localtest?serverVersion=16&charset=utf8" \
+  -e "MEILI_URL=http://meilisearch:7700" -e "MEILI_KEY=<MEILI_MASTER_KEY>" \
+  -e "MERCURE_URL=http://mercure/.well-known/mercure" -e "MERCURE_JWT_SECRET=<MERCURE_JWT_SECRET>" \
+  pim-api -c "php bin/console cache:clear --env=test -q && php -d memory_limit=1G vendor/bin/phpunit --testsuite integration"
+```
+
+Kluczowe decyzje (każda odkryta boleśnie):
+
+- **`--entrypoint sh`** — domyślny entrypoint obrazu robi doctrine-checki i
+  zjada argumenty.
+- **Wolumen `pim_api_vendor`** — vendor z obrazu stacka; przy podejrzeniu
+  dryfu porównaj `md5 composer.lock` drzewa z tym w kontenerze.
+- **DEDYKOWANA nazwa bazy** (`pim_localtest`) na roli owner — ResetDatabase
+  drop/create'uje ją swobodnie, zero kolizji z bazą dev i z `pim_test` innej
+  sesji.
+- **Symulacja env CI**: dołóż `-e MESSENGER_TRANSPORT_DSN=in-memory://`
+  (CI pinuje in-memory; lokalny default `sync://` zmienia semantykę testów
+  asertujących skutki async).
+- Sekrety `<...>` weź z root `.env` — nie hardcoduj ich w komendach
+  zapisywanych do plików.
+
+## Odpowiednik dla PHPStan na obcym drzewie
+
+```bash
+docker run --rm --entrypoint sh -v "$TREE":/app -v pim_api_vendor:/app/vendor \
+  --network pim_default -e APP_ENV=dev pim-api \
+  -c "php bin/console cache:warmup --env=dev -q && php vendor/bin/phpstan analyse --memory-limit=512M --no-progress"
+```


### PR DESCRIPTION
## Summary

Jeden PR dla czterech findingów docs współdzielących te same pliki i jeden flow onboardingu dnia pierwszego (issues zostają osobne, każde z własnym proofem przy zamknięciu):

- **#2180 (L1/L2/L3):** README status → wskazanie na `current_status.md` bez hardcodowanej fazy (dryfowała 2 miesiące); zakres ADR bez sztywnego numeru; ONBOARDING Day-1 `pim:db:reset` z `--force` (confirm pada pod `-T`); gitignorowane `Zrodla/...` → trackowane `docs/audits/`.
- **#2179 (L9):** nowa sekcja README „Troubleshooting (dzień pierwszy)" — tabela symptom→heal (dev-cache corruption z twardym ostrzeżeniem „HTTP 200 ≠ sukces", MinIO degraded, rate-limiter auth, pusty-DB toast, `database is being accessed`) — awans z `agent/lessons.md`.
- **#2183 (L12):** README quality gates: lokalna bramka = `--testsuite=unit`; procedura kernel/Api przeniesiona do **`docs/testing/local-kernel-suites.md`** (docker run + wolumen vendor + dedykowana baza owner + JWT test-env + symulacja env CI).
- **#2182 pkt 1 (L11):** sekcja E2E — macOS też wymaga wpisu `/etc/hosts` (Node nie rozwiązuje `*.localhost`).

## #2182 pkt 2 (triage 1932) — wynik

Nie „deterministyczny lokalny fail": na aktualnym main spec jest **flaky lokalnie (pass/fail/pass w 3 runach)** — „2× ten sam wynik" z cold-start to pech próby. Klasa zgodna z lekcją #2119 (axe liczy kontrast w trakcie animacji/fade). Szczegóły i decyzja w komentarzu zamykającym #2182.

## Weryfikacja

Docs-only (paths-ignore → lekki CI). Każda komenda w zmienionych sekcjach była wykonana w tej sesji na żywym stacku (heal-e z tabeli, unit-suite, reset z --force).

Refs #2179 #2180 #2182 #2183

🤖 Generated with [Claude Code](https://claude.com/claude-code)