### PR TITLE
fix(agent): koniec zawieszania czatu na 'Planuję' + bloczki inbox/history w ustawieniach

### DIFF
--- a/apps/admin/e2e/1979-agent-byok-settings.spec.ts
+++ b/apps/admin/e2e/1979-agent-byok-settings.spec.ts
@@ -17,6 +17,14 @@ test('BYOK settings set, rotate-visible-prefix and disable on the live API', asy
   await expect(page.getByTestId('agent-settings')).toBeVisible();
   await expect(page.getByTestId('agent-key-state')).toBeVisible();
 
+  // Right-column shortcuts into the agent inbox / run history
+  // (those routes have no sidebar entry, so this is the way in).
+  await expect(page.getByTestId('agent-shortcut-inbox')).toHaveAttribute('href', '/agent/inbox');
+  await expect(page.getByTestId('agent-shortcut-history')).toHaveAttribute(
+    'href',
+    '/agent/history',
+  );
+
   const a11y = await new AxeBuilder({ page }).include('[data-testid="agent-settings"]').analyze();
   expect(a11y.violations.filter((v) => v.impact === 'serious' || v.impact === 'critical')).toEqual(
     [],

--- a/apps/admin/src/features/agent/chat/AgentChatSheet.tsx
+++ b/apps/admin/src/features/agent/chat/AgentChatSheet.tsx
@@ -63,9 +63,9 @@ export function AgentChatSheet() {
   const [sending, setSending] = useState(false);
   const [livePhase, setLivePhase] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
-  // AGENT-P6-07 (#1980) — live phases over SSE; polling stays as the
-  // fallback whenever the stream is not connected.
-  const { connected: sseConnected, lastEvent } = useAgentRunStream(open ? runId : null);
+  // AGENT-P6-07 (#1980) — live phases over SSE; polling runs in parallel
+  // (see below) so a fast run can't hang the UI if the stream lags.
+  const { lastEvent } = useAgentRunStream(open ? runId : null);
 
   const refresh = useCallback(async (id: string) => {
     try {
@@ -93,13 +93,17 @@ export function AgentChatSheet() {
     return () => window.removeEventListener(OPEN_AGENT_CHAT_EVENT, onOpenEvent);
   }, [refresh]);
 
-  // Poll while the loop is busy server-side (planning/committing) -
-  // ONLY as the fallback when the SSE stream is down (P6-07).
+  // #2147 — poll while the loop is busy server-side (planning/committing),
+  // REGARDLESS of the SSE stream. With a synchronous loop the run can reach
+  // awaiting_input/awaiting_approval before the stream connects, so the
+  // terminal status event is missed and the UI would hang on "Planuję…"
+  // forever if polling deferred to SSE. SSE still drives live phases; this
+  // guarantees the terminal transition is always observed.
   useEffect(() => {
-    if (!open || runId === null || run === null || !isRunBusy(run.status) || sseConnected) return;
+    if (!open || runId === null || run === null || !isRunBusy(run.status)) return;
     const timer = window.setInterval(() => void refresh(runId), 2500);
     return () => window.clearInterval(timer);
-  }, [open, runId, run, refresh, sseConnected]);
+  }, [open, runId, run, refresh]);
 
   // SSE events: a status transition re-reads the run (fresh transcript);
   // a progress tick just updates the live phase label.

--- a/apps/admin/src/features/settings/ai/agent-shortcuts.tsx
+++ b/apps/admin/src/features/settings/ai/agent-shortcuts.tsx
@@ -1,0 +1,76 @@
+import { ChevronRight, History, Inbox } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+
+/**
+ * Right-column shortcuts on Settings → AI into the agent inbox and run
+ * history. Those routes (`/agent/inbox`, `/agent/history`) exist but
+ * have no sidebar entry, so this is the primary way a user reaches
+ * them — rendered as cards next to the BYOK key panel.
+ */
+function ShortcutCard({
+  to,
+  icon,
+  title,
+  description,
+  testid,
+}: {
+  to: string;
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  testid: string;
+}) {
+  return (
+    <Link
+      to={to}
+      data-testid={testid}
+      className="group flex items-start gap-3 rounded-xl border border-zinc-200 bg-white p-4 transition-colors hover:border-purple-300 hover:bg-purple-50/40"
+    >
+      <span className="mt-0.5 grid size-9 shrink-0 place-items-center rounded-lg bg-purple-100 text-purple-600">
+        {icon}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="flex items-center gap-1 text-sm font-semibold text-zinc-900">
+          {title}
+          <ChevronRight
+            className="size-4 text-zinc-400 transition-transform group-hover:translate-x-0.5"
+            aria-hidden
+          />
+        </span>
+        <span className="mt-0.5 block text-xs text-zinc-500">{description}</span>
+      </span>
+    </Link>
+  );
+}
+
+export function AgentShortcuts() {
+  const { t } = useTranslation();
+
+  return (
+    <aside className="mt-6 space-y-3 lg:mt-0" aria-label="Skróty agenta">
+      <ShortcutCard
+        to="/agent/inbox"
+        testid="agent-shortcut-inbox"
+        icon={<Inbox className="size-4" aria-hidden />}
+        title={t('agent.settings.shortcut_inbox_title', {
+          defaultValue: 'Skrzynka akceptacji',
+        })}
+        description={t('agent.settings.shortcut_inbox_desc', {
+          defaultValue: 'Zatwierdź lub odrzuć propozycje agenta (diff before → after).',
+        })}
+      />
+      <ShortcutCard
+        to="/agent/history"
+        testid="agent-shortcut-history"
+        icon={<History className="size-4" aria-hidden />}
+        title={t('agent.settings.shortcut_history_title', {
+          defaultValue: 'Historia runów',
+        })}
+        description={t('agent.settings.shortcut_history_desc', {
+          defaultValue: 'Przejrzyj wykonane operacje i cofnij je („Cofnij tę operację").',
+        })}
+      />
+    </aside>
+  );
+}

--- a/apps/admin/src/features/settings/ai/index.tsx
+++ b/apps/admin/src/features/settings/ai/index.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { toast } from '@/components/ui/toast';
 import { getAgentCost } from '@/features/agent/api';
 import { httpErrorDetail, jsonFetch } from '@/lib/http';
+import { AgentShortcuts } from './agent-shortcuts';
 
 interface AgentKeyStatus {
   agent_feature_enabled: boolean;
@@ -111,218 +112,227 @@ export function AiSettingsPage() {
   };
 
   return (
-    <div className="max-w-2xl space-y-6" data-testid="agent-settings">
-      <div>
-        <h1 className="flex items-center gap-2 text-xl font-semibold tracking-tight">
-          <Sparkles className="size-5 text-purple-600" aria-hidden />
-          {t('agent.settings.title', { defaultValue: 'AI / Agent' })}
-        </h1>
-        <p className="text-sm text-zinc-500">
-          {t('agent.settings.subtitle', {
-            defaultValue:
-              'Agent działa na Twoim kluczu Anthropic (BYOK). Bez aktywnego klucza agent jest wyłączony.',
-          })}
-        </p>
-      </div>
-
-      {status === null ? (
-        statusQuery.isError ? (
-          <p className="text-sm text-red-600" role="alert">
-            {httpErrorDetail(statusQuery.error) ?? String(statusQuery.error)}
+    <div
+      className="grid items-start gap-6 lg:grid-cols-[minmax(0,42rem)_18rem]"
+      data-testid="agent-settings"
+    >
+      <div className="space-y-6">
+        <div>
+          <h1 className="flex items-center gap-2 text-xl font-semibold tracking-tight">
+            <Sparkles className="size-5 text-purple-600" aria-hidden />
+            {t('agent.settings.title', { defaultValue: 'AI / Agent' })}
+          </h1>
+          <p className="text-sm text-zinc-500">
+            {t('agent.settings.subtitle', {
+              defaultValue:
+                'Agent działa na Twoim kluczu Anthropic (BYOK). Bez aktywnego klucza agent jest wyłączony.',
+            })}
           </p>
+        </div>
+
+        {status === null ? (
+          statusQuery.isError ? (
+            <p className="text-sm text-red-600" role="alert">
+              {httpErrorDetail(statusQuery.error) ?? String(statusQuery.error)}
+            </p>
+          ) : (
+            <p className="flex items-center gap-2 text-sm text-zinc-500" role="status">
+              <Loader2 className="size-4 animate-spin" aria-hidden />
+              {t('agent.settings.loading', { defaultValue: 'Wczytywanie…' })}
+            </p>
+          )
         ) : (
-          <p className="flex items-center gap-2 text-sm text-zinc-500" role="status">
-            <Loader2 className="size-4 animate-spin" aria-hidden />
-            {t('agent.settings.loading', { defaultValue: 'Wczytywanie…' })}
-          </p>
-        )
-      ) : (
-        <>
-          {!status.agent_feature_enabled && (
-            <p className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
-              {t('agent.settings.feature_off', {
-                defaultValue:
-                  'Warstwa agenta jest globalnie wyłączona (AGENT_ENABLED) — klucz można skonfigurować, ale runy nie wystartują.',
-              })}
-            </p>
-          )}
+          <>
+            {!status.agent_feature_enabled && (
+              <p className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
+                {t('agent.settings.feature_off', {
+                  defaultValue:
+                    'Warstwa agenta jest globalnie wyłączona (AGENT_ENABLED) — klucz można skonfigurować, ale runy nie wystartują.',
+                })}
+              </p>
+            )}
 
-          <section
-            className="rounded-xl border border-zinc-200 bg-white p-4"
-            aria-labelledby="agent-key-heading"
-          >
-            <h2 id="agent-key-heading" className="flex items-center gap-2 text-sm font-semibold">
-              <KeyRound className="size-4 text-zinc-500" aria-hidden />
-              {t('agent.settings.key_heading', { defaultValue: 'Klucz Anthropic' })}
-            </h2>
-
-            <dl className="mt-3 grid grid-cols-2 gap-2 text-sm">
-              <dt className="text-zinc-500">
-                {t('agent.settings.state', { defaultValue: 'Stan' })}
-              </dt>
-              <dd data-testid="agent-key-state">
-                {status.enabled
-                  ? t('agent.settings.state_on', { defaultValue: 'Aktywny — agent włączony' })
-                  : status.configured
-                    ? t('agent.settings.state_disabled', { defaultValue: 'Wyłączony (soft-off)' })
-                    : t('agent.settings.state_missing', {
-                        defaultValue: 'Brak klucza — agent wymaga klucza',
-                      })}
-              </dd>
-              {status.key_prefix !== null && (
-                <>
-                  <dt className="text-zinc-500">
-                    {t('agent.settings.prefix', { defaultValue: 'Prefiks' })}
-                  </dt>
-                  <dd className="font-mono" data-testid="agent-key-prefix">
-                    {status.key_prefix}…
-                  </dd>
-                </>
-              )}
-              {status.last_used_at !== null && (
-                <>
-                  <dt className="text-zinc-500">
-                    {t('agent.settings.last_used', { defaultValue: 'Ostatnio użyty' })}
-                  </dt>
-                  <dd>{new Date(status.last_used_at).toLocaleString()}</dd>
-                </>
-              )}
-            </dl>
-
-            <form
-              className="mt-4 flex items-end gap-2"
-              onSubmit={(event) => {
-                event.preventDefault();
-                void saveKey();
-              }}
-            >
-              <label className="flex-1 text-sm">
-                <span className="mb-1 block text-zinc-500">
-                  {status.configured
-                    ? t('agent.settings.rotate_label', {
-                        defaultValue: 'Nowy klucz (rotacja zastępuje obecny)',
-                      })
-                    : t('agent.settings.set_label', { defaultValue: 'Klucz API (sk-ant-…)' })}
-                </span>
-                <input
-                  type="password"
-                  value={draftKey}
-                  onChange={(event) => setDraftKey(event.target.value)}
-                  autoComplete="off"
-                  placeholder="sk-ant-api03-…"
-                  className="w-full rounded-md border border-zinc-200 px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-zinc-400"
-                  data-testid="agent-key-input"
-                />
-              </label>
-              <Button
-                type="submit"
-                disabled={busy || draftKey.trim() === ''}
-                data-testid="agent-key-save"
-              >
-                {busy ? (
-                  <Loader2 className="size-4 animate-spin" />
-                ) : (
-                  t('agent.settings.save', { defaultValue: 'Zapisz' })
-                )}
-              </Button>
-              {status.enabled && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={busy}
-                  onClick={() => void disable()}
-                  data-testid="agent-key-disable"
-                >
-                  {t('agent.settings.disable', { defaultValue: 'Wyłącz agenta' })}
-                </Button>
-              )}
-            </form>
-            <p className="mt-2 text-xs text-zinc-500">
-              {t('agent.settings.never_plaintext', {
-                defaultValue:
-                  'Klucz jest szyfrowany (AES-256-GCM) i nigdy nie wraca w odpowiedziach — widzisz tylko prefiks.',
-              })}
-            </p>
-          </section>
-
-          {cost !== null && (
             <section
               className="rounded-xl border border-zinc-200 bg-white p-4"
-              aria-labelledby="agent-cost-heading"
-              data-testid="agent-cost"
+              aria-labelledby="agent-key-heading"
             >
-              <h2 id="agent-cost-heading" className="flex items-center gap-2 text-sm font-semibold">
-                <Sparkles className="size-4 text-zinc-500" aria-hidden />
-                {t('agent.settings.cost_heading', { defaultValue: 'Koszt i limity' })}
+              <h2 id="agent-key-heading" className="flex items-center gap-2 text-sm font-semibold">
+                <KeyRound className="size-4 text-zinc-500" aria-hidden />
+                {t('agent.settings.key_heading', { defaultValue: 'Klucz Anthropic' })}
               </h2>
-              <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-                <dt className="text-zinc-500">
-                  {t('agent.settings.cost_today', { defaultValue: 'Dziś' })}
-                </dt>
-                <dd data-testid="agent-cost-today">
-                  ${cost.cost_today_usd} · {cost.tokens_today} tok · {cost.runs_today}{' '}
-                  {t('agent.settings.runs', { defaultValue: 'runów' })}
-                </dd>
-                <dt className="text-zinc-500">
-                  {t('agent.settings.cost_month', { defaultValue: 'Ten miesiąc' })}
-                </dt>
-                <dd>
-                  ${cost.cost_month_usd} · {cost.tokens_month} tok · {cost.runs_month}{' '}
-                  {t('agent.settings.runs', { defaultValue: 'runów' })}
-                </dd>
-              </dl>
-              <div className="mt-3 space-y-2">
-                <CapBar
-                  label={`${t('agent.settings.cap_day', { defaultValue: 'Limit dzienny' })} ($${cost.day_cap_usd})`}
-                  pct={cost.day_cap_pct}
-                />
-                <CapBar
-                  label={`${t('agent.settings.cap_month', { defaultValue: 'Limit miesięczny' })} ($${cost.month_cap_usd})`}
-                  pct={cost.month_cap_pct}
-                />
-              </div>
-            </section>
-          )}
 
-          <section
-            className="rounded-xl border border-zinc-200 bg-white p-4"
-            aria-labelledby="agent-transparency-heading"
-          >
-            <h2
-              id="agent-transparency-heading"
-              className="flex items-center gap-2 text-sm font-semibold"
+              <dl className="mt-3 grid grid-cols-2 gap-2 text-sm">
+                <dt className="text-zinc-500">
+                  {t('agent.settings.state', { defaultValue: 'Stan' })}
+                </dt>
+                <dd data-testid="agent-key-state">
+                  {status.enabled
+                    ? t('agent.settings.state_on', { defaultValue: 'Aktywny — agent włączony' })
+                    : status.configured
+                      ? t('agent.settings.state_disabled', { defaultValue: 'Wyłączony (soft-off)' })
+                      : t('agent.settings.state_missing', {
+                          defaultValue: 'Brak klucza — agent wymaga klucza',
+                        })}
+                </dd>
+                {status.key_prefix !== null && (
+                  <>
+                    <dt className="text-zinc-500">
+                      {t('agent.settings.prefix', { defaultValue: 'Prefiks' })}
+                    </dt>
+                    <dd className="font-mono" data-testid="agent-key-prefix">
+                      {status.key_prefix}…
+                    </dd>
+                  </>
+                )}
+                {status.last_used_at !== null && (
+                  <>
+                    <dt className="text-zinc-500">
+                      {t('agent.settings.last_used', { defaultValue: 'Ostatnio użyty' })}
+                    </dt>
+                    <dd>{new Date(status.last_used_at).toLocaleString()}</dd>
+                  </>
+                )}
+              </dl>
+
+              <form
+                className="mt-4 flex items-end gap-2"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  void saveKey();
+                }}
+              >
+                <label className="flex-1 text-sm">
+                  <span className="mb-1 block text-zinc-500">
+                    {status.configured
+                      ? t('agent.settings.rotate_label', {
+                          defaultValue: 'Nowy klucz (rotacja zastępuje obecny)',
+                        })
+                      : t('agent.settings.set_label', { defaultValue: 'Klucz API (sk-ant-…)' })}
+                  </span>
+                  <input
+                    type="password"
+                    value={draftKey}
+                    onChange={(event) => setDraftKey(event.target.value)}
+                    autoComplete="off"
+                    placeholder="sk-ant-api03-…"
+                    className="w-full rounded-md border border-zinc-200 px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-zinc-400"
+                    data-testid="agent-key-input"
+                  />
+                </label>
+                <Button
+                  type="submit"
+                  disabled={busy || draftKey.trim() === ''}
+                  data-testid="agent-key-save"
+                >
+                  {busy ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    t('agent.settings.save', { defaultValue: 'Zapisz' })
+                  )}
+                </Button>
+                {status.enabled && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={busy}
+                    onClick={() => void disable()}
+                    data-testid="agent-key-disable"
+                  >
+                    {t('agent.settings.disable', { defaultValue: 'Wyłącz agenta' })}
+                  </Button>
+                )}
+              </form>
+              <p className="mt-2 text-xs text-zinc-500">
+                {t('agent.settings.never_plaintext', {
+                  defaultValue:
+                    'Klucz jest szyfrowany (AES-256-GCM) i nigdy nie wraca w odpowiedziach — widzisz tylko prefiks.',
+                })}
+              </p>
+            </section>
+
+            {cost !== null && (
+              <section
+                className="rounded-xl border border-zinc-200 bg-white p-4"
+                aria-labelledby="agent-cost-heading"
+                data-testid="agent-cost"
+              >
+                <h2
+                  id="agent-cost-heading"
+                  className="flex items-center gap-2 text-sm font-semibold"
+                >
+                  <Sparkles className="size-4 text-zinc-500" aria-hidden />
+                  {t('agent.settings.cost_heading', { defaultValue: 'Koszt i limity' })}
+                </h2>
+                <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+                  <dt className="text-zinc-500">
+                    {t('agent.settings.cost_today', { defaultValue: 'Dziś' })}
+                  </dt>
+                  <dd data-testid="agent-cost-today">
+                    ${cost.cost_today_usd} · {cost.tokens_today} tok · {cost.runs_today}{' '}
+                    {t('agent.settings.runs', { defaultValue: 'runów' })}
+                  </dd>
+                  <dt className="text-zinc-500">
+                    {t('agent.settings.cost_month', { defaultValue: 'Ten miesiąc' })}
+                  </dt>
+                  <dd>
+                    ${cost.cost_month_usd} · {cost.tokens_month} tok · {cost.runs_month}{' '}
+                    {t('agent.settings.runs', { defaultValue: 'runów' })}
+                  </dd>
+                </dl>
+                <div className="mt-3 space-y-2">
+                  <CapBar
+                    label={`${t('agent.settings.cap_day', { defaultValue: 'Limit dzienny' })} ($${cost.day_cap_usd})`}
+                    pct={cost.day_cap_pct}
+                  />
+                  <CapBar
+                    label={`${t('agent.settings.cap_month', { defaultValue: 'Limit miesięczny' })} ($${cost.month_cap_usd})`}
+                    pct={cost.month_cap_pct}
+                  />
+                </div>
+              </section>
+            )}
+
+            <section
+              className="rounded-xl border border-zinc-200 bg-white p-4"
+              aria-labelledby="agent-transparency-heading"
             >
-              <ShieldCheck className="size-4 text-zinc-500" aria-hidden />
-              {t('agent.settings.transparency_heading', { defaultValue: 'Co trafia do modelu' })}
-            </h2>
-            <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-zinc-600">
-              <li>
-                {t('agent.settings.transparency_intent', {
-                  defaultValue: 'Twoja intencja i kolejne wiadomości rozmowy.',
-                })}
-              </li>
-              <li>
-                {t('agent.settings.transparency_context', {
-                  defaultValue:
-                    'Kontekst widoku: kod typu obiektu, aktywny filtr, liczność selekcji (bez pełnych danych produktów).',
-                })}
-              </li>
-              <li>
-                {t('agent.settings.transparency_results', {
-                  defaultValue:
-                    'Wyniki narzędzi: liczniki, kody i minimalne projekcje (id, kod, nazwa, kompletność) — tylko to, co narzędzie zwróci.',
-                })}
-              </li>
-              <li>
-                {t('agent.settings.transparency_never', {
-                  defaultValue:
-                    'Nigdy: Twój klucz, hasła, tokeny API ani dane innych tenantów. Zapis do katalogu wyłącznie po Twojej akceptacji.',
-                })}
-              </li>
-            </ul>
-          </section>
-        </>
-      )}
+              <h2
+                id="agent-transparency-heading"
+                className="flex items-center gap-2 text-sm font-semibold"
+              >
+                <ShieldCheck className="size-4 text-zinc-500" aria-hidden />
+                {t('agent.settings.transparency_heading', { defaultValue: 'Co trafia do modelu' })}
+              </h2>
+              <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-zinc-600">
+                <li>
+                  {t('agent.settings.transparency_intent', {
+                    defaultValue: 'Twoja intencja i kolejne wiadomości rozmowy.',
+                  })}
+                </li>
+                <li>
+                  {t('agent.settings.transparency_context', {
+                    defaultValue:
+                      'Kontekst widoku: kod typu obiektu, aktywny filtr, liczność selekcji (bez pełnych danych produktów).',
+                  })}
+                </li>
+                <li>
+                  {t('agent.settings.transparency_results', {
+                    defaultValue:
+                      'Wyniki narzędzi: liczniki, kody i minimalne projekcje (id, kod, nazwa, kompletność) — tylko to, co narzędzie zwróci.',
+                  })}
+                </li>
+                <li>
+                  {t('agent.settings.transparency_never', {
+                    defaultValue:
+                      'Nigdy: Twój klucz, hasła, tokeny API ani dane innych tenantów. Zapis do katalogu wyłącznie po Twojej akceptacji.',
+                  })}
+                </li>
+              </ul>
+            </section>
+          </>
+        )}
+      </div>
+      <AgentShortcuts />
     </div>
   );
 }


### PR DESCRIPTION
Closes #2242

## Problem
Operator: „nie widzę bloczków z historią/poleceniami agenta w ustawieniach" + „agent nie działa" (czat wisi na „Planuję…").

## Root cause
**#2147 nigdy nie został zmergowany** — parked OPEN gdy sesja przeszła do bulk-arithmetic. Działał tylko na dev-stacku przez `docker cp`; gdy checkout się zmienił, zniknął. Nic nie „wyleciało z main" — nigdy go tam nie było. Main poszedł 58 commitów naprzód, backend #2147 koliduje z niezależnie dodanym `TenantAgentConfig`.

## Fix (FE-only, re-aplikowany na aktualny main)
1. **Chat-hang** (`AgentChatSheet`): polling działa **niezależnie od SSE**. Synchroniczny run osiąga `awaiting_input`/`awaiting_approval` zanim SSE się połączy → terminalny event ginął → UI wisiał na „Planuję…". Usunięty `sseConnected` z guarda pollingu (SSE dalej napędza live phases).
2. **Bloczki** (`AgentShortcuts`): prawa kolumna w `/settings/ai` z linkami do `/agent/inbox` i `/agent/history` (trasy istnieją, brak w sidebarze).

## Testy
- E2E `1979-agent-byok-settings`: asercja że bloczki inbox/history mają `href` do `/agent/inbox` + `/agent/history`; axe a11y scan obejmuje nowe karty (clean); flow klucza BYOK bez zmian.
- tsc + biome zielone.

## Odłożone → follow-up
Selektor modelu + prompt caching (backend model-override) — wymaga reconciliacji z `TenantAgentConfig` na main (osobny ticket). Backend agenta na main **działa** (runy osiągają `done`/`awaiting_input`) — problem był wyłącznie w FE.

## Smoke test
(uzupełnię — restart stacka na aktualny main + czat nie wisi + bloczki widoczne)

🤖 Generated with [Claude Code](https://claude.com/claude-code)