### PR TITLE
feat(dashboard): DASH-04 — kontekst Dashboard (ADR-0026) + GET /api/dashboard/summary

### DIFF
--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -209,6 +209,16 @@ parameters:
               - type: directory
                 value: 'src/ApiConfigurator/.*'
 
+        # ─── Dashboard (ADR-0026, DASH-04 #2255) ───────────────────────
+        # Thin read-only aggregate context for the admin dashboard. Reads
+        # other BCs via their Contracts seams; tables without a seam are
+        # read with raw tenant-scoped DBAL SQL (policy in ADR-0026), so no
+        # *_Internals dependency is allowed here.
+        - name: Dashboard
+          collectors:
+              - type: directory
+                value: 'src/Dashboard/.*'
+
         # ─── Vendor (third-party + PHP-internal classes) ───────────────
         # AUD-053 (W3-1): every dependency from a first-party class onto a
         # framework/library/PHP-internal class (Symfony, Doctrine, API
@@ -297,6 +307,17 @@ parameters:
         # AUD-053 (W3-1): `Vendor` appears in every ruleset below so that
         # framework / library / PHP-internal edges resolve to an allowed
         # layer instead of inflating the Uncovered count.
+
+        # ADR-0026 (DASH-04 #2255) — read-only dashboard aggregates. Only
+        # Contracts seams + Shared; cross-BC data without a seam is read
+        # via raw tenant-scoped SQL, never via *_Internals classes.
+        Dashboard:
+            - Catalog_Contracts
+            - Channel_Contracts
+            - Identity_Contracts
+            - Shared
+            - Vendor
+
         Catalog_Internals:
             - Catalog_Contracts
             - Asset_Contracts

--- a/apps/api/src/Dashboard/Application/Query/DashboardSummaryQuery.php
+++ b/apps/api/src/Dashboard/Application/Query/DashboardSummaryQuery.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dashboard\Application\Query;
+
+use App\Catalog\Contracts\Query\ChannelCompletenessPort;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use LogicException;
+
+/**
+ * DASH-04 (#2255, ADR-0026) — the dashboard KPI + completeness aggregate:
+ * one COUNT-FILTER pass over product-kind objects (totals, cumulative
+ * completeness thresholds, avg, 30-day created delta) plus the per-channel
+ * aggregate from the Catalog Contracts port.
+ *
+ * Completeness deltas (`delta30d`, `weeklyDeltaPoints`) stay null until the
+ * daily snapshots land (DASH-05); `openAlerts` stays null until the alert
+ * aggregator lands (DASH-09). The FE renders "no trend" for nulls — never
+ * a fabricated arrow (NUI-02).
+ */
+final readonly class DashboardSummaryQuery
+{
+    /** Publish-ready threshold, matching the FE PUBLISH_READY_THRESHOLD. */
+    private const int READY_THRESHOLD = 80;
+
+    /** Cumulative "at least N%" thresholds the distribution strip reads. */
+    private const array THRESHOLDS = [25, 50, self::READY_THRESHOLD, 100];
+
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private TenantContext $tenantContext,
+        private ChannelCompletenessPort $channelCompleteness,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function summary(): array
+    {
+        $tenant = $this->tenantContext->get();
+        if (!$tenant instanceof Tenant) {
+            throw new LogicException('Cannot build the dashboard summary without a current tenant.');
+        }
+
+        $filters = [];
+        foreach (self::THRESHOLDS as $threshold) {
+            $filters[] = \sprintf(
+                'COUNT(*) FILTER (WHERE completeness_pct >= %d) AS gte_%d',
+                $threshold,
+                $threshold,
+            );
+        }
+
+        // tenant-safe: explicit tenant_id predicate (raw SQL bypasses the
+        // Doctrine TenantFilter); RLS is the backstop.
+        $row = $this->entityManager->getConnection()->fetchAssociative(
+            'SELECT COUNT(*) AS total, '
+            .'COALESCE(AVG(completeness_pct), 0) AS avg_pct, '
+            ."COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '30 days') AS created_30d, "
+            .implode(', ', $filters)
+            ." FROM objects WHERE tenant_id = :tenant AND kind = 'product'",
+            ['tenant' => $tenant->getId()->toRfc4122()],
+        );
+
+        $total = $this->intOf($row['total'] ?? 0);
+        $ready = $this->intOf($row['gte_'.self::READY_THRESHOLD] ?? 0);
+        $avgRaw = $row['avg_pct'] ?? 0;
+
+        $buckets = [];
+        foreach (self::THRESHOLDS as $threshold) {
+            $buckets[] = [
+                'gte' => $threshold,
+                'count' => $this->intOf($row['gte_'.$threshold] ?? 0),
+            ];
+        }
+
+        $channels = [];
+        foreach ($this->channelCompleteness->perChannel(self::READY_THRESHOLD) as $channel) {
+            $channels[] = [
+                'code' => $channel->channelCode,
+                'name' => $channel->channelName,
+                'avgPct' => $channel->avgPct,
+                'readyCount' => $channel->readyCount,
+            ];
+        }
+
+        return [
+            'products' => [
+                'total' => $total,
+                'delta30d' => $this->intOf($row['created_30d'] ?? 0),
+            ],
+            'publishReady' => [
+                'count' => $ready,
+                'pct' => $total > 0 ? (int) round($ready / $total * 100) : 0,
+                'delta30d' => null,
+            ],
+            'avgCompleteness' => [
+                'pct' => (int) round(\is_numeric($avgRaw) ? (float) $avgRaw : 0.0),
+                'delta30d' => null,
+                'weeklyDeltaPoints' => null,
+            ],
+            'buckets' => $buckets,
+            'channels' => $channels,
+            'openAlerts' => null,
+        ];
+    }
+
+    private function intOf(mixed $value): int
+    {
+        return (int) (\is_scalar($value) ? $value : 0);
+    }
+}

--- a/apps/api/src/Dashboard/Presentation/Controller/DashboardSummaryController.php
+++ b/apps/api/src/Dashboard/Presentation/Controller/DashboardSummaryController.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dashboard\Presentation\Controller;
+
+use App\Dashboard\Application\Query\DashboardSummaryQuery;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Identity\Contracts\Auth\CurrentUserProvider;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * DASH-04 (#2255, ADR-0026) — the dashboard KPI + completeness aggregate
+ * behind the Pulpit widgets: one call replaces the FE's nine count probes
+ * (4× totalItems + 5× completeness[gte]).
+ */
+final class DashboardSummaryController
+{
+    public function __construct(
+        private readonly DashboardSummaryQuery $query,
+        private readonly CurrentUserProvider $currentUser,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/dashboard/summary',
+        name: 'pim_dashboard_summary',
+        methods: ['GET'],
+    )]
+    #[RequiresPermission(module: 'products', action: 'view')]
+    public function __invoke(): JsonResponse
+    {
+        if (null === $this->currentUser->userId() || null === $this->currentUser->tenant()) {
+            throw new UnauthorizedHttpException('JWT', 'Authenticated user required.');
+        }
+
+        return new JsonResponse($this->query->summary(), Response::HTTP_OK);
+    }
+}

--- a/apps/api/tests/Api/Dashboard/DashboardSummaryApiTest.php
+++ b/apps/api/tests/Api/Dashboard/DashboardSummaryApiTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Dashboard;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Channel\Domain\Entity\Channel;
+use App\Identity\Domain\Entity\User;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * DASH-04 (#2255, ADR-0026) — GET /api/dashboard/summary aggregates the
+ * REAL objects table against Postgres: totals, cumulative completeness
+ * buckets, publish-ready share, avg, the created-in-30d delta and the
+ * per-channel aggregate; permission-gated and tenant-isolated.
+ */
+final class DashboardSummaryApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function summaryAggregatesKpisBucketsAndChannels(): void
+    {
+        $tenant = $this->demoTenant();
+        $this->seedProducts($tenant, [
+            ['sku' => 'P-100', 'pct' => 100, 'per_channel' => ['shopify' => 100]],
+            ['sku' => 'P-060', 'pct' => 60, 'per_channel' => ['shopify' => 40]],
+            ['sku' => 'P-030', 'pct' => 30, 'per_channel' => []],
+        ]);
+        $this->em()->persist(new Channel('shopify', 'Shopify'));
+        $this->em()->flush();
+
+        // Backdate one product beyond the 30-day window — the products
+        // delta must count only the two recent ones.
+        $this->em()->getConnection()->executeStatement(
+            "UPDATE objects SET created_at = NOW() - INTERVAL '40 days' WHERE code = 'P-030'",
+        );
+        $this->em()->clear();
+
+        $response = $this->authenticatedClient()->request('GET', '/api/dashboard/summary');
+
+        self::assertResponseIsSuccessful();
+        $body = $response->toArray();
+
+        self::assertSame(['total' => 3, 'delta30d' => 2], $body['products']);
+        self::assertSame(['count' => 1, 'pct' => 33, 'delta30d' => null], $body['publishReady']);
+        self::assertSame(
+            ['pct' => 63, 'delta30d' => null, 'weeklyDeltaPoints' => null],
+            $body['avgCompleteness'],
+            '(100+60+30)/3 rounded',
+        );
+        self::assertSame(
+            [
+                ['gte' => 25, 'count' => 3],
+                ['gte' => 50, 'count' => 2],
+                ['gte' => 80, 'count' => 1],
+                ['gte' => 100, 'count' => 1],
+            ],
+            $body['buckets'],
+        );
+        self::assertSame(
+            [['code' => 'shopify', 'name' => 'Shopify', 'avgPct' => 70, 'readyCount' => 1]],
+            $body['channels'],
+        );
+        self::assertNull($body['openAlerts']);
+    }
+
+    #[Test]
+    public function emptyCatalogYieldsZeroesNotDivisionErrors(): void
+    {
+        $response = $this->authenticatedClient()->request('GET', '/api/dashboard/summary');
+
+        self::assertResponseIsSuccessful();
+        $body = $response->toArray();
+        self::assertSame(['total' => 0, 'delta30d' => 0], $body['products']);
+        self::assertSame(['count' => 0, 'pct' => 0, 'delta30d' => null], $body['publishReady']);
+        self::assertSame([], $body['channels']);
+    }
+
+    #[Test]
+    public function anonymousRequestIsRejected(): void
+    {
+        static::createClient()->request('GET', '/api/dashboard/summary');
+
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    #[Test]
+    public function userWithoutProductsViewIsForbidden(): void
+    {
+        $tenant = $this->demoTenant();
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $stub = new User($tenant, 'norole@demo.localhost', '', ['ROLE_USER']);
+        $noRole = new User(
+            $tenant,
+            'norole@demo.localhost',
+            $hasher->hashPassword($stub, 'changeme'),
+            ['ROLE_USER'],
+        );
+        $this->em()->persist($noRole);
+        $this->em()->flush();
+
+        $this->authenticatedClient('norole@demo.localhost')->request('GET', '/api/dashboard/summary');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    #[Test]
+    public function foreignTenantObjectsNeverLeakIntoTheNumbers(): void
+    {
+        $tenant = $this->demoTenant();
+        $this->seedProducts($tenant, [['sku' => 'MINE-1', 'pct' => 100, 'per_channel' => []]]);
+        $this->em()->flush();
+
+        $beta = new Tenant('beta', 'Beta Tenant');
+        $this->em()->persist($beta);
+        $this->em()->flush();
+        self::getContainer()->get(\App\Catalog\Application\BuiltInObjectTypeSeeder::class)->seed($beta);
+        $this->seedProducts($beta, [
+            ['sku' => 'BETA-1', 'pct' => 0, 'per_channel' => []],
+            ['sku' => 'BETA-2', 'pct' => 0, 'per_channel' => []],
+        ]);
+        $this->em()->flush();
+        $this->em()->clear();
+
+        $response = $this->authenticatedClient()->request('GET', '/api/dashboard/summary');
+
+        self::assertResponseIsSuccessful();
+        $body = $response->toArray();
+        self::assertSame(3, $this->demoTenantAgnosticTotal(), 'sanity: both tenants hold objects');
+        self::assertSame(['total' => 1, 'delta30d' => 1], $body['products']);
+        self::assertSame(
+            ['pct' => 100, 'delta30d' => null, 'weeklyDeltaPoints' => null],
+            $body['avgCompleteness'],
+            'foreign tenant zeros must not drag the average',
+        );
+    }
+
+    private function demoTenant(): Tenant
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        return $tenant;
+    }
+
+    /**
+     * @param list<array{sku: string, pct: int, per_channel: array<string, int>}> $products
+     */
+    private function seedProducts(Tenant $tenant, array $products): void
+    {
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $type);
+
+        foreach ($products as $spec) {
+            $object = new CatalogObject($type, $spec['sku']);
+            $completeness = ['global' => $spec['pct']];
+            if ([] !== $spec['per_channel']) {
+                $completeness['per_channel'] = $spec['per_channel'];
+            }
+            $object->recordCompleteness($completeness);
+            $this->em()->persist($object);
+        }
+        $this->em()->flush();
+    }
+
+    private function demoTenantAgnosticTotal(): int
+    {
+        $count = $this->em()->getConnection()->fetchOne(
+            "SELECT COUNT(*) FROM objects WHERE kind = 'product'",
+        );
+
+        return (int) (\is_scalar($count) ? $count : 0);
+    }
+}

--- a/docs/adr/0026-dashboard-read-model.md
+++ b/docs/adr/0026-dashboard-read-model.md
@@ -1,0 +1,96 @@
+# ADR-0026: Kontekst Dashboard — read-model agregatów pulpitu
+
+- **Status:** accepted
+- **Data:** 2026-07-05
+- **Kontekst:** epik DASH (uinteraktywnienie dashboardu), tickety DASH-04 (#2255), DASH-05, DASH-07, DASH-09
+- **Powiązane:** ADR-0013 (Deptrac jako strażnik granic), ADR-0014 (Shared kernel), `docs/api/jsonb-schemas.md` §3 (completeness), `Project Plan/UI/dashboard-brief-makiety.md`, `Project Plan/UI/Wdrozenie_grafiki/dashboard-do-oprogramowania.md`
+
+## Kontekst
+
+Dashboard (Pulpit) potrzebuje agregatów, które przecinają bounded contexty:
+
+- **KPI + kompletność** — Catalog (`objects.completeness_pct`, `completeness->per_channel`),
+- **aktywność zespołu** — Identity (`audit_logs`) + Catalog (`objects.created_at`),
+- **Centrum akcji** — Integration (`integration_sync_runs`), Import (`import_sessions`), Export.Feed (`feed_runs`), ApiConfigurator (`api_webhook_deliveries`),
+- **delty/trendy** — historyczne snapshoty, których nikt dziś nie utrzymuje.
+
+Żaden istniejący kontekst nie jest właścicielem takiego przekroju. `Shared` jest w Deptrac
+leafem (ADR-0014) i nie może zależeć od kontraktów innych BC. Rozproszenie endpointów
+dashboardowych po kontekstach źródłowych (po jednym na BC) rozbiłoby publiczny kontrakt
+pulpitu na 4-5 miejsc i wymusiłoby na FE ponowną agregację.
+
+Dodatkowe decyzje operatora (2026-07-04, sesja planistyczna epiku DASH):
+
+1. **Alerty Centrum akcji = agregator on-the-fly**, NIE materializowana encja `Alert`
+   (żadnych event subscriberów w 4 BC; źródła są tanimi, indeksowanymi zapytaniami po
+   statusach). Stan „przeczytane" trzyma mała tabela ack-ów po deterministycznym
+   fingerprincie.
+2. **Delty/trendy = dzienne snapshoty agregatów** (tabela `dashboard_snapshots` + job w
+   istniejącym schedulerze maintenance). Dopóki snapshot na horyzoncie (7d/30d) nie
+   istnieje — kafle renderują się bez delty (reguła NUI-02: zero fabrykowanych trendów).
+
+## Decyzja
+
+### Nowy, cienki kontekst `src/Dashboard` (read-model)
+
+- **Charakter:** wyłącznie odczytowy widok agregujący + dwie małe encje własne
+  (`DashboardSnapshot` — DASH-05, `DashboardAlertAck` — DASH-09). Kontekst NIE jest
+  właścicielem żadnych danych domenowych innych BC i nie wystawia zapisu do nich.
+- **Powierzchnia HTTP:** custom `#[Route]` kontrolery `GET /api/dashboard/*` (wzorzec
+  CQRS/ADR-0012, przykład: `ImportThroughputController`), gate'owane
+  `#[RequiresPermission]`, widoczne w OpenAPI przez `CustomRouteOpenApiFactory`.
+- **Deptrac:** nowa warstwa `Dashboard` (collector `src/Dashboard/.*`) z rulesetem
+  `[Catalog_Contracts, Channel_Contracts, Identity_Contracts, Shared, Vendor]`.
+
+### Polityka odczytu danych innych BC
+
+1. **Preferencja: port w `<BC>\Contracts`** — gdy seam istnieje lub jest tani
+   (np. `Catalog\Contracts\Query\ChannelCompletenessPort`, DASH-03 #2254).
+2. **Dopuszczalny: surowy DBAL SQL z jawnym predykatem `tenant_id`** — dla tabel BC,
+   które nie mają użytecznych Contracts (`integration_sync_runs`, `import_sessions`,
+   `feed_runs`, `api_webhook_deliveries`, `audit_logs`). Precedens:
+   `SqlCompletenessReport` („raw SQL bypasses the Doctrine TenantFilter; RLS is the
+   backstop") oraz `ChannelNodeMappingController` (query cross-BC po `objects`).
+   Deptrac pilnuje zależności klasowych — read-model NIE importuje encji ani serwisów
+   Internals innych BC; czyta tabele. RLS pozostaje twardym backstopem izolacji.
+3. **Zakaz:** zapis do tabel innych BC, import klas `*_Internals`, logika domenowa
+   w kontekście Dashboard.
+
+### Snapshoty dzienne (`dashboard_snapshots`, DASH-05)
+
+Wiersz per tenant per dzień: `products_total`, `publish_ready_count`,
+`avg_completeness_pct`, `per_channel JSONB`; UNIQUE(tenant_id, snapshot_date).
+Wypełniany komendą `pim:dashboard:snapshot` (iteracja po tenantach, upsert) wpiętą
+w `MaintenanceSchedule` (transport `scheduler_maintenance`). Delty liczone jako
+`bieżąca wartość − snapshot(horyzont)`; brak snapshotu ⇒ `null` ⇒ UI bez delty.
+Snapshoty są też punktem odniesienia detektora „spadek kompletności poniżej progu"
+w Centrum akcji (DASH-09).
+
+### Alerty (DASH-09)
+
+`AlertFeedAggregator` — UNION czterech źródeł statusowych w oknie czasowym
++ detektor spadków ze snapshotów + LEFT JOIN `dashboard_alert_acks`
+(UNIQUE(tenant_id, fingerprint); fingerprinty deterministyczne, np.
+`sync_run:{uuid}`, `webhook:{profileId}:{eventType}:{yyyy-mm-dd}`). Okno czasowe
+zastępuje TTL; brak dryfu storage'u względem źródeł prawdy.
+
+## Konsekwencje
+
+- (+) Jeden publiczny kontrakt pulpitu (`/api/dashboard/*`) zamiast N endpointów po BC;
+  FE przestaje re-agregować (9 requestów → 1 na widget-grupę).
+- (+) Zero nowych seamów zdarzeniowych w 4 BC; koszt utrzymania ograniczony do SQL-i
+  odczytowych chronionych testami kernelowymi na realnym Postgresie.
+- (+) Snapshoty odblokowują uczciwe delty (brak fabrykowanych trendów) i detektor spadków.
+- (−) Read-model zna nazwy tabel innych BC — akceptowane świadomie (pkt 2 polityki);
+  zmiany schematów tych tabel muszą uwzględnić dashboard (testy kernelowe łapią drift).
+- (−) Snapshoty zaczynają się od wdrożenia — delty 30d pojawią się po 30 dniach.
+
+## Alternatywy odrzucone
+
+- **Endpointy per-BC** — rozbicie kontraktu, N×CORS-of-concerns w FE, brak miejsca na
+  przekroje (alerty łączą 4 BC w jednym feedzie).
+- **Materializowana encja `Alert` + event subscribery** — wymaga wymyślenia seamów
+  zdarzeń w Import/Export/Integration/ApiConfigurator (dziś ich brak), dubluje stan
+  źródłowy i wprowadza dryf; odrzucona decyzją operatora 2026-07-04.
+- **Rozszerzenie `Shared`** — złamanie „Shared jest leafem" (ADR-0014) i degradacja
+  kernela do worka na wszystko.

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -12872,6 +12872,32 @@
                 "x-cortex-permission": "settings.integrations.manage"
             }
         },
+        "/api/dashboard/summary": {
+            "get": {
+                "operationId": "api_dashboard_summary_get",
+                "tags": [
+                    "dashboard"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api dashboard summary",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "products.view"
+            }
+        },
         "/api/exports/columns": {
             "get": {
                 "operationId": "api_exports_columns_get",


### PR DESCRIPTION
## Cel

Czwarty ticket epiku DASH: agregaty pulpitu przecinają bounded contexty, a `Shared` jest leafem — powstaje cienki read-only kontekst `src/Dashboard` (ADR-0026) i pierwszy endpoint `GET /api/dashboard/summary`, który zastępuje 9 sond FE (4× totalItems + 5× `completeness[gte]`) jednym zapytaniem.

## Zmiany

- **ADR-0026** (`docs/adr/0026-dashboard-read-model.md`): nowy kontekst read-model; polityka odczytu cross-BC (Contracts seam → preferencja; raw DBAL z jawnym `tenant_id` dla tabel bez seamu — precedens `SqlCompletenessReport", RLS backstop; zakaz `*_Internals`); utrwala decyzje operatora z 2026-07-04: alerty = agregator + tabela ack-ów (DASH-09), delty = dzienne snapshoty (DASH-05).
- **Deptrac**: warstwa `Dashboard` (`src/Dashboard/.*`) z rulesetem `[Catalog_Contracts, Channel_Contracts, Identity_Contracts, Shared, Vendor]` — **0 violations**.
- **`DashboardSummaryQuery`**: jeden SQL po `objects` (`COUNT(*) FILTER` progi 25/50/80/100 + AVG + `created_at >= NOW()-30d`, jawny `tenant_id", scope `kind='product'`) + kanały z `ChannelCompletenessPort` (#2254 — pierwszy konsument portu).
- **`DashboardSummaryController`**: `#[RequiresPermission(module: 'products', action: 'view')]`, wzorzec `ImportThroughputController`. Kontrakt zgodny z fasadą FE (DASH-06 podmienia wnętrze `use-dashboard-summary.ts` bez ruszania komponentów); `delta30d` kompletności / `weeklyDeltaPoints` / `openAlerts` = null do DASH-05/09 (FE renderuje „brak trendu").
- **OpenAPI**: regeneracja `docs/api-spec/v0.json` (+26 linii — wyłącznie nowa trasa; auto-dokumentacja przez `CustomRouteOpenApiFactory`).

## Testy (real Postgres, kontener api)

`tests/Api/Dashboard/DashboardSummaryApiTest.php` — **5/5 OK (17 asercji)**: matematyka agregatów (total/delta30d z backdate, publishReady pct, avg, buckety kumulatywne, kanały z portu), pusty katalog bez dzielenia przez zero, 401 anonim, 403 user bez `products.view", izolacja tenantów (sanity-check: obiekty obu tenantów w bazie, odpowiedź widzi tylko swoje).

## Smoke test (żywy stack, https://pim.localhost)

```
GET /api/dashboard/summary (Bearer admin@demo.localhost)
HTTP 200
{"products":{"total":194,"delta30d":194},"publishReady":{"count":194,"pct":100,…},
 "buckets":[{"gte":25,"count":194},…],"channels":[{"code":"allegro","name":"Allegro","avgPct":100,"readyCount":194}],"openAlerts":null}
```

## Gates (lokalnie w kontenerze api)

PHPUnit nowy suite **5/5 OK** · PHPStan (max, pełny src+tests) **No errors** · php-cs-fixer **0 do poprawy** · deptrac **0 errors** (nowa warstwa) · OpenAPI spec zregenerowany.

Closes #2255