### PR TITLE
feat(dashboard): DASH-05 — dzienne snapshoty KPI + uczciwe delty w summary

### DIFF
--- a/apps/api/config/packages/doctrine.yaml
+++ b/apps/api/config/packages/doctrine.yaml
@@ -162,6 +162,12 @@ doctrine:
                 dir: '%kernel.project_dir%/src/Backup/Infrastructure/Doctrine/Orm/Mapping'
                 prefix: 'App\Backup\Domain\Entity'
                 alias: Backup
+            Dashboard:
+                type: xml
+                is_bundle: false
+                dir: '%kernel.project_dir%/src/Dashboard/Infrastructure/Doctrine/Orm/Mapping'
+                prefix: 'App\Dashboard\Domain\Entity'
+                alias: Dashboard
         controller_resolver:
             auto_mapping: false
 

--- a/apps/api/migrations/Version20260705060000.php
+++ b/apps/api/migrations/Version20260705060000.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * DASH-05 (#2257, ADR-0026) — `dashboard_snapshots`: one row per tenant per
+ * day with the dashboard KPI aggregates (products total, publish-ready
+ * count, avg completeness, per-channel JSONB). Written daily by
+ * `pim:dashboard:snapshot` on the maintenance schedule; read by the
+ * summary endpoint to compute honest deltas and by the completeness-drop
+ * alert detector (DASH-09).
+ *
+ * TenantScoped with the W1-1 FORCE RLS pattern (Version20260628110000):
+ * fail-closed tenant-isolation policy + super-admin break-glass bypass.
+ * Explicit runtime-role GRANT per the #2177 pattern — default privileges
+ * are lost on pg_restore (see Version20260704050000 docblock), and the
+ * snapshot job INSERTs as `pim_app` from the worker.
+ */
+final class Version20260705060000 extends AbstractMigration
+{
+    private const string TABLE = 'dashboard_snapshots';
+
+    public function getDescription(): string
+    {
+        return 'DASH-05: add dashboard_snapshots (daily KPI aggregates per tenant) + FORCE RLS + pim_app grant.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE dashboard_snapshots (
+                id UUID NOT NULL,
+                tenant_id UUID NOT NULL,
+                snapshot_date DATE NOT NULL,
+                products_total INT NOT NULL,
+                publish_ready_count INT NOT NULL,
+                avg_completeness_pct SMALLINT NOT NULL,
+                per_channel JSONB NOT NULL,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY (id)
+            )
+            SQL);
+        $this->addSql(
+            'CREATE UNIQUE INDEX dashboard_snapshots_tenant_date_uniq '
+            .'ON dashboard_snapshots (tenant_id, snapshot_date)'
+        );
+        $this->addSql('CREATE INDEX dashboard_snapshots_tenant_idx ON dashboard_snapshots (tenant_id)');
+        $this->addSql(
+            'ALTER TABLE dashboard_snapshots ADD CONSTRAINT FK_dashboard_snapshots_tenant '
+            .'FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+
+        // ── Row-Level Security (W1-1 FORCE pattern) ───────────────────────
+        $predicate = "tenant_id = NULLIF(current_setting('app.current_tenant', true), '')::uuid";
+
+        $this->addSql(\sprintf('ALTER TABLE %s ENABLE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s FORCE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf(
+            'CREATE POLICY tenant_isolation_%s ON %s USING (%s) WITH CHECK (%s)',
+            self::TABLE,
+            self::TABLE,
+            $predicate,
+            $predicate,
+        ));
+        $this->addSql(\sprintf(
+            'CREATE POLICY super_admin_bypass_%s ON %s '
+            ."USING (current_setting('app.is_super_admin', true) = 'true') "
+            ."WITH CHECK (current_setting('app.is_super_admin', true) = 'true')",
+            self::TABLE,
+            self::TABLE,
+        ));
+
+        // Runtime-role grant (#2177): survives pg_restore privilege loss.
+        $this->addSql('GRANT SELECT, INSERT, UPDATE, DELETE ON dashboard_snapshots TO pim_app');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(\sprintf('DROP POLICY IF EXISTS super_admin_bypass_%s ON %s', self::TABLE, self::TABLE));
+        $this->addSql(\sprintf('DROP POLICY IF EXISTS tenant_isolation_%s ON %s', self::TABLE, self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s NO FORCE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s DISABLE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql('DROP TABLE dashboard_snapshots');
+    }
+}

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -138,6 +138,7 @@ parameters:
               - src/ApiConfigurator/Domain/Entity/WebhookDelivery.php
               - src/Identity/Domain/Entity/TenantAgentConfig.php
               - src/Catalog/Domain/Entity/MenuConfiguration.php
+              - src/Dashboard/Domain/Entity/DashboardSnapshot.php
               # Import/Domain entities extend AggregateRoot — their
               # doctrine.associationType emission is the flaky one the
               # `reportUnmatched: false` above guards against (see comment).

--- a/apps/api/src/Dashboard/Application/Query/DashboardAggregates.php
+++ b/apps/api/src/Dashboard/Application/Query/DashboardAggregates.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dashboard\Application\Query;
+
+use App\Catalog\Contracts\Query\ChannelCompleteness;
+
+/**
+ * DASH-05 (#2257) — the raw dashboard aggregates, shared by the summary
+ * endpoint (composes the JSON response + snapshot deltas on top) and the
+ * daily snapshot command (persists them verbatim).
+ */
+final readonly class DashboardAggregates
+{
+    /**
+     * @param array<int, int>           $cumulativeBuckets threshold => "at least" count
+     * @param list<ChannelCompleteness> $channels
+     */
+    public function __construct(
+        public int $productsTotal,
+        public int $createdLast30d,
+        public int $publishReadyCount,
+        public int $avgCompletenessPct,
+        public array $cumulativeBuckets,
+        public array $channels,
+    ) {
+    }
+
+    public function publishReadyPct(): int
+    {
+        return $this->productsTotal > 0
+            ? (int) round($this->publishReadyCount / $this->productsTotal * 100)
+            : 0;
+    }
+}

--- a/apps/api/src/Dashboard/Application/Query/DashboardSummaryQuery.php
+++ b/apps/api/src/Dashboard/Application/Query/DashboardSummaryQuery.php
@@ -7,6 +7,7 @@ namespace App\Dashboard\Application\Query;
 use App\Catalog\Contracts\Query\ChannelCompletenessPort;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use LogicException;
 
@@ -16,10 +17,11 @@ use LogicException;
  * completeness thresholds, avg, 30-day created delta) plus the per-channel
  * aggregate from the Catalog Contracts port.
  *
- * Completeness deltas (`delta30d`, `weeklyDeltaPoints`) stay null until the
- * daily snapshots land (DASH-05); `openAlerts` stays null until the alert
- * aggregator lands (DASH-09). The FE renders "no trend" for nulls — never
- * a fabricated arrow (NUI-02).
+ * DASH-05 (#2257) — completeness deltas come from `dashboard_snapshots`
+ * (daily job): current value minus the snapshot at the 30d/7d horizon.
+ * No snapshot at the horizon ⇒ null ⇒ the FE renders "no trend" — never
+ * a fabricated arrow (NUI-02). `openAlerts` stays null until the alert
+ * aggregator lands (DASH-09).
  */
 final readonly class DashboardSummaryQuery
 {
@@ -37,14 +39,12 @@ final readonly class DashboardSummaryQuery
     }
 
     /**
-     * @return array<string, mixed>
+     * The raw aggregates for the current tenant — shared by the summary
+     * response and the daily snapshot command.
      */
-    public function summary(): array
+    public function aggregates(): DashboardAggregates
     {
-        $tenant = $this->tenantContext->get();
-        if (!$tenant instanceof Tenant) {
-            throw new LogicException('Cannot build the dashboard summary without a current tenant.');
-        }
+        $tenant = $this->currentTenant();
 
         $filters = [];
         foreach (self::THRESHOLDS as $threshold) {
@@ -66,20 +66,42 @@ final readonly class DashboardSummaryQuery
             ['tenant' => $tenant->getId()->toRfc4122()],
         );
 
-        $total = $this->intOf($row['total'] ?? 0);
-        $ready = $this->intOf($row['gte_'.self::READY_THRESHOLD] ?? 0);
-        $avgRaw = $row['avg_pct'] ?? 0;
-
         $buckets = [];
         foreach (self::THRESHOLDS as $threshold) {
-            $buckets[] = [
-                'gte' => $threshold,
-                'count' => $this->intOf($row['gte_'.$threshold] ?? 0),
-            ];
+            $buckets[$threshold] = $this->intOf($row['gte_'.$threshold] ?? 0);
+        }
+        $avgRaw = $row['avg_pct'] ?? 0;
+
+        return new DashboardAggregates(
+            productsTotal: $this->intOf($row['total'] ?? 0),
+            createdLast30d: $this->intOf($row['created_30d'] ?? 0),
+            publishReadyCount: $buckets[self::READY_THRESHOLD],
+            avgCompletenessPct: (int) round(\is_numeric($avgRaw) ? (float) $avgRaw : 0.0),
+            cumulativeBuckets: $buckets,
+            channels: $this->channelCompleteness->perChannel(self::READY_THRESHOLD),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function summary(): array
+    {
+        $tenant = $this->currentTenant();
+        $aggregates = $this->aggregates();
+        $horizons = $this->snapshotHorizons($tenant);
+
+        $ready30 = $horizons[30]['publish_ready_count'] ?? null;
+        $avg30 = $horizons[30]['avg_completeness_pct'] ?? null;
+        $avg7 = $horizons[7]['avg_completeness_pct'] ?? null;
+
+        $buckets = [];
+        foreach ($aggregates->cumulativeBuckets as $threshold => $count) {
+            $buckets[] = ['gte' => $threshold, 'count' => $count];
         }
 
         $channels = [];
-        foreach ($this->channelCompleteness->perChannel(self::READY_THRESHOLD) as $channel) {
+        foreach ($aggregates->channels as $channel) {
             $channels[] = [
                 'code' => $channel->channelCode,
                 'name' => $channel->channelName,
@@ -90,23 +112,77 @@ final readonly class DashboardSummaryQuery
 
         return [
             'products' => [
-                'total' => $total,
-                'delta30d' => $this->intOf($row['created_30d'] ?? 0),
+                'total' => $aggregates->productsTotal,
+                'delta30d' => $aggregates->createdLast30d,
             ],
             'publishReady' => [
-                'count' => $ready,
-                'pct' => $total > 0 ? (int) round($ready / $total * 100) : 0,
-                'delta30d' => null,
+                'count' => $aggregates->publishReadyCount,
+                'pct' => $aggregates->publishReadyPct(),
+                'delta30d' => null === $ready30 ? null : $aggregates->publishReadyCount - $ready30,
             ],
             'avgCompleteness' => [
-                'pct' => (int) round(\is_numeric($avgRaw) ? (float) $avgRaw : 0.0),
-                'delta30d' => null,
-                'weeklyDeltaPoints' => null,
+                'pct' => $aggregates->avgCompletenessPct,
+                'delta30d' => null === $avg30 ? null : $aggregates->avgCompletenessPct - $avg30,
+                'weeklyDeltaPoints' => null === $avg7 ? null : $aggregates->avgCompletenessPct - $avg7,
             ],
             'buckets' => $buckets,
             'channels' => $channels,
             'openAlerts' => null,
         ];
+    }
+
+    /**
+     * Snapshot rows at exactly the 30d and 7d horizons, keyed by horizon.
+     * A missed cron day simply yields no delta for that horizon — honest
+     * nulls over approximated windows.
+     *
+     * @return array<int, array{publish_ready_count: int, avg_completeness_pct: int}>
+     */
+    private function snapshotHorizons(Tenant $tenant): array
+    {
+        // tenant-safe: explicit tenant_id predicate (see aggregates()).
+        $rows = $this->entityManager->getConnection()->fetchAllAssociative(
+            'SELECT snapshot_date, publish_ready_count, avg_completeness_pct '
+            .'FROM dashboard_snapshots '
+            .'WHERE tenant_id = :tenant '
+            .'AND snapshot_date IN (CURRENT_DATE - 30, CURRENT_DATE - 7)',
+            ['tenant' => $tenant->getId()->toRfc4122()],
+        );
+
+        $horizon30 = $this->dateString('-30 days');
+        $horizon7 = $this->dateString('-7 days');
+
+        $byHorizon = [];
+        foreach ($rows as $row) {
+            $date = \is_string($row['snapshot_date'] ?? null) ? $row['snapshot_date'] : '';
+            $values = [
+                'publish_ready_count' => $this->intOf($row['publish_ready_count'] ?? 0),
+                'avg_completeness_pct' => $this->intOf($row['avg_completeness_pct'] ?? 0),
+            ];
+            if ($date === $horizon30) {
+                $byHorizon[30] = $values;
+            }
+            if ($date === $horizon7) {
+                $byHorizon[7] = $values;
+            }
+        }
+
+        return $byHorizon;
+    }
+
+    private function currentTenant(): Tenant
+    {
+        $tenant = $this->tenantContext->get();
+        if (!$tenant instanceof Tenant) {
+            throw new LogicException('Cannot build the dashboard summary without a current tenant.');
+        }
+
+        return $tenant;
+    }
+
+    private function dateString(string $modifier): string
+    {
+        return new DateTimeImmutable('today')->modify($modifier)->format('Y-m-d');
     }
 
     private function intOf(mixed $value): int

--- a/apps/api/src/Dashboard/Domain/Entity/DashboardSnapshot.php
+++ b/apps/api/src/Dashboard/Domain/Entity/DashboardSnapshot.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dashboard\Domain\Entity;
+
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * DASH-05 (#2257, ADR-0026) — one row per tenant per day with the dashboard
+ * KPI aggregates. Written by `pim:dashboard:snapshot` (daily maintenance
+ * schedule); read by DashboardSummaryQuery to compute honest deltas
+ * (current value minus the snapshot at the 7d/30d horizon) and by the
+ * completeness-drop alert detector (DASH-09).
+ */
+class DashboardSnapshot implements TenantScoped
+{
+    private Uuid $id;
+
+    private ?Tenant $tenant = null;
+
+    private DateTimeImmutable $snapshotDate;
+
+    private int $productsTotal;
+
+    private int $publishReadyCount;
+
+    private int $avgCompletenessPct;
+
+    /** @var array<string, array{avgPct: int, readyCount: int}> */
+    private array $perChannel;
+
+    private DateTimeImmutable $createdAt;
+
+    /**
+     * @param array<string, array{avgPct: int, readyCount: int}> $perChannel
+     */
+    public function __construct(
+        DateTimeImmutable $snapshotDate,
+        int $productsTotal,
+        int $publishReadyCount,
+        int $avgCompletenessPct,
+        array $perChannel,
+    ) {
+        $this->id = Uuid::v7();
+        $this->snapshotDate = $snapshotDate;
+        $this->productsTotal = $productsTotal;
+        $this->publishReadyCount = $publishReadyCount;
+        $this->avgCompletenessPct = $avgCompletenessPct;
+        $this->perChannel = $perChannel;
+        $this->createdAt = new DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant already assigned to this snapshot.');
+        }
+        $this->tenant = $tenant;
+    }
+
+    public function getSnapshotDate(): DateTimeImmutable
+    {
+        return $this->snapshotDate;
+    }
+
+    public function getProductsTotal(): int
+    {
+        return $this->productsTotal;
+    }
+
+    public function getPublishReadyCount(): int
+    {
+        return $this->publishReadyCount;
+    }
+
+    public function getAvgCompletenessPct(): int
+    {
+        return $this->avgCompletenessPct;
+    }
+
+    /**
+     * @return array<string, array{avgPct: int, readyCount: int}>
+     */
+    public function getPerChannel(): array
+    {
+        return $this->perChannel;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/apps/api/src/Dashboard/Infrastructure/Doctrine/Orm/Mapping/DashboardSnapshot.orm.xml
+++ b/apps/api/src/Dashboard/Infrastructure/Doctrine/Orm/Mapping/DashboardSnapshot.orm.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Dashboard\Domain\Entity\DashboardSnapshot"
+            table="dashboard_snapshots">
+
+        <unique-constraints>
+            <unique-constraint name="dashboard_snapshots_tenant_date_uniq" columns="tenant_id,snapshot_date"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="dashboard_snapshots_tenant_idx" columns="tenant_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="snapshotDate" type="date_immutable" column="snapshot_date"/>
+        <field name="productsTotal" type="integer" column="products_total"/>
+        <field name="publishReadyCount" type="integer" column="publish_ready_count"/>
+        <field name="avgCompletenessPct" type="smallint" column="avg_completeness_pct"/>
+        <field name="perChannel" type="json" column="per_channel">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Dashboard/Presentation/Command/DashboardSnapshotCommand.php
+++ b/apps/api/src/Dashboard/Presentation/Command/DashboardSnapshotCommand.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dashboard\Presentation\Command;
+
+use App\Dashboard\Application\Query\DashboardSummaryQuery;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Uid\Uuid;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * DASH-05 (#2257, ADR-0026) — daily `dashboard_snapshots` writer: one
+ * upsert per active tenant with the same aggregates the summary endpoint
+ * serves (single source of the math: {@see DashboardSummaryQuery::aggregates}).
+ *
+ * Cross-tenant iteration mirrors the TenantPurger pattern: the RLS GUC
+ * `app.current_tenant` is pinned per tenant for the duration of its
+ * statements (the worker connects as `pim_app`, and dashboard_snapshots
+ * has FORCE RLS) and reset in a finally. The explicit tenant_id VALUES
+ * are defence in depth on top of RLS; under the test schema (no RLS
+ * policies) they are the only guard — exactly what the tests assert.
+ *
+ * Scheduled daily at 03:45 UTC via MaintenanceSchedule; `--dry-run`
+ * prints the would-be rows without writing.
+ */
+#[AsCommand(
+    name: 'pim:dashboard:snapshot',
+    description: 'Upsert today\'s dashboard KPI snapshot for every active tenant.',
+)]
+final class DashboardSnapshotCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly TenantContext $tenantContext,
+        private readonly DashboardSummaryQuery $query,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Print the would-be snapshots without writing.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $dryRun = true === $input->getOption('dry-run');
+        $connection = $this->entityManager->getConnection();
+
+        /** @var list<Tenant> $tenants */
+        $tenants = $this->entityManager->getRepository(Tenant::class)->findAll();
+        $written = 0;
+
+        foreach ($tenants as $tenant) {
+            if (!$tenant->isActive()) {
+                continue;
+            }
+            $tenantId = $tenant->getId()->toRfc4122();
+
+            try {
+                $connection->executeStatement(
+                    "SELECT set_config('app.current_tenant', :t, false)",
+                    ['t' => $tenantId],
+                );
+                $this->tenantContext->set($tenant);
+
+                $aggregates = $this->query->aggregates();
+
+                $perChannel = [];
+                foreach ($aggregates->channels as $channel) {
+                    $perChannel[$channel->channelCode] = [
+                        'avgPct' => $channel->avgPct,
+                        'readyCount' => $channel->readyCount,
+                    ];
+                }
+
+                if ($dryRun) {
+                    $io->writeln(\sprintf(
+                        '[dry-run] %s: total=%d ready=%d avg=%d%% channels=%d',
+                        $tenant->getCode(),
+                        $aggregates->productsTotal,
+                        $aggregates->publishReadyCount,
+                        $aggregates->avgCompletenessPct,
+                        \count($perChannel),
+                    ));
+                    ++$written;
+                    continue;
+                }
+
+                // tenant-safe: explicit tenant_id VALUE + RLS GUC pinned above.
+                $connection->executeStatement(
+                    'INSERT INTO dashboard_snapshots '
+                    .'(id, tenant_id, snapshot_date, products_total, publish_ready_count, '
+                    .'avg_completeness_pct, per_channel, created_at) '
+                    .'VALUES (:id, :tenant, CURRENT_DATE, :total, :ready, :avg, :per_channel, NOW()) '
+                    .'ON CONFLICT (tenant_id, snapshot_date) DO UPDATE SET '
+                    .'products_total = EXCLUDED.products_total, '
+                    .'publish_ready_count = EXCLUDED.publish_ready_count, '
+                    .'avg_completeness_pct = EXCLUDED.avg_completeness_pct, '
+                    .'per_channel = EXCLUDED.per_channel, '
+                    .'created_at = EXCLUDED.created_at',
+                    [
+                        'id' => Uuid::v7()->toRfc4122(),
+                        'tenant' => $tenantId,
+                        'total' => $aggregates->productsTotal,
+                        'ready' => $aggregates->publishReadyCount,
+                        'avg' => $aggregates->avgCompletenessPct,
+                        'per_channel' => json_encode($perChannel, JSON_THROW_ON_ERROR),
+                    ],
+                );
+                ++$written;
+            } finally {
+                $connection->executeStatement("SELECT set_config('app.current_tenant', '', false)");
+            }
+        }
+
+        $io->success(\sprintf(
+            $dryRun ? '%d tenant snapshot(s) computed (dry-run, nothing written).' : '%d tenant snapshot(s) upserted.',
+            $written,
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/apps/api/src/Shared/Infrastructure/Scheduler/MaintenanceSchedule.php
+++ b/apps/api/src/Shared/Infrastructure/Scheduler/MaintenanceSchedule.php
@@ -47,6 +47,8 @@ final class MaintenanceSchedule implements ScheduleProviderInterface
             RecurringMessage::cron('0 3 * * *', new RunMaintenanceCommand('pim:tenants:purge-deleted')),
             // Abandoned staged-upload TTL sweep (IMP2-2.2) — 03:30 UTC daily.
             RecurringMessage::cron('30 3 * * *', new RunMaintenanceCommand('pim:import:purge-staged')),
+            // Dashboard KPI snapshot per tenant (DASH-05 #2257) — 03:45 UTC daily.
+            RecurringMessage::cron('45 3 * * *', new RunMaintenanceCommand('pim:dashboard:snapshot')),
         );
     }
 }

--- a/apps/api/tests/Api/Dashboard/DashboardSummaryApiTest.php
+++ b/apps/api/tests/Api/Dashboard/DashboardSummaryApiTest.php
@@ -71,6 +71,41 @@ final class DashboardSummaryApiTest extends CatalogApiTestCase
     }
 
     #[Test]
+    public function snapshotsAtTheHorizonsUnlockHonestDeltas(): void
+    {
+        $tenant = $this->demoTenant();
+        $this->seedProducts($tenant, [
+            ['sku' => 'P-100', 'pct' => 100, 'per_channel' => []],
+            ['sku' => 'P-060', 'pct' => 60, 'per_channel' => []],
+            ['sku' => 'P-030', 'pct' => 30, 'per_channel' => []],
+        ]);
+
+        // DASH-05: snapshots exactly at the 30d and 7d horizons.
+        $this->em()->getConnection()->executeStatement(
+            'INSERT INTO dashboard_snapshots '
+            .'(id, tenant_id, snapshot_date, products_total, publish_ready_count, avg_completeness_pct, per_channel, created_at) VALUES '
+            ."(:id30, :tenant, CURRENT_DATE - 30, 2, 0, 40, '{}', NOW()), "
+            ."(:id7, :tenant, CURRENT_DATE - 7, 3, 1, 55, '{}', NOW())",
+            [
+                'id30' => '01980000-0000-7000-8000-000000000030',
+                'id7' => '01980000-0000-7000-8000-000000000007',
+                'tenant' => $tenant->getId()->toRfc4122(),
+            ],
+        );
+
+        $response = $this->authenticatedClient()->request('GET', '/api/dashboard/summary');
+
+        self::assertResponseIsSuccessful();
+        $body = $response->toArray();
+        // Current: ready=1, avg=63. Horizon 30d: ready 0, avg 40; 7d: avg 55.
+        self::assertSame(['count' => 1, 'pct' => 33, 'delta30d' => 1], $body['publishReady']);
+        self::assertSame(
+            ['pct' => 63, 'delta30d' => 23, 'weeklyDeltaPoints' => 8],
+            $body['avgCompleteness'],
+        );
+    }
+
+    #[Test]
     public function emptyCatalogYieldsZeroesNotDivisionErrors(): void
     {
         $response = $this->authenticatedClient()->request('GET', '/api/dashboard/summary');

--- a/apps/api/tests/Integration/Dashboard/DashboardSnapshotCommandTest.php
+++ b/apps/api/tests/Integration/Dashboard/DashboardSnapshotCommandTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Dashboard;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * DASH-05 (#2257) — `pim:dashboard:snapshot` upserts one row per active
+ * tenant per day with the same aggregates the summary endpoint serves:
+ * idempotent re-runs, per-channel JSONB payload, soft-deleted tenants
+ * skipped, `--dry-run` writes nothing.
+ */
+final class DashboardSnapshotCommandTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function upsertsOneRowPerActiveTenantAndStaysIdempotent(): void
+    {
+        $em = $this->em();
+
+        $alpha = $this->tenantWithProducts($em, 'alpha', [
+            ['sku' => 'A-1', 'pct' => 100, 'per_channel' => ['shopify' => 100]],
+            ['sku' => 'A-2', 'pct' => 40, 'per_channel' => ['shopify' => 20]],
+        ]);
+        $this->tenantWithProducts($em, 'beta', [
+            ['sku' => 'B-1', 'pct' => 0, 'per_channel' => []],
+        ]);
+
+        $gamma = new Tenant('gamma', 'Gamma Tenant');
+        $gamma->softDelete();
+        $em->persist($gamma);
+        $em->flush();
+
+        $tester = $this->tester();
+        $tester->execute([]);
+        $tester->assertCommandIsSuccessful();
+
+        $rows = $em->getConnection()->fetchAllAssociative(
+            'SELECT t.code, s.products_total, s.publish_ready_count, s.avg_completeness_pct, s.per_channel '
+            .'FROM dashboard_snapshots s JOIN tenants t ON t.id = s.tenant_id ORDER BY t.code',
+        );
+
+        self::assertCount(2, $rows, 'one row per ACTIVE tenant (gamma is soft-deleted)');
+        self::assertSame('alpha', $rows[0]['code']);
+        self::assertSame(2, $this->intOf($rows[0]['products_total']));
+        self::assertSame(1, $this->intOf($rows[0]['publish_ready_count']));
+        self::assertSame(70, $this->intOf($rows[0]['avg_completeness_pct']));
+        self::assertSame(
+            ['shopify' => ['avgPct' => 60, 'readyCount' => 1]],
+            json_decode($this->strOf($rows[0]['per_channel']), true),
+        );
+        self::assertSame('beta', $rows[1]['code']);
+        self::assertSame(1, $this->intOf($rows[1]['products_total']));
+        self::assertSame(0, $this->intOf($rows[1]['publish_ready_count']));
+
+        // Second run on the same day: still one row per tenant (upsert),
+        // values refreshed after alpha gains a product.
+        $this->addProduct($em, $alpha, 'A-3', 100);
+        $tester->execute([]);
+        $tester->assertCommandIsSuccessful();
+
+        $after = $em->getConnection()->fetchAllAssociative(
+            'SELECT t.code, s.products_total FROM dashboard_snapshots s '
+            .'JOIN tenants t ON t.id = s.tenant_id ORDER BY t.code',
+        );
+        self::assertCount(2, $after, 'idempotent per (tenant, date)');
+        self::assertSame(3, $this->intOf($after[0]['products_total']), 'upsert refreshed the aggregates');
+    }
+
+    #[Test]
+    public function dryRunComputesButWritesNothing(): void
+    {
+        $em = $this->em();
+        $this->tenantWithProducts($em, 'alpha', [['sku' => 'A-1', 'pct' => 50, 'per_channel' => []]]);
+
+        $tester = $this->tester();
+        $tester->execute(['--dry-run' => true]);
+        $tester->assertCommandIsSuccessful();
+
+        self::assertStringContainsString('[dry-run] alpha: total=1', $tester->getDisplay());
+        self::assertSame(
+            0,
+            $this->intOf($em->getConnection()->fetchOne('SELECT COUNT(*) FROM dashboard_snapshots')),
+            'dry-run must not write',
+        );
+    }
+
+    private function intOf(mixed $value): int
+    {
+        return (int) (\is_scalar($value) ? $value : 0);
+    }
+
+    private function strOf(mixed $value): string
+    {
+        return \is_scalar($value) ? (string) $value : '';
+    }
+
+    /**
+     * @param list<array{sku: string, pct: int, per_channel: array<string, int>}> $products
+     */
+    private function tenantWithProducts(EntityManagerInterface $em, string $code, array $products): Tenant
+    {
+        $tenant = new Tenant($code, ucfirst($code).' Tenant');
+        $em->persist($tenant);
+        $em->flush();
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+
+        $type = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $em->persist($type);
+        foreach ($products as $spec) {
+            $object = new CatalogObject($type, $spec['sku']);
+            $completeness = ['global' => $spec['pct']];
+            if ([] !== $spec['per_channel']) {
+                $completeness['per_channel'] = $spec['per_channel'];
+            }
+            $object->recordCompleteness($completeness);
+            $em->persist($object);
+        }
+        $em->flush();
+
+        return $tenant;
+    }
+
+    private function addProduct(EntityManagerInterface $em, Tenant $tenant, string $sku, int $pct): void
+    {
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+        $type = $em->getRepository(ObjectType::class)->findOneBy(['code' => 'product', 'tenant' => $tenant]);
+        \assert($type instanceof ObjectType);
+        $object = new CatalogObject($type, $sku);
+        $object->recordCompleteness(['global' => $pct]);
+        $em->persist($object);
+        $em->flush();
+    }
+
+    private function tester(): CommandTester
+    {
+        $kernel = self::$kernel;
+        \assert(null !== $kernel, 'kernel is booted by the fixture helpers');
+
+        return new CommandTester(new Application($kernel)->find('pim:dashboard:snapshot'));
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}

--- a/apps/api/tests/Integration/Scheduler/MaintenanceScheduleTest.php
+++ b/apps/api/tests/Integration/Scheduler/MaintenanceScheduleTest.php
@@ -52,12 +52,13 @@ final class MaintenanceScheduleTest extends KernelTestCase
         self::assertSame(
             [
                 'pim:audit:cleanup',
+                'pim:dashboard:snapshot',
                 'pim:exports:cleanup',
                 'pim:import:purge-staged',
                 'pim:tenants:purge-deleted',
             ],
             $commands,
-            'The maintenance schedule must drive all four retention/offboarding commands.',
+            'The maintenance schedule must drive every retention/offboarding/snapshot command.',
         );
     }
 }


### PR DESCRIPTION
## Cel

Piąty ticket epiku DASH (ADR-0026): kafle i badge trendu dostają historyczne punkty odniesienia — tabela `dashboard_snapshots` + dzienny job + delty w `GET /api/dashboard/summary`.

## Zmiany

- **Migracja `Version20260705060000`**: `dashboard_snapshots` (UNIQUE(tenant_id, snapshot_date), per_channel JSONB) + **W1-1 FORCE RLS** (tenant isolation + super-admin bypass) + **GRANT dla `pim_app`** (wzorzec #2177 — default privileges giną przy pg_restore, a job INSERTuje jako `pim_app` z workera).
- **Encja `DashboardSnapshot`** (TenantScoped) + mapping XML + rejestracja mappingu kontekstu Dashboard w `doctrine.yaml` (schema testowa buduje się z metadanych ORM). Wpis na liście ignorów `doctrine.associationType` (udokumentowana konwencja: „New TenantScoped entities should be added here").
- **`pim:dashboard:snapshot`** (`--dry-run`): iteracja po aktywnych tenantach (soft-deleted pomijane), per tenant pinowanie GUC `app.current_tenant` (wzorzec `TenantPurger", reset w finally) + UPSERT `ON CONFLICT (tenant_id, snapshot_date)`. Wpis w `MaintenanceSchedule`: **03:45 UTC dziennie** (po istniejących sweepach).
- **`DashboardAggregates` DTO**: wspólna matematyka agregatów dla endpointu i joba — snapshot i odpowiedź nie mogą się rozjechać.
- **`DashboardSummaryQuery`**: `publishReady.delta30d", `avgCompleteness.delta30d` (horyzont 30d) i `weeklyDeltaPoints` (7d) = bieżąca wartość − snapshot o `snapshot_date` RÓWNO na horyzoncie; brak snapshotu ⇒ null ⇒ FE renderuje „brak trendu" (pominięty dzień crona = uczciwy null, nie przybliżone okno).

## Testy (real Postgres, kontener api)

- `DashboardSnapshotCommandTest` — **2 testy**: wiersz per AKTYWNY tenant (gamma soft-deleted pominięta), matematyka (avg 70, ready 1, per_channel `{shopify:{avgPct:60,readyCount:1}}`), idempotentny upsert z odświeżeniem wartości po dodaniu produktu, `--dry-run` nie pisze.
- `DashboardSummaryApiTest` — **+1 test** (razem 6): seed snapshotów na horyzontach → `delta30d=1", `avgCompleteness.delta30d=23", `weeklyDeltaPoints=8`; istniejące testy pilnują null-i bez snapshotów.
- Razem suite'y Dashboard: **8/8 (36 asercji)**.

## Smoke test (żywy stack, https://pim.localhost)

```
doctrine:migrations:migrate → [OK] Version20260705060000
pim:dashboard:snapshot --dry-run → [dry-run] acme: total=3 ready=3 avg=100% · 2 computed, nothing written
pim:dashboard:snapshot → [OK] 2 tenant snapshot(s) upserted
psql: demo | 2026-07-05 | 194 | 194 | 100 | {"allegro":{"avgPct":100,"readyCount":194}}
```

## Gates (lokalnie w kontenerze api)

PHPUnit Dashboard **8/8 OK (36 asercji)** · PHPStan (max, pełny) **No errors** · php-cs-fixer zastosowany · deptrac **0 violations**. Bez nowej trasy → OpenAPI bez zmian.

Closes #2257