### PR TITLE
feat(agent): selektor modelu (Haiku) + prompt caching + restore UX agenta (#2147 od nowa)

### DIFF
--- a/apps/admin/e2e/1979-agent-byok-settings.spec.ts
+++ b/apps/admin/e2e/1979-agent-byok-settings.spec.ts
@@ -22,12 +22,42 @@ test('BYOK settings set, rotate-visible-prefix and disable on the live API', asy
     [],
   );
 
+  // Right-column shortcuts into inbox / run history are always present
+  // (the routes have no sidebar entry — this is the only way in).
+  await expect(page.getByTestId('agent-shortcut-inbox')).toHaveAttribute('href', '/agent/inbox');
+  await expect(page.getByTestId('agent-shortcut-history')).toHaveAttribute(
+    'href',
+    '/agent/history',
+  );
+
   // Set a syntactically valid test key on the live endpoint.
   await page.getByTestId('agent-key-input').fill('sk-ant-api03-playwright-e2e-test-key');
   await page.getByTestId('agent-key-save').click();
   await expect(page.getByTestId('agent-key-state')).toContainText(/Aktywny|Active/);
   await expect(page.getByTestId('agent-key-prefix')).toBeVisible();
   await expect(page.getByTestId('agent-key-prefix')).not.toContainText('playwright-e2e-test-key');
+
+  // With a key configured, the model + caching card appears. Pin Haiku
+  // (the cheap testing pick) and toggle caching off — both hit the live
+  // PATCH endpoint.
+  await expect(page.getByTestId('agent-model')).toBeVisible();
+  await page.getByTestId('agent-model-select').selectOption('claude-haiku-4-5');
+  await expect(page.getByTestId('agent-model-select')).toHaveValue('claude-haiku-4-5');
+
+  // The toggle is a controlled checkbox whose state only flips after the
+  // async PATCH + query refetch, so Playwright's check()/uncheck() (which
+  // expect the DOM to change on click) fail. Use click() + expect() with
+  // auto-retry instead. Idempotent: the E2E hits the live PATCH endpoint
+  // and the DB is NOT reset between retries, so force a known state first.
+  const caching = page.getByTestId('agent-caching-toggle');
+  if (!(await caching.isChecked())) {
+    await caching.click();
+    await expect(caching).toBeChecked();
+  }
+  await caching.click();
+  await expect(caching).not.toBeChecked();
+  await caching.click();
+  await expect(caching).toBeChecked();
 
   // Disable: soft-off for the tenant.
   await page.getByTestId('agent-key-disable').click();

--- a/apps/admin/src/features/agent/chat/AgentChatSheet.tsx
+++ b/apps/admin/src/features/agent/chat/AgentChatSheet.tsx
@@ -65,7 +65,10 @@ export function AgentChatSheet() {
   const scrollRef = useRef<HTMLDivElement>(null);
   // AGENT-P6-07 (#1980) — live phases over SSE; polling stays as the
   // fallback whenever the stream is not connected.
-  const { connected: sseConnected, lastEvent } = useAgentRunStream(open ? runId : null);
+  // SSE drives the live phase label; the status transition itself is
+  // guaranteed by polling (see the effect below), so `connected` is not
+  // consulted here.
+  const { lastEvent } = useAgentRunStream(open ? runId : null);
 
   const refresh = useCallback(async (id: string) => {
     try {
@@ -93,13 +96,17 @@ export function AgentChatSheet() {
     return () => window.removeEventListener(OPEN_AGENT_CHAT_EVENT, onOpenEvent);
   }, [refresh]);
 
-  // Poll while the loop is busy server-side (planning/committing) -
-  // ONLY as the fallback when the SSE stream is down (P6-07).
+  // Poll while the loop is busy server-side (planning/committing).
+  // Runs REGARDLESS of the SSE stream: with a synchronous loop the run
+  // can reach awaiting_input before the stream even connects, so the
+  // terminal `status` event is missed and the UI would hang on
+  // "Planuję…" forever if polling deferred to SSE. SSE still drives the
+  // live phase label; polling guarantees the status transition lands.
   useEffect(() => {
-    if (!open || runId === null || run === null || !isRunBusy(run.status) || sseConnected) return;
+    if (!open || runId === null || run === null || !isRunBusy(run.status)) return;
     const timer = window.setInterval(() => void refresh(runId), 2500);
     return () => window.clearInterval(timer);
-  }, [open, runId, run, refresh, sseConnected]);
+  }, [open, runId, run, refresh]);
 
   // SSE events: a status transition re-reads the run (fresh transcript);
   // a progress tick just updates the live phase label.

--- a/apps/admin/src/features/agent/history/AgentHistoryPage.tsx
+++ b/apps/admin/src/features/agent/history/AgentHistoryPage.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronRight, Loader2, Undo2 } from 'lucide-react';
+import { ChevronDown, ChevronRight, Loader2, MessageSquare, Undo2, X } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
@@ -8,10 +8,13 @@ import {
   type AgentRunDetail,
   type AgentRunStatus,
   type AgentRunSummary,
+  cancelAgentRun,
   getAgentRun,
+  isRunTerminal,
   listAgentRuns,
   rollbackAgentRun,
 } from '@/features/agent/api';
+import { OPEN_AGENT_CHAT_EVENT } from '@/features/agent/chat/AgentChatSheet';
 import { httpErrorDetail } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
@@ -84,6 +87,22 @@ export function AgentHistoryPage() {
       await reload();
     } catch (error) {
       // P5-04 boundary: a schema-op with data refuses with reasons.
+      setRollbackError(httpErrorDetail(error) ?? String(error));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  // A non-terminal run (awaiting_input left unanswered, a stuck plan)
+  // blocks starting a new one ("1 active run per user"). Cancelling it
+  // here is the escape hatch so the user isn't wedged.
+  const cancel = async (run: AgentRunSummary) => {
+    setBusyId(run.id);
+    setRollbackError(null);
+    try {
+      await cancelAgentRun(run.id);
+      await reload();
+    } catch (error) {
       setRollbackError(httpErrorDetail(error) ?? String(error));
     } finally {
       setBusyId(null);
@@ -173,6 +192,33 @@ export function AgentHistoryPage() {
                   {' · '}
                   {new Date(run.started_at).toLocaleString()}
                 </span>
+                {run.status === 'awaiting_input' && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      window.dispatchEvent(
+                        new CustomEvent(OPEN_AGENT_CHAT_EVENT, { detail: { runId: run.id } }),
+                      )
+                    }
+                    data-testid="agent-history-continue"
+                  >
+                    <MessageSquare className="mr-1 size-3.5" aria-hidden />
+                    {t('agent.history.continue', { defaultValue: 'Kontynuuj w czacie' })}
+                  </Button>
+                )}
+                {!isRunTerminal(run.status) && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={busyId === run.id}
+                    onClick={() => void cancel(run)}
+                    data-testid="agent-history-cancel"
+                  >
+                    <X className="mr-1 size-3.5" aria-hidden />
+                    {t('agent.history.cancel', { defaultValue: 'Anuluj run' })}
+                  </Button>
+                )}
                 {run.status === 'done' && (
                   <Button
                     variant="outline"
@@ -216,6 +262,36 @@ export function AgentHistoryPage() {
                           })}
                         </span>
                       </div>
+                      {detail.messages.length > 0 && (
+                        <div className="space-y-1.5" data-testid="agent-history-transcript">
+                          {detail.messages.map((message, index) => {
+                            const text = message.content
+                              .map((block) => ('text' in block ? block.text : ''))
+                              .join('')
+                              .trim();
+                            if (text === '') return null;
+                            return (
+                              <div
+                                // biome-ignore lint/suspicious/noArrayIndexKey: transcript is append-only and static per run
+                                key={index}
+                                className={cn(
+                                  'rounded-lg px-3 py-2 text-[13px]',
+                                  message.role === 'user'
+                                    ? 'bg-zinc-100 text-zinc-800'
+                                    : 'bg-purple-50 text-purple-900',
+                                )}
+                              >
+                                <span className="mb-0.5 block text-[10.5px] font-semibold uppercase tracking-wide opacity-60">
+                                  {message.role === 'user'
+                                    ? t('agent.history.you', { defaultValue: 'Ty' })
+                                    : t('agent.history.agent', { defaultValue: 'Agent' })}
+                                </span>
+                                <span className="whitespace-pre-wrap">{text}</span>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      )}
                       {detail.tool_calls.length === 0 ? (
                         <p className="text-zinc-500">
                           {t('agent.history.no_tools', {

--- a/apps/admin/src/features/settings/ai/agent-shortcuts.tsx
+++ b/apps/admin/src/features/settings/ai/agent-shortcuts.tsx
@@ -1,0 +1,76 @@
+import { ChevronRight, History, Inbox } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+
+/**
+ * Right-column shortcuts on Settings → AI into the agent inbox and run
+ * history. Those routes (`/agent/inbox`, `/agent/history`) exist but
+ * have no sidebar entry, so this is the primary way a user reaches
+ * them — rendered as cards next to the BYOK key panel.
+ */
+function ShortcutCard({
+  to,
+  icon,
+  title,
+  description,
+  testid,
+}: {
+  to: string;
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  testid: string;
+}) {
+  return (
+    <Link
+      to={to}
+      data-testid={testid}
+      className="group flex items-start gap-3 rounded-xl border border-zinc-200 bg-white p-4 transition-colors hover:border-purple-300 hover:bg-purple-50/40"
+    >
+      <span className="mt-0.5 grid size-9 shrink-0 place-items-center rounded-lg bg-purple-100 text-purple-600">
+        {icon}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="flex items-center gap-1 text-sm font-semibold text-zinc-900">
+          {title}
+          <ChevronRight
+            className="size-4 text-zinc-400 transition-transform group-hover:translate-x-0.5"
+            aria-hidden
+          />
+        </span>
+        <span className="mt-0.5 block text-xs text-zinc-500">{description}</span>
+      </span>
+    </Link>
+  );
+}
+
+export function AgentShortcuts() {
+  const { t } = useTranslation();
+
+  return (
+    <aside className="mt-6 space-y-3 lg:mt-0" aria-label="Skróty agenta">
+      <ShortcutCard
+        to="/agent/inbox"
+        testid="agent-shortcut-inbox"
+        icon={<Inbox className="size-4" aria-hidden />}
+        title={t('agent.settings.shortcut_inbox_title', {
+          defaultValue: 'Skrzynka akceptacji',
+        })}
+        description={t('agent.settings.shortcut_inbox_desc', {
+          defaultValue: 'Zatwierdź lub odrzuć propozycje agenta (diff before → after).',
+        })}
+      />
+      <ShortcutCard
+        to="/agent/history"
+        testid="agent-shortcut-history"
+        icon={<History className="size-4" aria-hidden />}
+        title={t('agent.settings.shortcut_history_title', {
+          defaultValue: 'Historia runów',
+        })}
+        description={t('agent.settings.shortcut_history_desc', {
+          defaultValue: 'Przejrzyj wykonane operacje i cofnij je („Cofnij tę operację").',
+        })}
+      />
+    </aside>
+  );
+}

--- a/apps/admin/src/features/settings/ai/index.tsx
+++ b/apps/admin/src/features/settings/ai/index.tsx
@@ -1,11 +1,12 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { KeyRound, Loader2, ShieldCheck, Sparkles } from 'lucide-react';
+import { Cpu, KeyRound, Loader2, ShieldCheck, Sparkles, Zap } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { toast } from '@/components/ui/toast';
 import { getAgentCost } from '@/features/agent/api';
 import { httpErrorDetail, jsonFetch } from '@/lib/http';
+import { AgentShortcuts } from './agent-shortcuts';
 
 interface AgentKeyStatus {
   agent_feature_enabled: boolean;
@@ -15,6 +16,9 @@ interface AgentKeyStatus {
   enabled_at: string | null;
   disabled_at: string | null;
   last_used_at: string | null;
+  model: string | null;
+  prompt_caching_enabled: boolean;
+  selectable_models: string[];
 }
 
 const JSON_OPTS = { contentType: 'application/json', accept: 'application/json' } as const;
@@ -23,11 +27,26 @@ const AGENT_KEY_QUERY_KEY = ['settings', 'agent-key'] as const;
 const AGENT_COST_QUERY_KEY = ['settings', 'agent-cost'] as const;
 
 /**
+ * Friendly labels for the selectable model overrides. Kept in sync with
+ * AgentKeyController::SELECTABLE_MODELS; the API is the source of truth
+ * for which ids are offered, this map only prettifies known ones.
+ */
+const MODEL_LABELS: Record<string, string> = {
+  'claude-haiku-4-5': 'Haiku 4.5 — najtańszy',
+  'claude-sonnet-4-6': 'Sonnet 4.6 — zbalansowany',
+  'claude-opus-4-8': 'Opus 4.8 — najsilniejszy',
+};
+
+/**
  * AGENT-P6-06 (#1979) — BYOK settings (Piotr, PRD §4.2): set/rotate the
  * tenant's Anthropic key (plaintext never comes back - only the display
  * prefix + timestamps), soft-disable as the per-tenant agent-off
  * toggle, and the §10.3 transparency copy explaining what leaves the
  * system towards the model.
+ *
+ * Extended with a per-tenant model override + prompt-caching toggle,
+ * and right-column shortcuts into the agent inbox / run history (the
+ * routes exist but have no sidebar entry).
  */
 function CapBar({ label, pct }: { label: string; pct: number }) {
   const clamped = Math.max(0, Math.min(100, pct));
@@ -110,8 +129,20 @@ export function AiSettingsPage() {
     }
   };
 
+  const patchSetting = async (body: Record<string, unknown>) => {
+    setBusy(true);
+    try {
+      await jsonFetch('/api/settings/agent-key', { ...JSON_OPTS, method: 'PATCH', body });
+      await reload();
+    } catch (error) {
+      toast.error(httpErrorDetail(error) ?? String(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
   return (
-    <div className="max-w-2xl space-y-6" data-testid="agent-settings">
+    <div className="space-y-6" data-testid="agent-settings">
       <div>
         <h1 className="flex items-center gap-2 text-xl font-semibold tracking-tight">
           <Sparkles className="size-5 text-purple-600" aria-hidden />
@@ -125,204 +156,297 @@ export function AiSettingsPage() {
         </p>
       </div>
 
-      {status === null ? (
-        statusQuery.isError ? (
-          <p className="text-sm text-red-600" role="alert">
-            {httpErrorDetail(statusQuery.error) ?? String(statusQuery.error)}
-          </p>
-        ) : (
-          <p className="flex items-center gap-2 text-sm text-zinc-500" role="status">
-            <Loader2 className="size-4 animate-spin" aria-hidden />
-            {t('agent.settings.loading', { defaultValue: 'Wczytywanie…' })}
-          </p>
-        )
-      ) : (
-        <>
-          {!status.agent_feature_enabled && (
-            <p className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
-              {t('agent.settings.feature_off', {
-                defaultValue:
-                  'Warstwa agenta jest globalnie wyłączona (AGENT_ENABLED) — klucz można skonfigurować, ale runy nie wystartują.',
-              })}
-            </p>
-          )}
-
-          <section
-            className="rounded-xl border border-zinc-200 bg-white p-4"
-            aria-labelledby="agent-key-heading"
-          >
-            <h2 id="agent-key-heading" className="flex items-center gap-2 text-sm font-semibold">
-              <KeyRound className="size-4 text-zinc-500" aria-hidden />
-              {t('agent.settings.key_heading', { defaultValue: 'Klucz Anthropic' })}
-            </h2>
-
-            <dl className="mt-3 grid grid-cols-2 gap-2 text-sm">
-              <dt className="text-zinc-500">
-                {t('agent.settings.state', { defaultValue: 'Stan' })}
-              </dt>
-              <dd data-testid="agent-key-state">
-                {status.enabled
-                  ? t('agent.settings.state_on', { defaultValue: 'Aktywny — agent włączony' })
-                  : status.configured
-                    ? t('agent.settings.state_disabled', { defaultValue: 'Wyłączony (soft-off)' })
-                    : t('agent.settings.state_missing', {
-                        defaultValue: 'Brak klucza — agent wymaga klucza',
-                      })}
-              </dd>
-              {status.key_prefix !== null && (
-                <>
-                  <dt className="text-zinc-500">
-                    {t('agent.settings.prefix', { defaultValue: 'Prefiks' })}
-                  </dt>
-                  <dd className="font-mono" data-testid="agent-key-prefix">
-                    {status.key_prefix}…
-                  </dd>
-                </>
+      <div className="gap-6 lg:grid lg:grid-cols-[minmax(0,42rem)_18rem] lg:items-start">
+        <div className="space-y-6">
+          {status === null ? (
+            statusQuery.isError ? (
+              <p className="text-sm text-red-600" role="alert">
+                {httpErrorDetail(statusQuery.error) ?? String(statusQuery.error)}
+              </p>
+            ) : (
+              <p className="flex items-center gap-2 text-sm text-zinc-500" role="status">
+                <Loader2 className="size-4 animate-spin" aria-hidden />
+                {t('agent.settings.loading', { defaultValue: 'Wczytywanie…' })}
+              </p>
+            )
+          ) : (
+            <>
+              {!status.agent_feature_enabled && (
+                <p className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
+                  {t('agent.settings.feature_off', {
+                    defaultValue:
+                      'Warstwa agenta jest globalnie wyłączona (AGENT_ENABLED) — klucz można skonfigurować, ale runy nie wystartują.',
+                  })}
+                </p>
               )}
-              {status.last_used_at !== null && (
-                <>
-                  <dt className="text-zinc-500">
-                    {t('agent.settings.last_used', { defaultValue: 'Ostatnio użyty' })}
-                  </dt>
-                  <dd>{new Date(status.last_used_at).toLocaleString()}</dd>
-                </>
-              )}
-            </dl>
 
-            <form
-              className="mt-4 flex items-end gap-2"
-              onSubmit={(event) => {
-                event.preventDefault();
-                void saveKey();
-              }}
-            >
-              <label className="flex-1 text-sm">
-                <span className="mb-1 block text-zinc-500">
-                  {status.configured
-                    ? t('agent.settings.rotate_label', {
-                        defaultValue: 'Nowy klucz (rotacja zastępuje obecny)',
-                      })
-                    : t('agent.settings.set_label', { defaultValue: 'Klucz API (sk-ant-…)' })}
-                </span>
-                <input
-                  type="password"
-                  value={draftKey}
-                  onChange={(event) => setDraftKey(event.target.value)}
-                  autoComplete="off"
-                  placeholder="sk-ant-api03-…"
-                  className="w-full rounded-md border border-zinc-200 px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-zinc-400"
-                  data-testid="agent-key-input"
-                />
-              </label>
-              <Button
-                type="submit"
-                disabled={busy || draftKey.trim() === ''}
-                data-testid="agent-key-save"
+              <section
+                className="rounded-xl border border-zinc-200 bg-white p-4"
+                aria-labelledby="agent-key-heading"
               >
-                {busy ? (
-                  <Loader2 className="size-4 animate-spin" />
-                ) : (
-                  t('agent.settings.save', { defaultValue: 'Zapisz' })
-                )}
-              </Button>
-              {status.enabled && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={busy}
-                  onClick={() => void disable()}
-                  data-testid="agent-key-disable"
+                <h2
+                  id="agent-key-heading"
+                  className="flex items-center gap-2 text-sm font-semibold"
                 >
-                  {t('agent.settings.disable', { defaultValue: 'Wyłącz agenta' })}
-                </Button>
+                  <KeyRound className="size-4 text-zinc-500" aria-hidden />
+                  {t('agent.settings.key_heading', { defaultValue: 'Klucz Anthropic' })}
+                </h2>
+
+                <dl className="mt-3 grid grid-cols-2 gap-2 text-sm">
+                  <dt className="text-zinc-500">
+                    {t('agent.settings.state', { defaultValue: 'Stan' })}
+                  </dt>
+                  <dd data-testid="agent-key-state">
+                    {status.enabled
+                      ? t('agent.settings.state_on', { defaultValue: 'Aktywny — agent włączony' })
+                      : status.configured
+                        ? t('agent.settings.state_disabled', {
+                            defaultValue: 'Wyłączony (soft-off)',
+                          })
+                        : t('agent.settings.state_missing', {
+                            defaultValue: 'Brak klucza — agent wymaga klucza',
+                          })}
+                  </dd>
+                  {status.key_prefix !== null && (
+                    <>
+                      <dt className="text-zinc-500">
+                        {t('agent.settings.prefix', { defaultValue: 'Prefiks' })}
+                      </dt>
+                      <dd className="font-mono" data-testid="agent-key-prefix">
+                        {status.key_prefix}…
+                      </dd>
+                    </>
+                  )}
+                  {status.last_used_at !== null && (
+                    <>
+                      <dt className="text-zinc-500">
+                        {t('agent.settings.last_used', { defaultValue: 'Ostatnio użyty' })}
+                      </dt>
+                      <dd>{new Date(status.last_used_at).toLocaleString()}</dd>
+                    </>
+                  )}
+                </dl>
+
+                <form
+                  className="mt-4 flex items-end gap-2"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    void saveKey();
+                  }}
+                >
+                  <label className="flex-1 text-sm">
+                    <span className="mb-1 block text-zinc-500">
+                      {status.configured
+                        ? t('agent.settings.rotate_label', {
+                            defaultValue: 'Nowy klucz (rotacja zastępuje obecny)',
+                          })
+                        : t('agent.settings.set_label', { defaultValue: 'Klucz API (sk-ant-…)' })}
+                    </span>
+                    <input
+                      type="password"
+                      value={draftKey}
+                      onChange={(event) => setDraftKey(event.target.value)}
+                      autoComplete="off"
+                      placeholder="sk-ant-api03-…"
+                      className="w-full rounded-md border border-zinc-200 px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-zinc-400"
+                      data-testid="agent-key-input"
+                    />
+                  </label>
+                  <Button
+                    type="submit"
+                    disabled={busy || draftKey.trim() === ''}
+                    data-testid="agent-key-save"
+                  >
+                    {busy ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      t('agent.settings.save', { defaultValue: 'Zapisz' })
+                    )}
+                  </Button>
+                  {status.enabled && (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      disabled={busy}
+                      onClick={() => void disable()}
+                      data-testid="agent-key-disable"
+                    >
+                      {t('agent.settings.disable', { defaultValue: 'Wyłącz agenta' })}
+                    </Button>
+                  )}
+                </form>
+                <p className="mt-2 text-xs text-zinc-500">
+                  {t('agent.settings.never_plaintext', {
+                    defaultValue:
+                      'Klucz jest szyfrowany (AES-256-GCM) i nigdy nie wraca w odpowiedziach — widzisz tylko prefiks.',
+                  })}
+                </p>
+              </section>
+
+              {status.configured && (
+                <section
+                  className="rounded-xl border border-zinc-200 bg-white p-4"
+                  aria-labelledby="agent-model-heading"
+                  data-testid="agent-model"
+                >
+                  <h2
+                    id="agent-model-heading"
+                    className="flex items-center gap-2 text-sm font-semibold"
+                  >
+                    <Cpu className="size-4 text-zinc-500" aria-hidden />
+                    {t('agent.settings.model_heading', { defaultValue: 'Model i buforowanie' })}
+                  </h2>
+
+                  <label className="mt-3 block text-sm">
+                    <span className="mb-1 block text-zinc-500">
+                      {t('agent.settings.model_label', { defaultValue: 'Model agenta' })}
+                    </span>
+                    <select
+                      value={status.model ?? ''}
+                      disabled={busy}
+                      onChange={(event) =>
+                        void patchSetting({
+                          model: event.target.value === '' ? null : event.target.value,
+                        })
+                      }
+                      data-testid="agent-model-select"
+                      className="w-full rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-400"
+                    >
+                      <option value="">
+                        {t('agent.settings.model_auto', {
+                          defaultValue: 'Automatycznie (Sonnet; schema-ops na Opus)',
+                        })}
+                      </option>
+                      {status.selectable_models.map((id) => (
+                        <option key={id} value={id}>
+                          {MODEL_LABELS[id] ?? id}
+                        </option>
+                      ))}
+                    </select>
+                    <span className="mt-1 block text-xs text-zinc-500">
+                      {t('agent.settings.model_hint', {
+                        defaultValue:
+                          'Puste = dobór automatyczny. Wybór modelu przypina wszystkie operacje do niego (np. Haiku do tanich testów). Zmiana modelu resetuje bufor promptu.',
+                      })}
+                    </span>
+                  </label>
+
+                  <label className="mt-4 flex items-start gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={status.prompt_caching_enabled}
+                      disabled={busy}
+                      onChange={(event) =>
+                        void patchSetting({ prompt_caching_enabled: event.target.checked })
+                      }
+                      data-testid="agent-caching-toggle"
+                      className="mt-0.5 size-4 rounded border-zinc-300"
+                    />
+                    <span>
+                      <span className="flex items-center gap-1 font-medium text-zinc-900">
+                        <Zap className="size-3.5 text-amber-500" aria-hidden />
+                        {t('agent.settings.caching_label', {
+                          defaultValue: 'Buforowanie promptu',
+                        })}
+                      </span>
+                      <span className="mt-0.5 block text-xs text-zinc-500">
+                        {t('agent.settings.caching_hint', {
+                          defaultValue:
+                            'Agent wysyła stały fragment (instrukcje + definicje narzędzi) raz i przez 5 minut płaci za jego ponowne użycie ~10% ceny. Pierwsze wywołanie kosztuje ~25% więcej (zapis), kolejne w oknie są tańsze. Zalecane: włączone.',
+                        })}
+                      </span>
+                    </span>
+                  </label>
+                </section>
               )}
-            </form>
-            <p className="mt-2 text-xs text-zinc-500">
-              {t('agent.settings.never_plaintext', {
-                defaultValue:
-                  'Klucz jest szyfrowany (AES-256-GCM) i nigdy nie wraca w odpowiedziach — widzisz tylko prefiks.',
-              })}
-            </p>
-          </section>
 
-          {cost !== null && (
-            <section
-              className="rounded-xl border border-zinc-200 bg-white p-4"
-              aria-labelledby="agent-cost-heading"
-              data-testid="agent-cost"
-            >
-              <h2 id="agent-cost-heading" className="flex items-center gap-2 text-sm font-semibold">
-                <Sparkles className="size-4 text-zinc-500" aria-hidden />
-                {t('agent.settings.cost_heading', { defaultValue: 'Koszt i limity' })}
-              </h2>
-              <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-                <dt className="text-zinc-500">
-                  {t('agent.settings.cost_today', { defaultValue: 'Dziś' })}
-                </dt>
-                <dd data-testid="agent-cost-today">
-                  ${cost.cost_today_usd} · {cost.tokens_today} tok · {cost.runs_today}{' '}
-                  {t('agent.settings.runs', { defaultValue: 'runów' })}
-                </dd>
-                <dt className="text-zinc-500">
-                  {t('agent.settings.cost_month', { defaultValue: 'Ten miesiąc' })}
-                </dt>
-                <dd>
-                  ${cost.cost_month_usd} · {cost.tokens_month} tok · {cost.runs_month}{' '}
-                  {t('agent.settings.runs', { defaultValue: 'runów' })}
-                </dd>
-              </dl>
-              <div className="mt-3 space-y-2">
-                <CapBar
-                  label={`${t('agent.settings.cap_day', { defaultValue: 'Limit dzienny' })} ($${cost.day_cap_usd})`}
-                  pct={cost.day_cap_pct}
-                />
-                <CapBar
-                  label={`${t('agent.settings.cap_month', { defaultValue: 'Limit miesięczny' })} ($${cost.month_cap_usd})`}
-                  pct={cost.month_cap_pct}
-                />
-              </div>
-            </section>
+              {cost !== null && (
+                <section
+                  className="rounded-xl border border-zinc-200 bg-white p-4"
+                  aria-labelledby="agent-cost-heading"
+                  data-testid="agent-cost"
+                >
+                  <h2
+                    id="agent-cost-heading"
+                    className="flex items-center gap-2 text-sm font-semibold"
+                  >
+                    <Sparkles className="size-4 text-zinc-500" aria-hidden />
+                    {t('agent.settings.cost_heading', { defaultValue: 'Koszt i limity' })}
+                  </h2>
+                  <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+                    <dt className="text-zinc-500">
+                      {t('agent.settings.cost_today', { defaultValue: 'Dziś' })}
+                    </dt>
+                    <dd data-testid="agent-cost-today">
+                      ${cost.cost_today_usd} · {cost.tokens_today} tok · {cost.runs_today}{' '}
+                      {t('agent.settings.runs', { defaultValue: 'runów' })}
+                    </dd>
+                    <dt className="text-zinc-500">
+                      {t('agent.settings.cost_month', { defaultValue: 'Ten miesiąc' })}
+                    </dt>
+                    <dd>
+                      ${cost.cost_month_usd} · {cost.tokens_month} tok · {cost.runs_month}{' '}
+                      {t('agent.settings.runs', { defaultValue: 'runów' })}
+                    </dd>
+                  </dl>
+                  <div className="mt-3 space-y-2">
+                    <CapBar
+                      label={`${t('agent.settings.cap_day', { defaultValue: 'Limit dzienny' })} ($${cost.day_cap_usd})`}
+                      pct={cost.day_cap_pct}
+                    />
+                    <CapBar
+                      label={`${t('agent.settings.cap_month', { defaultValue: 'Limit miesięczny' })} ($${cost.month_cap_usd})`}
+                      pct={cost.month_cap_pct}
+                    />
+                  </div>
+                </section>
+              )}
+
+              <section
+                className="rounded-xl border border-zinc-200 bg-white p-4"
+                aria-labelledby="agent-transparency-heading"
+              >
+                <h2
+                  id="agent-transparency-heading"
+                  className="flex items-center gap-2 text-sm font-semibold"
+                >
+                  <ShieldCheck className="size-4 text-zinc-500" aria-hidden />
+                  {t('agent.settings.transparency_heading', {
+                    defaultValue: 'Co trafia do modelu',
+                  })}
+                </h2>
+                <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-zinc-600">
+                  <li>
+                    {t('agent.settings.transparency_intent', {
+                      defaultValue: 'Twoja intencja i kolejne wiadomości rozmowy.',
+                    })}
+                  </li>
+                  <li>
+                    {t('agent.settings.transparency_context', {
+                      defaultValue:
+                        'Kontekst widoku: kod typu obiektu, aktywny filtr, liczność selekcji (bez pełnych danych produktów).',
+                    })}
+                  </li>
+                  <li>
+                    {t('agent.settings.transparency_results', {
+                      defaultValue:
+                        'Wyniki narzędzi: liczniki, kody i minimalne projekcje (id, kod, nazwa, kompletność) — tylko to, co narzędzie zwróci.',
+                    })}
+                  </li>
+                  <li>
+                    {t('agent.settings.transparency_never', {
+                      defaultValue:
+                        'Nigdy: Twój klucz, hasła, tokeny API ani dane innych tenantów. Zapis do katalogu wyłącznie po Twojej akceptacji.',
+                    })}
+                  </li>
+                </ul>
+              </section>
+            </>
           )}
+        </div>
 
-          <section
-            className="rounded-xl border border-zinc-200 bg-white p-4"
-            aria-labelledby="agent-transparency-heading"
-          >
-            <h2
-              id="agent-transparency-heading"
-              className="flex items-center gap-2 text-sm font-semibold"
-            >
-              <ShieldCheck className="size-4 text-zinc-500" aria-hidden />
-              {t('agent.settings.transparency_heading', { defaultValue: 'Co trafia do modelu' })}
-            </h2>
-            <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-zinc-600">
-              <li>
-                {t('agent.settings.transparency_intent', {
-                  defaultValue: 'Twoja intencja i kolejne wiadomości rozmowy.',
-                })}
-              </li>
-              <li>
-                {t('agent.settings.transparency_context', {
-                  defaultValue:
-                    'Kontekst widoku: kod typu obiektu, aktywny filtr, liczność selekcji (bez pełnych danych produktów).',
-                })}
-              </li>
-              <li>
-                {t('agent.settings.transparency_results', {
-                  defaultValue:
-                    'Wyniki narzędzi: liczniki, kody i minimalne projekcje (id, kod, nazwa, kompletność) — tylko to, co narzędzie zwróci.',
-                })}
-              </li>
-              <li>
-                {t('agent.settings.transparency_never', {
-                  defaultValue:
-                    'Nigdy: Twój klucz, hasła, tokeny API ani dane innych tenantów. Zapis do katalogu wyłącznie po Twojej akceptacji.',
-                })}
-              </li>
-            </ul>
-          </section>
-        </>
-      )}
+        <AgentShortcuts />
+      </div>
     </div>
   );
 }

--- a/apps/api/migrations/Version20260704140000.php
+++ b/apps/api/migrations/Version20260704140000.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Agent settings — per-tenant model override + prompt-caching toggle
+ * on tenant_agent_configs.
+ *
+ * - `model` NULL = platform default (Sonnet for read/write/action,
+ *   Opus for schema-ops); a concrete id pins every tool kind.
+ * - `prompt_caching_enabled` default true: the agent's stable prefix
+ *   (system + tool definitions) is a caching win, and on BYOK the
+ *   saving accrues to the tenant.
+ */
+final class Version20260704140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add tenant_agent_configs.model (nullable) + prompt_caching_enabled (default true)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE tenant_agent_configs ADD model VARCHAR(64) DEFAULT NULL');
+        $this->addSql('ALTER TABLE tenant_agent_configs ADD prompt_caching_enabled BOOLEAN DEFAULT true NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE tenant_agent_configs DROP model');
+        $this->addSql('ALTER TABLE tenant_agent_configs DROP prompt_caching_enabled');
+    }
+}

--- a/apps/api/src/Agent/Application/Llm/AgentLlmClientInterface.php
+++ b/apps/api/src/Agent/Application/Llm/AgentLlmClientInterface.php
@@ -14,8 +14,10 @@ use App\Shared\Domain\Tenant;
 interface AgentLlmClientInterface
 {
     /**
-     * @param list<array<string, mixed>> $messages Anthropic message shapes (camelCase SDK keys)
-     * @param list<array<string, mixed>> $tools    tool definitions from the registry
+     * @param list<array<string, mixed>> $messages      Anthropic message shapes (camelCase SDK keys)
+     * @param list<array<string, mixed>> $tools         tool definitions from the registry
+     * @param bool                       $promptCaching when true, mark the stable system+tools prefix
+     *                                                  with an ephemeral cache breakpoint
      */
-    public function create(Tenant $tenant, string $model, string $system, array $messages, array $tools): AgentLlmResponse;
+    public function create(Tenant $tenant, string $model, string $system, array $messages, array $tools, bool $promptCaching = true): AgentLlmResponse;
 }

--- a/apps/api/src/Agent/Application/Llm/AgentLlmResponse.php
+++ b/apps/api/src/Agent/Application/Llm/AgentLlmResponse.php
@@ -21,12 +21,16 @@ final readonly class AgentLlmResponse
 
     /**
      * @param list<array<string, mixed>> $contentBlocks
+     * @param int                        $cacheReadTokens     tokens served from the prompt cache (~0.1x price)
+     * @param int                        $cacheCreationTokens tokens written to the prompt cache (~1.25x price, 5-min TTL)
      */
     public function __construct(
         public string $stopReason,
         public array $contentBlocks,
         public int $inputTokens,
         public int $outputTokens,
+        public int $cacheReadTokens = 0,
+        public int $cacheCreationTokens = 0,
     ) {
     }
 

--- a/apps/api/src/Agent/Application/Run/AgentLoopRunner.php
+++ b/apps/api/src/Agent/Application/Run/AgentLoopRunner.php
@@ -14,6 +14,7 @@ use App\Agent\Application\Tool\ToolRegistry;
 use App\Agent\Domain\Entity\AgentMessage;
 use App\Agent\Domain\Entity\AgentRun;
 use App\Agent\Infrastructure\Anthropic\AgentModelSelector;
+use App\Identity\Contracts\Byok\ByokConfigReaderInterface;
 use App\Shared\Domain\Tenant;
 use Doctrine\ORM\EntityManagerInterface;
 use Throwable;
@@ -47,6 +48,7 @@ final readonly class AgentLoopRunner
         private AgentModelSelector $models,
         private AgentSystemPromptBuilder $prompts,
         private UsageCostCalculator $costs,
+        private ByokConfigReaderInterface $tenantConfig,
         private EntityManagerInterface $entityManager,
         private \Symfony\Component\Messenger\MessageBusInterface $eventBus,
         private int $maxToolCallsPerRun,
@@ -60,10 +62,16 @@ final readonly class AgentLoopRunner
         $context = new AgentToolContext($userId, $tenant, $run->getContext());
 
         $tools = $this->registry->toAnthropicToolDefs($userId);
-        $model = $this->registry->hasKind($userId, ToolKind::Schema)
+        // A per-tenant model override (Settings -> AI) pins every tool
+        // kind to one model; absent it, schema-ops get the Opus tier and
+        // everything else the Sonnet tier (P0-06).
+        $override = $this->tenantConfig->modelOverride($tenant);
+        $model = $override ?? ($this->registry->hasKind($userId, ToolKind::Schema)
             ? $this->models->schemaModel()
-            : $this->models->defaultModel();
+            : $this->models->defaultModel());
         $run->setModel($model);
+
+        $promptCaching = $this->tenantConfig->isPromptCachingEnabled($tenant);
 
         $system = $this->prompts->build($run);
         // AGENT-P4-01 (#1968) — a re-dispatched run (next user turn after
@@ -93,11 +101,17 @@ final readonly class AgentLoopRunner
                     return;
                 }
 
-                $response = $this->llm->create($tenant, $model, $system, $messages, $tools);
+                $response = $this->llm->create($tenant, $model, $system, $messages, $tools, $promptCaching);
                 $run->addUsage(
                     $response->inputTokens,
                     $response->outputTokens,
-                    $this->costs->costUsd($model, $response->inputTokens, $response->outputTokens),
+                    $this->costs->costUsd(
+                        $model,
+                        $response->inputTokens,
+                        $response->outputTokens,
+                        $response->cacheReadTokens,
+                        $response->cacheCreationTokens,
+                    ),
                 );
                 $this->persistMessage($run, AgentMessage::ROLE_ASSISTANT, $response->contentBlocks);
                 $messages[] = ['role' => 'assistant', 'content' => $response->contentBlocks];

--- a/apps/api/src/Agent/Application/Run/UsageCostCalculator.php
+++ b/apps/api/src/Agent/Application/Run/UsageCostCalculator.php
@@ -14,6 +14,14 @@ use App\Agent\Infrastructure\Anthropic\AgentModelSelector;
  */
 final readonly class UsageCostCalculator
 {
+    /**
+     * Prompt-cache multipliers on the input rate (Anthropic pricing):
+     * a cache READ costs ~0.1x base input; a cache WRITE costs ~1.25x
+     * (5-minute TTL — the default the client uses).
+     */
+    private const float CACHE_READ_MULTIPLIER = 0.1;
+    private const float CACHE_WRITE_MULTIPLIER = 1.25;
+
     public function __construct(
         private AgentModelSelector $models,
         private float $defaultInputPerMtok,
@@ -24,15 +32,26 @@ final readonly class UsageCostCalculator
     }
 
     /**
+     * @param int $cacheReadTokens     tokens served from the cache (billed at ~0.1x input)
+     * @param int $cacheCreationTokens tokens written to the cache (billed at ~1.25x input)
+     *
      * @return numeric-string USD with 6 decimals
      */
-    public function costUsd(string $model, int $inputTokens, int $outputTokens): string
+    public function costUsd(string $model, int $inputTokens, int $outputTokens, int $cacheReadTokens = 0, int $cacheCreationTokens = 0): string
     {
+        // A per-tenant model override (e.g. Haiku) is billed at the
+        // default tier here — a conservative over-estimate for limits;
+        // exact per-model pricing is a follow-up if it ever matters.
         [$in, $out] = $model === $this->models->schemaModel()
             ? [$this->schemaInputPerMtok, $this->schemaOutputPerMtok]
             : [$this->defaultInputPerMtok, $this->defaultOutputPerMtok];
 
-        $cost = ($inputTokens * $in + $outputTokens * $out) / 1_000_000;
+        $cost = (
+            $inputTokens * $in
+            + $outputTokens * $out
+            + $cacheReadTokens * $in * self::CACHE_READ_MULTIPLIER
+            + $cacheCreationTokens * $in * self::CACHE_WRITE_MULTIPLIER
+        ) / 1_000_000;
 
         return number_format($cost, 6, '.', '');
     }

--- a/apps/api/src/Agent/Infrastructure/Anthropic/SdkAgentLlmClient.php
+++ b/apps/api/src/Agent/Infrastructure/Anthropic/SdkAgentLlmClient.php
@@ -25,14 +25,24 @@ final readonly class SdkAgentLlmClient implements AgentLlmClientInterface
     ) {
     }
 
-    public function create(Tenant $tenant, string $model, string $system, array $messages, array $tools): AgentLlmResponse
+    public function create(Tenant $tenant, string $model, string $system, array $messages, array $tools, bool $promptCaching = true): AgentLlmResponse
     {
         $client = $this->clientFactory->forTenant($tenant);
+
+        // Prompt caching (ephemeral): a single breakpoint on the system
+        // block caches the whole stable prefix — the SDK renders tools
+        // before system, so tools + system are cached together (docs:
+        // render order tools -> system -> messages). The volatile
+        // transcript stays after the breakpoint. Passing system as a
+        // text block (not a bare string) is what carries the marker.
+        $systemArg = $promptCaching
+            ? [['type' => 'text', 'text' => $system, 'cache_control' => ['type' => 'ephemeral']]]
+            : $system;
 
         $message = $client->messages->create(
             model: $model,
             maxTokens: self::MAX_TOKENS,
-            system: $system,
+            system: $systemArg,
             // Wire-shape arrays; the SDK normalizes them (camelCase keys).
             // @phpstan-ignore argument.type
             messages: $messages,
@@ -54,6 +64,8 @@ final readonly class SdkAgentLlmClient implements AgentLlmClientInterface
             contentBlocks: $blocks,
             inputTokens: $message->usage->inputTokens,
             outputTokens: $message->usage->outputTokens,
+            cacheReadTokens: $message->usage->cacheReadInputTokens ?? 0,
+            cacheCreationTokens: $message->usage->cacheCreationInputTokens ?? 0,
         );
     }
 }

--- a/apps/api/src/Agent/Infrastructure/Testing/CannedAgentLlmClient.php
+++ b/apps/api/src/Agent/Infrastructure/Testing/CannedAgentLlmClient.php
@@ -19,7 +19,7 @@ use App\Shared\Domain\Tenant;
  */
 final readonly class CannedAgentLlmClient implements AgentLlmClientInterface
 {
-    public function create(Tenant $tenant, string $model, string $system, array $messages, array $tools): AgentLlmResponse
+    public function create(Tenant $tenant, string $model, string $system, array $messages, array $tools, bool $promptCaching = true): AgentLlmResponse
     {
         return new AgentLlmResponse(
             stopReason: AgentLlmResponse::STOP_END_TURN,

--- a/apps/api/src/Identity/Application/ByokKeyManager.php
+++ b/apps/api/src/Identity/Application/ByokKeyManager.php
@@ -130,4 +130,43 @@ final readonly class ByokKeyManager implements ByokConfigReaderInterface, ByokKe
 
         return null !== $config && $config->isEnabled();
     }
+
+    public function modelOverride(Tenant $tenant): ?string
+    {
+        return $this->configs->findForTenant($tenant)?->getModel();
+    }
+
+    public function isPromptCachingEnabled(Tenant $tenant): bool
+    {
+        // Default to true when unconfigured — caching is the sensible
+        // default and matches the entity/column default.
+        return $this->configs->findForTenant($tenant)?->isPromptCachingEnabled() ?? true;
+    }
+
+    /**
+     * Per-tenant model override (`null` = platform default). Requires a
+     * configured key — a model choice without an agent makes no sense.
+     */
+    public function setModel(Tenant $tenant, ?string $model): void
+    {
+        $config = $this->configs->findForTenant($tenant);
+        if (null === $config) {
+            throw new LogicException('Configure the Anthropic key before choosing a model.');
+        }
+        $config->setModel($model);
+        $this->configs->save($config);
+    }
+
+    /**
+     * Prompt-caching toggle. Requires a configured key.
+     */
+    public function setPromptCaching(Tenant $tenant, bool $enabled): void
+    {
+        $config = $this->configs->findForTenant($tenant);
+        if (null === $config) {
+            throw new LogicException('Configure the Anthropic key before toggling prompt caching.');
+        }
+        $config->setPromptCachingEnabled($enabled);
+        $this->configs->save($config);
+    }
 }

--- a/apps/api/src/Identity/Contracts/Byok/ByokConfigReaderInterface.php
+++ b/apps/api/src/Identity/Contracts/Byok/ByokConfigReaderInterface.php
@@ -15,4 +15,18 @@ use App\Shared\Domain\Tenant;
 interface ByokConfigReaderInterface
 {
     public function isProactiveScanEnabled(Tenant $tenant): bool;
+
+    /**
+     * Per-tenant model override, or `null` for the platform default
+     * (the Agent's AgentModelSelector then picks Sonnet/Opus per tool
+     * kind). A concrete id pins every kind to that model.
+     */
+    public function modelOverride(Tenant $tenant): ?string;
+
+    /**
+     * Whether the tenant opted into Anthropic prompt caching (ephemeral
+     * cache on the stable system+tools prefix). Defaults to true when
+     * no config row exists.
+     */
+    public function isPromptCachingEnabled(Tenant $tenant): bool;
 }

--- a/apps/api/src/Identity/Domain/Entity/TenantAgentConfig.php
+++ b/apps/api/src/Identity/Domain/Entity/TenantAgentConfig.php
@@ -62,6 +62,23 @@ class TenantAgentConfig implements TenantScoped
      */
     private bool $proactiveScanEnabled = false;
 
+    /**
+     * Per-tenant model override. `null` = the platform default (Sonnet
+     * for read/write/action, Opus for schema-ops — resolved by
+     * AgentModelSelector). A concrete id (`claude-haiku-4-5`,
+     * `claude-sonnet-4-6`, `claude-opus-4-8`) pins every tool kind to
+     * that model — e.g. Haiku for cheap testing.
+     */
+    private ?string $model = null;
+
+    /**
+     * Prompt caching (Anthropic ephemeral cache) toggle. On by default:
+     * the agent's stable prefix (system prompt + tool definitions) is a
+     * textbook caching win, and on BYOK the saving accrues to the
+     * tenant. Off only makes sense for very sparse, single-shot usage.
+     */
+    private bool $promptCachingEnabled = true;
+
     private DateTimeImmutable $createdAt;
 
     private DateTimeImmutable $updatedAt;
@@ -176,6 +193,28 @@ class TenantAgentConfig implements TenantScoped
     {
         $this->proactiveScanEnabled = $enabled;
         $this->updatedAt = new DateTimeImmutable();
+    }
+
+    public function getModel(): ?string
+    {
+        return $this->model;
+    }
+
+    public function setModel(?string $model): void
+    {
+        $this->model = ('' === $model) ? null : $model;
+        $this->touch();
+    }
+
+    public function isPromptCachingEnabled(): bool
+    {
+        return $this->promptCachingEnabled;
+    }
+
+    public function setPromptCachingEnabled(bool $enabled): void
+    {
+        $this->promptCachingEnabled = $enabled;
+        $this->touch();
     }
 
     public function getLastUsedAt(): ?DateTimeImmutable

--- a/apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/TenantAgentConfig.orm.xml
+++ b/apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/TenantAgentConfig.orm.xml
@@ -32,6 +32,12 @@
                 <option name="default">false</option>
             </options>
         </field>
+        <field name="model" type="string" length="64" column="model" nullable="true"/>
+        <field name="promptCachingEnabled" type="boolean" column="prompt_caching_enabled">
+            <options>
+                <option name="default">true</option>
+            </options>
+        </field>
 
         <field name="createdAt" type="datetime_immutable" column="created_at"/>
         <field name="updatedAt" type="datetime_immutable" column="updated_at"/>

--- a/apps/api/src/Identity/Presentation/Controller/AgentKeyController.php
+++ b/apps/api/src/Identity/Presentation/Controller/AgentKeyController.php
@@ -27,6 +27,17 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
  */
 final readonly class AgentKeyController
 {
+    /**
+     * Selectable model overrides exposed in Settings → AI. Absent /
+     * null means the platform default (Sonnet for read/write, Opus for
+     * schema-ops). Haiku is the cheapest — the testing pick.
+     */
+    private const array SELECTABLE_MODELS = [
+        'claude-haiku-4-5',
+        'claude-sonnet-4-6',
+        'claude-opus-4-8',
+    ];
+
     public function __construct(
         private ByokKeyManager $keys,
         private TenantAgentConfigRepositoryInterface $configs,
@@ -52,6 +63,9 @@ final readonly class AgentKeyController
             'disabled_at' => $config?->getDisabledAt()?->format(DateTimeInterface::ATOM),
             'last_used_at' => $config?->getLastUsedAt()?->format(DateTimeInterface::ATOM),
             'proactive_scan_enabled' => $config?->isProactiveScanEnabled() ?? false,
+            'model' => $config?->getModel(),
+            'prompt_caching_enabled' => $config?->isPromptCachingEnabled() ?? true,
+            'selectable_models' => self::SELECTABLE_MODELS,
         ]);
     }
 
@@ -82,7 +96,10 @@ final readonly class AgentKeyController
     }
 
     /**
-     * AGENT-P8-01 (#1983) — the proactive-scan opt-in (per tenant).
+     * Partial update of the per-tenant agent settings — any subset of
+     * `proactive_scan_enabled` (P8-01), `model`, and
+     * `prompt_caching_enabled`. Each provided field is validated; the
+     * rest are left untouched. All require a configured key.
      */
     #[Route('/api/settings/agent-key', name: 'pim_agent_key_patch', methods: ['PATCH'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
@@ -93,14 +110,40 @@ final readonly class AgentKeyController
 
         /** @var array<string, mixed> $body */
         $body = json_decode($request->getContent(), true) ?? [];
-        $proactive = $body['proactive_scan_enabled'] ?? null;
-        if (!\is_bool($proactive)) {
-            throw new BadRequestHttpException('proactive_scan_enabled must be a boolean.');
+        $response = [];
+
+        if (\array_key_exists('proactive_scan_enabled', $body)) {
+            $proactive = $body['proactive_scan_enabled'];
+            if (!\is_bool($proactive)) {
+                throw new BadRequestHttpException('proactive_scan_enabled must be a boolean.');
+            }
+            $this->keys->setProactiveScan($tenant, $proactive);
+            $response['proactive_scan_enabled'] = $proactive;
         }
 
-        $this->keys->setProactiveScan($tenant, $proactive);
+        if (\array_key_exists('model', $body)) {
+            $model = $body['model'];
+            if (null !== $model && !\in_array($model, self::SELECTABLE_MODELS, true)) {
+                throw new BadRequestHttpException(\sprintf('model must be null (auto) or one of: %s.', implode(', ', self::SELECTABLE_MODELS)));
+            }
+            $this->keys->setModel($tenant, $model);
+            $response['model'] = $model;
+        }
 
-        return new JsonResponse(['proactive_scan_enabled' => $proactive]);
+        if (\array_key_exists('prompt_caching_enabled', $body)) {
+            $caching = $body['prompt_caching_enabled'];
+            if (!\is_bool($caching)) {
+                throw new BadRequestHttpException('prompt_caching_enabled must be a boolean.');
+            }
+            $this->keys->setPromptCaching($tenant, $caching);
+            $response['prompt_caching_enabled'] = $caching;
+        }
+
+        if ([] === $response) {
+            throw new BadRequestHttpException('No recognized settings in the request body.');
+        }
+
+        return new JsonResponse($response);
     }
 
     #[Route('/api/settings/agent-key', name: 'pim_agent_key_disable', methods: ['DELETE'])]

--- a/apps/api/tests/Api/Agent/AgentKeySettingsApiTest.php
+++ b/apps/api/tests/Api/Agent/AgentKeySettingsApiTest.php
@@ -119,6 +119,56 @@ final class AgentKeySettingsApiTest extends ApiTestCase
     }
 
     #[Test]
+    public function modelOverrideAndPromptCachingPatch(): void
+    {
+        $client = $this->authenticatedClient();
+
+        // Defaults before any config row exists: no override, caching on.
+        $status = $client->request('GET', '/api/settings/agent-key')->toArray(false);
+        self::assertNull($status['model']);
+        self::assertTrue($status['prompt_caching_enabled']);
+        self::assertIsArray($status['selectable_models']);
+        self::assertContains('claude-haiku-4-5', $status['selectable_models']);
+
+        // A settings change requires a configured key.
+        $client->request('PUT', '/api/settings/agent-key', [
+            'json' => ['api_key' => 'sk-ant-api03-config-secret-123456'],
+        ]);
+
+        // Pin the model to Haiku (the cheap testing pick).
+        $patch = $client->request('PATCH', '/api/settings/agent-key', [
+            'json' => ['model' => 'claude-haiku-4-5'],
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+        ]);
+        self::assertSame(200, $patch->getStatusCode());
+        self::assertSame('claude-haiku-4-5', $patch->toArray(false)['model']);
+
+        // Turn prompt caching off.
+        $client->request('PATCH', '/api/settings/agent-key', [
+            'json' => ['prompt_caching_enabled' => false],
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+        ]);
+
+        $status = $client->request('GET', '/api/settings/agent-key')->toArray(false);
+        self::assertSame('claude-haiku-4-5', $status['model']);
+        self::assertFalse($status['prompt_caching_enabled']);
+
+        // An unknown model id is rejected.
+        $bad = $client->request('PATCH', '/api/settings/agent-key', [
+            'json' => ['model' => 'gpt-4'],
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+        ]);
+        self::assertSame(400, $bad->getStatusCode());
+
+        // Clearing the override (null) returns to automatic selection.
+        $client->request('PATCH', '/api/settings/agent-key', [
+            'json' => ['model' => null],
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+        ]);
+        self::assertNull($client->request('GET', '/api/settings/agent-key')->toArray(false)['model']);
+    }
+
+    #[Test]
     public function anonymousIsRejected(): void
     {
         $response = static::createClient()->request('GET', '/api/settings/agent-key');

--- a/apps/api/tests/Integration/Agent/AgentLoopRunnerTest.php
+++ b/apps/api/tests/Integration/Agent/AgentLoopRunnerTest.php
@@ -167,7 +167,7 @@ final class AgentLoopRunnerTest extends KernelTestCase
         [$run, $tenant, $em] = $this->fixture();
 
         $llm = new class implements AgentLlmClientInterface {
-            public function create(Tenant $tenant, string $model, string $system, array $messages, array $tools): AgentLlmResponse
+            public function create(Tenant $tenant, string $model, string $system, array $messages, array $tools, bool $promptCaching = true): AgentLlmResponse
             {
                 throw new RuntimeException('backoff exhausted');
             }
@@ -211,7 +211,7 @@ final class AgentLoopRunnerTest extends KernelTestCase
             {
             }
 
-            public function create(Tenant $tenant, string $model, string $system, array $messages, array $tools): AgentLlmResponse
+            public function create(Tenant $tenant, string $model, string $system, array $messages, array $tools, bool $promptCaching = true): AgentLlmResponse
             {
                 $response = $this->script[$this->turn] ?? null;
                 if (null === $response) {
@@ -246,6 +246,22 @@ final class AgentLoopRunnerTest extends KernelTestCase
             models: $selector,
             prompts: new AgentSystemPromptBuilder(),
             costs: new UsageCostCalculator($selector, 3.0, 15.0, 5.0, 25.0),
+            tenantConfig: new class implements \App\Identity\Contracts\Byok\ByokConfigReaderInterface {
+                public function isProactiveScanEnabled(Tenant $tenant): bool
+                {
+                    return false;
+                }
+
+                public function modelOverride(Tenant $tenant): ?string
+                {
+                    return null;
+                }
+
+                public function isPromptCachingEnabled(Tenant $tenant): bool
+                {
+                    return true;
+                }
+            },
             entityManager: $em,
             eventBus: new class implements \Symfony\Component\Messenger\MessageBusInterface {
                 public function dispatch(object $message, array $stamps = []): \Symfony\Component\Messenger\Envelope

--- a/apps/api/tests/Integration/Agent/ModelSelectionTest.php
+++ b/apps/api/tests/Integration/Agent/ModelSelectionTest.php
@@ -115,9 +115,28 @@ final class ModelSelectionTest extends KernelTestCase
         $selector = new AgentModelSelector('claude-sonnet-test', 'claude-opus-test');
 
         $llm = new class implements AgentLlmClientInterface {
-            public function create(Tenant $tenant, string $model, string $system, array $messages, array $tools): AgentLlmResponse
+            public function create(Tenant $tenant, string $model, string $system, array $messages, array $tools, bool $promptCaching = true): AgentLlmResponse
             {
                 return new AgentLlmResponse('end_turn', [['type' => 'text', 'text' => 'ok']], 10, 5);
+            }
+        };
+
+        // No per-tenant override / caching-off: exercises the default
+        // kind-based model selection this test asserts.
+        $tenantConfig = new class implements \App\Identity\Contracts\Byok\ByokConfigReaderInterface {
+            public function isProactiveScanEnabled(Tenant $tenant): bool
+            {
+                return false;
+            }
+
+            public function modelOverride(Tenant $tenant): ?string
+            {
+                return null;
+            }
+
+            public function isPromptCachingEnabled(Tenant $tenant): bool
+            {
+                return true;
             }
         };
 
@@ -129,6 +148,7 @@ final class ModelSelectionTest extends KernelTestCase
             models: $selector,
             prompts: new AgentSystemPromptBuilder(),
             costs: new UsageCostCalculator($selector, 3.0, 15.0, 5.0, 25.0),
+            tenantConfig: $tenantConfig,
             entityManager: $em,
             eventBus: new class implements \Symfony\Component\Messenger\MessageBusInterface {
                 public function dispatch(object $message, array $stamps = []): \Symfony\Component\Messenger\Envelope

--- a/apps/api/tests/Integration/Agent/PromptInjectionRedTeamTest.php
+++ b/apps/api/tests/Integration/Agent/PromptInjectionRedTeamTest.php
@@ -275,7 +275,7 @@ final class PromptInjectionRedTeamTest extends KernelTestCase
             {
             }
 
-            public function create(Tenant $tenant, string $model, string $system, array $messages, array $tools): AgentLlmResponse
+            public function create(Tenant $tenant, string $model, string $system, array $messages, array $tools, bool $promptCaching = true): AgentLlmResponse
             {
                 $response = $this->script[$this->turn] ?? null;
                 if (null === $response) {
@@ -331,6 +331,22 @@ final class PromptInjectionRedTeamTest extends KernelTestCase
             models: $selector,
             prompts: new AgentSystemPromptBuilder(),
             costs: new UsageCostCalculator($selector, 3.0, 15.0, 5.0, 25.0),
+            tenantConfig: new class implements \App\Identity\Contracts\Byok\ByokConfigReaderInterface {
+                public function isProactiveScanEnabled(Tenant $tenant): bool
+                {
+                    return false;
+                }
+
+                public function modelOverride(Tenant $tenant): ?string
+                {
+                    return null;
+                }
+
+                public function isPromptCachingEnabled(Tenant $tenant): bool
+                {
+                    return true;
+                }
+            },
             entityManager: $em,
             eventBus: $bus,
             maxToolCallsPerRun: 10,


### PR DESCRIPTION
Closes #2242
Closes #2244

## Kontekst
**#2147 nigdy nie został zmergowany** (parked OPEN, 58 commitów za main) — działał na dev-stacku tylko przez ręczny deploy, który zniknął przy zmianie checkoutu. Stąd „zniknięte" bloczki, wiszący czat i brak selektora Haiku. Per decyzja operatora: rozpisane od nowa (#2244) i wprowadzone ponownie na aktualny main. Sprawdzone per-plik: **main nie ruszył żadnego z 21 plików** od merge-base → port 1:1, migracja przetimestampowana (`Version20260704140000`, ALTER na istniejącej tabeli). Stary #2147 i tymczasowy #2243 zamknięte z komentarzem.

## Zakres (pełny restore #2147)
- **Selektor modelu per-tenant**: `tenant_agent_configs.model` (null = platform default; konkretny id pinuje wszystkie tool kinds — np. **Haiku do tanich testów**). Loop honoruje przez `ByokConfigReaderInterface::modelOverride`.
- **Prompt caching** (default ON): stabilny prefix (system + tools) markowany jako ephemeral-cacheable; `UsageCostCalculator` wycenia cache read/write.
- **UI /settings/ai**: select modelu (Haiku/Sonnet/Opus z labelkami) + toggle caching z opisem konsekwencji + **bloczki** do `/agent/inbox` i `/agent/history` (prawa kolumna).
- **Chat-hang fix**: polling niezależnie od SSE — koniec wiecznego „Planuję…" gdy run osiąga `awaiting_input` zanim stream się połączy.
- **Historia runów**: transcript, „Kontynuuj w czacie" dla `awaiting_input`, anulowanie nie-terminalnych runów.

## Bramki
PHPStan max ✅ · Deptrac 0 violations ✅ · php-cs-fixer 0 ✅ · biome + tsc ✅ · 14 testów (ModelSelection, AgentLoopRunner, PromptInjectionRedTeam, AgentKeySettingsApi) ✅

## Smoke test na żywym stacku (pim.localhost, realny klucz BYOK)
1. Migracja zaaplikowana → kolumny `model` + `prompt_caching_enabled` w DB.
2. `GET /api/settings/agent-key` → `selectable_models: [haiku, sonnet, opus]`, `model: null`, `caching: true`.
3. `PATCH {"model":"claude-haiku-4-5"}` → 200, status pokazuje haiku.
4. `PATCH {"prompt_caching_enabled":false/true}` → 200, flip potwierdzony.
5. **Realny run agenta → `agent_runs.model = claude-haiku-4-5`** (wykonany na Haiku), status `awaiting_input`, cancel 200 i **persystuje** (fix #2160 działa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)