### PR TITLE
feat(admin): DASH-02 — żywe KPI i kompletność + drill-downy z kafli

### DIFF
--- a/apps/admin/e2e/view-13-dashboard-command-center.spec.ts
+++ b/apps/admin/e2e/view-13-dashboard-command-center.spec.ts
@@ -107,16 +107,35 @@ test('VIEW-13 — command center renders all five sections with mock values', as
   await expect(page.getByRole('button', { name: 'Eksport feed XML', exact: true })).toBeVisible();
   await expect(page.getByText(/zaakceptowanych zmian w tym tygodniu/)).toHaveCount(0);
 
-  // 3. KPI band — the four pinned tiles with exact mock values.
-  // ("10 984" also renders inside the health card, hence .first()).
-  await expect(page.getByText('12 847', { exact: true })).toBeVisible();
-  await expect(page.getByText('10 984', { exact: true }).first()).toBeVisible();
+  // 3. KPI band — products & publish-ready are LIVE since DASH-02 (#2251):
+  // structural assertions + drill-down hrefs instead of mock literals. The
+  // avg-completeness ("87%") and alerts tiles stay on mock values until
+  // their backends land (DASH-06 / DASH-10).
+  const main = page.locator('main');
+  const productsTile = main.getByRole('link', { name: /łącznie w katalogu/ });
+  await expect(productsTile).toBeVisible();
+  await expect(productsTile).toHaveAttribute('href', '/products');
+  await expect(productsTile.locator('.num').first()).toHaveText(/^[\d\s ]+$/);
+  const readyTile = main.getByRole('link', { name: /Gotowe do publikacji/ });
+  await expect(readyTile).toHaveAttribute('href', /completeness_pct/);
+  await expect(readyTile.locator('.num').first()).toHaveText(/^[\d\s ]+$/);
   await expect(page.getByText('87%', { exact: true })).toBeVisible();
+  // Live tiles render the honest no-trend line (no fabricated deltas).
+  await expect(page.getByText('brak trendu', { exact: true }).first()).toBeVisible();
   await expect(page.getByText('24h · brak trendu')).toBeVisible();
+  await expect(main.getByRole('link', { name: /Otwarte alerty/ })).toHaveAttribute(
+    'href',
+    '#action-center',
+  );
 
-  // 4. Catalog health — ring caption, bucket legend, worst-first channels.
+  // 4. Catalog health — live ring + ready line, clickable bucket legend,
+  // worst-first channels (still mock until DASH-03/06). The weekly-trend
+  // badge must NOT render on live data (no aggregate yet — DASH-05).
   await expect(page.getByRole('heading', { name: 'Kompletność katalogu' })).toBeVisible();
   await expect(page.getByText('gotowe do publikacji', { exact: true })).toBeVisible();
+  await expect(page.getByText(/SKU ≥ 80%/)).toBeVisible();
+  await expect(page.getByText(/pkt \/ tydz\./)).toHaveCount(0);
+  expect(await page.getByRole('link', { name: /Pokaż produkty o kompletności/ }).count()).toBe(5);
   await expect(page.getByText('Kompletność wg kanału')).toBeVisible();
   await expect(page.getByText('Google Shopping', { exact: true })).toBeVisible();
   await expect(page.getByText('Comarch ERP XL', { exact: true })).toBeVisible();
@@ -151,6 +170,13 @@ test('VIEW-13 — command center renders all five sections with mock values', as
     (text) => !/Failed to load resource|EventSource|mercure/i.test(text),
   );
   expect(realErrors).toEqual([]);
+
+  // Drill-down smoke (last — it navigates away): the publish-ready tile
+  // lands on the products list with the completeness filter pre-seeded
+  // (#2249 URL seeding).
+  await readyTile.click();
+  await expect(page).toHaveURL(/\/products\?filter/);
+  await expect(page.getByRole('region', { name: 'Filtr zaawansowany' })).toBeVisible();
 });
 
 test('VIEW-13 — dashboard passes the axe-core WCAG A/AA scan', async ({ page }) => {

--- a/apps/admin/src/features/dashboard/components/ActionCenter.tsx
+++ b/apps/admin/src/features/dashboard/components/ActionCenter.tsx
@@ -65,9 +65,12 @@ export function ActionCenter() {
   const headingId = useId();
 
   return (
+    // id — anchor target for the KPI alerts tile drill-down (DASH-02 #2251);
+    // scroll-mt keeps the heading below the sticky topbar after the jump.
     <section
+      id="action-center"
       aria-labelledby={headingId}
-      className="rounded-2xl border border-line bg-surface p-6 soft-shadow"
+      className="scroll-mt-24 rounded-2xl border border-line bg-surface p-6 soft-shadow"
     >
       <div className="flex flex-wrap items-end justify-between gap-x-4 gap-y-3">
         <div>

--- a/apps/admin/src/features/dashboard/components/CatalogHealthCard.tsx
+++ b/apps/admin/src/features/dashboard/components/CatalogHealthCard.tsx
@@ -1,25 +1,122 @@
 import { useId } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
 
 import { CATALOG_HEALTH } from '../mocks';
+import type { DashboardCompleteness } from '../use-dashboard-completeness';
+import { formatInt, useDashboardSummary } from '../use-dashboard-summary';
+
+interface BucketVm {
+  label: string;
+  count: number;
+  /** Decorative segment color (bar + legend dot + ring). */
+  color: string;
+  /** Products-list drill-down with the matching completeness filter (#2249). */
+  href: string;
+}
+
+interface HealthVm {
+  readyPercent: number;
+  readyCount: string;
+  totalLine: string;
+  /** null = no weekly aggregate yet → the trend badge is not rendered. */
+  weeklyDeltaPoints: number | null;
+  buckets: BucketVm[];
+}
+
+const filterHref = (expr: string): string => `/products?${expr}`;
+
+/**
+ * DASH-02 (#2251) — the five distribution buckets in mock order, each with
+ * its drill-down filter. Counts come from either the live cumulative
+ * aggregate or the mock.
+ */
+const BUCKET_DEFS: ReadonlyArray<Omit<BucketVm, 'count'>> = [
+  {
+    label: '100%',
+    color: '#15803d',
+    href: filterHref('filter[completeness_pct][op]=gte&filter[completeness_pct][value]=100'),
+  },
+  {
+    label: '80–99%',
+    color: '#22c55e',
+    href: filterHref('filter[completeness_pct][op]=between&filter[completeness_pct][value]=80,99'),
+  },
+  {
+    label: '50–79%',
+    color: '#f97316',
+    href: filterHref('filter[completeness_pct][op]=between&filter[completeness_pct][value]=50,79'),
+  },
+  {
+    label: '25–49%',
+    color: '#ef4444',
+    href: filterHref('filter[completeness_pct][op]=between&filter[completeness_pct][value]=25,49'),
+  },
+  {
+    label: '< 25%',
+    color: '#cbd5e1',
+    href: filterHref('filter[completeness_pct][op]=lt&filter[completeness_pct][value]=25'),
+  },
+];
+
+/** Cumulative "at least N%" counts → disjoint bucket counts, mock order. */
+function disjointCounts(live: DashboardCompleteness): number[] {
+  const at = (gte: number): number => live.buckets.find((b) => b.gte === gte)?.count ?? 0;
+  return [
+    at(100),
+    Math.max(0, at(80) - at(100)),
+    Math.max(0, at(50) - at(80)),
+    Math.max(0, at(25) - at(50)),
+    Math.max(0, live.total - at(25)),
+  ];
+}
+
+function buildVm(live: DashboardCompleteness | null): HealthVm {
+  if (live === null) {
+    // Endpoint degraded → approved mock values, per-widget (brief §8.3).
+    return {
+      readyPercent: CATALOG_HEALTH.readyPercent,
+      readyCount: CATALOG_HEALTH.readyCount,
+      totalLine: CATALOG_HEALTH.totalLine,
+      weeklyDeltaPoints: CATALOG_HEALTH.weeklyDeltaPoints,
+      buckets: BUCKET_DEFS.map((def, i) => ({
+        ...def,
+        count: CATALOG_HEALTH.buckets[i]?.count ?? 0,
+      })),
+    };
+  }
+  const counts = disjointCounts(live);
+  return {
+    readyPercent: live.publishReadyPct,
+    readyCount: formatInt(live.publishReady),
+    totalLine: `/ ${formatInt(live.total)} SKU ≥ 80%`,
+    // No weekly aggregate exists yet (DASH-05 snapshots) — hide the badge
+    // instead of decorating live data with the mock trend.
+    weeklyDeltaPoints: null,
+    buckets: BUCKET_DEFS.map((def, i) => ({ ...def, count: counts[i] ?? 0 })),
+  };
+}
 
 /**
  * Donut ring: publish-ready share in ink, the sub-threshold buckets as
  * colored slivers (50–79 orange, 25–49 red, <25 light gray) — matching the
  * approved mock. Purely decorative; the numbers live in the legend.
  */
-function ReadyRing({ percent }: { percent: number }) {
+function ReadyRing({ percent, buckets }: { percent: number; buckets: BucketVm[] }) {
   const { t } = useTranslation();
   const size = 176;
   const stroke = 15;
   const r = (size - stroke) / 2;
   const c = 2 * Math.PI * r;
 
-  const total = CATALOG_HEALTH.buckets.reduce((sum, bucket) => sum + bucket.count, 0);
-  const belowThreshold = CATALOG_HEALTH.buckets.slice(2); // 50–79 / 25–49 / <25
+  const total = buckets.reduce((sum, bucket) => sum + bucket.count, 0);
+  const belowThreshold = buckets.slice(2); // 50–79 / 25–49 / <25
   const segments = [
     { share: percent / 100, color: 'var(--ink)' },
-    ...belowThreshold.map((bucket) => ({ share: bucket.count / total, color: bucket.color })),
+    ...belowThreshold.map((bucket) => ({
+      share: total > 0 ? bucket.count / total : 0,
+      color: bucket.color,
+    })),
   ];
 
   let offset = 0;
@@ -78,14 +175,21 @@ function ReadyRing({ percent }: { percent: number }) {
 }
 
 /**
- * VIEW-13 (#2143) — "Zdrowie danych / Kompletność katalogu" card: ready
- * ring, completeness distribution (stacked bar + legend) and per-channel
- * completeness sorted worst-first. All values static mock.
+ * VIEW-13 (#2143) / DASH-02 (#2251) — "Zdrowie danych / Kompletność
+ * katalogu" card. Ring, ready count and the distribution buckets are live
+ * (completeness aggregate via the summary façade) and degrade to the
+ * approved mock per widget; every bucket legend row drills down to the
+ * products list with the matching filter. Per-channel completeness stays
+ * mock until its aggregate endpoint lands (DASH-03/DASH-06); the weekly
+ * trend badge renders only when trend data exists (mock path) — never a
+ * fabricated trend on live data.
  */
 export function CatalogHealthCard() {
   const { t } = useTranslation();
   const headingId = useId();
-  const total = CATALOG_HEALTH.buckets.reduce((sum, bucket) => sum + bucket.count, 0);
+  const { completeness } = useDashboardSummary();
+  const vm = buildVm(completeness);
+  const total = vm.buckets.reduce((sum, bucket) => sum + bucket.count, 0);
 
   return (
     <section
@@ -101,50 +205,61 @@ export function CatalogHealthCard() {
             {t('dashboard.health.title', { defaultValue: 'Kompletność katalogu' })}
           </h2>
         </div>
-        <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-emerald-50 px-2.5 py-1 text-[12px] font-medium text-emerald-700">
-          <span className="size-1.5 rounded-full bg-emerald-600" aria-hidden />
-          {t('dashboard.health.weekly_trend', {
-            defaultValue: '+ {{count}} pkt / tydz.',
-            count: CATALOG_HEALTH.weeklyDeltaPoints,
-          })}
-        </span>
+        {vm.weeklyDeltaPoints !== null ? (
+          <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-emerald-50 px-2.5 py-1 text-[12px] font-medium text-emerald-700">
+            <span className="size-1.5 rounded-full bg-emerald-600" aria-hidden />
+            {t('dashboard.health.weekly_trend', {
+              defaultValue: '+ {{count}} pkt / tydz.',
+              count: vm.weeklyDeltaPoints,
+            })}
+          </span>
+        ) : null}
       </div>
 
       <div className="mt-6 flex flex-col items-center gap-6 sm:flex-row">
-        <ReadyRing percent={CATALOG_HEALTH.readyPercent} />
+        <ReadyRing percent={vm.readyPercent} buckets={vm.buckets} />
         <div className="min-w-0 flex-1">
           <p className="flex flex-wrap items-baseline gap-x-2">
             <span className="num display text-[30px] font-semibold leading-none text-ink">
-              {CATALOG_HEALTH.readyCount}
+              {vm.readyCount}
             </span>
-            <span className="num text-[13px] text-ink-2">{CATALOG_HEALTH.totalLine}</span>
+            <span className="num text-[13px] text-ink-2">{vm.totalLine}</span>
           </p>
           <div className="mt-3 flex h-2.5 w-full gap-px overflow-hidden rounded-full" aria-hidden>
-            {CATALOG_HEALTH.buckets.map((bucket) => (
+            {vm.buckets.map((bucket) => (
               <span
                 key={bucket.label}
                 className="h-full"
                 style={{
-                  width: `${(bucket.count / total) * 100}%`,
+                  width: `${total > 0 ? (bucket.count / total) * 100 : 0}%`,
                   backgroundColor: bucket.color,
                 }}
               />
             ))}
           </div>
-          <dl className="mt-4 grid grid-cols-2 gap-x-6 gap-y-2">
-            {CATALOG_HEALTH.buckets.map((bucket) => (
-              <div key={bucket.label} className="flex items-center gap-2 text-[13px]">
-                <span
-                  className="size-2 shrink-0 rounded-full"
-                  style={{ backgroundColor: bucket.color }}
-                  aria-hidden
-                />
-                <dt className="num text-ink-2">{bucket.label}</dt>
-                {/* Mock renders raw digits (4210) — no grouping below 5 digits. */}
-                <dd className="num ml-auto font-medium text-ink">{bucket.count}</dd>
-              </div>
+          <ul className="mt-4 grid grid-cols-2 gap-x-6 gap-y-2">
+            {vm.buckets.map((bucket) => (
+              <li key={bucket.label}>
+                <Link
+                  to={bucket.href}
+                  className="flex items-center gap-2 rounded text-[13px] hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink"
+                  aria-label={t('dashboard.health.bucket_link_aria', {
+                    defaultValue: 'Pokaż produkty o kompletności {{bucket}}',
+                    bucket: bucket.label,
+                  })}
+                >
+                  <span
+                    className="size-2 shrink-0 rounded-full"
+                    style={{ backgroundColor: bucket.color }}
+                    aria-hidden
+                  />
+                  <span className="num text-ink-2">{bucket.label}</span>
+                  {/* Mock renders raw digits (4210) — no grouping below 5 digits. */}
+                  <span className="num ml-auto font-medium text-ink">{bucket.count}</span>
+                </Link>
+              </li>
             ))}
-          </dl>
+          </ul>
         </div>
       </div>
 

--- a/apps/admin/src/features/dashboard/components/KpiBand.tsx
+++ b/apps/admin/src/features/dashboard/components/KpiBand.tsx
@@ -1,7 +1,10 @@
 import { ArrowRight, ArrowUp } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
 
 import { KPI_TILES, type KpiKey } from '../mocks';
+import { formatInt, useDashboardSummary } from '../use-dashboard-summary';
 
 const TILE_COPY: Record<KpiKey, { label: string; hint: string }> = {
   products: { label: 'Produkty', hint: 'łącznie w katalogu' },
@@ -11,22 +14,76 @@ const TILE_COPY: Record<KpiKey, { label: string; hint: string }> = {
 };
 
 /**
- * VIEW-13 (#2143) — KPI band, four static tiles per the approved mock.
- * Values and deltas are mock data; the alerts tile deliberately renders
- * "brak trendu" instead of a fabricated arrow (NUI-02 rule). The previous
- * configurable 4-of-8 tile picker was dropped with the redesign — the mock
- * pins exactly these four tiles.
+ * DASH-02 (#2251) — per-tile drill-down (brief §5-C: every KPI leads
+ * somewhere). Completeness thresholds deep-link through the URL filter
+ * seeding added in #2249; the alerts tile is a same-page anchor.
+ */
+const TILE_HREF: Record<KpiKey, string> = {
+  products: '/products',
+  publish_ready: '/products?filter[completeness_pct][op]=gte&filter[completeness_pct][value]=80',
+  avg_completeness: '/products?filter[completeness_pct][op]=lt&filter[completeness_pct][value]=80',
+  open_alerts: '#action-center',
+};
+
+interface TileVm {
+  key: KpiKey;
+  value: string;
+  /** Signed delta text; null = no trend data (never fabricate one). */
+  delta: string | null;
+  /** Copy for the null-delta line (alerts tile keeps its "24h" flavour). */
+  noTrendLabel: string;
+}
+
+/**
+ * VIEW-13 (#2143) / DASH-02 (#2251) — KPI band. Products and
+ * publish-ready values are live (existing count hooks via the summary
+ * façade) and degrade to the approved mock values per widget; their
+ * deltas render as "brak trendu" until the daily snapshot aggregates
+ * exist (DASH-05) — NUI-02 rule: never fabricate a trend. The
+ * avg-completeness and alerts tiles stay on mock values until their
+ * backends land (DASH-06 / DASH-10).
  */
 export function KpiBand() {
   const { t } = useTranslation();
+  const { productsTotal, completeness } = useDashboardSummary();
+
+  const noTrendGeneric = t('dashboard.kpi.no_trend_generic', { defaultValue: 'brak trendu' });
+  const noTrendAlerts = t('dashboard.kpi.no_trend', { defaultValue: '24h · brak trendu' });
+
+  const tiles: TileVm[] = KPI_TILES.map((mock) => {
+    switch (mock.key) {
+      case 'products':
+        return productsTotal === null
+          ? { ...mock, noTrendLabel: noTrendGeneric }
+          : {
+              key: mock.key,
+              value: formatInt(productsTotal),
+              delta: null,
+              noTrendLabel: noTrendGeneric,
+            };
+      case 'publish_ready':
+        return completeness === null
+          ? { ...mock, noTrendLabel: noTrendGeneric }
+          : {
+              key: mock.key,
+              value: formatInt(completeness.publishReady),
+              delta: null,
+              noTrendLabel: noTrendGeneric,
+            };
+      default:
+        return { ...mock, noTrendLabel: noTrendAlerts };
+    }
+  });
+
+  const tileClass =
+    'flex flex-col rounded-2xl border border-line bg-surface p-5 soft-shadow transition-shadow hover:soft-shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink';
 
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
-      {KPI_TILES.map((tile) => (
-        <div
-          key={tile.key}
-          className="flex flex-col rounded-2xl border border-line bg-surface p-5 soft-shadow"
-        >
+      {tiles.map((tile) => (
+        // The alerts tile is a same-page anchor — a native <a> scrolls to
+        // the target; router Links do not scroll on hash-only navigation.
+        <TileLink key={tile.key} href={TILE_HREF[tile.key]} className={tileClass}>
           <span className="text-[13px] font-medium text-ink-2">
             {t(`dashboard.kpi.${tile.key}.label`, { defaultValue: TILE_COPY[tile.key].label })}
           </span>
@@ -45,17 +102,38 @@ export function KpiBand() {
                 </span>
               </>
             ) : (
-              <span className="text-ink-2">
-                {t('dashboard.kpi.no_trend', { defaultValue: '24h · brak trendu' })}
-              </span>
+              <span className="text-ink-2">{tile.noTrendLabel}</span>
             )}
           </span>
           <span className="mt-5 flex items-center justify-between text-[12.5px] text-ink-2">
             {t(`dashboard.kpi.${tile.key}.hint`, { defaultValue: TILE_COPY[tile.key].hint })}
             <ArrowRight className="size-4" aria-hidden />
           </span>
-        </div>
+        </TileLink>
       ))}
     </div>
+  );
+}
+
+function TileLink({
+  href,
+  className,
+  children,
+}: {
+  href: string;
+  className: string;
+  children: ReactNode;
+}) {
+  if (href.startsWith('#')) {
+    return (
+      <a href={href} className={className}>
+        {children}
+      </a>
+    );
+  }
+  return (
+    <Link to={href} className={className}>
+      {children}
+    </Link>
   );
 }

--- a/apps/admin/src/features/dashboard/components/__tests__/CommandCenter.test.tsx
+++ b/apps/admin/src/features/dashboard/components/__tests__/CommandCenter.test.tsx
@@ -1,50 +1,155 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { DashboardSummary } from '../../use-dashboard-summary';
+
+/**
+ * DASH-02 (#2251) — the summary façade is mocked so each case pins one
+ * path: degraded (null → approved mock values per widget) or live
+ * (values from the aggregate). formatInt stays real (re-exported from
+ * the actual module).
+ */
+const summaryState: DashboardSummary = {
+  productsTotal: null,
+  completeness: null,
+  isLoading: false,
+};
+
+vi.mock('../../use-dashboard-summary', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../use-dashboard-summary')>();
+  return {
+    ...actual,
+    useDashboardSummary: (): DashboardSummary => ({ ...summaryState }),
+  };
+});
 
 import { ActionCenter } from '../ActionCenter';
 import { CatalogHealthCard } from '../CatalogHealthCard';
 import { KpiBand } from '../KpiBand';
 
-/**
- * VIEW-13 (#2143) — command-center dashboard mock. Locks in the pinned KPI
- * values, the health card structure and the action-center counters, plus the
- * operator decision that no widget renders a MOCK badge.
- */
+const renderWithRouter = (node: ReactNode) => render(<MemoryRouter>{node}</MemoryRouter>);
+
+const LIVE_COMPLETENESS = {
+  total: 194,
+  publishReady: 120,
+  publishReadyPct: 62,
+  buckets: [
+    { gte: 25, count: 180 },
+    { gte: 50, count: 170 },
+    { gte: 80, count: 120 },
+    { gte: 100, count: 40 },
+  ],
+};
+
+beforeEach(() => {
+  summaryState.productsTotal = null;
+  summaryState.completeness = null;
+  summaryState.isLoading = false;
+});
+
 describe('KpiBand', () => {
-  it('renders the four pinned tiles with exact mock values', () => {
-    render(<KpiBand />);
+  it('degrades to the approved mock values when the aggregates are unavailable', () => {
+    renderWithRouter(<KpiBand />);
     expect(screen.getByText('12 847')).toBeInTheDocument();
     expect(screen.getByText('10 984')).toBeInTheDocument();
     expect(screen.getByText('87%')).toBeInTheDocument();
     expect(screen.getByText('Gotowe do publikacji')).toBeInTheDocument();
   });
 
-  it('renders "brak trendu" on the alerts tile instead of a fake delta', () => {
-    render(<KpiBand />);
+  it('renders live counts with "brak trendu" instead of the mock deltas', () => {
+    summaryState.productsTotal = 194;
+    summaryState.completeness = LIVE_COMPLETENESS;
+    renderWithRouter(<KpiBand />);
+    expect(screen.getByText('194')).toBeInTheDocument();
+    expect(screen.getByText('120')).toBeInTheDocument();
+    // Live tiles never fabricate a trend (NUI-02); only the still-mock
+    // avg-completeness tile keeps its approved delta.
+    expect(screen.getAllByText('brak trendu')).toHaveLength(2);
+    expect(screen.queryAllByText(/^\+(184|312)$/)).toHaveLength(0);
+    expect(screen.getByText('+3 pkt')).toBeInTheDocument();
+  });
+
+  it('renders every tile as a drill-down link (brief §5-C)', () => {
+    renderWithRouter(<KpiBand />);
+    expect(screen.getByRole('link', { name: /łącznie w katalogu/ })).toHaveAttribute(
+      'href',
+      '/products',
+    );
+    expect(screen.getByRole('link', { name: /Gotowe do publikacji/ })).toHaveAttribute(
+      'href',
+      expect.stringContaining('filter[completeness_pct][op]=gte'),
+    );
+    expect(screen.getByRole('link', { name: /Średnia kompletność/ })).toHaveAttribute(
+      'href',
+      expect.stringContaining('filter[completeness_pct][op]=lt'),
+    );
+    expect(screen.getByRole('link', { name: /Otwarte alerty/ })).toHaveAttribute(
+      'href',
+      '#action-center',
+    );
+  });
+
+  it('renders "24h · brak trendu" on the alerts tile instead of a fake delta', () => {
+    renderWithRouter(<KpiBand />);
     expect(screen.getByText('24h · brak trendu')).toBeInTheDocument();
-    // Exactly three tiles carry a delta arrow (products, ready, completeness).
-    expect(screen.getAllByText(/^\+(184|312|3 pkt)$/)).toHaveLength(3);
   });
 
   it('does not render any MOCK badge (operator decision)', () => {
-    render(<KpiBand />);
+    renderWithRouter(<KpiBand />);
     expect(screen.queryByText('MOCK')).not.toBeInTheDocument();
   });
 });
 
 describe('CatalogHealthCard', () => {
-  it('renders ring value, bucket legend and worst-first channels', () => {
-    render(<CatalogHealthCard />);
+  it('degrades to mock ring, legend and channels when the aggregate is unavailable', () => {
+    renderWithRouter(<CatalogHealthCard />);
     expect(screen.getByText('85%')).toBeInTheDocument();
     expect(screen.getByText('gotowe do publikacji')).toBeInTheDocument();
     expect(screen.getByText('4210')).toBeInTheDocument();
     expect(screen.getByText('80–99%')).toBeInTheDocument();
+    // Mock path carries the approved weekly-trend badge.
+    expect(screen.getByText(/pkt \/ tydz\./)).toBeInTheDocument();
     expect(screen.getByText('Kompletność wg kanału')).toBeInTheDocument();
     const channels = ['Google Shopping', 'BaseLinker', 'Shopify', 'Comarch ERP XL'];
     for (const channel of channels) {
       expect(screen.getByText(channel)).toBeInTheDocument();
     }
     expect(screen.queryByText('MOCK')).not.toBeInTheDocument();
+  });
+
+  it('renders the live aggregate: disjoint buckets, ready count, no fabricated trend badge', () => {
+    summaryState.completeness = LIVE_COMPLETENESS;
+    renderWithRouter(<CatalogHealthCard />);
+    expect(screen.getByText('62%')).toBeInTheDocument();
+    expect(screen.getByText('120')).toBeInTheDocument();
+    expect(screen.getByText(/194 SKU ≥ 80%/)).toBeInTheDocument();
+    // Cumulative [25:180, 50:170, 80:120, 100:40] over 194 total →
+    // disjoint [40, 80, 50, 10, 14].
+    const legend = ['40', '80', '50', '10', '14'];
+    for (const count of legend) {
+      expect(screen.getAllByText(count).length).toBeGreaterThan(0);
+    }
+    expect(screen.queryByText(/pkt \/ tydz\./)).not.toBeInTheDocument();
+  });
+
+  it('drills down from every bucket legend row to the filtered products list', () => {
+    renderWithRouter(<CatalogHealthCard />);
+    const bucketLinks = screen.getAllByRole('link', { name: /Pokaż produkty o kompletności/ });
+    expect(bucketLinks).toHaveLength(5);
+    expect(bucketLinks[0]).toHaveAttribute(
+      'href',
+      expect.stringContaining('filter[completeness_pct][op]=gte'),
+    );
+    expect(bucketLinks[1]).toHaveAttribute(
+      'href',
+      expect.stringContaining('filter[completeness_pct][op]=between'),
+    );
+    expect(bucketLinks[4]).toHaveAttribute(
+      'href',
+      expect.stringContaining('filter[completeness_pct][op]=lt'),
+    );
   });
 });
 
@@ -60,5 +165,10 @@ describe('ActionCenter', () => {
     expect(screen.getAllByText('Ostrzeżenie')).toHaveLength(3);
     expect(screen.getByRole('button', { name: 'Pobierz raport błędów' })).toBeInTheDocument();
     expect(screen.queryByText('MOCK')).not.toBeInTheDocument();
+  });
+
+  it('carries the anchor id the KPI alerts tile jumps to', () => {
+    const { container } = render(<ActionCenter />);
+    expect(container.querySelector('section#action-center')).not.toBeNull();
   });
 });

--- a/apps/admin/src/features/dashboard/use-dashboard-summary.ts
+++ b/apps/admin/src/features/dashboard/use-dashboard-summary.ts
@@ -1,0 +1,31 @@
+import { type DashboardCompleteness, useDashboardCompleteness } from './use-dashboard-completeness';
+import { useDashboardCounts } from './use-dashboard-counts';
+
+export interface DashboardSummary {
+  /** Live product total; null = endpoint degraded (caller falls back to mock). */
+  productsTotal: number | null;
+  /** Live completeness aggregate; null = degraded (caller falls back to mock). */
+  completeness: DashboardCompleteness | null;
+  isLoading: boolean;
+}
+
+/**
+ * DASH-02 (#2251) — façade over the two existing dashboard hooks, shaped
+ * like the future `GET /api/dashboard/summary` DTO. DASH-06 swaps the
+ * internals for the single endpoint without touching the components.
+ */
+export function useDashboardSummary(): DashboardSummary {
+  const counts = useDashboardCounts();
+  const completeness = useDashboardCompleteness();
+
+  return {
+    productsTotal: counts.data?.products ?? null,
+    completeness: completeness.data ?? null,
+    isLoading: counts.isLoading || completeness.isLoading,
+  };
+}
+
+/** pl-PL digit grouping (12847 → "12 847", NBSP separator like the mock). */
+export function formatInt(value: number): string {
+  return new Intl.NumberFormat('pl-PL').format(value);
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -989,7 +989,8 @@
         "hint": "needs intervention"
       },
       "period_30d": "30 days",
-      "no_trend": "24h · no trend"
+      "no_trend": "24h · no trend",
+      "no_trend_generic": "no trend yet"
     },
     "health": {
       "eyebrow": "Data health",
@@ -998,7 +999,8 @@
       "ring_caption": "ready to publish",
       "ring_aria": "{{percent}}% of products ready to publish",
       "channels_header": "Completeness by channel",
-      "channels_sort": "sort: worst first"
+      "channels_sort": "sort: worst first",
+      "bucket_link_aria": "Show products with {{bucket}} completeness"
     },
     "activity": {
       "eyebrow": "Catalog activity",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -999,7 +999,8 @@
         "hint": "wymaga interwencji"
       },
       "period_30d": "30 dni",
-      "no_trend": "24h · brak trendu"
+      "no_trend": "24h · brak trendu",
+      "no_trend_generic": "brak trendu"
     },
     "health": {
       "eyebrow": "Zdrowie danych",
@@ -1008,7 +1009,8 @@
       "ring_caption": "gotowe do publikacji",
       "ring_aria": "{{percent}}% produktów gotowych do publikacji",
       "channels_header": "Kompletność wg kanału",
-      "channels_sort": "sort: najgorszy pierwszy"
+      "channels_sort": "sort: najgorszy pierwszy",
+      "bucket_link_aria": "Pokaż produkty o kompletności {{bucket}}"
     },
     "activity": {
       "eyebrow": "Aktywność katalogu",


### PR DESCRIPTION
## Cel

Drugi ticket epiku DASH: kafle KPI (Produkty, Gotowe do publikacji) i karta „Kompletność katalogu" przechodzą z mocka na dane live z istniejących hooków; każdy kafel i próg legendy prowadzi do listy produktów z założonym filtrem (deep-link z #2250).

## Zmiany

- **Nowa fasada `use-dashboard-summary.ts`** — składa `use-dashboard-counts` (NUI-02) + `use-dashboard-completeness` (AUD-058) w kształt przyszłego DTO `GET /api/dashboard/summary`; DASH-06 podmieni wnętrze bez ruszania komponentów. + `formatInt` (pl-PL).
- **`KpiBand.tsx`** — Produkty/Gotowe = live (fallback do wartości mocka per widget przy degradacji); delty live kafli = „brak trendu" (NUI-02: zero fabrykowanych strzałek); Średnia kompletność i Alerty zostają na mocku (DASH-06/DASH-10). Każdy kafel = link: `/products`, filtr `gte 80`, filtr `lt 80`, kotwica `#action-center` (natywny `<a>` — router Link nie scrolluje przy hash-only).
- **`CatalogHealthCard.tsx`** — ring %, licznik gotowych, `/ N SKU ≥ 80%" i progi dystrybucji live (rozłączne z kumulatywnych: `c100, c80−c100, c50−c80, c25−c50, total−c25`); legenda progów = linki `between`/`gte`/`lt`; **badge „+X pkt/tydz." ukryty na ścieżce live** (brak agregatu tygodniowego do DASH-05 — świadome odejście od „zostaw mock": nie dekorujemy żywych danych zmyślonym trendem); kanały zostają na mocku (DASH-03/06).
- **`ActionCenter.tsx`** — `id="action-center"` + `scroll-mt-24` (target kotwicy).
- i18n: `dashboard.kpi.no_trend_generic`, `dashboard.health.bucket_link_aria` (pl+en).

## Testy

- `CommandCenter.test.tsx` — przepisany: mock fasady, ścieżki degraded (wartości mocka + badge) i live (194/120, matematyka rozłącznych progów, badge ukryty, 2× „brak trendu", zero `+184/+312"), hrefy wszystkich drill-downów (10 testów).
- `view-13-dashboard-command-center.spec.ts` — asercje strukturalne dla żywych kafli (regex liczbowy + hrefy) zamiast literałów „12 847"/„10 984"; asercja braku badge trendu na live; 5 klikalnych progów legendy; **drill-down smoke na końcu**: klik „Gotowe do publikacji" → `/products?filter…` z widocznym panelem filtrów; axe WCAG A/AA i zero-MOCK bez zmian.

## Smoke test (żywy stack, https://pim.localhost)

Playwright na działającym stacku: login → `/dashboard` → kafle pokazują **żywe wartości** (194 produkty z realnej bazy), ring/progi z realnego agregatu `completeness[gte]` (5× `GET /api/products` 200), klik kafla → lista z aktywnym filtrem, **zero błędów w konsoli** (asercja w specu), axe A/AA green. Wynik: **4/4 passed** (view-13 ×2 + deep-link ×2).

Gates lokalnie: typecheck ✅ · biome ✅ · vitest 133/133 ✅ · build ✅ · Playwright 4/4 ✅

Closes #2251