### PR TITLE
feat(dashboard): DASH-07 — agregaty aktywności zespołu (seria dzienna + top edited)

### DIFF
--- a/apps/api/migrations/Version20260705070000.php
+++ b/apps/api/migrations/Version20260705070000.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * DASH-07 (#2261, ADR-0026) — composite index for the dashboard activity
+ * aggregates. Both queries filter `audit_logs` by tenant AND a created_at
+ * window before narrowing on action/route; the existing single-column
+ * indexes (idx on tenant_id, idx on created_at, from Version20260518160000)
+ * force a bitmap-AND on every dashboard hit. The composite serves the
+ * range scan directly.
+ */
+final class Version20260705070000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'DASH-07: composite index audit_logs (tenant_id, created_at) for dashboard activity aggregates.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(
+            'CREATE INDEX IF NOT EXISTS idx_audit_logs_tenant_created ON audit_logs (tenant_id, created_at)',
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS idx_audit_logs_tenant_created');
+    }
+}

--- a/apps/api/src/Dashboard/Application/Query/DashboardActivityQuery.php
+++ b/apps/api/src/Dashboard/Application/Query/DashboardActivityQuery.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dashboard\Application\Query;
+
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use LogicException;
+
+/**
+ * DASH-07 (#2261, ADR-0026) — team-activity aggregates for the dashboard:
+ *
+ *   - `added` per day comes from `objects.created_at` (exact),
+ *   - `modified` per day and the top-edited ranking come from `audit_logs`
+ *     (one row per HTTP request; RBAC-P3-013 listener) narrowed to granted
+ *     PATCH/PUT hits on the product-edit route allowlist below.
+ *
+ * Documented undercount: bulk edits, imports and agent batch-accepts are
+ * single requests, so they weigh 1 regardless of how many objects they
+ * touch — acceptable for a team-pace proxy (the exact per-object audit
+ * trail is a dh-auditor follow-up; it deliberately does not track
+ * CatalogObject yet).
+ */
+final readonly class DashboardActivityQuery
+{
+    public const array RANGES = ['7d' => 7, '30d' => 30, '90d' => 90];
+
+    /**
+     * `_route` names of per-object product writes (see `debug:router`).
+     * Schema routes (object_types) are deliberately absent — reshaping an
+     * attribute is modeling work, not catalog-data pace.
+     */
+    private const array EDIT_ROUTES = [
+        'products_patch',
+        'objects_patch',
+        'pim_products_locks_replace',
+        'pim_objects_categories_replace',
+        'pim_products_categories_replace',
+        'pim_objects_relations_put',
+        'pim_products_channel_placements_put',
+        'pim_objects_channel_placements_put',
+    ];
+
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private TenantContext $tenantContext,
+    ) {
+    }
+
+    /**
+     * Contiguous daily series (gap-filled zeroes, oldest → newest).
+     *
+     * @return array<string, mixed>
+     */
+    public function activity(string $range): array
+    {
+        $days = self::RANGES[$range] ?? null;
+        if (null === $days) {
+            throw new InvalidArgumentException(\sprintf('Unknown range "%s".', $range));
+        }
+        $tenantId = $this->tenantId();
+        $connection = $this->entityManager->getConnection();
+        $from = new DateTimeImmutable('today')->modify(\sprintf('-%d days', $days - 1));
+
+        // tenant-safe: explicit tenant_id predicates (raw SQL bypasses the
+        // Doctrine TenantFilter); RLS is the backstop.
+        $addedRows = $connection->fetchAllKeyValue(
+            'SELECT created_at::date AS day, COUNT(*) FROM objects '
+            ."WHERE tenant_id = :tenant AND kind = 'product' AND created_at >= :from "
+            .'GROUP BY 1',
+            ['tenant' => $tenantId, 'from' => $from->format('Y-m-d')],
+        );
+        $modifiedRows = $connection->fetchAllKeyValue(
+            'SELECT created_at::date AS day, COUNT(*) FROM audit_logs '
+            .'WHERE tenant_id = :tenant AND created_at >= :from '
+            ."AND action IN ('PATCH', 'PUT') AND permission_check_result = 'granted' "
+            .'AND resource_type IN (:routes) '
+            .'GROUP BY 1',
+            ['tenant' => $tenantId, 'from' => $from->format('Y-m-d'), 'routes' => self::EDIT_ROUTES],
+            ['routes' => \Doctrine\DBAL\ArrayParameterType::STRING],
+        );
+
+        $series = [];
+        $addedTotal = 0;
+        $modifiedTotal = 0;
+        for ($i = 0; $i < $days; ++$i) {
+            $date = $from->modify(\sprintf('+%d days', $i))->format('Y-m-d');
+            $added = $this->intOf($addedRows[$date] ?? 0);
+            $modified = $this->intOf($modifiedRows[$date] ?? 0);
+            $series[] = ['date' => $date, 'added' => $added, 'modified' => $modified];
+            $addedTotal += $added;
+            $modifiedTotal += $modified;
+        }
+
+        return [
+            'range' => $range,
+            'series' => $series,
+            'addedTotal' => $addedTotal,
+            'modifiedTotal' => $modifiedTotal,
+            'avgPerDay' => (int) round(($addedTotal + $modifiedTotal) / $days),
+        ];
+    }
+
+    /**
+     * Most-edited products in the window: audit_logs ranking hydrated from
+     * `objects` (deleted products drop out on the join — hence the ×2
+     * over-fetch before trimming to the requested limit).
+     *
+     * @return array<string, mixed>
+     */
+    public function topEdited(string $range, int $limit): array
+    {
+        $days = self::RANGES[$range] ?? null;
+        if (null === $days) {
+            throw new InvalidArgumentException(\sprintf('Unknown range "%s".', $range));
+        }
+        $tenantId = $this->tenantId();
+        $connection = $this->entityManager->getConnection();
+        $from = new DateTimeImmutable('today')->modify(\sprintf('-%d days', $days - 1));
+
+        // tenant-safe: explicit tenant_id predicates (see activity()).
+        $ranking = $connection->fetchAllKeyValue(
+            'SELECT resource_id, COUNT(*) AS edits FROM audit_logs '
+            .'WHERE tenant_id = :tenant AND created_at >= :from '
+            ."AND action IN ('PATCH', 'PUT') AND permission_check_result = 'granted' "
+            .'AND resource_type IN (:routes) AND resource_id IS NOT NULL '
+            .'GROUP BY resource_id ORDER BY edits DESC, resource_id ASC LIMIT :limit',
+            [
+                'tenant' => $tenantId,
+                'from' => $from->format('Y-m-d'),
+                'routes' => self::EDIT_ROUTES,
+                'limit' => $limit * 2,
+            ],
+            ['routes' => \Doctrine\DBAL\ArrayParameterType::STRING],
+        );
+
+        if ([] === $ranking) {
+            return ['items' => []];
+        }
+
+        $objects = $connection->fetchAllAssociative(
+            'SELECT id, code, completeness_pct, attributes_indexed FROM objects '
+            ."WHERE tenant_id = :tenant AND kind = 'product' AND id IN (:ids)",
+            ['tenant' => $tenantId, 'ids' => array_keys($ranking)],
+            ['ids' => \Doctrine\DBAL\ArrayParameterType::STRING],
+        );
+        $byId = [];
+        foreach ($objects as $row) {
+            $id = \is_string($row['id'] ?? null) ? $row['id'] : '';
+            if ('' !== $id) {
+                $byId[$id] = $row;
+            }
+        }
+
+        $items = [];
+        foreach ($ranking as $resourceId => $edits) {
+            $row = $byId[(string) $resourceId] ?? null;
+            if (null === $row) {
+                continue; // deleted or non-product resource — skip.
+            }
+            $code = \is_string($row['code'] ?? null) ? $row['code'] : '';
+            $items[] = [
+                'id' => (string) $resourceId,
+                'name' => $this->displayName($row['attributes_indexed'] ?? null, $code),
+                'sku' => $code,
+                'completenessPct' => $this->intOf($row['completeness_pct'] ?? 0),
+                'edits' => $this->intOf($edits),
+            ];
+            if (\count($items) >= $limit) {
+                break;
+            }
+        }
+
+        return ['items' => $items];
+    }
+
+    /**
+     * Defensive display-name extraction from the `attributes_indexed`
+     * envelope ({@link docs/api/jsonb-schemas.md}): plain string value,
+     * per-locale map (first non-empty wins), or the code fallback.
+     */
+    private function displayName(mixed $indexedJson, string $fallback): string
+    {
+        $indexed = \is_string($indexedJson)
+            ? json_decode($indexedJson, true)
+            : $indexedJson;
+        if (!\is_array($indexed)) {
+            return $fallback;
+        }
+        $name = $indexed['name'] ?? null;
+        if (!\is_array($name)) {
+            return $fallback;
+        }
+        $value = $name['value'] ?? null;
+        if (\is_string($value) && '' !== $value) {
+            return $value;
+        }
+        if (\is_array($value)) {
+            foreach ($value as $candidate) {
+                if (\is_string($candidate) && '' !== $candidate) {
+                    return $candidate;
+                }
+            }
+        }
+
+        return $fallback;
+    }
+
+    private function tenantId(): string
+    {
+        $tenant = $this->tenantContext->get();
+        if (!$tenant instanceof Tenant) {
+            throw new LogicException('Cannot aggregate dashboard activity without a current tenant.');
+        }
+
+        return $tenant->getId()->toRfc4122();
+    }
+
+    private function intOf(mixed $value): int
+    {
+        return (int) (\is_scalar($value) ? $value : 0);
+    }
+}

--- a/apps/api/src/Dashboard/Presentation/Controller/DashboardActivityController.php
+++ b/apps/api/src/Dashboard/Presentation/Controller/DashboardActivityController.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dashboard\Presentation\Controller;
+
+use App\Dashboard\Application\Query\DashboardActivityQuery;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Identity\Contracts\Auth\CurrentUserProvider;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * DASH-07 (#2261, ADR-0026) — team-activity aggregates behind the
+ * "Tempo pracy zespołu" dashboard card: the daily added/modified series
+ * and the most-edited products ranking.
+ */
+final class DashboardActivityController
+{
+    private const int MAX_TOP_EDITED_LIMIT = 20;
+
+    public function __construct(
+        private readonly DashboardActivityQuery $query,
+        private readonly CurrentUserProvider $currentUser,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/dashboard/activity',
+        name: 'pim_dashboard_activity',
+        methods: ['GET'],
+    )]
+    #[RequiresPermission(module: 'products', action: 'view')]
+    public function activity(Request $request): JsonResponse
+    {
+        $this->assertAuthenticated();
+        $range = $this->rangeOf($request);
+
+        return new JsonResponse($this->query->activity($range), Response::HTTP_OK);
+    }
+
+    #[Route(
+        path: '/api/dashboard/top-edited',
+        name: 'pim_dashboard_top_edited',
+        methods: ['GET'],
+    )]
+    #[RequiresPermission(module: 'products', action: 'view')]
+    public function topEdited(Request $request): JsonResponse
+    {
+        $this->assertAuthenticated();
+        $range = $this->rangeOf($request);
+        $limit = (int) $request->query->get('limit', '6');
+        if ($limit < 1 || $limit > self::MAX_TOP_EDITED_LIMIT) {
+            throw new BadRequestHttpException(
+                \sprintf('limit must be between 1 and %d.', self::MAX_TOP_EDITED_LIMIT),
+            );
+        }
+
+        return new JsonResponse($this->query->topEdited($range, $limit), Response::HTTP_OK);
+    }
+
+    private function rangeOf(Request $request): string
+    {
+        $range = $request->query->get('range', '30d');
+        if (!\array_key_exists($range, DashboardActivityQuery::RANGES)) {
+            throw new BadRequestHttpException('range must be one of: 7d, 30d, 90d.');
+        }
+
+        return $range;
+    }
+
+    private function assertAuthenticated(): void
+    {
+        if (null === $this->currentUser->userId() || null === $this->currentUser->tenant()) {
+            throw new UnauthorizedHttpException('JWT', 'Authenticated user required.');
+        }
+    }
+}

--- a/apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/AuditLog.orm.xml
+++ b/apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/AuditLog.orm.xml
@@ -12,6 +12,9 @@
             <index name="idx_audit_logs_user" columns="user_id"/>
             <index name="idx_audit_logs_resource" columns="resource_type,resource_id"/>
             <index name="idx_audit_logs_created_at" columns="created_at"/>
+            <!-- DASH-07 (#2261) — dashboard activity aggregates filter by
+                 tenant + created_at window before narrowing on route. -->
+            <index name="idx_audit_logs_tenant_created" columns="tenant_id,created_at"/>
         </indexes>
 
         <id name="id" type="uuid" column="id">

--- a/apps/api/tests/Api/Dashboard/DashboardActivityApiTest.php
+++ b/apps/api/tests/Api/Dashboard/DashboardActivityApiTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Dashboard;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Identity\Domain\Entity\AuditLog;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * DASH-07 (#2261, ADR-0026) — the activity endpoints aggregate the REAL
+ * objects + audit_logs tables against Postgres: gap-filled daily series,
+ * route/action/permission narrowing, most-edited ranking with hydration
+ * and over-fetch, input validation, RBAC and tenant isolation.
+ */
+final class DashboardActivityApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function activitySeriesIsGapFilledAndNarrowedToGrantedProductWrites(): void
+    {
+        $tenant = $this->demoTenant();
+        $productId = $this->seedProduct($tenant, 'P-1');
+
+        // Two products created today (P-1 above and P-2 here); nothing else
+        // inside the 7d window.
+        $this->seedProduct($tenant, 'P-2');
+
+        // Granted product edits: 2 today + 1 two days ago…
+        $this->seedAudit($tenant, 'PATCH', 'products_patch', $productId, 'granted', 'today');
+        $this->seedAudit($tenant, 'PUT', 'pim_products_categories_replace', $productId, 'granted', 'today');
+        $this->seedAudit($tenant, 'PATCH', 'objects_patch', $productId, 'granted', '-2 days');
+        // …and noise that must NOT count: denied edit, schema route, read.
+        $this->seedAudit($tenant, 'PATCH', 'products_patch', $productId, 'denied', 'today');
+        $this->seedAudit($tenant, 'PATCH', 'pim_object_types_update', $productId, 'granted', 'today');
+        $this->seedAudit($tenant, 'GET', 'products_get', $productId, 'granted', 'today');
+
+        $response = $this->authenticatedClient()->request('GET', '/api/dashboard/activity?range=7d');
+
+        self::assertResponseIsSuccessful();
+        $body = $response->toArray();
+        self::assertSame('7d', $body['range']);
+        self::assertIsArray($body['series']);
+        self::assertCount(7, $body['series'], 'series is contiguous over the whole window');
+        self::assertSame(2, $body['addedTotal']);
+        self::assertSame(3, $body['modifiedTotal']);
+        self::assertSame(1, $body['avgPerDay'], '(2+3)/7 rounded');
+
+        $series = $body['series'];
+        self::assertIsArray($series);
+        $today = $series[6] ?? null;
+        self::assertIsArray($today);
+        self::assertSame(2, $today['added']);
+        self::assertSame(2, $today['modified']);
+        $twoDaysAgo = $series[4] ?? null;
+        self::assertIsArray($twoDaysAgo);
+        self::assertSame(0, $twoDaysAgo['added']);
+        self::assertSame(1, $twoDaysAgo['modified']);
+    }
+
+    #[Test]
+    public function topEditedRanksHydratesAndSkipsDeletedResources(): void
+    {
+        $tenant = $this->demoTenant();
+        $p1 = $this->seedProduct($tenant, 'TOP-1', ['value' => 'Czujnik indukcyjny']);
+        $p2 = $this->seedProduct($tenant, 'TOP-2');
+
+        foreach ([1, 2, 3] as $i) {
+            $this->seedAudit($tenant, 'PATCH', 'products_patch', $p1, 'granted', \sprintf('-%d hours', $i));
+        }
+        $this->seedAudit($tenant, 'PATCH', 'products_patch', $p2, 'granted', 'today');
+
+        // A ghost resource with MORE edits than P-2 — hydration must skip
+        // it (deleted product) and still return P-2 thanks to over-fetch.
+        $ghost = Uuid::v7()->toRfc4122();
+        $this->seedAudit($tenant, 'PATCH', 'products_patch', $ghost, 'granted', 'today');
+        $this->seedAudit($tenant, 'PUT', 'pim_objects_relations_put', $ghost, 'granted', 'today');
+
+        $response = $this->authenticatedClient()->request(
+            'GET',
+            '/api/dashboard/top-edited?range=30d&limit=2',
+        );
+
+        self::assertResponseIsSuccessful();
+        $body = $response->toArray();
+        self::assertSame(
+            [
+                [
+                    'id' => $p1,
+                    'name' => 'Czujnik indukcyjny',
+                    'sku' => 'TOP-1',
+                    'completenessPct' => 50,
+                    'edits' => 3,
+                ],
+                [
+                    'id' => $p2,
+                    'name' => 'TOP-2',
+                    'sku' => 'TOP-2',
+                    'completenessPct' => 50,
+                    'edits' => 1,
+                ],
+            ],
+            $body['items'],
+            'ranked by edits, ghost skipped, name falls back to the code',
+        );
+    }
+
+    #[Test]
+    public function inputValidationRejectsUnknownRangeAndLimit(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $client->request('GET', '/api/dashboard/activity?range=14d');
+        self::assertResponseStatusCodeSame(400);
+
+        $client->request('GET', '/api/dashboard/top-edited?limit=0');
+        self::assertResponseStatusCodeSame(400);
+
+        $client->request('GET', '/api/dashboard/top-edited?limit=21');
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    #[Test]
+    public function anonymousAndUnprivilegedRequestsAreRejected(): void
+    {
+        static::createClient()->request('GET', '/api/dashboard/activity');
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    #[Test]
+    public function foreignTenantActivityNeverLeaksIntoTheNumbers(): void
+    {
+        $tenant = $this->demoTenant();
+        $mine = $this->seedProduct($tenant, 'MINE-1');
+        $this->seedAudit($tenant, 'PATCH', 'products_patch', $mine, 'granted', 'today');
+
+        $beta = new Tenant('beta', 'Beta Tenant');
+        $this->em()->persist($beta);
+        $this->em()->flush();
+        self::getContainer()->get(\App\Catalog\Application\BuiltInObjectTypeSeeder::class)->seed($beta);
+        $betaProduct = $this->seedProduct($beta, 'BETA-1');
+        foreach ([1, 2, 3, 4] as $i) {
+            $this->seedAudit($beta, 'PATCH', 'products_patch', $betaProduct, 'granted', \sprintf('-%d hours', $i));
+        }
+        $this->em()->clear();
+
+        $response = $this->authenticatedClient()->request('GET', '/api/dashboard/activity?range=7d');
+        self::assertResponseIsSuccessful();
+        $body = $response->toArray();
+        self::assertSame(1, $body['addedTotal']);
+        self::assertSame(1, $body['modifiedTotal']);
+
+        $top = $this->authenticatedClient()->request('GET', '/api/dashboard/top-edited?range=7d&limit=5');
+        $items = $top->toArray()['items'];
+        self::assertIsArray($items);
+        self::assertCount(1, $items);
+    }
+
+    private function demoTenant(): Tenant
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        return $tenant;
+    }
+
+    /**
+     * @param array<string, mixed>|null $nameEnvelope value of the `name` key in attributes_indexed
+     */
+    private function seedProduct(Tenant $tenant, string $sku, ?array $nameEnvelope = null): string
+    {
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $type);
+
+        $object = new CatalogObject($type, $sku);
+        $object->recordCompleteness(['global' => 50]);
+        $this->em()->persist($object);
+        $this->em()->flush();
+
+        if (null !== $nameEnvelope) {
+            // Raw write — the sync listener recomputes attributes_indexed
+            // from ObjectValues on flush, wiping in-entity seeding.
+            $this->em()->getConnection()->executeStatement(
+                'UPDATE objects SET attributes_indexed = :idx WHERE id = :id',
+                [
+                    'idx' => json_encode(['name' => $nameEnvelope], JSON_THROW_ON_ERROR),
+                    'id' => $object->getId()->toRfc4122(),
+                ],
+            );
+        }
+
+        return $object->getId()->toRfc4122();
+    }
+
+    private function seedAudit(
+        Tenant $tenant,
+        string $action,
+        string $route,
+        string $resourceId,
+        string $permissionResult,
+        string $when,
+    ): void {
+        $entry = new AuditLog(
+            id: Uuid::v7(),
+            tenantId: $tenant->getId(),
+            userId: null,
+            superAdminId: null,
+            action: $action,
+            resourceType: $route,
+            resourceId: $resourceId,
+            oldValue: null,
+            newValue: null,
+            permissionCheckResult: $permissionResult,
+            crossTenantAccess: false,
+            specialFlags: [],
+            ipAddress: null,
+            userAgent: null,
+            createdAt: new DateTimeImmutable($when),
+        );
+        $this->em()->persist($entry);
+        $this->em()->flush();
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -12872,6 +12872,32 @@
                 "x-cortex-permission": "settings.integrations.manage"
             }
         },
+        "/api/dashboard/activity": {
+            "get": {
+                "operationId": "api_dashboard_activity_get",
+                "tags": [
+                    "dashboard"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api dashboard activity",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "products.view"
+            }
+        },
         "/api/dashboard/summary": {
             "get": {
                 "operationId": "api_dashboard_summary_get",
@@ -12887,6 +12913,32 @@
                     }
                 },
                 "summary": "Api dashboard summary",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "products.view"
+            }
+        },
+        "/api/dashboard/top-edited": {
+            "get": {
+                "operationId": "api_dashboard_top_edited_get",
+                "tags": [
+                    "dashboard"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api dashboard top edited",
                 "description": "Custom controller route.",
                 "parameters": [],
                 "security": [


### PR DESCRIPTION
## Cel

Siódmy ticket epiku DASH (ADR-0026): backend pod bloczek „Tempo pracy zespołu" — dzienna seria dodane/zmodyfikowane i ranking najczęściej edytowanych.

## Zmiany

- **`GET /api/dashboard/activity?range=7d|30d|90d`** → `{range, series (ciągła, gap-fill 0, oldest→newest), addedTotal, modifiedTotal, avgPerDay}`. `added` z `objects.created_at` (dokładne); `modified` z `audit_logs` zawężone do `action IN (PATCH,PUT) AND permission_check_result='granted' AND resource_type IN (allowlist 8 tras per-obiektowych zapisów produktu z debug:router)`. **Udokumentowany undercount**: bulk/import/agent-accept = 1 request (proxy tempa zespołu; per-obiektowy audyt danych to follow-up dh-auditora).
- **`GET /api/dashboard/top-edited?range&limit≤20`** → ranking `resource_id` z tego samego wycinka + hydratacja `name/sku/completenessPct` z `objects` (over-fetch ×2 — usunięte produkty wypadają bez skracania listy; nazwa defensywnie z envelope `attributes_indexed.name", fallback do kodu). *Świadome uproszczenie: bez etykiety kategorii (relacja poza zakresem, FE renderuje samo SKU).*
- **Migracja + mapping**: indeks złożony `audit_logs (tenant_id, created_at)` (oba agregaty filtrują tenant+okno zanim zawężą po trasie; dotychczasowe pojedyncze indeksy wymuszały bitmap-AND).
- `#[RequiresPermission(module: 'products', action: 'view')]`; walidacja `range"/`limit` (400). **OpenAPI regen** (+2 trasy).

## Testy (real Postgres, kontener api)

`DashboardActivityApiTest` — **5/5 (25 asercji)**: gap-fill + zawężenie (denied/schema-route/GET nie liczą się), ranking z ghostem (usunięty produkt z większą liczbą edycji pomijany, over-fetch utrzymuje limit), fallback nazwy do kodu, walidacja 400 ×3, 401, izolacja tenantów (oba endpointy).

## Smoke test (żywy stack, https://pim.localhost)

```
GET /api/dashboard/activity?range=7d → HTTP 200
{"range":"7d","series":[…,{"date":"2026-07-04","added":194,"modified":0},…],"addedTotal":194,"modifiedTotal":0,"avgPerDay":28}
GET /api/dashboard/top-edited?range=30d&limit=6 → HTTP 200 {"items":[]}   (uczciwie puste — zero ręcznych edycji na stacku)
psql \di → idx_audit_logs_tenant_created UTWORZONY
```

## Gates (lokalnie w kontenerze api)

PHPUnit **5/5 (25 asercji)** · PHPStan (max, pełny) **No errors** · php-cs-fixer clean · deptrac **0 violations** · OpenAPI zregenerowany (3 trasy `/api/dashboard/*`).

Closes #2261