### PR TITLE
docs(dashboard): DASH-11 — sweep końcowy epiku (język 'mock' → 'live')

### DIFF
--- a/apps/admin/e2e/view-13-dashboard-command-center.spec.ts
+++ b/apps/admin/e2e/view-13-dashboard-command-center.spec.ts
@@ -6,13 +6,15 @@ import { loginAsAdmin } from './helpers/auth';
 /**
  * VIEW-13 (#2143) — dashboard "command center" redesign.
  *
- * Asserts the pixel-perfect layout renders end-to-end: greeting + dark agent
- * hero (LIVE since #2246 — chips come from /api/agent/capabilities, stubbed
- * here for determinism), the four pinned KPI tiles, catalog health card
- * (ring + buckets + per-channel completeness), team activity card (range
- * toggle + most edited) and the full-width action center. Also locks in the
- * operator decisions: no MOCK badges anywhere on the page and no audit-log
- * pill in the topbar.
+ * Asserts the layout renders end-to-end against LIVE data (epic DASH,
+ * #2249–#2274): greeting + dark agent hero (chips from
+ * /api/agent/capabilities, stubbed here for determinism), the four KPI
+ * tiles + catalog health (GET /api/dashboard/summary), team activity
+ * (range toggle → /activity + /top-edited) and the action center
+ * (/alerts). Assertions are structural (numbers/hrefs/empty states), not
+ * pinned mock literals, so they hold as the demo catalog changes. Also
+ * locks in the operator decisions: no MOCK badges anywhere on the page
+ * and no audit-log pill in the topbar.
  */
 
 const CAPABILITIES_STUB = {
@@ -73,7 +75,7 @@ test.beforeEach(async ({ page }) => {
   });
 });
 
-test('VIEW-13 — command center renders all five sections with mock values', async ({ page }) => {
+test('VIEW-13 — command center renders all five sections with live data', async ({ page }) => {
   const consoleErrors: string[] = [];
   page.on('console', (message) => {
     if (message.type() === 'error') {
@@ -182,7 +184,7 @@ test('VIEW-13 — command center renders all five sections with mock values', as
   await expect(page.locator('main').getByText('MOCK', { exact: true })).toHaveCount(0);
   await expect(page.getByText(/Audit log/)).toHaveCount(0);
 
-  // No red console errors (network noise excluded — static mock page).
+  // No red console errors (network noise excluded — live-data page).
   const realErrors = consoleErrors.filter(
     (text) => !/Failed to load resource|EventSource|mercure/i.test(text),
   );

--- a/apps/admin/src/features/dashboard/page.tsx
+++ b/apps/admin/src/features/dashboard/page.tsx
@@ -6,13 +6,15 @@ import { KpiBand } from './components/KpiBand';
 import { TeamActivityCard } from './components/TeamActivityCard';
 
 /**
- * Dashboard "command center" (VIEW-13 #2143) — pixel-perfect static mock of
- * the approved redesign: greeting → dark agent hero → KPI band →
- * [catalog health | team activity] → action center.
+ * Dashboard "command center" (VIEW-13 #2143) — the approved redesign:
+ * greeting → dark agent hero → KPI band → [catalog health | team
+ * activity] → action center.
  *
- * Every value on this page is static mock data (see ./mocks.ts) — the
- * per-widget backends land later via
- * Project Plan/UI/Wdrozenie_grafiki/dashboard-do-oprogramowania.md.
+ * Every widget is wired to live data (epic DASH, #2249–#2274): KPI +
+ * catalog health via GET /api/dashboard/summary, team activity via
+ * /activity + /top-edited, the action center via /alerts. The agent hero
+ * runs its own loop (#2246). Each widget degrades per-widget to an honest
+ * "—"/empty state on endpoint failure and never fabricates a trend.
  * Per operator decision (2026-07-03) the page carries NO mock badges or
  * banners — it must look exactly like the approved design.
  */


### PR DESCRIPTION
## Cel

Ostatni ticket epiku DASH: po zwiringowaniu wszystkich widgetów (#2249–#2274) i usunięciu `mocks.ts` (DASH-10) w kodzie zostały już tylko nieaktualne opisy „static mock". Sweep porządkowy.

## Zmiany

- **`page.tsx`** docblock: „pixel-perfect static mock… every value is static mock data (see ./mocks.ts)" → opis realnego stanu (wszystkie widgety live przez `/api/dashboard/summary|activity|top-edited|alerts`, degradacja per-widget, agent hero własnym loopem #2246).
- **`view-13-…spec.ts`**: nazwa testu `renders all five sections with **mock values**` → `**live data**`; docblock uściśla, że asercje są **strukturalne** (liczby/hrefy/empty states), nie pinowane literały mocka — dzięki temu trzymają się gdy demo-katalog się zmienia; komentarz „static mock page" → „live-data page".
- Decyzja operatora **zero MOCK badges** i brak audit-pill w topbarze — **bez zmian** (asercje zostają).

## Weryfikacja

- **Parytet i18n** `dashboard.*`: 72 klucze pl = 72 en, zero rozjazdów (skrypt porównujący spłaszczone drzewa).
- Brak martwych referencji do mocków: `grep` po `mocks|TEAM_ACTIVITY|CATALOG_HEALTH|KPI_TILES|ACTION_CENTER|use-dashboard-counts|use-dashboard-completeness` w `features/dashboard` = 0 trafień (poza żywymi hookami).
- Playwright view-13 **2/2** (render live + axe WCAG A/AA); typecheck ✅ · biome ✅.

Zmiana wyłącznie w komentarzach + nazwie testu — bez zmiany zachowania.

Closes #2273