### PR TITLE
fix(agent/search): sku→code w filtrach Meili + code filterable (#2237, odblokowuje write-flow agenta)

### DIFF
--- a/apps/api/src/Catalog/Application/Filter/FilterDslResolver.php
+++ b/apps/api/src/Catalog/Application/Filter/FilterDslResolver.php
@@ -556,6 +556,15 @@ final class FilterDslResolver
 
     private function meiliAttrPath(string $attr): string
     {
+        // #2237 — `sku` is the UI/agent alias for the natural key; the
+        // Meili document stores it as `code` (the physical column, mirroring
+        // COLUMN_MAP `sku => co.code` on the SQL path). Without this the
+        // agent's grounding filter `sku = "…"` hit a non-existent Meili field
+        // and the search degraded — misread as a backend outage.
+        if ('sku' === $attr) {
+            return 'code';
+        }
+
         if (str_contains($attr, '.')) {
             [$base, $locale] = explode('.', $attr, 2);
             $this->safeIdent($base);

--- a/apps/api/src/Search/Application/IndexSettingsTemplate.php
+++ b/apps/api/src/Search/Application/IndexSettingsTemplate.php
@@ -59,6 +59,11 @@ final class IndexSettingsTemplate
         'status', 'enabled',
         'completeness_pct', 'sync_status_aggregate',
         'category', 'parentId', 'mime_type',
+        // #2237 — the natural key (`code`, aliased `sku` in the DSL) is the
+        // primary way an agent or user grounds a single product ("edit
+        // SKU X"). Exact-match filtering on it needs it filterable in Meili;
+        // FilterDslResolver maps `sku -> code` so both spellings resolve here.
+        'code',
     ];
 
     /**

--- a/apps/api/tests/Unit/Catalog/FilterDslResolverTest.php
+++ b/apps/api/tests/Unit/Catalog/FilterDslResolverTest.php
@@ -131,6 +131,21 @@ final class FilterDslResolverTest extends TestCase
         self::assertStringContainsString('IS NULL', $sql);
     }
 
+    /**
+     * #2237 — the Meili document stores the natural key as `code`, so the
+     * `sku` DSL alias must compile to a `code` filter (mirroring COLUMN_MAP
+     * `sku => co.code` on the SQL path). Before this, `sku = "…"` hit a
+     * non-existent Meili field and the agent's grounding search degraded,
+     * misread as a backend outage.
+     */
+    public function testToMeilisearchFilterMapsSkuAliasToCode(): void
+    {
+        $filter = $this->resolver->toMeilisearchFilter(['attr' => 'sku', 'op' => '=', 'value' => 'DEMO-100']);
+
+        self::assertSame('code = "DEMO-100"', $filter);
+        self::assertStringNotContainsString('sku', $filter);
+    }
+
     public function testToCountSqlEmitsLocaleScopedJsonPath(): void
     {
         $sql = $this->resolver->toCountSql([


### PR DESCRIPTION
## Problem (live #2136 smoke)
Agent grounduje write szukając produktu po SKU, ale dokument Meili trzyma natural key jako `code`, a `sku` nie był ani polem Meili ani filterowalny. `toMeilisearchFilter` kompilował `sku = "…"` dosłownie → Meili 400 → `CatalogSearchService` łapał jako `degraded` → agent widział „Search engine unavailable" i **odmawiał każdego write'u po SKU** (żaden pending_change — repro u operatora i w moich runach).

## Fix
- `FilterDslResolver::meiliAttrPath`: `sku → code` (mirror COLUMN_MAP z SQL path).
- `IndexSettingsTemplate::RESERVED_FILTERABLE`: + `code`.
- Unit test `testToMeilisearchFilterMapsSkuAliasToCode` (przechodzi lokalnie).

Istniejące deploye aplikują nowy filterable przez `pim:search:health` / reindex.

## Live proof po fixie (pełny UC2 approval-flow na żywym LLM)
1. Reindex + provision → `code` filterable (Meili task succeeded).
2. Agent intent „znajdź SKU DEMO-100, ustaw short_description, przygotuj do zatwierdzenia":
   - `search_catalog` → **degraded: false**, hits array(20) (fix zadziałał)
   - `bulk_edit_values` → proposal awaiting approval, **pending_change_batch_id, affected=1**, cost $0.125
   - **APPROVE → HTTP 200, status "done", committed 1**
   - psql: `DEMO-100.short_description = "Smoke agenta 2237", provenance = agent` ✅
3. Reject: guard 409 gdy run nie jest awaiting_approval (poprawny).

Odblokowuje #2136 approval-flow (accept path udowodniony end-to-end).

## Follow-up (świadomie poza tym PR)
Głębsza część #2237 — `CatalogSearchService` powinien rozróżniać Meili 400 (błąd filtra, do korekty) od connection-error (outage) zamiast klasyfikować oba jako `degraded`. Ten PR usuwa główną przyczynę (sku niefilterowalny); rozróżnienie typów wyjątków = osobny, węższy refaktor.

Refs #2237 #2136