### PR TITLE
fix(import): bound S3 client timeouts — dokończenie #2221 (dead store fails fast)

### DIFF
--- a/apps/api/.env
+++ b/apps/api/.env
@@ -145,6 +145,14 @@ AWS_IMPORTS_BUCKET=pim-imports
 # so paid-tier "forever" retention (PRD §11.7) does not bleed into the
 # imports 7d cleanup. Free tier 7d cleanup lives in EXP-08.
 AWS_EXPORTS_BUCKET=pim-exports
+# #2221 — S3 client timeouts (seconds). Keep both UNDER PHP's 30s
+# max_execution_time so a dead object store fails fast with an exception
+# the RFC 7807 listener maps to 503, instead of hanging into a fatal HTML
+# 500. connect_timeout bounds establishing the TCP/TLS connection (a
+# stopped container never completes it); request_timeout bounds the whole
+# operation for a host that connects but stalls mid-transfer.
+AWS_ASSETS_CONNECT_TIMEOUT=5
+AWS_ASSETS_REQUEST_TIMEOUT=20
 ###< app/asset-storage ###
 
 ###> app/export-retention ###

--- a/apps/api/config/packages/flysystem.yaml
+++ b/apps/api/config/packages/flysystem.yaml
@@ -22,6 +22,21 @@ services:
               credentials:
                   key: '%env(AWS_ASSETS_KEY)%'
                   secret: '%env(AWS_ASSETS_SECRET)%'
+              # #2221 — bound every S3 op so a dead object store fails FAST
+              # with an exception instead of hanging until PHP's
+              # max_execution_time (30s) kills the worker with a fatal HTML
+              # 500. The chaos dry-run (#2137) stopped MinIO and parse-preview
+              # hung in Guzzle's curl handler for 30s: no FilesystemException
+              # was ever raised, so the RFC 7807 storage-outage listener never
+              # got a chance to map it to 503. `connect_timeout` bounds
+              # connection establishment (a stopped container never answers),
+              # `timeout` bounds the whole request; either breach surfaces as
+              # an AWS exception the Flysystem adapter wraps in
+              # UnableToWriteFile → the listener returns 503 problem+json.
+              # Overridable per-env; defaults stay under the 30s PHP ceiling.
+              http:
+                  connect_timeout: '%env(int:AWS_ASSETS_CONNECT_TIMEOUT)%'
+                  timeout: '%env(int:AWS_ASSETS_REQUEST_TIMEOUT)%'
 
 flysystem:
     storages:


### PR DESCRIPTION
## Dlaczego (SMOKE TEST RULE złapał niedorobiony fix)

Live smoke merged fixu #2229 (listener `FilesystemException`→503) na żywym stacku wykrył, że **przy zatrzymanym MinIO parse-preview NADAL zwracał 500 HTML** — ale przez `Maximum execution time of 30 seconds exceeded` w Guzzle CurlMultiHandler, a nie przez `FilesystemException`. Klient S3 nie miał **żadnego timeoutu** → martwy host wisiał do PHP `max_execution_time` (fatal 500), więc listener nigdy nie dostał wyjątku do zmapowania.

Dlatego #2221 pozostał OPEN (nie zamknięty bez smoke — CLOSED MEANS CLOSED).

## Fix (root-cause)
`connect_timeout: 5s` + `timeout: 20s` na współdzielonym `pim.assets.s3_client` (oba pod 30s sufitem PHP, override'owalne env `AWS_ASSETS_CONNECT_TIMEOUT`/`AWS_ASSETS_REQUEST_TIMEOUT`). Martwy store → wyjątek AWS → adapter Flysystem owija w `UnableToWriteFile` → listener (#2229) mapuje na 503 problem+json.

## Live smoke (pim.localhost, SMOKE TEST RULE)
```
docker compose stop minio
POST /api/import-sessions/parse-preview
  → HTTP 503 | application/problem+json | 0.12-0.38s   (było: 30s hang → HTML 500)
  body: {"type":"/errors/503","title":"Service Unavailable","status":503,
         "detail":"Object storage is temporarily unavailable. Try again later."}
docker compose start minio + restart api → 200
```

## Uwaga — osobny finding (recovery)
Smoke wykrył też, że po odzyskaniu MinIO worker FrankenPHP trzyma **stale connection** w puli S3 → 503 utrzymuje się aż do restartu api. To osobna klasa (worker-mode connection resiliency), zgłoszę jako osobny ticket — poza scope #2221 (degradacja PODCZAS awarii, tu naprawiona).

Test `ParsePreviewApiTest::parsePreviewAnswers503ProblemJsonWhenObjectStorageIsDown` (z #2229) pokrywa mapping FilesystemException→503; ten PR gwarantuje że dead-host ten wyjątek RZECZYWIŚCIE wyprodukuje.

Refs #2221