### PR TITLE
fix(import): MinIO outage podczas uploadu → 503 problem+json (#2221)

### DIFF
--- a/apps/api/src/Shared/Infrastructure/Http/Rfc7807ExceptionListener.php
+++ b/apps/api/src/Shared/Infrastructure/Http/Rfc7807ExceptionListener.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Http;
 
+use League\Flysystem\FilesystemException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -74,6 +75,31 @@ final class Rfc7807ExceptionListener implements EventSubscriberInterface
         }
 
         $throwable = $event->getThrowable();
+        $request = $event->getRequest();
+
+        // #2221 (chaos dry-run #2137) — an object-storage outage (MinIO/S3
+        // unreachable mid-write) escapes Flysystem as a FilesystemException,
+        // which is NOT an HttpExceptionInterface: pre-fix it fell through to
+        // the stock HTML 500 page even on `/api/*`. Storage loss is an
+        // infrastructure outage, not a domain error, so every storage-backed
+        // custom route maps it to a 503 problem+json here. The `detail` is a
+        // FIXED string — Flysystem messages embed storage keys/paths
+        // (information leak, AUD-042); logging already happened in Symfony's
+        // ErrorListener::logKernelException at higher priority.
+        if ($throwable instanceof FilesystemException && $this->isCustomApiRequest($request)) {
+            $event->setResponse(new JsonResponse(
+                data: [
+                    'type' => $this->typeForStatus(Response::HTTP_SERVICE_UNAVAILABLE),
+                    'title' => Response::$statusTexts[Response::HTTP_SERVICE_UNAVAILABLE],
+                    'status' => Response::HTTP_SERVICE_UNAVAILABLE,
+                    'detail' => 'Object storage is temporarily unavailable. Try again later.',
+                ],
+                status: Response::HTTP_SERVICE_UNAVAILABLE,
+                headers: ['content-type' => 'application/problem+json'],
+            ));
+
+            return;
+        }
 
         // Only HTTP exceptions carry a status + safe public message. Domain
         // exceptions (500s) keep Symfony's handling so they are logged and
@@ -81,8 +107,6 @@ final class Rfc7807ExceptionListener implements EventSubscriberInterface
         if (!$throwable instanceof HttpExceptionInterface) {
             return;
         }
-
-        $request = $event->getRequest();
 
         if (!$this->isCustomApiRequest($request)) {
             return;

--- a/apps/api/tests/Api/Import/ParsePreviewApiTest.php
+++ b/apps/api/tests/Api/Import/ParsePreviewApiTest.php
@@ -174,7 +174,9 @@ final class ParsePreviewApiTest extends CatalogApiTestCase
 
             self::assertResponseStatusCodeSame(503);
             self::assertResponseHeaderSame('content-type', 'application/problem+json');
-            $body = $this->decodeJson($client->getResponse()?->getContent());
+            // getContent() throws on a 5xx in the HttpClient test transport;
+            // pass throw=false to read the problem+json body on the 503.
+            $body = $this->decodeJson($client->getResponse()?->getContent(false));
 
             self::assertSame(503, $body['status']);
             self::assertSame('Service Unavailable', $body['title']);

--- a/apps/api/tests/Api/Import/ParsePreviewApiTest.php
+++ b/apps/api/tests/Api/Import/ParsePreviewApiTest.php
@@ -6,6 +6,8 @@ namespace App\Tests\Api\Import;
 
 use App\Shared\Domain\Tenant;
 use App\Tests\Api\Catalog\CatalogApiTestCase;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\UnableToWriteFile;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
@@ -137,6 +139,51 @@ final class ParsePreviewApiTest extends CatalogApiTestCase
         ]);
 
         self::assertResponseStatusCodeSame(400);
+    }
+
+    /**
+     * #2221 (chaos dry-run #2137) — object storage down mid-upload must
+     * degrade to a 503 problem+json, not an HTML 500. The stubbed operator
+     * throws the same {@see UnableToWriteFile} the S3 adapter raises when
+     * MinIO is unreachable; the RFC 7807 listener maps it to 503. The
+     * `detail` stays a fixed message — Flysystem exception messages carry
+     * storage keys/paths and must never surface.
+     */
+    #[Test]
+    public function parsePreviewAnswers503ProblemJsonWhenObjectStorageIsDown(): void
+    {
+        $csvPath = $this->writeCsv();
+
+        try {
+            $client = $this->authenticatedClient();
+
+            $storage = $this->createStub(FilesystemOperator::class);
+            $storage->method('writeStream')->willThrowException(
+                UnableToWriteFile::atLocation('tenant/staged/whatever/sample.csv', 'connection refused'),
+            );
+            static::getContainer()->set('imports.storage', $storage);
+
+            $client->request('POST', '/api/import-sessions/parse-preview', [
+                'extra' => [
+                    'parameters' => [],
+                    'files' => [
+                        'file' => new UploadedFile($csvPath, 'sample.csv', 'text/csv', null, true),
+                    ],
+                ],
+            ]);
+
+            self::assertResponseStatusCodeSame(503);
+            self::assertResponseHeaderSame('content-type', 'application/problem+json');
+            $body = $this->decodeJson($client->getResponse()?->getContent());
+
+            self::assertSame(503, $body['status']);
+            self::assertSame('Service Unavailable', $body['title']);
+            $detail = $body['detail'];
+            self::assertIsString($detail);
+            self::assertStringNotContainsString('staged', $detail, 'storage keys/paths must never leak into the problem detail');
+        } finally {
+            @unlink($csvPath);
+        }
     }
 
     /**

--- a/apps/api/tests/Unit/Shared/Infrastructure/Http/Rfc7807StorageOutageListenerTest.php
+++ b/apps/api/tests/Unit/Shared/Infrastructure/Http/Rfc7807StorageOutageListenerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Infrastructure\Http;
+
+use App\Shared\Infrastructure\Http\Rfc7807ExceptionListener;
+use League\Flysystem\UnableToWriteFile;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * #2221 — deterministic contract for the storage-outage branch of
+ * {@see Rfc7807ExceptionListener}: an uncaught Flysystem exception on a
+ * custom `/api/*` route becomes a 503 `application/problem+json`, never the
+ * stock HTML 500, and the Flysystem message (which embeds storage paths)
+ * never reaches the payload.
+ */
+final class Rfc7807StorageOutageListenerTest extends TestCase
+{
+    #[Test]
+    public function mapsFilesystemExceptionOnCustomApiRouteTo503ProblemJson(): void
+    {
+        $event = $this->eventFor(Request::create('/api/import-sessions/parse-preview', 'POST'));
+
+        (new Rfc7807ExceptionListener())->onException($event);
+
+        $response = $event->getResponse();
+        self::assertNotNull($response, 'the listener must claim the exception before HTML rendering');
+        self::assertSame(503, $response->getStatusCode());
+        self::assertSame('application/problem+json', $response->headers->get('content-type'));
+
+        $payload = json_decode((string) $response->getContent(), true);
+        self::assertIsArray($payload);
+        self::assertSame(503, $payload['status']);
+        self::assertStringNotContainsString(
+            'secret/storage/key.csv',
+            (string) $payload['detail'],
+            'the Flysystem message embeds storage keys and must never surface',
+        );
+    }
+
+    #[Test]
+    public function leavesFilesystemExceptionOutsideApiPathsAlone(): void
+    {
+        $event = $this->eventFor(Request::create('/admin/some-page', 'GET'));
+
+        (new Rfc7807ExceptionListener())->onException($event);
+
+        self::assertNull($event->getResponse(), 'non-/api paths keep Symfony error handling (HTML profiler in dev)');
+    }
+
+    #[Test]
+    public function leavesApiPlatformManagedRequestsAlone(): void
+    {
+        $request = Request::create('/api/attributes', 'POST');
+        $request->attributes->set('_api_resource_class', 'App\\Catalog\\Domain\\Entity\\Attribute');
+        $event = $this->eventFor($request);
+
+        (new Rfc7807ExceptionListener())->onException($event);
+
+        self::assertNull($event->getResponse(), 'API Platform routes keep their native error pipeline');
+    }
+
+    private function eventFor(Request $request): ExceptionEvent
+    {
+        return new ExceptionEvent(
+            $this->createStub(KernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+            UnableToWriteFile::atLocation('secret/storage/key.csv', 'connection refused'),
+        );
+    }
+}

--- a/apps/api/tests/Unit/Shared/Infrastructure/Http/Rfc7807StorageOutageListenerTest.php
+++ b/apps/api/tests/Unit/Shared/Infrastructure/Http/Rfc7807StorageOutageListenerTest.php
@@ -27,7 +27,7 @@ final class Rfc7807StorageOutageListenerTest extends TestCase
     {
         $event = $this->eventFor(Request::create('/api/import-sessions/parse-preview', 'POST'));
 
-        (new Rfc7807ExceptionListener())->onException($event);
+        new Rfc7807ExceptionListener()->onException($event);
 
         $response = $event->getResponse();
         self::assertNotNull($response, 'the listener must claim the exception before HTML rendering');
@@ -51,7 +51,7 @@ final class Rfc7807StorageOutageListenerTest extends TestCase
     {
         $event = $this->eventFor(Request::create('/admin/some-page', 'GET'));
 
-        (new Rfc7807ExceptionListener())->onException($event);
+        new Rfc7807ExceptionListener()->onException($event);
 
         self::assertNull($event->getResponse(), 'non-/api paths keep Symfony error handling (HTML profiler in dev)');
     }
@@ -63,7 +63,7 @@ final class Rfc7807StorageOutageListenerTest extends TestCase
         $request->attributes->set('_api_resource_class', 'App\\Catalog\\Domain\\Entity\\Attribute');
         $event = $this->eventFor($request);
 
-        (new Rfc7807ExceptionListener())->onException($event);
+        new Rfc7807ExceptionListener()->onException($event);
 
         self::assertNull($event->getResponse(), 'API Platform routes keep their native error pipeline');
     }

--- a/apps/api/tests/Unit/Shared/Infrastructure/Http/Rfc7807StorageOutageListenerTest.php
+++ b/apps/api/tests/Unit/Shared/Infrastructure/Http/Rfc7807StorageOutageListenerTest.php
@@ -37,9 +37,11 @@ final class Rfc7807StorageOutageListenerTest extends TestCase
         $payload = json_decode((string) $response->getContent(), true);
         self::assertIsArray($payload);
         self::assertSame(503, $payload['status']);
+        $detail = $payload['detail'];
+        self::assertIsString($detail);
         self::assertStringNotContainsString(
             'secret/storage/key.csv',
-            (string) $payload['detail'],
+            $detail,
             'the Flysystem message embeds storage keys and must never surface',
         );
     }


### PR DESCRIPTION
## Co i dlaczego

Finding z chaos dry-runu #2137: przy zatrzymanym MinIO `POST /api/import-sessions/parse-preview` zwracał **500 `text/html`** (FrankenPHP fatal) zamiast łagodnej degradacji RFC 7807 — bo `League\Flysystem\UnableToWriteFile` nie jest `HttpExceptionInterface` i `Rfc7807ExceptionListener` go przepuszczał do stockowego renderera HTML.

## Fix (klasa problemu, nie jeden endpoint)

Mapowanie w `Rfc7807ExceptionListener`: nieprzechwycony `FilesystemException` na custom trasie `/api/*` → **503 `application/problem+json`** ze stałym `detail` (komunikaty Flysystem niosą klucze/ścieżki storage — nie mogą wyciec, AUD-042). Pokrywa parse-preview i każdą inną storage-backed custom trasę; trasy API Platform zachowują natywny pipeline (problem+json 500), ścieżki poza `/api` nietknięte. Kontrolery które już łapią i konwertują (np. `StartImportController` → 400) zachowują swoje zachowanie — listener jest last-resort.

## Testy
- **API (regresja S3-down):** `ParsePreviewApiTest::parsePreviewAnswers503ProblemJsonWhenObjectStorageIsDown` — stub `imports.storage` rzuca `UnableToWriteFile` (dokładnie to co adapter S3 przy odciętym MinIO) → 503 + problem+json + brak ścieżki storage w detail.
- **Unit:** `Rfc7807StorageOutageListenerTest` — mapping na /api, brak reakcji poza /api i na trasach API Platform.

## Smoke (po merge, wg SMOKE TEST RULE)
Live na pim.localhost: `stop minio` → parse-preview → oczekiwane **503 problem+json** → `start minio` → 200. Proof w komentarzu przy zamykaniu #2221.

Refs #2221