### PR TITLE
feat(dashboard): DASH-09 — feed alertów Centrum akcji + ack po fingerprincie

### DIFF
--- a/apps/api/migrations/Version20260705090000.php
+++ b/apps/api/migrations/Version20260705090000.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * DASH-09 (#2265, ADR-0026) — `dashboard_alert_acks`: the "oznacz jako
+ * przeczytane" state for the action-center feed. Alerts themselves are
+ * aggregated on the fly from the four status tables + the snapshot-based
+ * completeness-drop detector (operator decision 2026-07-04: NO
+ * materialized Alert entity); this table only remembers which
+ * deterministic fingerprint a tenant acknowledged. The time window
+ * replaces TTL, so no cleanup job is required.
+ *
+ * TenantScoped with the W1-1 FORCE RLS pattern + explicit runtime-role
+ * GRANT (#2177 — default privileges are lost on pg_restore and the ack
+ * INSERT runs as `pim_app`).
+ */
+final class Version20260705090000 extends AbstractMigration
+{
+    private const string TABLE = 'dashboard_alert_acks';
+
+    public function getDescription(): string
+    {
+        return 'DASH-09: add dashboard_alert_acks (fingerprint ack state) + FORCE RLS + pim_app grant.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE dashboard_alert_acks (
+                id UUID NOT NULL,
+                tenant_id UUID NOT NULL,
+                fingerprint VARCHAR(160) NOT NULL,
+                acked_by UUID DEFAULT NULL,
+                acked_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY (id)
+            )
+            SQL);
+        $this->addSql(
+            'CREATE UNIQUE INDEX dashboard_alert_acks_tenant_fingerprint_uniq '
+            .'ON dashboard_alert_acks (tenant_id, fingerprint)'
+        );
+        $this->addSql('CREATE INDEX dashboard_alert_acks_tenant_idx ON dashboard_alert_acks (tenant_id)');
+        $this->addSql(
+            'ALTER TABLE dashboard_alert_acks ADD CONSTRAINT FK_dashboard_alert_acks_tenant '
+            .'FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+
+        // ── Row-Level Security (W1-1 FORCE pattern) ───────────────────────
+        $predicate = "tenant_id = NULLIF(current_setting('app.current_tenant', true), '')::uuid";
+
+        $this->addSql(\sprintf('ALTER TABLE %s ENABLE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s FORCE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf(
+            'CREATE POLICY tenant_isolation_%s ON %s USING (%s) WITH CHECK (%s)',
+            self::TABLE,
+            self::TABLE,
+            $predicate,
+            $predicate,
+        ));
+        $this->addSql(\sprintf(
+            'CREATE POLICY super_admin_bypass_%s ON %s '
+            ."USING (current_setting('app.is_super_admin', true) = 'true') "
+            ."WITH CHECK (current_setting('app.is_super_admin', true) = 'true')",
+            self::TABLE,
+            self::TABLE,
+        ));
+
+        // Runtime-role grant (#2177): survives pg_restore privilege loss.
+        $this->addSql('GRANT SELECT, INSERT, UPDATE, DELETE ON dashboard_alert_acks TO pim_app');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(\sprintf('DROP POLICY IF EXISTS super_admin_bypass_%s ON %s', self::TABLE, self::TABLE));
+        $this->addSql(\sprintf('DROP POLICY IF EXISTS tenant_isolation_%s ON %s', self::TABLE, self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s NO FORCE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql(\sprintf('ALTER TABLE %s DISABLE ROW LEVEL SECURITY', self::TABLE));
+        $this->addSql('DROP TABLE dashboard_alert_acks');
+    }
+}

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -139,6 +139,7 @@ parameters:
               - src/Identity/Domain/Entity/TenantAgentConfig.php
               - src/Catalog/Domain/Entity/MenuConfiguration.php
               - src/Dashboard/Domain/Entity/DashboardSnapshot.php
+              - src/Dashboard/Domain/Entity/DashboardAlertAck.php
               # Import/Domain entities extend AggregateRoot — their
               # doctrine.associationType emission is the flaky one the
               # `reportUnmatched: false` above guards against (see comment).

--- a/apps/api/src/Dashboard/Application/Query/AlertFeedAggregator.php
+++ b/apps/api/src/Dashboard/Application/Query/AlertFeedAggregator.php
@@ -1,0 +1,383 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dashboard\Application\Query;
+
+use App\Catalog\Contracts\Query\ChannelCompletenessPort;
+use App\Identity\Contracts\Policy\PermissionCheckerInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+use const DATE_ATOM;
+
+/**
+ * DASH-09 (#2265, ADR-0026) — the action-center feed, aggregated ON THE
+ * FLY from the four status tables + the snapshot-based completeness-drop
+ * detector (operator decision 2026-07-04: no materialized Alert entity;
+ * the time window replaces TTL, `dashboard_alert_acks` holds the only
+ * persisted state, keyed by deterministic fingerprints).
+ *
+ * Items carry STRUCTURED params, not pre-baked strings — the FE composes
+ * titles via i18n so pl/en stay in parity.
+ *
+ * Per-type RBAC (brief §8.4): a user only sees alert types whose source
+ * module they can read; the checker codes mirror the source controllers'
+ * `#[RequiresPermission]` gates. The completeness-drop type rides on the
+ * route's own products.view gate.
+ *
+ * @phpstan-type AlertItem array{fingerprint: string, type: string, severity: string, occurredAt: string, params: array<string, mixed>, context: array<string, string>}
+ */
+final readonly class AlertFeedAggregator
+{
+    public const array WINDOWS = ['1d' => 1, '7d' => 7, '30d' => 30];
+
+    /** Publish-ready threshold — matches DashboardSummaryQuery. */
+    private const int READY_THRESHOLD = 80;
+
+    /** type => permission code required to SEE alerts of that type. */
+    private const array TYPE_PERMISSIONS = [
+        'sync_run' => 'integration.admin',
+        'import_session' => 'import_session.read',
+        'feed_run' => 'exports.view_all',
+        'webhook' => 'api_profile.read',
+        'completeness_drop' => null,
+    ];
+
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private TenantContext $tenantContext,
+        private ChannelCompletenessPort $channelCompleteness,
+        private PermissionCheckerInterface $permissionChecker,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function alerts(Uuid $userId, string $window, int $limit): array
+    {
+        $days = self::WINDOWS[$window] ?? null;
+        if (null === $days) {
+            throw new InvalidArgumentException(\sprintf('Unknown window "%s".', $window));
+        }
+        $tenant = $this->currentTenant();
+        $from = new DateTimeImmutable(\sprintf('-%d days', $days));
+
+        $items = array_merge(
+            $this->syncRunAlerts($tenant, $from),
+            $this->importSessionAlerts($tenant, $from),
+            $this->feedRunAlerts($tenant, $from),
+            $this->webhookAlerts($tenant, $from),
+            $this->completenessDropAlerts($tenant),
+        );
+
+        // Per-type RBAC filter (brief §8.4) — degraded types simply vanish.
+        $items = array_values(array_filter($items, function (array $item) use ($userId): bool {
+            $permission = self::TYPE_PERMISSIONS[$item['type']] ?? null;
+
+            return null === $permission || $this->permissionChecker->userHasPermission($userId, $permission);
+        }));
+
+        // Acked fingerprints disappear from the feed (tenant-scoped state).
+        $acked = $this->ackedFingerprints($tenant, array_column($items, 'fingerprint'));
+        $items = array_values(array_filter(
+            $items,
+            static fn (array $item): bool => !\in_array($item['fingerprint'], $acked, true),
+        ));
+
+        // Critical first, newest first within a severity (mock order).
+        usort($items, static function (array $a, array $b): int {
+            if ($a['severity'] !== $b['severity']) {
+                return 'critical' === $a['severity'] ? -1 : 1;
+            }
+
+            return strcmp($b['occurredAt'], $a['occurredAt']);
+        });
+
+        $total = \count($items);
+        $critical = \count(array_filter($items, static fn (array $i): bool => 'critical' === $i['severity']));
+
+        return [
+            'total' => $total,
+            'critical' => $critical,
+            'warnings' => $total - $critical,
+            'allCount' => $total,
+            'items' => \array_slice($items, 0, $limit),
+        ];
+    }
+
+    /** Unread alert count for the KPI tile (24h window). */
+    public function openCount(Uuid $userId): int
+    {
+        $feed = $this->alerts($userId, '1d', 0);
+        $total = $feed['total'] ?? 0;
+
+        return (int) (\is_scalar($total) ? $total : 0);
+    }
+
+    public function acknowledge(string $fingerprint, ?Uuid $userId): void
+    {
+        $tenant = $this->currentTenant();
+
+        // tenant-safe: explicit tenant_id VALUE (RLS backstop); idempotent
+        // by the unique (tenant_id, fingerprint) index.
+        $this->entityManager->getConnection()->executeStatement(
+            'INSERT INTO dashboard_alert_acks (id, tenant_id, fingerprint, acked_by, acked_at) '
+            .'VALUES (:id, :tenant, :fingerprint, :user, NOW()) '
+            .'ON CONFLICT (tenant_id, fingerprint) DO NOTHING',
+            [
+                'id' => Uuid::v7()->toRfc4122(),
+                'tenant' => $tenant->getId()->toRfc4122(),
+                'fingerprint' => $fingerprint,
+                'user' => $userId?->toRfc4122(),
+            ],
+        );
+    }
+
+    /**
+     * @return list<AlertItem>
+     */
+    private function syncRunAlerts(Tenant $tenant, DateTimeImmutable $from): array
+    {
+        // tenant-safe: explicit tenant_id predicate (raw SQL bypasses the
+        // Doctrine TenantFilter); RLS is the backstop. Same note applies to
+        // every source query below.
+        $rows = $this->entityManager->getConnection()->fetchAllAssociative(
+            'SELECT r.id, r.status, r.failed_count, r.finished_at, c.name AS connection_name, c.id AS connection_id '
+            .'FROM integration_sync_runs r '
+            .'JOIN integration_sync_bindings b ON b.id = r.binding_id '
+            .'JOIN integration_connections c ON c.id = b.connection_id '
+            .'WHERE r.tenant_id = :tenant AND r.finished_at >= :from '
+            ."AND (r.status = 'failed' OR (r.status = 'partial' AND r.failed_count > 0))",
+            ['tenant' => $tenant->getId()->toRfc4122(), 'from' => $from->format(DATE_ATOM)],
+        );
+
+        $items = [];
+        foreach ($rows as $row) {
+            $items[] = [
+                'fingerprint' => 'sync_run:'.$this->str($row['id'] ?? ''),
+                'type' => 'sync_run',
+                'severity' => 'critical',
+                'occurredAt' => $this->str($row['finished_at'] ?? ''),
+                'params' => [
+                    'sourceName' => $this->str($row['connection_name'] ?? ''),
+                    'failedCount' => $this->intOf($row['failed_count'] ?? 0),
+                    'status' => $this->str($row['status'] ?? ''),
+                ],
+                'context' => [
+                    'syncRunId' => $this->str($row['id'] ?? ''),
+                    'connectionId' => $this->str($row['connection_id'] ?? ''),
+                ],
+            ];
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return list<AlertItem>
+     */
+    private function importSessionAlerts(Tenant $tenant, DateTimeImmutable $from): array
+    {
+        $rows = $this->entityManager->getConnection()->fetchAllAssociative(
+            'SELECT id, file_name, status, error_count, completed_at FROM import_sessions '
+            .'WHERE tenant_id = :tenant AND completed_at >= :from '
+            ."AND (status = 'failed' OR (status = 'partial' AND error_count > 0))",
+            ['tenant' => $tenant->getId()->toRfc4122(), 'from' => $from->format(DATE_ATOM)],
+        );
+
+        $items = [];
+        foreach ($rows as $row) {
+            $items[] = [
+                'fingerprint' => 'import_session:'.$this->str($row['id'] ?? ''),
+                'type' => 'import_session',
+                'severity' => 'critical',
+                'occurredAt' => $this->str($row['completed_at'] ?? ''),
+                'params' => [
+                    'sourceName' => $this->str($row['file_name'] ?? ''),
+                    'errorCount' => $this->intOf($row['error_count'] ?? 0),
+                    'status' => $this->str($row['status'] ?? ''),
+                ],
+                'context' => ['sessionId' => $this->str($row['id'] ?? '')],
+            ];
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return list<AlertItem>
+     */
+    private function feedRunAlerts(Tenant $tenant, DateTimeImmutable $from): array
+    {
+        $rows = $this->entityManager->getConnection()->fetchAllAssociative(
+            'SELECT r.id, r.feed_profile_id, r.error_message, COALESCE(r.completed_at, r.started_at) AS occurred_at, '
+            .'p.name AS feed_name '
+            .'FROM feed_runs r '
+            .'LEFT JOIN feed_profiles p ON p.id = r.feed_profile_id '
+            ."WHERE r.tenant_id = :tenant AND r.status = 'error' "
+            .'AND COALESCE(r.completed_at, r.started_at) >= :from',
+            ['tenant' => $tenant->getId()->toRfc4122(), 'from' => $from->format(DATE_ATOM)],
+        );
+
+        $items = [];
+        foreach ($rows as $row) {
+            $items[] = [
+                'fingerprint' => 'feed_run:'.$this->str($row['id'] ?? ''),
+                'type' => 'feed_run',
+                'severity' => 'warning',
+                'occurredAt' => $this->str($row['occurred_at'] ?? ''),
+                'params' => [
+                    'sourceName' => '' !== $this->str($row['feed_name'] ?? '')
+                        ? $this->str($row['feed_name'] ?? '')
+                        : $this->str($row['feed_profile_id'] ?? ''),
+                    'reason' => $this->str($row['error_message'] ?? ''),
+                ],
+                'context' => ['feedProfileId' => $this->str($row['feed_profile_id'] ?? '')],
+            ];
+        }
+
+        return $items;
+    }
+
+    /**
+     * Dead-letter deliveries grouped per (profile, event, day) — the mock's
+     * "3 dostawy w dead-letter" aggregation.
+     *
+     * @return list<AlertItem>
+     */
+    private function webhookAlerts(Tenant $tenant, DateTimeImmutable $from): array
+    {
+        $rows = $this->entityManager->getConnection()->fetchAllAssociative(
+            'SELECT d.profile_id, d.event_type, d.updated_at::date AS day, COUNT(*) AS deliveries, '
+            .'MAX(d.updated_at) AS last_at, MAX(d.http_status) AS http_status, MAX(p.name) AS profile_name '
+            .'FROM api_webhook_deliveries d '
+            .'LEFT JOIN api_profiles p ON p.id = d.profile_id '
+            ."WHERE d.tenant_id = :tenant AND d.status = 'failed' AND d.updated_at >= :from "
+            .'GROUP BY d.profile_id, d.event_type, d.updated_at::date',
+            ['tenant' => $tenant->getId()->toRfc4122(), 'from' => $from->format(DATE_ATOM)],
+        );
+
+        $items = [];
+        foreach ($rows as $row) {
+            $profileId = $this->str($row['profile_id'] ?? '');
+            $eventType = $this->str($row['event_type'] ?? '');
+            $items[] = [
+                'fingerprint' => \sprintf('webhook:%s:%s:%s', $profileId, $eventType, $this->str($row['day'] ?? '')),
+                'type' => 'webhook',
+                'severity' => 'warning',
+                'occurredAt' => $this->str($row['last_at'] ?? ''),
+                'params' => [
+                    'sourceName' => '' !== $this->str($row['profile_name'] ?? '') ? $this->str($row['profile_name'] ?? '') : $profileId,
+                    'eventType' => $eventType,
+                    'deliveries' => $this->intOf($row['deliveries'] ?? 0),
+                    'httpStatus' => $this->intOf($row['http_status'] ?? 0),
+                ],
+                'context' => ['profileId' => $profileId],
+            ];
+        }
+
+        return $items;
+    }
+
+    /**
+     * A channel dropping below the publish threshold since yesterday's
+     * snapshot (DASH-05 provides the reference point).
+     *
+     * @return list<AlertItem>
+     */
+    private function completenessDropAlerts(Tenant $tenant): array
+    {
+        $row = $this->entityManager->getConnection()->fetchAssociative(
+            'SELECT per_channel FROM dashboard_snapshots '
+            .'WHERE tenant_id = :tenant AND snapshot_date = CURRENT_DATE - 1',
+            ['tenant' => $tenant->getId()->toRfc4122()],
+        );
+        if (false === $row) {
+            return []; // no reference point yet — never fabricate a drop.
+        }
+        $rawPerChannel = $this->str($row['per_channel'] ?? '');
+        $decoded = json_decode('' !== $rawPerChannel ? $rawPerChannel : '{}', true);
+        $yesterday = \is_array($decoded) ? $decoded : [];
+
+        $today = new DateTimeImmutable('today')->format('Y-m-d');
+        $items = [];
+        foreach ($this->channelCompleteness->perChannel(self::READY_THRESHOLD) as $channel) {
+            $previous = $yesterday[$channel->channelCode] ?? null;
+            $previousPct = \is_array($previous) ? $this->intOf($previous['avgPct'] ?? null) : null;
+            if (null === $previousPct) {
+                continue;
+            }
+            if ($channel->avgPct < self::READY_THRESHOLD && $previousPct >= self::READY_THRESHOLD) {
+                $items[] = [
+                    'fingerprint' => \sprintf('completeness_drop:%s:%s', $channel->channelCode, $today),
+                    'type' => 'completeness_drop',
+                    'severity' => 'warning',
+                    'occurredAt' => $today,
+                    'params' => [
+                        'sourceName' => $channel->channelName,
+                        'avgPct' => $channel->avgPct,
+                        'previousPct' => $previousPct,
+                        'threshold' => self::READY_THRESHOLD,
+                    ],
+                    'context' => ['channelCode' => $channel->channelCode],
+                ];
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * @param list<string> $fingerprints
+     *
+     * @return list<string>
+     */
+    private function ackedFingerprints(Tenant $tenant, array $fingerprints): array
+    {
+        if ([] === $fingerprints) {
+            return [];
+        }
+        $rows = $this->entityManager->getConnection()->fetchFirstColumn(
+            'SELECT fingerprint FROM dashboard_alert_acks '
+            .'WHERE tenant_id = :tenant AND fingerprint IN (:fingerprints)',
+            [
+                'tenant' => $tenant->getId()->toRfc4122(),
+                'fingerprints' => $fingerprints,
+            ],
+            ['fingerprints' => \Doctrine\DBAL\ArrayParameterType::STRING],
+        );
+
+        return array_values(array_filter($rows, 'is_string'));
+    }
+
+    private function currentTenant(): Tenant
+    {
+        $tenant = $this->tenantContext->get();
+        if (!$tenant instanceof Tenant) {
+            throw new LogicException('Cannot aggregate alerts without a current tenant.');
+        }
+
+        return $tenant;
+    }
+
+    private function intOf(mixed $value): ?int
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        return (int) (\is_scalar($value) ? $value : 0);
+    }
+
+    private function str(mixed $value): string
+    {
+        return \is_scalar($value) ? (string) $value : '';
+    }
+}

--- a/apps/api/src/Dashboard/Application/Query/DashboardSummaryQuery.php
+++ b/apps/api/src/Dashboard/Application/Query/DashboardSummaryQuery.php
@@ -10,6 +10,7 @@ use App\Shared\Domain\Tenant;
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use LogicException;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * DASH-04 (#2255, ADR-0026) — the dashboard KPI + completeness aggregate:
@@ -35,6 +36,7 @@ final readonly class DashboardSummaryQuery
         private EntityManagerInterface $entityManager,
         private TenantContext $tenantContext,
         private ChannelCompletenessPort $channelCompleteness,
+        private AlertFeedAggregator $alerts,
     ) {
     }
 
@@ -85,7 +87,7 @@ final readonly class DashboardSummaryQuery
     /**
      * @return array<string, mixed>
      */
-    public function summary(): array
+    public function summary(Uuid $userId): array
     {
         $tenant = $this->currentTenant();
         $aggregates = $this->aggregates();
@@ -127,7 +129,8 @@ final readonly class DashboardSummaryQuery
             ],
             'buckets' => $buckets,
             'channels' => $channels,
-            'openAlerts' => null,
+            // DASH-09 — unread alerts in the last 24h, per-user RBAC view.
+            'openAlerts' => ['count' => $this->alerts->openCount($userId)],
         ];
     }
 

--- a/apps/api/src/Dashboard/Domain/Entity/DashboardAlertAck.php
+++ b/apps/api/src/Dashboard/Domain/Entity/DashboardAlertAck.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dashboard\Domain\Entity;
+
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * DASH-09 (#2265, ADR-0026) — one acknowledged action-center fingerprint
+ * per row. Alerts are aggregated on the fly (no Alert entity, operator
+ * decision 2026-07-04); this is the only persisted alert state.
+ */
+class DashboardAlertAck implements TenantScoped
+{
+    private Uuid $id;
+
+    private ?Tenant $tenant = null;
+
+    private string $fingerprint;
+
+    private ?Uuid $ackedBy;
+
+    private DateTimeImmutable $ackedAt;
+
+    public function __construct(string $fingerprint, ?Uuid $ackedBy)
+    {
+        $this->id = Uuid::v7();
+        $this->fingerprint = $fingerprint;
+        $this->ackedBy = $ackedBy;
+        $this->ackedAt = new DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant already assigned to this ack.');
+        }
+        $this->tenant = $tenant;
+    }
+
+    public function getFingerprint(): string
+    {
+        return $this->fingerprint;
+    }
+
+    public function getAckedBy(): ?Uuid
+    {
+        return $this->ackedBy;
+    }
+
+    public function getAckedAt(): DateTimeImmutable
+    {
+        return $this->ackedAt;
+    }
+}

--- a/apps/api/src/Dashboard/Infrastructure/Doctrine/Orm/Mapping/DashboardAlertAck.orm.xml
+++ b/apps/api/src/Dashboard/Infrastructure/Doctrine/Orm/Mapping/DashboardAlertAck.orm.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Dashboard\Domain\Entity\DashboardAlertAck"
+            table="dashboard_alert_acks">
+
+        <unique-constraints>
+            <unique-constraint name="dashboard_alert_acks_tenant_fingerprint_uniq" columns="tenant_id,fingerprint"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="dashboard_alert_acks_tenant_idx" columns="tenant_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="fingerprint" type="string" length="160"/>
+        <field name="ackedBy" type="uuid" column="acked_by" nullable="true"/>
+        <field name="ackedAt" type="datetime_immutable" column="acked_at"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Dashboard/Presentation/Controller/DashboardAlertsController.php
+++ b/apps/api/src/Dashboard/Presentation/Controller/DashboardAlertsController.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dashboard\Presentation\Controller;
+
+use App\Dashboard\Application\Query\AlertFeedAggregator;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Identity\Contracts\Auth\CurrentUserProvider;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * DASH-09 (#2265, ADR-0026) — the action-center feed: on-the-fly alert
+ * aggregation over the four status tables + the completeness-drop
+ * detector, and the idempotent per-fingerprint acknowledge.
+ */
+final class DashboardAlertsController
+{
+    private const int MAX_LIMIT = 50;
+
+    /** Deterministic fingerprint shape produced by AlertFeedAggregator. */
+    private const string FINGERPRINT_PATTERN = '/^[a-z_]+:[A-Za-z0-9:._-]{1,140}$/';
+
+    public function __construct(
+        private readonly AlertFeedAggregator $aggregator,
+        private readonly CurrentUserProvider $currentUser,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/dashboard/alerts',
+        name: 'pim_dashboard_alerts',
+        methods: ['GET'],
+    )]
+    #[RequiresPermission(module: 'products', action: 'view')]
+    public function alerts(Request $request): JsonResponse
+    {
+        $userId = $this->authenticatedUserId();
+
+        $window = $request->query->get('window', '7d');
+        if (!\array_key_exists($window, AlertFeedAggregator::WINDOWS)) {
+            throw new BadRequestHttpException('window must be one of: 1d, 7d, 30d.');
+        }
+        $limit = (int) $request->query->get('limit', '5');
+        if ($limit < 1 || $limit > self::MAX_LIMIT) {
+            throw new BadRequestHttpException(\sprintf('limit must be between 1 and %d.', self::MAX_LIMIT));
+        }
+
+        return new JsonResponse($this->aggregator->alerts($userId, $window, $limit), Response::HTTP_OK);
+    }
+
+    #[Route(
+        path: '/api/dashboard/alerts/{fingerprint}/ack',
+        name: 'pim_dashboard_alert_ack',
+        methods: ['POST'],
+        requirements: ['fingerprint' => '[A-Za-z0-9:._-]+'],
+    )]
+    #[RequiresPermission(module: 'products', action: 'view')]
+    public function acknowledge(string $fingerprint): JsonResponse
+    {
+        $userId = $this->authenticatedUserId();
+
+        if (1 !== preg_match(self::FINGERPRINT_PATTERN, $fingerprint)) {
+            throw new BadRequestHttpException('Malformed alert fingerprint.');
+        }
+
+        $this->aggregator->acknowledge($fingerprint, $userId);
+
+        return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+    }
+
+    private function authenticatedUserId(): Uuid
+    {
+        $userId = $this->currentUser->userId();
+        if (null === $userId || null === $this->currentUser->tenant()) {
+            throw new UnauthorizedHttpException('JWT', 'Authenticated user required.');
+        }
+
+        return $userId;
+    }
+}

--- a/apps/api/src/Dashboard/Presentation/Controller/DashboardSummaryController.php
+++ b/apps/api/src/Dashboard/Presentation/Controller/DashboardSummaryController.php
@@ -33,10 +33,11 @@ final class DashboardSummaryController
     #[RequiresPermission(module: 'products', action: 'view')]
     public function __invoke(): JsonResponse
     {
-        if (null === $this->currentUser->userId() || null === $this->currentUser->tenant()) {
+        $userId = $this->currentUser->userId();
+        if (null === $userId || null === $this->currentUser->tenant()) {
             throw new UnauthorizedHttpException('JWT', 'Authenticated user required.');
         }
 
-        return new JsonResponse($this->query->summary(), Response::HTTP_OK);
+        return new JsonResponse($this->query->summary($userId), Response::HTTP_OK);
     }
 }

--- a/apps/api/tests/Api/Dashboard/DashboardAlertsApiTest.php
+++ b/apps/api/tests/Api/Dashboard/DashboardAlertsApiTest.php
@@ -1,0 +1,337 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Dashboard;
+
+use App\ApiConfigurator\Domain\Entity\WebhookDelivery;
+use App\Catalog\Application\Query\SqlChannelCompletenessReport;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Channel\Domain\Entity\Channel;
+use App\Dashboard\Application\Query\AlertFeedAggregator;
+use App\Export\Feed\Domain\Entity\FeedRun;
+use App\Export\Feed\Domain\Enum\FeedRunStatus;
+use App\Export\Feed\Domain\Enum\FeedRunTrigger;
+use App\Identity\Contracts\Policy\PermissionCheckerInterface;
+use App\Import\Domain\Entity\ImportSession;
+use App\Integration\Generic\Domain\Entity\Connection;
+use App\Integration\Generic\Domain\Entity\SyncBinding;
+use App\Integration\Generic\Domain\Entity\SyncRun;
+use App\Integration\Generic\Domain\Enum\SyncDirection;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * DASH-09 (#2265, ADR-0026) — the action-center feed aggregates the REAL
+ * status tables against Postgres: all five alert types, severity sort,
+ * per-day webhook grouping, snapshot-based completeness-drop detection,
+ * ack persistence + idempotency, window narrowing, per-type RBAC
+ * filtering, input validation and tenant isolation.
+ */
+final class DashboardAlertsApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function feedAggregatesAllFiveTypesCriticalFirst(): void
+    {
+        $tenant = $this->demoTenant();
+        $this->seedSyncFailure($tenant, 'Mtodo Marketplace', 412);
+        $this->seedImportPartial($tenant, 'pim-catalog-0630.xlsx', 132);
+        $this->seedFeedError($tenant, 'brak pola <price>');
+        $this->seedWebhookDeadLetters($tenant, 'price.changed', 3);
+        $this->seedCompletenessDrop($tenant);
+
+        $response = $this->authenticatedClient()->request(
+            'GET',
+            '/api/dashboard/alerts?window=7d&limit=10',
+        );
+
+        self::assertResponseIsSuccessful();
+        $body = $response->toArray();
+        self::assertSame(5, $body['total']);
+        self::assertSame(2, $body['critical']);
+        self::assertSame(3, $body['warnings']);
+        self::assertSame(5, $body['allCount']);
+
+        $items = $body['items'];
+        self::assertIsArray($items);
+        self::assertCount(5, $items);
+        $types = array_column($items, 'type');
+        self::assertSame(
+            ['critical', 'critical', 'warning', 'warning', 'warning'],
+            array_column($items, 'severity'),
+            'critical first',
+        );
+        self::assertContains('sync_run', $types);
+        self::assertContains('import_session', $types);
+        self::assertContains('feed_run', $types);
+        self::assertContains('webhook', $types);
+        self::assertContains('completeness_drop', $types);
+
+        $sync = $this->paramsOf($items, 'sync_run');
+        self::assertSame('Mtodo Marketplace', $sync['sourceName']);
+        self::assertSame(412, $sync['failedCount']);
+        $import = $this->paramsOf($items, 'import_session');
+        self::assertSame('pim-catalog-0630.xlsx', $import['sourceName']);
+        self::assertSame(132, $import['errorCount']);
+        self::assertSame('brak pola <price>', $this->paramsOf($items, 'feed_run')['reason']);
+        $webhook = $this->paramsOf($items, 'webhook');
+        self::assertSame(3, $webhook['deliveries']);
+        self::assertSame('price.changed', $webhook['eventType']);
+        $drop = $this->paramsOf($items, 'completeness_drop');
+        self::assertSame('Allegro', $drop['sourceName']);
+        self::assertSame(40, $drop['avgPct']);
+        self::assertSame(90, $drop['previousPct']);
+    }
+
+    /**
+     * @param array<int|string, mixed> $items
+     *
+     * @return array<string, mixed>
+     */
+    private function paramsOf(array $items, string $type): array
+    {
+        foreach ($items as $item) {
+            if (!\is_array($item) || ($item['type'] ?? null) !== $type) {
+                continue;
+            }
+            $params = $item['params'] ?? null;
+            if (\is_array($params)) {
+                /* @var array<string, mixed> $params */
+                return $params;
+            }
+        }
+        self::fail(\sprintf('No alert of type "%s" in the feed.', $type));
+    }
+
+    #[Test]
+    public function acknowledgedFingerprintDisappearsAndAckStaysIdempotent(): void
+    {
+        $tenant = $this->demoTenant();
+        $this->seedFeedError($tenant, 'x');
+
+        $client = $this->authenticatedClient();
+        $feed = $client->request('GET', '/api/dashboard/alerts?window=7d&limit=10')->toArray();
+        self::assertSame(1, $feed['total']);
+        $items = $feed['items'];
+        self::assertIsArray($items);
+        $first = $items[0] ?? null;
+        self::assertIsArray($first);
+        $fingerprint = $first['fingerprint'] ?? '';
+        self::assertIsString($fingerprint);
+        self::assertStringStartsWith('feed_run:', $fingerprint);
+
+        $client->request('POST', \sprintf('/api/dashboard/alerts/%s/ack', $fingerprint));
+        self::assertResponseStatusCodeSame(204);
+        // Idempotent: the second ack is a no-op, not a 500.
+        $client->request('POST', \sprintf('/api/dashboard/alerts/%s/ack', $fingerprint));
+        self::assertResponseStatusCodeSame(204);
+
+        $after = $client->request('GET', '/api/dashboard/alerts?window=7d&limit=10')->toArray();
+        self::assertSame(0, $after['total']);
+        self::assertSame([], $after['items']);
+    }
+
+    #[Test]
+    public function windowNarrowsTheFeed(): void
+    {
+        $tenant = $this->demoTenant();
+        $run = $this->seedFeedError($tenant, 'stale');
+        // Push the failure outside the 7d window but inside 30d.
+        $this->em()->getConnection()->executeStatement(
+            "UPDATE feed_runs SET started_at = NOW() - INTERVAL '10 days', completed_at = NOW() - INTERVAL '10 days' WHERE id = :id",
+            ['id' => $run],
+        );
+
+        $client = $this->authenticatedClient();
+        self::assertSame(
+            0,
+            $client->request('GET', '/api/dashboard/alerts?window=7d&limit=10')->toArray()['total'],
+        );
+        self::assertSame(
+            1,
+            $client->request('GET', '/api/dashboard/alerts?window=30d&limit=10')->toArray()['total'],
+        );
+    }
+
+    #[Test]
+    public function summaryCarriesTheOpenAlertCount(): void
+    {
+        $tenant = $this->demoTenant();
+        $this->seedFeedError($tenant, 'y');
+        $this->seedImportPartial($tenant, 'z.xlsx', 5);
+
+        $body = $this->authenticatedClient()->request('GET', '/api/dashboard/summary')->toArray();
+        self::assertSame(['count' => 2], $body['openAlerts']);
+    }
+
+    #[Test]
+    public function perTypeRbacHidesSourcesTheUserCannotRead(): void
+    {
+        $tenant = $this->demoTenant();
+        $this->seedFeedError($tenant, 'hidden for import-only users');
+        $this->seedImportPartial($tenant, 'visible.xlsx', 1);
+
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $importOnlyChecker = new class implements PermissionCheckerInterface {
+            public function userHasPermission(Uuid $userId, string $permissionCode): bool
+            {
+                return 'import_session.read' === $permissionCode;
+            }
+        };
+        $aggregator = new AlertFeedAggregator(
+            $this->em(),
+            self::getContainer()->get(TenantContext::class),
+            new SqlChannelCompletenessReport($this->em(), self::getContainer()->get(TenantContext::class)),
+            $importOnlyChecker,
+        );
+
+        $feed = $aggregator->alerts(Uuid::v7(), '7d', 10);
+        self::assertSame(1, $feed['total'], 'feed_run alerts are invisible without exports.view_all');
+        $items = $feed['items'];
+        self::assertIsArray($items);
+        $first = $items[0] ?? null;
+        self::assertIsArray($first);
+        self::assertSame('import_session', $first['type'] ?? null);
+    }
+
+    #[Test]
+    public function inputValidationAndAuthGuards(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $client->request('GET', '/api/dashboard/alerts?window=90d');
+        self::assertResponseStatusCodeSame(400);
+        $client->request('GET', '/api/dashboard/alerts?limit=0');
+        self::assertResponseStatusCodeSame(400);
+        // Passes the route requirement but not the fingerprint pattern
+        // (the type prefix must be lowercase snake_case).
+        $client->request('POST', '/api/dashboard/alerts/BadType:abc/ack');
+        self::assertResponseStatusCodeSame(400);
+
+        static::createClient()->request('GET', '/api/dashboard/alerts');
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    #[Test]
+    public function foreignTenantAlertsNeverLeak(): void
+    {
+        $tenant = $this->demoTenant();
+        $this->seedFeedError($tenant, 'mine');
+
+        $beta = new Tenant('beta', 'Beta Tenant');
+        $this->em()->persist($beta);
+        $this->em()->flush();
+        $this->seedFeedError($beta, 'theirs');
+        $this->em()->clear();
+
+        $body = $this->authenticatedClient()->request('GET', '/api/dashboard/alerts?window=7d&limit=10')->toArray();
+        self::assertSame(1, $body['total']);
+    }
+
+    private function demoTenant(): Tenant
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        return $tenant;
+    }
+
+    private function seedSyncFailure(Tenant $tenant, string $connectionName, int $failedCount): void
+    {
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $connection = new Connection('mtodo', $connectionName, 'https://api.example.test');
+        $this->em()->persist($connection);
+        $binding = new SyncBinding($connection, Uuid::v7(), SyncDirection::Inbound);
+        $this->em()->persist($binding);
+        $run = new SyncRun($binding, SyncDirection::Inbound);
+        $this->em()->persist($run);
+        $this->em()->flush();
+
+        $this->em()->getConnection()->executeStatement(
+            "UPDATE integration_sync_runs SET status = 'failed', failed_count = :failed, finished_at = NOW() WHERE id = :id",
+            ['failed' => $failedCount, 'id' => $run->getId()->toRfc4122()],
+        );
+    }
+
+    private function seedImportPartial(Tenant $tenant, string $fileName, int $errorCount): void
+    {
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        $session = new ImportSession(Uuid::v7(), $type, $fileName, 1024);
+        $this->em()->persist($session);
+        $this->em()->flush();
+
+        $this->em()->getConnection()->executeStatement(
+            "UPDATE import_sessions SET status = 'partial', error_count = :errors, completed_at = NOW() WHERE id = :id",
+            ['errors' => $errorCount, 'id' => $session->getId()->toRfc4122()],
+        );
+    }
+
+    private function seedFeedError(Tenant $tenant, string $reason): string
+    {
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $run = new FeedRun(Uuid::v7(), FeedRunTrigger::Manual, FeedRunStatus::Pending);
+        $this->em()->persist($run);
+        $this->em()->flush();
+
+        $id = $run->getId()->toRfc4122();
+        $this->em()->getConnection()->executeStatement(
+            "UPDATE feed_runs SET status = 'error', error_message = :reason, completed_at = NOW() WHERE id = :id",
+            ['reason' => $reason, 'id' => $id],
+        );
+
+        return $id;
+    }
+
+    private function seedWebhookDeadLetters(Tenant $tenant, string $eventType, int $count): void
+    {
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $profileId = Uuid::v7();
+        $ids = [];
+        for ($i = 0; $i < $count; ++$i) {
+            $delivery = new WebhookDelivery($profileId, $eventType, 'https://hook.example.test', ['i' => $i]);
+            $this->em()->persist($delivery);
+            $ids[] = $delivery->getId()->toRfc4122();
+        }
+        $this->em()->flush();
+
+        $this->em()->getConnection()->executeStatement(
+            "UPDATE api_webhook_deliveries SET status = 'failed', attempts = 5, http_status = 503, updated_at = NOW() WHERE id IN (:ids)",
+            ['ids' => $ids],
+            ['ids' => \Doctrine\DBAL\ArrayParameterType::STRING],
+        );
+    }
+
+    private function seedCompletenessDrop(Tenant $tenant): void
+    {
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $this->em()->persist(new Channel('allegro', 'Allegro'));
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $type);
+        $object = new CatalogObject($type, 'DROP-1');
+        $object->recordCompleteness(['global' => 40, 'per_channel' => ['allegro' => 40]]);
+        $this->em()->persist($object);
+        $this->em()->flush();
+
+        // Yesterday's snapshot says allegro was healthy (90%).
+        $this->em()->getConnection()->executeStatement(
+            'INSERT INTO dashboard_snapshots '
+            .'(id, tenant_id, snapshot_date, products_total, publish_ready_count, avg_completeness_pct, per_channel, created_at) '
+            .'VALUES (:id, :tenant, CURRENT_DATE - 1, 1, 1, 90, :per_channel, NOW())',
+            [
+                'id' => Uuid::v7()->toRfc4122(),
+                'tenant' => $tenant->getId()->toRfc4122(),
+                'per_channel' => json_encode(['allegro' => ['avgPct' => 90, 'readyCount' => 1]], JSON_THROW_ON_ERROR),
+            ],
+        );
+    }
+}

--- a/apps/api/tests/Api/Dashboard/DashboardAlertsApiTest.php
+++ b/apps/api/tests/Api/Dashboard/DashboardAlertsApiTest.php
@@ -103,8 +103,12 @@ final class DashboardAlertsApiTest extends CatalogApiTestCase
             }
             $params = $item['params'] ?? null;
             if (\is_array($params)) {
-                /* @var array<string, mixed> $params */
-                return $params;
+                $typed = [];
+                foreach ($params as $key => $value) {
+                    $typed[(string) $key] = $value;
+                }
+
+                return $typed;
             }
         }
         self::fail(\sprintf('No alert of type "%s" in the feed.', $type));

--- a/apps/api/tests/Api/Dashboard/DashboardSummaryApiTest.php
+++ b/apps/api/tests/Api/Dashboard/DashboardSummaryApiTest.php
@@ -67,7 +67,8 @@ final class DashboardSummaryApiTest extends CatalogApiTestCase
             [['code' => 'shopify', 'name' => 'Shopify', 'avgPct' => 70, 'readyCount' => 1]],
             $body['channels'],
         );
-        self::assertNull($body['openAlerts']);
+        // DASH-09 — live open-alert count (nothing seeded here → 0).
+        self::assertSame(['count' => 0], $body['openAlerts']);
     }
 
     #[Test]

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -12898,6 +12898,71 @@
                 "x-cortex-permission": "products.view"
             }
         },
+        "/api/dashboard/alerts": {
+            "get": {
+                "operationId": "api_dashboard_alerts_get",
+                "tags": [
+                    "dashboard"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api dashboard alerts",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "products.view"
+            }
+        },
+        "/api/dashboard/alerts/{fingerprint}/ack": {
+            "post": {
+                "operationId": "api_dashboard_alerts_fingerprint_ack_post",
+                "tags": [
+                    "dashboard"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api dashboard alerts fingerprint ack",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "fingerprint",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "products.view"
+            }
+        },
         "/api/dashboard/summary": {
             "get": {
                 "operationId": "api_dashboard_summary_get",


### PR DESCRIPTION
## Cel

Dziewiąty ticket epiku DASH (ADR-0026, decyzja operatora: **agregator on-the-fly + tabela ack-ów**, nie encja Alert): backend pod Centrum akcji.

## Zmiany

- **`AlertFeedAggregator`** — 5 typów alertów w oknie `1d|7d|30d` (okno zastępuje TTL):
  - `sync_run` (critical): `integration_sync_runs` failed / partial z `failed_count>0` + JOIN nazwa połączenia;
  - `import_session` (critical): failed / partial z błędami;
  - `feed_run` (warning): status error + powód + JOIN nazwa profilu feedu;
  - `webhook` (warning): dead-letter zgrupowane per (profil, event, dzień) — `webhook:{profileId}:{eventType}:{yyyy-mm-dd}` jak „3 dostawy" z makiety;
  - `completeness_drop` (warning): kanał `avgPct<80` dziś przy `>=80` we wczorajszym snapshocie (DASH-05; brak snapshotu ⇒ zero fabrykowanych spadków).
- **Pola strukturalne** (sourceName/failedCount/errorCount/reason/deliveries/avgPct…) — tytuły składa FE przez i18n; sort critical-first + occurredAt DESC.
- **Per-typ RBAC** (brief §8.4): mapa typ→kod lustrzana do gate'ów kontrolerów źródłowych (`integration.admin", `import_session.read", `exports.view_all", `api_profile.read").
- **`dashboard_alert_acks`** (migracja + encja + mapping): UNIQUE(tenant_id, fingerprint), W1-1 FORCE RLS, GRANT `pim_app`. `POST /api/dashboard/alerts/{fingerprint}/ack` idempotentny, walidacja formatu.
- **`GET /api/dashboard/alerts?window&limit≤50`** → `{total, critical, warnings, allCount, items[]}`.
- **`DashboardSummaryQuery`**: `openAlerts = {count}` live (24h, per-user RBAC). **OpenAPI regen** (5 tras `/api/dashboard/*`).

## Testy (real Postgres, kontener api)

`DashboardAlertsApiTest` — **7 testów / 44 asercje**: 5 typów critical-first z pełnymi params (sync przez łańcuch Connection→SyncBinding→SyncRun), ack znika + idempotencja, okno 7d/30d, `openAlerts.count` w summary, RBAC z fake checkerem, walidacje 400 + 401, izolacja tenantów. Suites Dashboard łącznie: **20/20 (103 asercje)**.

## Smoke test (żywy stack, https://pim.localhost)

```
GET /api/dashboard/alerts?window=30d&limit=5 → HTTP 200
{"total":1,"critical":1,…,"items":[{"fingerprint":"import_session:019f2d2c-…","type":"import_session",
 "severity":"critical","params":{"sourceName":"3-idosell-products-READY.csv","errorCount":4,"status":"partial"},…}]}
GET /api/dashboard/summary → "openAlerts": {"count": 1}
```
**Agregator wykrył realny, historyczny alert operatora** (wczorajszy partial import IdoSell, 4 błędy) — bez seedowania. Celowo bez ack-a w smoke (realny stan; ścieżka pokryta testami).

## Gates (lokalnie w kontenerze api)

PHPUnit Dashboard **20/20 (103 asercje)** · PHPStan (max, pełny) **No errors** · php-cs-fixer clean (pre-commit hook wymusił format) · deptrac **0 violations** · migracja na dev OK · OpenAPI zregenerowany.

Closes #2265