### PR TITLE
feat(admin): DASH-08 — „Tempo pracy zespołu" live (wykres z API, range w URL)

### DIFF
--- a/apps/admin/e2e/view-13-dashboard-command-center.spec.ts
+++ b/apps/admin/e2e/view-13-dashboard-command-center.spec.ts
@@ -148,14 +148,24 @@ test('VIEW-13 — command center renders all five sections with mock values', as
   const channelsEmpty = page.getByText(/Brak kanałów z danymi kompletności/);
   expect((await channelRows.count()) > 0 || (await channelsEmpty.count()) === 1).toBe(true);
 
-  // 5. Team activity — range toggle is interactive (cosmetic state only).
+  // 5. Team activity — live since DASH-08: the range toggle persists in
+  // the URL and reloads the series from the API; the ranking renders live
+  // rows or the honest empty state (fresh stacks carry no product edits).
   await expect(page.getByRole('heading', { name: 'Tempo pracy zespołu' })).toBeVisible();
   const range7 = page.getByRole('button', { name: '7 dni' });
   await expect(range7).toHaveAttribute('aria-pressed', 'false');
+  const activityReload = page.waitForResponse(
+    (res) => res.url().includes('/api/dashboard/activity') && res.url().includes('range=7d'),
+    { timeout: 15_000 },
+  );
   await range7.click();
   await expect(range7).toHaveAttribute('aria-pressed', 'true');
+  await expect(page).toHaveURL(/range=7d/);
+  expect((await activityReload).status()).toBe(200);
   await expect(page.getByText('Najczęściej edytowane')).toBeVisible();
-  await expect(page.getByText('Czujnik indukcyjny Festo IS-50 PNP M12')).toBeVisible();
+  const topRows = main.getByRole('link', { name: /edycji/ });
+  const topEmpty = page.getByText('Brak edycji produktów w tym okresie.');
+  expect((await topRows.count()) > 0 || (await topEmpty.count()) === 1).toBe(true);
 
   // 6. Action center — counters and all five mock items.
   await expect(page.getByRole('heading', { name: 'Centrum akcji' })).toBeVisible();

--- a/apps/admin/src/features/dashboard/components/TeamActivityCard.tsx
+++ b/apps/admin/src/features/dashboard/components/TeamActivityCard.tsx
@@ -1,48 +1,59 @@
 import { ArrowRight } from 'lucide-react';
-import { useId, useMemo, useState } from 'react';
+import { useId, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router';
+import { Link, useSearchParams } from 'react-router';
 
 import { cn } from '@/lib/utils';
 
-import { type ActivityRange, MOST_EDITED, TEAM_ACTIVITY } from '../mocks';
+import {
+  ACTIVITY_RANGES,
+  type ActivityRange,
+  type DashboardActivityDto,
+  isActivityRange,
+  useDashboardActivity,
+  useDashboardTopEdited,
+} from '../use-dashboard-activity';
+import { formatInt } from '../use-dashboard-summary';
 
-const RANGES: ActivityRange[] = ['7d', '30d', '90d'];
 const RANGE_LABELS: Record<ActivityRange, string> = {
   '7d': '7 dni',
   '30d': '30 dni',
   '90d': '90 dni',
 };
 
+const RANGE_DAYS: Record<ActivityRange, number> = { '7d': 7, '30d': 30, '90d': 90 };
+
 /**
  * Two-series line chart (added = ink, modified = light blue-gray with a soft
  * area fill), hand-rolled SVG like the previous dashboard chart — no chart
- * dependency for a static mock.
+ * dependency. Renders a flat baseline while the series is degraded/empty.
  */
-function ActivityLines({ range }: { range: ActivityRange }) {
+function ActivityLines({ series }: { series: DashboardActivityDto['series'] }) {
   const { t } = useTranslation();
-  const points = TEAM_ACTIVITY.series[range];
   // 25% headroom above the tallest point so the lines sit mid-chart like
-  // the approved mock instead of touching the card edge.
+  // the approved mock instead of touching the card edge; min 1 so an
+  // all-zero series stays a flat baseline instead of dividing by zero.
   const max = useMemo(
-    () => Math.max(...points.map((point) => Math.max(point.added, point.modified))) * 1.25,
-    [points],
+    () => Math.max(1, ...series.map((point) => Math.max(point.added, point.modified))) * 1.25,
+    [series],
   );
 
   const width = 640;
   const height = 210;
   const padY = 10;
   const innerH = height - padY * 2;
+  const lastIndex = Math.max(1, series.length - 1);
 
   const coords = (key: 'added' | 'modified') =>
-    points.map((point, i) => {
-      const x = (i / (points.length - 1)) * width;
+    series.map((point, i) => {
+      const x = (i / lastIndex) * width;
       const y = padY + innerH - (point[key] / max) * innerH;
       return `${x.toFixed(1)},${y.toFixed(1)}`;
     });
 
   const modifiedCoords = coords('modified');
-  const areaPath = `M 0,${height} L ${modifiedCoords.join(' L ')} L ${width},${height} Z`;
+  const areaPath =
+    series.length > 0 ? `M 0,${height} L ${modifiedCoords.join(' L ')} L ${width},${height} Z` : '';
 
   return (
     <svg
@@ -65,35 +76,67 @@ function ActivityLines({ range }: { range: ActivityRange }) {
           strokeWidth={1}
         />
       ))}
-      <path d={areaPath} fill="#e9edf4" opacity={0.55} />
-      <polyline
-        points={modifiedCoords.join(' ')}
-        fill="none"
-        stroke="#aebad0"
-        strokeWidth={1.75}
-        strokeLinejoin="round"
-      />
-      <polyline
-        points={coords('added').join(' ')}
-        fill="none"
-        stroke="var(--ink)"
-        strokeWidth={2}
-        strokeLinejoin="round"
-      />
+      {series.length > 0 ? (
+        <>
+          <path d={areaPath} fill="#e9edf4" opacity={0.55} />
+          <polyline
+            points={modifiedCoords.join(' ')}
+            fill="none"
+            stroke="#aebad0"
+            strokeWidth={1.75}
+            strokeLinejoin="round"
+          />
+          <polyline
+            points={coords('added').join(' ')}
+            fill="none"
+            stroke="var(--ink)"
+            strokeWidth={2}
+            strokeLinejoin="round"
+          />
+        </>
+      ) : null}
     </svg>
   );
 }
 
 /**
- * VIEW-13 (#2143) — "Aktywność katalogu / Tempo pracy zespołu" card:
- * range toggle (cosmetic state only), two-series activity chart and the
- * "Najczęściej edytowane" ranking. All values static mock.
+ * VIEW-13 (#2143) / DASH-08 (#2263) — "Aktywność katalogu / Tempo pracy
+ * zespołu" card, live on GET /api/dashboard/activity + /top-edited: the
+ * 7/30/90d toggle persists in the URL (`?range=`, shareable deep-link),
+ * the chart renders the real gap-filled series, and every most-edited row
+ * links to its product page. Degraded endpoint ⇒ "—" totals and a flat
+ * baseline; an empty ranking keeps the section with an honest empty state
+ * (brief §5-F / §8.3).
  */
 export function TeamActivityCard() {
   const { t } = useTranslation();
   const headingId = useId();
-  const [range, setRange] = useState<ActivityRange>('30d');
-  const axis = TEAM_ACTIVITY.axis[range];
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const rangeParam = searchParams.get('range');
+  const range: ActivityRange = isActivityRange(rangeParam) ? rangeParam : '30d';
+
+  const activity = useDashboardActivity(range).data ?? null;
+  const topEdited = useDashboardTopEdited(range).data ?? null;
+
+  const setRange = (next: ActivityRange): void => {
+    const params = new URLSearchParams(searchParams);
+    if (next === '30d') {
+      params.delete('range');
+    } else {
+      params.set('range', next);
+    }
+    setSearchParams(params, { replace: true });
+  };
+
+  const days = RANGE_DAYS[range];
+  const axisDaysAgo = (count: number): string =>
+    t('dashboard.activity.axis_days_ago', { defaultValue: '{{count}} dni temu', count });
+  const axis: [string, string, string] = [
+    axisDaysAgo(days - 1),
+    axisDaysAgo(Math.floor((days - 1) / 2)),
+    t('dashboard.activity.axis_today', { defaultValue: 'dziś' }),
+  ];
 
   return (
     <section
@@ -110,7 +153,7 @@ export function TeamActivityCard() {
           </h2>
         </div>
         <div className="inline-flex shrink-0 items-center rounded-lg border border-line bg-surface-muted p-0.5">
-          {RANGES.map((value) => (
+          {ACTIVITY_RANGES.map((value) => (
             <button
               key={value}
               type="button"
@@ -135,24 +178,30 @@ export function TeamActivityCard() {
           <span className="text-ink-2">
             {t('dashboard.activity.legend_added', { defaultValue: 'Dodane' })}
           </span>
-          <span className="num font-semibold text-ink">{TEAM_ACTIVITY.addedTotal}</span>
+          <span className="num font-semibold text-ink">
+            {activity === null ? '—' : formatInt(activity.addedTotal)}
+          </span>
         </span>
         <span className="flex items-center gap-2 text-[13px]">
           <span className="size-2 rounded-full bg-[#aebad0]" aria-hidden />
           <span className="text-ink-2">
             {t('dashboard.activity.legend_modified', { defaultValue: 'Zmodyfikowane' })}
           </span>
-          <span className="num font-semibold text-ink">{TEAM_ACTIVITY.modifiedTotal}</span>
+          <span className="num font-semibold text-ink">
+            {activity === null ? '—' : formatInt(activity.modifiedTotal)}
+          </span>
         </span>
-        <span className="ml-auto text-[12px] text-ink-2">
-          {t('dashboard.activity.avg_per_day', {
-            defaultValue: 'średnio {{count}} zmian / dzień',
-            count: TEAM_ACTIVITY.avgPerDay,
-          })}
-        </span>
+        {activity !== null ? (
+          <span className="ml-auto text-[12px] text-ink-2">
+            {t('dashboard.activity.avg_per_day', {
+              defaultValue: 'średnio {{count}} zmian / dzień',
+              count: activity.avgPerDay,
+            })}
+          </span>
+        ) : null}
       </div>
 
-      <ActivityLines range={range} />
+      <ActivityLines series={activity?.series ?? []} />
       <div className="mt-1.5 flex items-center justify-between text-[11px] text-ink-2" aria-hidden>
         <span>{axis[0]}</span>
         <span>{axis[1]}</span>
@@ -172,29 +221,40 @@ export function TeamActivityCard() {
             <ArrowRight className="size-3.5" aria-hidden />
           </Link>
         </div>
-        <ul className="mt-2 divide-y divide-line/70">
-          {MOST_EDITED.map((product) => (
-            <li key={product.sku} className="flex items-center gap-4 py-2.5">
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-[13.5px] font-medium text-ink">{product.name}</p>
-                <p className="mt-0.5 truncate text-[12px] text-ink-2">
-                  <span className="font-mono">{product.sku}</span>
-                  {' · '}
-                  {product.category}
-                </p>
-              </div>
-              <span className="num w-11 shrink-0 text-right text-[13px] text-ink-2">
-                {product.completeness}%
-              </span>
-              <span className="w-[74px] shrink-0 text-right text-[13px]">
-                <span className="num font-semibold text-ink">{product.edits}</span>{' '}
-                <span className="text-ink-2">
-                  {t('dashboard.activity.edits_suffix', { defaultValue: 'edycji' })}
-                </span>
-              </span>
-            </li>
-          ))}
-        </ul>
+        {topEdited === null || topEdited.items.length === 0 ? (
+          <p className="mt-3 text-[13px] text-ink-2">
+            {t('dashboard.activity.most_edited_empty', {
+              defaultValue: 'Brak edycji produktów w tym okresie.',
+            })}
+          </p>
+        ) : (
+          <ul className="mt-2 divide-y divide-line/70">
+            {topEdited.items.map((product) => (
+              <li key={product.id}>
+                <Link
+                  to={`/products/${product.id}`}
+                  className="flex items-center gap-4 rounded py-2.5 hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink"
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-[13.5px] font-medium text-ink">{product.name}</p>
+                    <p className="mt-0.5 truncate font-mono text-[12px] text-ink-2">
+                      {product.sku}
+                    </p>
+                  </div>
+                  <span className="num w-11 shrink-0 text-right text-[13px] text-ink-2">
+                    {product.completenessPct}%
+                  </span>
+                  <span className="w-[74px] shrink-0 text-right text-[13px]">
+                    <span className="num font-semibold text-ink">{product.edits}</span>{' '}
+                    <span className="text-ink-2">
+                      {t('dashboard.activity.edits_suffix', { defaultValue: 'edycji' })}
+                    </span>
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
     </section>
   );

--- a/apps/admin/src/features/dashboard/components/__tests__/CommandCenter.test.tsx
+++ b/apps/admin/src/features/dashboard/components/__tests__/CommandCenter.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { DashboardActivityDto, DashboardTopEditedDto } from '../../use-dashboard-activity';
 import type { DashboardSummary, DashboardSummaryDto } from '../../use-dashboard-summary';
 
 /**
@@ -25,11 +27,33 @@ vi.mock('../../use-dashboard-summary', async (importOriginal) => {
   };
 });
 
+const activityState: {
+  activity: DashboardActivityDto | null;
+  topEdited: DashboardTopEditedDto | null;
+} = { activity: null, topEdited: null };
+
+vi.mock('../../use-dashboard-activity', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../use-dashboard-activity')>();
+  return {
+    ...actual,
+    useDashboardActivity: () =>
+      ({ data: activityState.activity }) as unknown as ReturnType<
+        typeof actual.useDashboardActivity
+      >,
+    useDashboardTopEdited: () =>
+      ({ data: activityState.topEdited }) as unknown as ReturnType<
+        typeof actual.useDashboardTopEdited
+      >,
+  };
+});
+
 import { ActionCenter } from '../ActionCenter';
 import { CatalogHealthCard } from '../CatalogHealthCard';
 import { KpiBand } from '../KpiBand';
+import { TeamActivityCard } from '../TeamActivityCard';
 
-const renderWithRouter = (node: ReactNode) => render(<MemoryRouter>{node}</MemoryRouter>);
+const renderWithRouter = (node: ReactNode, initialEntries: string[] = ['/dashboard']) =>
+  render(<MemoryRouter initialEntries={initialEntries}>{node}</MemoryRouter>);
 
 const LIVE_SUMMARY: DashboardSummaryDto = {
   products: { total: 194, delta30d: 12 },
@@ -50,6 +74,8 @@ const LIVE_SUMMARY: DashboardSummaryDto = {
 
 beforeEach(() => {
   state.summary = null;
+  activityState.activity = null;
+  activityState.topEdited = null;
 });
 
 describe('KpiBand', () => {
@@ -146,6 +172,61 @@ describe('CatalogHealthCard', () => {
       'href',
       expect.stringContaining('filter[completeness_pct][op]=lt'),
     );
+  });
+});
+
+describe('TeamActivityCard', () => {
+  const LIVE_ACTIVITY: DashboardActivityDto = {
+    range: '7d',
+    series: [
+      { date: '2026-07-01', added: 2, modified: 5 },
+      { date: '2026-07-02', added: 0, modified: 1 },
+    ],
+    addedTotal: 2,
+    modifiedTotal: 6,
+    avgPerDay: 1,
+  };
+
+  it('degrades to "—" totals, a flat chart and the honest empty ranking', () => {
+    renderWithRouter(<TeamActivityCard />);
+    expect(screen.getAllByText('—')).toHaveLength(2);
+    expect(screen.getByText('Brak edycji produktów w tym okresie.')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /Wykres dziennych zmian/ })).toBeInTheDocument();
+  });
+
+  it('reads the range from the URL and marks the toggle as pressed', () => {
+    activityState.activity = LIVE_ACTIVITY;
+    renderWithRouter(<TeamActivityCard />, ['/dashboard?range=7d']);
+    expect(screen.getByRole('button', { name: '7 dni' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('6')).toBeInTheDocument();
+    expect(screen.getByText(/średnio 1 zmian \/ dzień/)).toBeInTheDocument();
+    expect(screen.getByText('6 dni temu')).toBeInTheDocument();
+    expect(screen.getByText('dziś')).toBeInTheDocument();
+  });
+
+  it('persists a toggle click in the URL (aria-pressed follows)', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<TeamActivityCard />);
+    expect(screen.getByRole('button', { name: '30 dni' })).toHaveAttribute('aria-pressed', 'true');
+    await user.click(screen.getByRole('button', { name: '90 dni' }));
+    expect(screen.getByRole('button', { name: '90 dni' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('89 dni temu')).toBeInTheDocument();
+  });
+
+  it('renders every most-edited row as a product-page link', () => {
+    activityState.topEdited = {
+      items: [
+        { id: 'p-1', name: 'Czujnik', sku: 'TOP-1', completenessPct: 96, edits: 47 },
+        { id: 'p-2', name: 'Zawór', sku: 'TOP-2', completenessPct: 72, edits: 34 },
+      ],
+    };
+    renderWithRouter(<TeamActivityCard />);
+    const rows = screen.getAllByRole('link', { name: /edycji/ });
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveAttribute('href', '/products/p-1');
+    expect(screen.getByText('Czujnik')).toBeInTheDocument();
+    expect(screen.queryByText('Brak edycji produktów w tym okresie.')).not.toBeInTheDocument();
   });
 });
 

--- a/apps/admin/src/features/dashboard/mocks.ts
+++ b/apps/admin/src/features/dashboard/mocks.ts
@@ -7,107 +7,13 @@
  * mechanical; the backend backlog lives in
  * Project Plan/UI/Wdrozenie_grafiki/dashboard-do-oprogramowania.md.
  *
- * Wired live so far (mock removed): KPI band + catalog health via
- * GET /api/dashboard/summary (DASH-02/06). Still mock below: team
- * activity (DASH-07/08) and the action center (DASH-09/10).
+ * Wired live so far (mock removed): KPI band + catalog health
+ * (GET /api/dashboard/summary, DASH-02/06) and team activity
+ * (GET /api/dashboard/activity + /top-edited, DASH-07/08). Still mock
+ * below: the action center (DASH-09/10).
  *
  * Do not import this module outside features/dashboard/.
  */
-
-// ---------------------------------------------------------------------------
-// Team activity (chart + most edited)
-// ---------------------------------------------------------------------------
-
-export type ActivityRange = '7d' | '30d' | '90d';
-
-export interface ActivityPoint {
-  added: number;
-  modified: number;
-}
-
-/**
- * Deterministic pseudo-noise series — literal enough to stay pixel-stable
- * between renders, jagged enough to read as real team activity.
- */
-const buildSeries = (length: number): ActivityPoint[] =>
-  Array.from({ length }, (_, i) => {
-    const weekend = i % 7 === 5 || i % 7 === 6;
-    const drift = i / (length - 1);
-    return {
-      added: weekend ? 14 + (i % 4) : 24 + ((i * 5) % 11) + Math.round(drift * 10),
-      modified: weekend ? 26 + (i % 5) : 40 + ((i * 7) % 15) + Math.round(drift * 16),
-    };
-  });
-
-export const TEAM_ACTIVITY = {
-  addedTotal: '1 354',
-  modifiedTotal: '2 141',
-  avgPerDay: 117,
-  series: {
-    '7d': buildSeries(7),
-    '30d': buildSeries(30),
-    '90d': buildSeries(90),
-  } satisfies Record<ActivityRange, ActivityPoint[]>,
-  /** X-axis captions per range: [left, middle, right]. */
-  axis: {
-    '7d': ['6 dni temu', '3 dni temu', 'dziś'],
-    '30d': ['29 dni temu', '14 dni temu', 'dziś'],
-    '90d': ['89 dni temu', '45 dni temu', 'dziś'],
-  } satisfies Record<ActivityRange, [string, string, string]>,
-};
-
-export interface MostEditedProduct {
-  name: string;
-  sku: string;
-  category: string;
-  completeness: number;
-  edits: number;
-}
-
-export const MOST_EDITED: MostEditedProduct[] = [
-  {
-    name: 'Czujnik indukcyjny Festo IS-50 PNP M12',
-    sku: 'FES-PNZ-IS50',
-    category: 'Czujniki',
-    completeness: 96,
-    edits: 47,
-  },
-  {
-    name: 'Rura zaciskowa DN50 stal nierdzewna 316L',
-    sku: 'KLI-RZP-DN50',
-    category: 'Hydraulika',
-    completeness: 88,
-    edits: 41,
-  },
-  {
-    name: 'Wkrętarka akumulatorowa Bosch GSR 18V-90',
-    sku: 'BSC-WKR-18V',
-    category: 'Elektronarzędzia',
-    completeness: 100,
-    edits: 38,
-  },
-  {
-    name: 'Zawór elektromagnetyczny SMC 24V solenoid',
-    sku: 'SMC-ZWR-24V',
-    category: 'Pneumatyka',
-    completeness: 72,
-    edits: 34,
-  },
-  {
-    name: 'Plecak fotograficzny Wandrd PRVKE Pro 31L',
-    sku: 'WAR-PLE-PRO',
-    category: 'Akcesoria',
-    completeness: 94,
-    edits: 29,
-  },
-  {
-    name: 'Złącze M12 Murr 4-pin IP67 ekranowane',
-    sku: 'MKP-TWR-IP67',
-    category: 'Złącza',
-    completeness: 67,
-    edits: 22,
-  },
-];
 
 // ---------------------------------------------------------------------------
 // Action center

--- a/apps/admin/src/features/dashboard/use-dashboard-activity.ts
+++ b/apps/admin/src/features/dashboard/use-dashboard-activity.ts
@@ -1,0 +1,54 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { jsonFetch } from '@/lib/http';
+
+export type ActivityRange = '7d' | '30d' | '90d';
+
+export const ACTIVITY_RANGES: readonly ActivityRange[] = ['7d', '30d', '90d'];
+
+export function isActivityRange(value: string | null): value is ActivityRange {
+  return null !== value && (ACTIVITY_RANGES as readonly string[]).includes(value);
+}
+
+/** 1:1 with GET /api/dashboard/activity (DASH-07). */
+export interface DashboardActivityDto {
+  range: ActivityRange;
+  /** Contiguous daily series, gap-filled, oldest → newest. */
+  series: Array<{ date: string; added: number; modified: number }>;
+  addedTotal: number;
+  modifiedTotal: number;
+  avgPerDay: number;
+}
+
+/** 1:1 with GET /api/dashboard/top-edited (DASH-07). */
+export interface DashboardTopEditedDto {
+  items: Array<{ id: string; name: string; sku: string; completenessPct: number; edits: number }>;
+}
+
+/**
+ * DASH-08 (#2263) — live team-activity series for the dashboard chart.
+ * Data is null while degraded (per-widget "—" state, brief §8.3); React
+ * Query keeps the last known series through transient errors.
+ */
+export function useDashboardActivity(range: ActivityRange) {
+  return useQuery({
+    queryKey: ['dashboard-activity', range],
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+    queryFn: async (): Promise<DashboardActivityDto> =>
+      jsonFetch<DashboardActivityDto>('/api/dashboard/activity', { query: { range } }),
+  });
+}
+
+/** DASH-08 (#2263) — most-edited products ranking for the same window. */
+export function useDashboardTopEdited(range: ActivityRange) {
+  return useQuery({
+    queryKey: ['dashboard-top-edited', range],
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+    queryFn: async (): Promise<DashboardTopEditedDto> =>
+      jsonFetch<DashboardTopEditedDto>('/api/dashboard/top-edited', {
+        query: { range, limit: 6 },
+      }),
+  });
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1015,6 +1015,9 @@
       "avg_per_day": "avg {{count}} changes / day",
       "chart_aria": "Daily catalog changes chart — added and modified products",
       "most_edited": "Most edited",
+      "most_edited_empty": "No product edits in this period.",
+      "axis_days_ago": "{{count}} days ago",
+      "axis_today": "today",
       "full_list": "Full list",
       "edits_suffix": "edits"
     },

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1025,6 +1025,9 @@
       "avg_per_day": "średnio {{count}} zmian / dzień",
       "chart_aria": "Wykres dziennych zmian w katalogu — dodane i zmodyfikowane produkty",
       "most_edited": "Najczęściej edytowane",
+      "most_edited_empty": "Brak edycji produktów w tym okresie.",
+      "axis_days_ago": "{{count}} dni temu",
+      "axis_today": "dziś",
       "full_list": "Pełna lista",
       "edits_suffix": "edycji"
     },


### PR DESCRIPTION
## Cel

Ósmy ticket epiku DASH: bloczek „Tempo pracy zespołu" przechodzi z pseudo-noise mocka na `GET /api/dashboard/activity` + `/top-edited` (#2262).

## Zmiany

- **Nowy hook `use-dashboard-activity.ts`** — `useDashboardActivity(range)` + `useDashboardTopEdited(range)` (React Query per range, DTO 1:1 z BE, walidator `isActivityRange`).
- **`TeamActivityCard.tsx`** — wykres z realnej serii (gap-fill z BE; pusta/degradowana seria = płaska linia bazowa bez dzielenia przez zero); **toggle 7/30/90 w URL** (`?range=", deep-link, default 30d bez wpisu w URL, `replace` bez śmiecenia historią); legenda/średnia z endpointu (`—" przy degradacji, średnia ukryta); oś czasu z range przez `t()` (`{{count}} dni temu"/„dziś" — najmniejszy count to 3, forma „dni" poprawna); wiersze rankingu = `Link` do `/products/:id` (bez etykiety kategorii — BE jej nie zwraca, świadome uproszczenie z DASH-07); empty state „Brak edycji produktów w tym okresie." (sekcja nie znika).
- **mocks.ts** — usunięte `TEAM_ACTIVITY"/`MOST_EDITED"/`ActivityRange` — został wyłącznie `ACTION_CENTER` (DASH-09/10).
- i18n: `most_edited_empty", `axis_days_ago", `axis_today` (pl+en).

## Testy

- `CommandCenter.test.tsx` — nowy describe TeamActivityCard (mock hooków aktywności): degradacja (`—" ×2 + empty state + wykres), range z URL (`?range=7d" → aria-pressed + „6 dni temu"), klik 90d → aria-pressed + „89 dni temu" (userEvent), wiersze jako linki `/products/:id` (15 testów łącznie).
- e2e `view-13` sekcja 5: klik 7d → **URL `?range=7d` + realny reload `GET /api/dashboard/activity?range=7d` (200)**; ranking = wiersze live LUB empty state (świeże stacki bez edycji); usunięty literał mocka „Czujnik indukcyjny Festo…".

## Smoke test (żywy stack, https://pim.localhost)

Playwright na działającym stacku: login → `/dashboard` → toggle 7 dni → URL `?range=7d", `GET /api/dashboard/activity?range=7d` **200** (realna seria: 194 dodane 2026-07-04), ranking pokazuje uczciwy empty state (zero ręcznych edycji na stacku), axe WCAG A/AA green, zero błędów konsoli. Wynik: **2/2 passed**.

Gates lokalnie: typecheck ✅ · biome ✅ · vitest ✅ · build ✅ · Playwright 2/2 ✅

Closes #2263