### PR TITLE
feat(catalog): DASH-03 — agregat kompletności per kanał (port Contracts + SQL)

### DIFF
--- a/apps/api/src/Catalog/Application/Query/SqlChannelCompletenessReport.php
+++ b/apps/api/src/Catalog/Application/Query/SqlChannelCompletenessReport.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Query;
+
+use App\Catalog\Contracts\Query\ChannelCompleteness;
+use App\Catalog\Contracts\Query\ChannelCompletenessPort;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use LogicException;
+
+/**
+ * DASH-03 (#2253) — SQL aggregation over the per-channel completeness
+ * section of `objects.completeness` (JSONB contract:
+ * docs/api/jsonb-schemas.md §3; the values are maintained by
+ * AttributesIndexedRebuilder — this port only READS).
+ *
+ * Scope: product-kind objects only — the dashboard widget speaks in SKU.
+ * Channel display names are resolved from the `channels` table by code
+ * (plain SQL join keeps this Catalog-internal; Deptrac governs class
+ * dependencies, not table reads) and fall back to the raw code for keys
+ * whose channel row no longer exists.
+ */
+final readonly class SqlChannelCompletenessReport implements ChannelCompletenessPort
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private TenantContext $tenantContext,
+    ) {
+    }
+
+    public function perChannel(int $thresholdPct = 80): array
+    {
+        $tenant = $this->tenantContext->get();
+        if (!$tenant instanceof Tenant) {
+            throw new LogicException('Cannot aggregate channel completeness without a current tenant.');
+        }
+        $tenantId = $tenant->getId()->toRfc4122();
+
+        $connection = $this->entityManager->getConnection();
+
+        // tenant-safe: explicit tenant_id predicate (raw SQL bypasses the
+        // Doctrine TenantFilter); RLS is the backstop.
+        $rows = $connection->fetchAllAssociative(
+            'SELECT kv.key AS channel_code, '
+            .'ROUND(AVG((kv.value)::numeric))::int AS avg_pct, '
+            .'COUNT(*) FILTER (WHERE (kv.value)::numeric >= :threshold) AS ready_count, '
+            .'MAX(c.name) AS channel_name '
+            .'FROM objects o '
+            ."CROSS JOIN LATERAL jsonb_each_text(o.completeness->'per_channel') AS kv "
+            .'LEFT JOIN channels c ON c.tenant_id = o.tenant_id AND c.code = kv.key '
+            ."WHERE o.tenant_id = :tenant AND o.kind = 'product' "
+            .'GROUP BY kv.key '
+            .'ORDER BY avg_pct ASC, kv.key ASC',
+            [
+                'threshold' => $thresholdPct,
+                'tenant' => $tenantId,
+            ],
+        );
+
+        $report = [];
+        foreach ($rows as $row) {
+            $code = \is_string($row['channel_code'] ?? null) ? $row['channel_code'] : '';
+            if ('' === $code) {
+                continue;
+            }
+            $name = \is_string($row['channel_name'] ?? null) && '' !== $row['channel_name']
+                ? $row['channel_name']
+                : $code;
+            $avgRaw = $row['avg_pct'] ?? 0;
+            $readyRaw = $row['ready_count'] ?? 0;
+
+            $report[] = new ChannelCompleteness(
+                channelCode: $code,
+                channelName: $name,
+                avgPct: (int) (\is_numeric($avgRaw) ? $avgRaw : 0),
+                readyCount: (int) (\is_numeric($readyRaw) ? $readyRaw : 0),
+            );
+        }
+
+        return $report;
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Query/ChannelCompleteness.php
+++ b/apps/api/src/Catalog/Contracts/Query/ChannelCompleteness.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Query;
+
+/**
+ * DASH-03 (#2253) — read-only per-channel completeness aggregate row.
+ * Percentages come from the `per_channel` section of `objects.completeness`
+ * (JSONB contract: docs/api/jsonb-schemas.md §3, maintained by
+ * AttributesIndexedRebuilder).
+ */
+final readonly class ChannelCompleteness
+{
+    public function __construct(
+        public string $channelCode,
+        /** Channel display name; falls back to the code when the channel row is gone. */
+        public string $channelName,
+        /** Average per-channel completeness across products, 0-100. */
+        public int $avgPct,
+        /** Products at/above the publish-ready threshold on this channel. */
+        public int $readyCount,
+    ) {
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Query/ChannelCompletenessPort.php
+++ b/apps/api/src/Catalog/Contracts/Query/ChannelCompletenessPort.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Query;
+
+/**
+ * DASH-03 (#2253) — Contracts seam over the per-channel completeness data
+ * (`objects.completeness->'per_channel'`). Read-only aggregate for the
+ * dashboard "Kompletność wg kanału" widget; tenant scope comes from
+ * explicit tenant predicates inside the implementation.
+ */
+interface ChannelCompletenessPort
+{
+    /**
+     * Per-channel average completeness + publish-ready counts over
+     * product-kind objects, sorted worst-first (lowest average first).
+     *
+     * @return list<ChannelCompleteness>
+     */
+    public function perChannel(int $thresholdPct = 80): array;
+}

--- a/apps/api/tests/Integration/Catalog/ChannelCompletenessReportTest.php
+++ b/apps/api/tests/Integration/Catalog/ChannelCompletenessReportTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Catalog;
+
+use App\Catalog\Application\Query\SqlChannelCompletenessReport;
+use App\Catalog\Contracts\Query\ChannelCompletenessPort;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Channel\Domain\Entity\Channel;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * DASH-03 (#2253) — the per-channel aggregate reads the REAL
+ * `completeness->'per_channel'` JSONB against Postgres: averages and
+ * publish-ready counts per channel, worst-first order, channel-name
+ * resolution with a code fallback, product-kind scope and tenant
+ * isolation.
+ */
+final class ChannelCompletenessReportTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function aggregatesPerChannelWorstFirstWithNameResolution(): void
+    {
+        [, $em] = $this->fixture();
+
+        $em->persist(new Channel('shopify', 'Shopify'));
+        $em->persist(new Channel('google', 'Google Shopping'));
+
+        $type = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $em->persist($type);
+
+        $p1 = new CatalogObject($type, 'P-1');
+        $p1->recordCompleteness(['global' => 80, 'per_channel' => ['shopify' => 90, 'google' => 40]]);
+        $em->persist($p1);
+
+        $p2 = new CatalogObject($type, 'P-2');
+        $p2->recordCompleteness(['global' => 70, 'per_channel' => ['shopify' => 70, 'google' => 60]]);
+        $em->persist($p2);
+
+        $p3 = new CatalogObject($type, 'P-3');
+        $p3->recordCompleteness([
+            'global' => 100,
+            'per_channel' => ['shopify' => 100, 'allegro' => 10],
+        ]);
+        $em->persist($p3);
+
+        // Legacy object without per_channel — must simply not contribute.
+        $legacy = new CatalogObject($type, 'P-LEGACY');
+        $legacy->recordCompleteness(['global' => 50]);
+        $em->persist($legacy);
+
+        // Non-product kinds stay out of the SKU-focused aggregate.
+        $assetType = new ObjectType('asset', ObjectKind::Asset, ['en' => 'Asset']);
+        $em->persist($assetType);
+        $asset = new CatalogObject($assetType, 'A-1');
+        $asset->recordCompleteness(['global' => 0, 'per_channel' => ['shopify' => 0]]);
+        $em->persist($asset);
+
+        $em->flush();
+
+        $report = $this->port()->perChannel();
+
+        self::assertSame(
+            ['allegro', 'google', 'shopify'],
+            array_map(static fn ($row) => $row->channelCode, $report),
+            'worst average first',
+        );
+
+        [$allegro, $google, $shopify] = $report;
+
+        // 'allegro' has no channels row — the code doubles as the name.
+        self::assertSame('allegro', $allegro->channelName);
+        self::assertSame(10, $allegro->avgPct);
+        self::assertSame(0, $allegro->readyCount);
+
+        self::assertSame('Google Shopping', $google->channelName);
+        self::assertSame(50, $google->avgPct);
+        self::assertSame(0, $google->readyCount);
+
+        self::assertSame('Shopify', $shopify->channelName);
+        self::assertSame(87, $shopify->avgPct, '(90+70+100)/3 rounded');
+        self::assertSame(2, $shopify->readyCount, 'two products at/above 80');
+    }
+
+    #[Test]
+    public function thresholdParameterDrivesTheReadyCount(): void
+    {
+        [, $em] = $this->fixture();
+
+        $type = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $em->persist($type);
+        $p1 = new CatalogObject($type, 'P-1');
+        $p1->recordCompleteness(['global' => 60, 'per_channel' => ['shopify' => 60]]);
+        $em->persist($p1);
+        $em->flush();
+
+        self::assertSame(0, $this->port()->perChannel(80)[0]->readyCount);
+        self::assertSame(1, $this->port()->perChannel(50)[0]->readyCount);
+    }
+
+    #[Test]
+    public function foreignTenantObjectsNeverLeakIntoTheNumbers(): void
+    {
+        [$alpha, $em] = $this->fixture();
+
+        $type = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $em->persist($type);
+        $mine = new CatalogObject($type, 'MINE-1');
+        $mine->recordCompleteness(['global' => 100, 'per_channel' => ['shopify' => 100]]);
+        $em->persist($mine);
+        $em->flush();
+
+        $beta = new Tenant('beta', 'Beta Tenant');
+        $em->persist($beta);
+        $em->flush();
+        self::getContainer()->get(TenantContext::class)->set($beta);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+        $betaType = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $em->persist($betaType);
+        for ($i = 0; $i < 5; ++$i) {
+            $obj = new CatalogObject($betaType, 'BETA-'.$i);
+            $obj->recordCompleteness(['global' => 0, 'per_channel' => ['shopify' => 0]]);
+            $em->persist($obj);
+        }
+        $em->flush();
+        $em->clear();
+
+        self::getContainer()->get(TenantContext::class)->set($alpha);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+
+        $report = $this->port()->perChannel();
+
+        self::assertCount(1, $report);
+        self::assertSame(100, $report[0]->avgPct, 'foreign tenant objects must not drag the average');
+        self::assertSame(1, $report[0]->readyCount);
+    }
+
+    /**
+     * @return array{0: Tenant, 1: EntityManagerInterface}
+     */
+    private function fixture(): array
+    {
+        $tenant = new Tenant('alpha', 'Alpha Tenant');
+        $em = $this->em();
+        $em->persist($tenant);
+        $em->flush();
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+
+        return [$tenant, $em];
+    }
+
+    private function port(): ChannelCompletenessPort
+    {
+        // Direct construction — the container inlines/removes the unused
+        // port alias until DASH-04 injects it into the dashboard endpoint.
+        return new SqlChannelCompletenessReport(
+            $this->em(),
+            self::getContainer()->get(TenantContext::class),
+        );
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}


### PR DESCRIPTION
## Cel

Trzeci ticket epiku DASH: `objects.completeness->per_channel` (JSONB, wyliczane przez `AttributesIndexedRebuilder`, kontrakt `docs/api/jsonb-schemas.md" §3) dostaje agregat, którym dashboard pokaże „Kompletność wg kanału". Konsument: endpoint `GET /api/dashboard/summary` (DASH-04) przez seam Contracts.

## Zmiany

- `Catalog/Contracts/Query/ChannelCompleteness.php` — DTO: `channelCode", `channelName", `avgPct", `readyCount`.
- `Catalog/Contracts/Query/ChannelCompletenessPort.php` — `perChannel(int $thresholdPct = 80): list<ChannelCompleteness>`.
- `Catalog/Application/Query/SqlChannelCompletenessReport.php` — `CROSS JOIN LATERAL jsonb_each_text(completeness->'per_channel')` po obiektach `kind='product'`, **jawny predykat `tenant_id`** (wzorzec `SqlCompletenessReport`; RLS backstop), nazwy z tabeli `channels` (LEFT JOIN, fallback do kodu dla osieroconych kluczy), sort worst-first.

## Testy (real Postgres, w kontenerze api)

`tests/Integration/Catalog/ChannelCompletenessReportTest.php` — 3 testy / 15 asercji:
- agregacja avg+ready per kanał, worst-first, nazwa z `channels` + fallback do kodu, obiekt legacy bez `per_channel` nie kontrybuuje, kind≠product wykluczony;
- parametr progu steruje `readyCount`;
- izolacja tenantów (obce obiekty nie zaniżają średniej).

Port instancjonowany bezpośrednio w teście — kontener wycina nieużywany alias do czasu wstrzyknięcia w DASH-04.

## Gates (lokalnie w kontenerze api)

PHPUnit **3/3 OK (15 asercji)** · PHPStan (max) **No errors** · php-cs-fixer **0/9 do poprawy** · deptrac **0 errors**.

Bez nowej trasy HTTP → bez regeneracji OpenAPI; bez zmian deptrac.yaml (Catalog-internal). Substrate ticket zgodnie ze scope issue (port + SQL; user-facing flow dochodzi w DASH-04/06).

Closes #2253