### PR TITLE
fix(agent): grant + recreate processed_messages for pim_app (#2136 live-smoke finding)

### DIFF
--- a/apps/api/migrations/Version20260704120000.php
+++ b/apps/api/migrations/Version20260704120000.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * GOLIVE #2136 (agent live-smoke finding) — grant + self-heal
+ * `processed_messages` for the runtime role.
+ *
+ * The IdempotencyMiddleware runs on every worker-consumed message and
+ * INSERTs into `processed_messages`. The agent async loop routes
+ * AgentRunMessage to the worker-drained `import` transport, so it is the
+ * first path that actually exercises that INSERT as `pim_app` on the
+ * operator's stack — nothing else consumed a worker message under RLS
+ * before the agent BYOK key was live. It surfaced two gaps:
+ *
+ *   1. The original table migration (Version20260429170000) predates the
+ *      #2177 grant pattern and issued NO `GRANT ... TO pim_app`. The W1-1
+ *      default privileges normally cover owner-created tables, but a
+ *      pg_restore drops them (known quirk, see Version20260704050000) — so
+ *      the runtime role could be left unable to INSERT.
+ *   2. On a stack where the table went missing entirely (restore/reset that
+ *      kept the migration_versions row), the middleware's self-heal tries
+ *      `CREATE TABLE` as `pim_app` and dies with 42501 (permission denied
+ *      for schema public) — the runtime role has no DDL by design. The
+ *      table can only be (re)created by the owner, i.e. here.
+ *
+ * This migration is idempotent belt-and-braces for both: `CREATE TABLE IF
+ * NOT EXISTS` recreates a vanished table, and the explicit grant is safe to
+ * repeat. DDL is 1:1 with Version20260429170000 + IdempotencyMiddleware's
+ * self-heal. Infra table: NO tenant_id, NO RLS (global messenger
+ * bookkeeping, same class as messenger_messages).
+ */
+final class Version20260704120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Grant processed_messages to pim_app + recreate if missing — the agent worker path is the first to INSERT as the runtime role (#2136)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS processed_messages (
+                message_id UUID PRIMARY KEY,
+                handler_class VARCHAR(255) NOT NULL,
+                processed_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL
+            )
+            SQL);
+        $this->addSql('CREATE INDEX IF NOT EXISTS processed_messages_handler_idx ON processed_messages (handler_class)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS processed_messages_processed_at_idx ON processed_messages (processed_at)');
+        $this->addSql('GRANT SELECT, INSERT, UPDATE, DELETE ON processed_messages TO pim_app');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Non-destructive: the table predates this migration (created by
+        // Version20260429170000). Only the grant is this migration's to
+        // revoke; dropping the table would break the earlier migration's
+        // invariant. Revoke is best-effort (role may not exist on a
+        // single-role sandbox).
+        $this->addSql('REVOKE SELECT, INSERT, UPDATE, DELETE ON processed_messages FROM pim_app');
+    }
+}

--- a/apps/api/src/Shared/Infrastructure/Messenger/IdempotencyMiddleware.php
+++ b/apps/api/src/Shared/Infrastructure/Messenger/IdempotencyMiddleware.php
@@ -39,9 +39,17 @@ use Symfony\Component\Uid\Uuid;
  * `42P01` (undefined table) and dead-letter the whole queue. The middleware
  * self-heals: on the first `TableNotFoundException` it creates the table on
  * demand (idempotent `CREATE TABLE IF NOT EXISTS`, matching the migration
- * DDL) and retries — so delivery never depends on migrate-before-worker
- * ordering. The create is attempted once per worker process (a static flag
- * keeps the steady-state path a single INSERT).
+ * DDL) and retries. The create is attempted once per worker process (a
+ * static flag keeps the steady-state path a single INSERT).
+ *
+ * NOTE (#2136) — the self-heal only works where the runtime connection can
+ * issue DDL. Under the W1-1 privilege split the runtime role `pim_app` has
+ * NO DDL, so the on-demand `CREATE TABLE` raises `42501` (permission denied
+ * for schema public) rather than succeeding. On such a deploy the table +
+ * grant are the OWNER's responsibility — migration Version20260704120000
+ * (idempotent `CREATE ... IF NOT EXISTS` + `GRANT ... TO pim_app`) is the
+ * source of truth; the self-heal is only a fallback for single-role
+ * sandboxes (CI PHPUnit, throwaway) where the runtime role also owns DDL.
  */
 final class IdempotencyMiddleware implements MiddlewareInterface
 {


### PR DESCRIPTION
## Jak znaleziony (SMOKE TEST RULE / #2136 live LLM)

Operator wprowadził klucz Anthropic (BYOK) → uruchomiłem live smoke agenta. **Każdy run agenta dead-letterował** z:
```
SQLSTATE[42501]: permission denied for schema public
CREATE TABLE IF NOT EXISTS processed_messages ...
```

Agent async loop routuje `AgentRunMessage` na transport `import` (drenowany przez workera), więc to **pierwsza ścieżka realnie wykonująca** `IdempotencyMiddleware::INSERT processed_messages` jako runtime role `pim_app` pod RLS. Nic wcześniej nie konsumowało worker-message pod RLS na stacku operatora → niewidoczne bez live agenta. **Dokładnie po to istnieje #2136.**

## Dwie przyczyny, jedna migracja
1. Oryginalna migracja tabeli (`Version20260429170000`) jest **sprzed wzorca grantu #2177** — nie nadała `GRANT ... TO pim_app`. Domyślne privilege W1-1 pokrywają tabele ownera, ale **pg_restore je zrzuca** (znany quirk).
2. Na stacku gdzie tabela **zniknęła** (restore/reset zachowujący wiersz `migration_versions`), self-heal middleware próbuje `CREATE TABLE` jako `pim_app` (brak DDL w privilege-split) → 42501.

`Version20260704120000`: idempotentne `CREATE TABLE IF NOT EXISTS` (odtwarza znikniętą tabelę) + `GRANT SELECT,INSERT,UPDATE,DELETE ... TO pim_app` (bezpieczny do powtórzenia). Docblock middleware skorygowany: self-heal działa tylko w single-role sandbox (CI), nie w privilege-split — źródłem prawdy jest migracja.

## Weryfikacja
- Migracja odpalona forward na dev (owner conn): **1 migration, 4 SQL, OK**. Idempotentna (tabela już była → CREATE no-op + regrant).
- **Live proof po fixie**: agent run przeszedł end-to-end — real tool call `aggregate_count` → `{"matched":100}` → odpowiedź „W katalogu znajduje się łącznie 100 produktów.", cost $0.066, model Opus. (Przed fixem: dead-letter 42501.)
- Istniejący `IdempotencyMiddlewareSelfHealTest` (single-role test DB) nietknięty — zmiana dotyczy tylko privilege-split path.

Refs #2136