### PR TITLE
fix(agent): ostrzeżenie gdy utworzony atrybut zostaje niepodpięty (#2279)

### DIFF
--- a/apps/api/src/Agent/Application/Tool/CreateUpdateAttributeTool.php
+++ b/apps/api/src/Agent/Application/Tool/CreateUpdateAttributeTool.php
@@ -44,6 +44,7 @@ final readonly class CreateUpdateAttributeTool implements AgentToolInterface, Pr
         return 'Propose creating or updating a SINGLE attribute (upsert by code: an existing code is updated, a new one created). '
             .'Nothing changes until a human approves. Valid types: '.implode(', ', self::VALID_TYPES).'. '
             .'type is required when creating; omit it when only updating labels/flags of an existing attribute. '
+            .'An attribute created without groups is a LIBRARY entry only - it will not appear on any product until the user attaches it to a group or object type in Modeling, so always tell the user this when you create an unattached attribute. '
             .'Deleting attributes is not available - tell the user to do that in the modeling UI.';
     }
 
@@ -147,11 +148,23 @@ final readonly class CreateUpdateAttributeTool implements AgentToolInterface, Pr
             ),
         ]);
 
+        // #2279 — a group-less attribute commits fine but stays a library
+        // entry with no object-type link, so it never surfaces on products
+        // and is easy to mistake for "nothing happened". Make the model
+        // spell out the follow-up when the user didn't attach it anywhere.
+        $note = 'Schema proposal awaits human approval in the inbox. Nothing is changed yet.';
+        if ([] === $groupCodes) {
+            $note .= ' IMPORTANT: no group was given, so once approved this attribute is created in the LIBRARY only'
+                .' - it will NOT appear on any product until the user attaches it to a group or object type in Modeling.'
+                .' Tell the user this explicitly and, if they meant to use it on products, offer to attach it.';
+        }
+
         return [
             'pending_change_batch_id' => $batchId->toRfc4122(),
             'affected_count' => 1,
             'code' => $code,
-            'note' => 'Schema proposal awaits human approval in the inbox. Nothing is changed yet.',
+            'attached_to_groups' => [] !== $groupCodes,
+            'note' => $note,
         ];
     }
 

--- a/apps/api/tests/Unit/Agent/CreateUpdateAttributeToolTest.php
+++ b/apps/api/tests/Unit/Agent/CreateUpdateAttributeToolTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Agent;
+
+use App\Agent\Application\Tool\AgentToolContext;
+use App\Agent\Application\Tool\CreateUpdateAttributeTool;
+use App\Agent\Application\Tool\ToolKind;
+use App\Catalog\Contracts\PendingChanges\PendingChangesPort;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * #2279 — a group-less attribute commits fine but stays a library entry
+ * with no object-type link, so it never shows on products. The tool must
+ * make the model tell the user the attribute is unattached (otherwise the
+ * create looks like it silently did nothing).
+ */
+final class CreateUpdateAttributeToolTest extends TestCase
+{
+    #[Test]
+    public function metadataDeclaresASchemaToolGuardedByModeling(): void
+    {
+        $tool = new CreateUpdateAttributeTool($this->pendingChanges());
+
+        self::assertSame('create_update_attribute', $tool->name());
+        self::assertSame('modeling.attributes.add_edit', $tool->requiredPermission());
+        self::assertSame(ToolKind::Schema, $tool->kind());
+        self::assertStringContainsStringIgnoringCase('library', $tool->description());
+    }
+
+    #[Test]
+    public function agrouplessAttributeWarnsItIsUnattached(): void
+    {
+        $tool = new CreateUpdateAttributeTool($this->pendingChanges());
+
+        $result = $tool->execute(
+            ['code' => 'test_from_block', 'type' => 'text', 'label' => ['pl' => 'Test']],
+            $this->context(),
+        );
+
+        self::assertArrayHasKey('pending_change_batch_id', $result);
+        self::assertFalse($result['attached_to_groups']);
+        $note = $result['note'];
+        self::assertIsString($note);
+        self::assertStringContainsStringIgnoringCase('library', $note);
+        self::assertStringContainsStringIgnoringCase('will not appear on any product', $note);
+    }
+
+    #[Test]
+    public function anAttributeWithGroupsDoesNotWarn(): void
+    {
+        $tool = new CreateUpdateAttributeTool($this->pendingChanges());
+
+        $result = $tool->execute(
+            ['code' => 'weight', 'type' => 'number', 'label' => ['pl' => 'Waga'], 'groups' => ['dimensions']],
+            $this->context(),
+        );
+
+        self::assertTrue($result['attached_to_groups']);
+        $note = $result['note'];
+        self::assertIsString($note);
+        self::assertStringNotContainsStringIgnoringCase('will not appear on any product', $note);
+    }
+
+    private function context(): AgentToolContext
+    {
+        return new AgentToolContext(Uuid::v7(), new Tenant('alpha', 'Alpha'), []);
+    }
+
+    private function pendingChanges(): PendingChangesPort
+    {
+        return new class implements PendingChangesPort {
+            public function materialize(Uuid $batchId, string $provenance, iterable $drafts): int
+            {
+                return 1;
+            }
+
+            public function listBatch(Uuid $batchId, int $limit = 100, int $offset = 0): array
+            {
+                return [];
+            }
+
+            public function iterateBatch(Uuid $batchId): iterable
+            {
+                return [];
+            }
+
+            public function countBatch(Uuid $batchId): int
+            {
+                return 0;
+            }
+
+            public function accept(Uuid $batchId): int
+            {
+                return 0;
+            }
+
+            public function reject(Uuid $batchId): int
+            {
+                return 0;
+            }
+
+            public function expire(Uuid $batchId): int
+            {
+                return 0;
+            }
+
+            public function annotate(Uuid $changeId, array $meta): void
+            {
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
Agent tworzył atrybut bez grupy poprawnie, ale nie sygnalizował, że taki atrybut jest tylko biblioteczny i nie pojawi się na żadnym produkcie — operator odbierał to jako „nie zadziałało" (#2246 follow-up).

## Root cause
`CreateUpdateAttributeTool` materializuje atrybut bez `object_type_attributes` i (gdy user nie poda) bez grupy. `note` do modelu mówił tylko „awaits approval" — brak sygnału, że group-less atrybut jest nieużyteczny na produktach.

## Backend changes (Agent BC)
- `execute()`: gdy brak grup → `note` dopisuje imperatywne ostrzeżenie („LIBRARY only, will NOT appear on any product until attached in Modeling; tell the user, offer to attach") + pole `attached_to_groups: bool`.
- `description()`: zdanie instruujące model, by zawsze informował o niepodpiętym atrybucie.
- Bez auto-podpięcia (szanujemy „bez grupy"), bez zmian commitu.

## Quality gates
- PHPStan max: 0 (pełna analiza).
- cs-fixer: 0.
- PHPUnit: `CreateUpdateAttributeToolTest` 3/3 (bez grup → ostrzeżenie + flag false; z grupami → brak ostrzeżenia + flag true; metadata).
- agent-removability: kod wyłącznie w `src/Agent/`.
- OpenAPI/migracje: brak zmian.

## Smoke test plan (po merge, na żywym agencie BYOK)
1. Bloczek/⌘K: „dodaj atrybut X typu text bez grupy" → zatwierdź w Skrzynce.
2. Odpowiedź agenta MUSI zawierać ostrzeżenie, że atrybut jest w bibliotece i trzeba go podpiąć w Modelowaniu, żeby użyć na produktach.

## Świadome odejścia
- Domyślne podpięcie atrybutu do ObjectType przez agenta — osobna decyzja UX (model może zaproponować podpięcie w kolejnym kroku).

🤖 Generated with [Claude Code](https://claude.com/claude-code)