### PR TITLE
build(monitoring): alerty na awarię zależności — blackbox probes + up==0 (#2222)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -459,6 +459,34 @@ services:
       retries: 5
       start_period: 20s
 
+  # ─── Blackbox exporter (dependency availability probes) ───────────────────
+  #
+  # #2222 (chaos dry-run #2137). Probes each dependency's keyless health
+  # surface — Meili /health, MinIO /minio/health/live, Mercure /healthz over
+  # HTTP, Redis + Postgres over plain TCP connect — so Prometheus gets a
+  # `probe_success` series per dependency and the pim-dependencies alert
+  # group can page on outages the API otherwise degrades around silently.
+  # One prober instead of per-dependency exporters/auth-env keeps the
+  # cold-start surface flat (no master-key plumbing into prometheus.yml).
+  blackbox:
+    image: prom/blackbox-exporter:v0.25.0
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 64M
+          cpus: "0.25"
+    volumes:
+      - ./docker/prometheus/blackbox.yml:/etc/blackbox_exporter/config.yml:ro
+    expose:
+      - "9115"
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:9115/"]
+      interval: 15s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+
 # Named volumes for monitoring state. Add to the prod overlay only — base
 # compose stays free of monitoring infrastructure (devs use Symfony's web
 # profiler instead of Prometheus locally).

--- a/docker/prometheus/alerts.yml
+++ b/docker/prometheus/alerts.yml
@@ -64,3 +64,61 @@ groups:
             past 10 minutes. Check pg_stat_statements for the offender
             and the PgBouncer admin console (port 6432) for connection
             pool saturation.
+
+  # ─── Dependency availability (#2222, chaos dry-run #2137) ─────────────
+  #
+  # The API degrades gracefully when a dependency dies (search 503
+  # problem+json, storage 503) — which is exactly why the operator needs
+  # an alert: the outage is otherwise invisible until a user reports
+  # broken search/uploads. Probes come from the blackbox exporter
+  # (prometheus.yml jobs dependencies-http / dependencies-tcp).
+  - name: pim-dependencies
+    interval: 15s
+    rules:
+      # One rule covers every probed dependency; the `dependency` label
+      # (meilisearch / minio / mercure / redis / postgres) names the victim.
+      # 2m of failed probes = real outage, not a container restart blip.
+      - alert: DependencyDown
+        expr: probe_success == 0
+        for: 2m
+        labels:
+          severity: critical
+          runbook: docs/runbook/disaster-recovery.md
+        annotations:
+          summary: "Dependency {{ $labels.dependency }} is DOWN"
+          description: |
+            Blackbox probe against {{ $labels.instance }} has failed for
+            2 minutes. The API degrades (search/upload answer 503) but the
+            feature is dead for users. Check `docker compose ps` and the
+            container logs for {{ $labels.dependency }}; a restart heals
+            the common cases (see the MinIO degraded-state note in the
+            disaster-recovery runbook).
+
+      # The API itself was scraped from day one but had no up==0 alert
+      # either — a dead FrankenPHP container fired nothing.
+      - alert: ApiDown
+        expr: up{job="pim-api"} == 0
+        for: 2m
+        labels:
+          severity: critical
+          runbook: docs/runbook/disaster-recovery.md
+        annotations:
+          summary: "PIM API is not answering Prometheus scrapes"
+          description: |
+            The pim-api scrape target has been down for 2 minutes. The
+            edge (Caddy) is likely serving 502s. Check the api container
+            health and logs.
+
+      # If the prober dies, every DependencyDown rule goes silent while
+      # looking healthy — alert on the watcher itself.
+      - alert: BlackboxProberDown
+        expr: up{job=~"dependencies-(http|tcp)"} == 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Blackbox exporter is down — dependency alerting is blind"
+          description: |
+            Prometheus cannot scrape the blackbox exporter, so dependency
+            outages will NOT fire DependencyDown. Restart the blackbox
+            container to restore outage visibility.

--- a/docker/prometheus/blackbox.yml
+++ b/docker/prometheus/blackbox.yml
@@ -1,0 +1,29 @@
+# Blackbox exporter probe modules (#2222).
+#
+# The chaos dry-run (#2137) showed a dependency outage (Meili / MinIO /
+# Redis / Mercure down) degrades the API gracefully but fires NO alert —
+# none of those services were scraped at all. Rather than one exporter per
+# dependency (redis_exporter, MinIO auth env, Meili experimental-metrics
+# flag + master-key plumbing into prometheus.yml), a single blackbox
+# exporter probes each dependency's UNAUTHENTICATED health surface:
+#
+#   http_2xx    — Meilisearch /health, MinIO /minio/health/live,
+#                 Mercure /healthz (all keyless by design)
+#   tcp_connect — Redis :6379 and Postgres :5432 (no native HTTP health)
+#
+# `probe_success == 0` is the alert signal (see alerts.yml,
+# group pim-dependencies). Rich native metrics per dependency stay a
+# follow-up — availability is what #2222 needs.
+modules:
+  http_2xx:
+    prober: http
+    timeout: 5s
+    http:
+      preferred_ip_protocol: ip4
+      valid_status_codes: []  # default: any 2xx
+      follow_redirects: true
+  tcp_connect:
+    prober: tcp
+    timeout: 5s
+    tcp:
+      preferred_ip_protocol: ip4

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -37,6 +37,50 @@ scrape_configs:
           # the single-API-service scale.
           tier: web
 
+  # ─── Dependency availability (#2222) ──────────────────────────────────
+  #
+  # Chaos dry-run #2137: a Meili/MinIO/Redis/Mercure outage degraded the
+  # API gracefully but fired NO alert — none of those services were
+  # scraped. One blackbox exporter probes each dependency's keyless
+  # health surface (modules in blackbox.yml); `probe_success == 0` drives
+  # the pim-dependencies alert group. The `dependency` label carries a
+  # stable human name so alert annotations don't parse URLs.
+  - job_name: "dependencies-http"
+    metrics_path: /probe
+    params:
+      module: [http_2xx]
+    static_configs:
+      - targets: ["http://meilisearch:7700/health"]
+        labels: { dependency: meilisearch, tier: data }
+      - targets: ["http://minio:9000/minio/health/live"]
+        labels: { dependency: minio, tier: data }
+      - targets: ["http://mercure/healthz"]
+        labels: { dependency: mercure, tier: web }
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: "blackbox:9115"
+
+  - job_name: "dependencies-tcp"
+    metrics_path: /probe
+    params:
+      module: [tcp_connect]
+    static_configs:
+      - targets: ["redis:6379"]
+        labels: { dependency: redis, tier: data }
+      - targets: ["database:5432"]
+        labels: { dependency: postgres, tier: data }
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: "blackbox:9115"
+
   - job_name: "prometheus"
     static_configs:
       - targets: ["localhost:9090"]


### PR DESCRIPTION
## Co i dlaczego

Finding z chaos dry-runu #2137: awaria Meili/MinIO/Redis/Mercure degraduje API łagodnie (503 problem+json / 200) i **nie strzela żadnym alertem** — Prometheus scrape'ował tylko `pim-api` + samego siebie. Operator dowiaduje się o martwym searchu/uploadzie od użytkownika.

## Podejście: jeden blackbox exporter zamiast per-dependency exporterów

Sondy empirycznie potwierdzone na dev stacku:
- Meili `/metrics` wymaga **experimental flag + master key w prometheus.yml** (plumbing sekretu do statycznego configu = nowa klasa blokerów dnia 1),
- MinIO metrics wymaga `MINIO_PROMETHEUS_AUTH_TYPE`, Redis nie ma natywnych metryk, Mercure (Caddy) ma admin API zamknięte.
- **Wszystkie cztery mają keyless health surface**: Meili `/health` 200, MinIO `/minio/health/live` 200, Mercure `/healthz` 200, Redis/Postgres TCP.

Stąd: `prom/blackbox-exporter` (64M limit) + moduły `http_2xx`/`tcp_connect` (`docker/prometheus/blackbox.yml`), scrape joby `dependencies-http`/`dependencies-tcp` z labelką `dependency`, i grupa alertów `pim-dependencies`:
- **DependencyDown** — `probe_success == 0` for 2m (critical, per zależność: meilisearch/minio/mercure/redis/postgres),
- **ApiDown** — `up{job="pim-api"} == 0` for 2m (critical; API też nie miało alertu na własną śmierć),
- **BlackboxProberDown** — watcher nie może umrzeć po cichu (warning, 5m).

Bogate natywne metryki per zależność = świadomy follow-up; #2222 potrzebuje widoczności outage'u.

## Walidacja
- `promtool check config` — SUCCESS (6 reguł).
- Merged `-f docker-compose.yml -f docker-compose.prod.yml config` — OK.
- **Weryfikacja live na dev stacku** (ad-hoc prometheus+blackbox na sieci compose, stop meilisearch → DependencyDown pending→firing → start → resolved) — wynik dokleję w komentarzu do PR-a.

Refs #2222