### PR TITLE
fix(catalog): lista atrybutów pokazuje wszystkie (>200), najnowsze pierwsze (#2277)

### DIFF
--- a/apps/admin/e2e/2277-attributes-list-newest-first.spec.ts
+++ b/apps/admin/e2e/2277-attributes-list-newest-first.spec.ts
@@ -1,0 +1,80 @@
+import { expect, type Page, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * #2277 — the modeling attributes list must surface a just-created
+ * attribute. Attribute ids are UUIDv7 (time-ordered), so the list sorts
+ * by id descending: newest first. Stubbed so the order assertion is
+ * deterministic regardless of the seed data.
+ */
+
+// Ascending id order in the API response; the UI must flip it to
+// newest-first (attr_new → attr_mid → attr_old).
+const ATTRS = [
+  { id: '019f0000-0000-7000-8000-000000000001', code: 'attr_old', type: 'text' },
+  { id: '019f5000-0000-7000-8000-000000000002', code: 'attr_mid', type: 'text' },
+  { id: '019f9999-0000-7000-8000-000000000003', code: 'attr_new', type: 'text' },
+];
+
+async function stubAttributes(page: Page) {
+  await page.route(
+    (url) => url.pathname === '/api/attributes',
+    (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/ld+json',
+        body: JSON.stringify({
+          '@context': '/api/contexts/Attribute',
+          '@id': '/api/attributes',
+          '@type': 'Collection',
+          totalItems: ATTRS.length,
+          member: ATTRS.map((a) => ({
+            '@id': `/api/attributes/${a.id}`,
+            '@type': 'Attribute',
+            id: a.id,
+            code: a.code,
+            label: { en: a.code },
+            type: a.type,
+          })),
+        }),
+      }),
+  );
+  // Per-row usage + options fan-out and the group combobox: empty stubs
+  // to keep the render deterministic and quiet.
+  await page.route(
+    (url) => /\/api\/attributes\/[^/]+\/usage$/.test(url.pathname),
+    (route) => route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+  );
+  await page.route(
+    (url) => /\/api\/attributes\/[^/]+\/options$/.test(url.pathname),
+    (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{"member":[]}' }),
+  );
+  await page.route(
+    (url) => url.pathname === '/api/attribute_groups',
+    (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/ld+json',
+        body: JSON.stringify({ totalItems: 0, member: [] }),
+      }),
+  );
+}
+
+test('attributes list renders newest first so a fresh attribute is at the top', async ({
+  page,
+}) => {
+  await page.addInitScript(() => window.localStorage.setItem('i18nextLng', 'pl'));
+  await stubAttributes(page);
+  await loginAsAdmin(page);
+  await page.goto('/modeling/attributes');
+
+  const rows = page.locator('a[href*="/modeling/attributes/019f"]');
+  await expect(rows).toHaveCount(3);
+
+  // Newest-first: attr_new before attr_mid before attr_old.
+  await expect(rows.nth(0)).toContainText('attr_new');
+  await expect(rows.nth(1)).toContainText('attr_mid');
+  await expect(rows.nth(2)).toContainText('attr_old');
+});

--- a/apps/admin/src/features/catalog/attributes/list.tsx
+++ b/apps/admin/src/features/catalog/attributes/list.tsx
@@ -103,7 +103,10 @@ export function AttributesListPage() {
     description: group.code,
   }));
 
-  const attributes = result.data;
+  // #2277 — newest first: attribute ids are UUIDv7 (time-ordered), so a
+  // descending id sort puts a just-created attribute at the top of the
+  // library instead of the tail, where it was easy to miss.
+  const attributes = [...result.data].sort((a, b) => (a.id < b.id ? 1 : a.id > b.id ? -1 : 0));
   const isLoading = listQuery.isLoading;
   const usage = useAttributeUsage(attributes);
   const optionCounts = useOptionCounts(attributes);

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/Attribute.xml
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/Attribute.xml
@@ -28,9 +28,20 @@
         </filters>
 
         <operations>
+            <!--
+                #2277: the admin attributes list (list.tsx) fetches with
+                pagination off and searches/filters client-side, like the
+                rest of the admin's entity lists. The default page size is
+                therefore the effective ceiling on how many attributes the
+                UI can see. 200 silently truncated tenants past that count
+                (CLAUDE.md target is "200+ atrybutów"), hiding newly created
+                attributes. Raised to 1000 headroom for the bounded
+                attribute domain; true server-side pagination is the
+                follow-up if counts ever reach thousands.
+            -->
             <operation class="ApiPlatform\Metadata\GetCollection"
                        uriTemplate="/attributes{._format}"
-                       paginationItemsPerPage="200"
+                       paginationItemsPerPage="1000"
                        security="is_granted('READ', 'App\\Catalog\\Domain\\Entity\\Attribute')"/>
             <operation class="ApiPlatform\Metadata\Get"
                        uriTemplate="/attributes/{id}{._format}"

--- a/apps/api/tests/Api/Catalog/AttributesCrudApiTest.php
+++ b/apps/api/tests/Api/Catalog/AttributesCrudApiTest.php
@@ -62,6 +62,42 @@ final class AttributesCrudApiTest extends CatalogApiTestCase
     }
 
     #[Test]
+    public function collectionReturnsEveryAttributeBeyondTheLegacy200Cap(): void
+    {
+        // #2277 — the admin list fetches with pagination off; a 200 page
+        // cap silently hid attributes past the 200th (CLAUDE.md target is
+        // "200+ atrybutów"). Seed past the cap and assert the collection
+        // returns them all, not a truncated 200.
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        for ($i = 0; $i < 205; ++$i) {
+            $em->persist(new Attribute(
+                \sprintf('cap_attr_%04d', $i),
+                ['en' => 'Cap '.$i],
+                AttributeType::Text,
+            ));
+        }
+        $em->flush();
+
+        $response = $this->authenticatedClient()->request('GET', '/api/attributes');
+        self::assertSame(200, $response->getStatusCode());
+        $payload = $response->toArray();
+        $total = $payload['totalItems'] ?? $payload['hydra:totalItems'] ?? 0;
+        $members = $payload['member'] ?? $payload['hydra:member'] ?? [];
+        self::assertIsInt($total);
+        self::assertIsArray($members);
+        self::assertGreaterThan(200, $total, 'fixture must exceed the old cap');
+        self::assertCount(
+            $total,
+            $members,
+            'the collection must return every attribute, not truncate at 200',
+        );
+    }
+
+    #[Test]
     public function postRejectsNonSnakeCaseCode(): void
     {
         $client = $this->authenticatedClient();


### PR DESCRIPTION
## Summary
Lista atrybutów w Modelowaniu gubiła atrybuty powyżej 200. Odkryte podczas testu bloczka agenta (#2246): agent utworzył atrybut, operator zatwierdził, atrybut **powstał** — ale nie był widoczny na liście.

## Root cause
`list.tsx` pobiera przez `useList({ pagination: { mode: 'off' } })` i filtruje po kliencie, a kolekcja `GET /api/attributes` miała `paginationItemsPerPage="200"` (klient nie może wyłączyć paginacji). Przy 289 atrybutach na stacku (seed load-testu) najnowszy ląduje w ogonie ~89, którego lista nigdy nie pobiera. Domyślny porządek `id ASC` (UUIDv7 = najstarsze pierwsze) chował świeże atrybuty na końcu.

## Backend changes
- `Attribute.xml`: `paginationItemsPerPage` 200 → **1000** (zapas dla domeny „200+" per CLAUDE.md; spójne z konwencją apki — 44 listy używają `mode:'off'`).

## Frontend changes
- `list.tsx`: sort **najnowsze pierwsze** (po `id` malejąco — UUIDv7 time-ordered; zero zmian API). Świeżo utworzony atrybut jest na górze; client-side search/type/group-filter bez zmian.

## Quality gates
- PHPStan max: 0.
- Biome: 0.
- PHPUnit: `AttributesCrudApiTest` 11/11 (nowy case: >200 atrybutów → kolekcja zwraca wszystkie, nie ucina na 200).
- Playwright: `2277-attributes-list-newest-first.spec.ts` zielony (zweryfikowany na żywym stacku — lista renderuje najnowsze pierwsze).
- OpenAPI snapshot: bez zmian (paginationItemsPerPage nie trafia do spec).
- composer/pnpm audit: bez nowych zależności.

## Smoke test plan (po merge)
1. Login (admin@demo.localhost / changeme).
2. `/modeling/attributes` → nagłówek „N w bibliotece" == badge zakładki (dziś 289, wszystkie).
3. Utwórz atrybut → wróć na listę → jest na górze i wyszukiwarka go znajduje.

## Świadome odejścia
- Prawdziwa paginacja server-side + server-side search — follow-up dla skali >~1000 atrybutów (dziś domena „200+", zapas 1000 wystarcza).
- N+1 zapytań `/usage`+`/options` per wiersz — istniejący, osobny problem perf, poza zakresem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)