### PR TITLE
refactor(search): canonical Meilisearch literal escaper (#2225)

### DIFF
--- a/apps/api/src/Catalog/Application/Filter/FilterDslResolver.php
+++ b/apps/api/src/Catalog/Application/Filter/FilterDslResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Catalog\Application\Filter;
 
+use App\Shared\Infrastructure\Meilisearch\MeiliFilterLiteral;
 use RuntimeException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Throwable;
@@ -575,7 +576,7 @@ final class FilterDslResolver
             return $value ? 'true' : 'false';
         }
         if (\is_string($value)) {
-            return '"'.str_replace(['\\', '"'], ['\\\\', '\\"'], $value).'"';
+            return MeiliFilterLiteral::quote($value);
         }
         throw new RuntimeException('Unsupported Meilisearch literal type.');
     }

--- a/apps/api/src/Search/Application/CatalogSearchService.php
+++ b/apps/api/src/Search/Application/CatalogSearchService.php
@@ -8,6 +8,7 @@ use App\Catalog\Domain\ObjectKind;
 use App\Identity\Application\CurrentTenantProvider;
 use App\Search\Infrastructure\MeilisearchClientFactory;
 use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Meilisearch\MeiliFilterLiteral;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -102,14 +103,14 @@ final readonly class CatalogSearchService
             if (\is_array($value)) {
                 $orParts = [];
                 foreach ($value as $v) {
-                    $orParts[] = \sprintf('%s = "%s"', $key, addslashes((string) $v));
+                    $orParts[] = \sprintf('%s = %s', $key, MeiliFilterLiteral::quote((string) $v));
                 }
                 if ([] !== $orParts) {
                     $extraFilters[] = '('.implode(' OR ', $orParts).')';
                 }
                 continue;
             }
-            $extraFilters[] = \sprintf('%s = "%s"', $key, addslashes((string) $value));
+            $extraFilters[] = \sprintf('%s = %s', $key, MeiliFilterLiteral::quote((string) $value));
         }
         foreach ($rangeFilters as $key => $range) {
             if (isset($range['gte'])) {

--- a/apps/api/src/Shared/Infrastructure/Meilisearch/MeiliFilterLiteral.php
+++ b/apps/api/src/Shared/Infrastructure/Meilisearch/MeiliFilterLiteral.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Meilisearch;
+
+/**
+ * Canonical escaper for string literals interpolated into Meilisearch
+ * filter expressions (#2225, deep-audit consistency finding).
+ *
+ * Every writer that builds a `key = "value"` clause quotes the value
+ * through this helper so `"` and `\` inside user-supplied values stay part
+ * of the literal instead of terminating it. `addslashes()` also neutralised
+ * the double quote, but additionally escapes `'` and NUL — a shape the
+ * Meilisearch filter grammar does not define. One shared escaper keeps the
+ * audit surface single-sourced.
+ */
+final class MeiliFilterLiteral
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * Returns the value as a double-quoted Meilisearch string literal with
+     * `\` and `"` escaped.
+     */
+    public static function quote(string $value): string
+    {
+        return '"'.str_replace(['\\', '"'], ['\\\\', '\\"'], $value).'"';
+    }
+}

--- a/apps/api/tests/Api/Search/SearchEndpointsApiTest.php
+++ b/apps/api/tests/Api/Search/SearchEndpointsApiTest.php
@@ -192,6 +192,31 @@ final class SearchEndpointsApiTest extends CatalogApiTestCase
         self::assertGreaterThanOrEqual(2, $body['totalHits'] ?? 0);
     }
 
+    /**
+     * #2225 — filter VALUE injection stays neutralised by the canonical
+     * escaper ({@see \App\Shared\Infrastructure\Meilisearch\MeiliFilterLiteral}).
+     *
+     * The payload smuggles `" OR enabled = "true` inside the value of a
+     * whitelisted key. If the value escaping ever regressed, the quote would
+     * terminate the literal and the `OR` clause would match every enabled
+     * product (the seeded ones) → totalHits >= 1. With correct escaping the
+     * whole payload is ONE literal that matches nothing → 200 with 0 hits,
+     * never an expression error and never a broadened result set.
+     */
+    #[Test]
+    public function searchNeutralisesFilterValueInjectionPayload(): void
+    {
+        $this->seedProduct('VAL-INJ-1', enabled: true);
+        $this->forceReindex(ObjectKind::Product);
+
+        $client = $this->authenticatedClient();
+        $payload = rawurlencode('zzz" OR enabled = "true');
+        $body = $client->request('GET', '/api/search/products?filter%5Benabled%5D='.$payload)->toArray();
+
+        self::assertResponseStatusCodeSame(200);
+        self::assertSame(0, $body['totalHits'] ?? -1, 'value payload must stay a single literal, not broaden the result set');
+    }
+
     #[Test]
     public function searchObjectsScopedToObjectTypeId(): void
     {

--- a/apps/api/tests/Unit/Shared/Infrastructure/Meilisearch/MeiliFilterLiteralTest.php
+++ b/apps/api/tests/Unit/Shared/Infrastructure/Meilisearch/MeiliFilterLiteralTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Infrastructure\Meilisearch;
+
+use App\Shared\Infrastructure\Meilisearch\MeiliFilterLiteral;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #2225 — canonical Meilisearch string-literal escaper. The exact quoted
+ * shapes below are the contract every filter-expression writer relies on:
+ * a `"` or `\` inside a user-supplied value must stay part of the literal
+ * instead of terminating it (and re-opening the expression for operators).
+ */
+final class MeiliFilterLiteralTest extends TestCase
+{
+    #[Test]
+    public function quotesPlainValueVerbatim(): void
+    {
+        self::assertSame('"Festo"', MeiliFilterLiteral::quote('Festo'));
+    }
+
+    #[Test]
+    public function escapesDoubleQuote(): void
+    {
+        self::assertSame('"a\\"b"', MeiliFilterLiteral::quote('a"b'));
+    }
+
+    #[Test]
+    public function escapesBackslash(): void
+    {
+        self::assertSame('"a\\\\b"', MeiliFilterLiteral::quote('a\\b'));
+    }
+
+    #[Test]
+    public function escapesBackslashBeforeQuoteWithoutDoubleProcessing(): void
+    {
+        // Input `a\"b` (backslash then quote): the backslash and the quote are
+        // escaped independently — `a\\\"b` — never collapsed into a lone `\"`
+        // that would leave the literal terminable.
+        self::assertSame('"a\\\\\\"b"', MeiliFilterLiteral::quote('a\\"b'));
+    }
+
+    #[Test]
+    public function neutralisesOrInjectionPayloadAsSingleLiteral(): void
+    {
+        $quoted = MeiliFilterLiteral::quote('zzz" OR enabled = "true');
+
+        // The payload's quotes are escaped, so the whole value remains ONE
+        // string literal — the `OR` never becomes an operator.
+        self::assertSame('"zzz\\" OR enabled = \\"true"', $quoted);
+    }
+}


### PR DESCRIPTION
## Co i dlaczego

Finding consistency z deep audytu #2131-2133 (**NIE podatność** — bypass obalony empirycznie): `CatalogSearchService` escapował wartości filtrów Meili przez `addslashes()`, a `FilterDslResolver` miał własny, równoważny escaper. Dwa ręczne escapery tej samej gramatyki = każdy audyt musi dowodzić obu.

## Zmiany
- Nowy `App\Shared\Infrastructure\Meilisearch\MeiliFilterLiteral::quote()` — jedyny kanoniczny escaper literałów stringowych filtrów Meili.
- `FilterDslResolver::meiliLiteral()` (gałąź string) i `CatalogSearchService` (2 miejsca po `addslashes()`) delegują do niego.
- Zero zmian semantyki dla `"` i `\` (identyczny replace); odpada jedynie nadmiarowe escapowanie `'` i NUL którego gramatyka Meili nie definiuje.

## Testy
- `MeiliFilterLiteralTest` (unit) — kształty literałów: quote, backslash, backslash+quote, payload OR-injection jako pojedynczy literał.
- `SearchEndpointsApiTest::searchNeutralisesFilterValueInjectionPayload` (live Meili) — value-injection w whitelistowanym kluczu → 200 / 0 hits (regresja: gdyby escaping padł, payload matchowałby seedowane produkty).

## Smoke
Live smoke na pim.localhost po merge (search z `"` w wartości filtra → 200), close #2225 z proofem.

Refs #2225