### PR TITLE
fix(search): indeksuj completeness_pct — dashboard drill-downy zwracają wyniki

### DIFF
--- a/apps/api/src/Search/Application/BulkCatalogObjectIndexer.php
+++ b/apps/api/src/Search/Application/BulkCatalogObjectIndexer.php
@@ -147,6 +147,11 @@ final readonly class BulkCatalogObjectIndexer
             'path' => $object->getPath(),
             'attributesIndexed' => $attributesIndexed,
             'completeness' => $object->getCompleteness(),
+            // Keep in lockstep with CatalogObjectIndexer::toDocument — the
+            // reserved filterable `completeness_pct` powers the dashboard
+            // drill-downs and the Red preset; the bulk reindex path must
+            // emit it too or a full rebuild silently drops the field.
+            'completeness_pct' => $object->getCompletenessPct(),
             'createdAt' => $object->getCreatedAt()->getTimestamp(),
             'updatedAt' => $object->getUpdatedAt()->getTimestamp(),
         ];

--- a/apps/api/src/Search/Application/CatalogObjectIndexer.php
+++ b/apps/api/src/Search/Application/CatalogObjectIndexer.php
@@ -213,6 +213,12 @@ final readonly class CatalogObjectIndexer
             'path' => $object->getPath(),
             'attributesIndexed' => $attributesIndexed,
             'completeness' => $object->getCompleteness(),
+            // `completeness_pct` is a reserved filterable attribute
+            // (IndexSettingsTemplate) that powers the dashboard drill-downs
+            // (`completeness_pct >= 80`) and the Red preset. Emit the
+            // denormalised smallint column so those filters actually match —
+            // the `completeness` JSONB blob above is not filterable in Meili.
+            'completeness_pct' => $object->getCompletenessPct(),
             'createdAt' => $object->getCreatedAt()->getTimestamp(),
             'updatedAt' => $object->getUpdatedAt()->getTimestamp(),
         ];

--- a/apps/api/src/Search/Application/DocumentFlattener.php
+++ b/apps/api/src/Search/Application/DocumentFlattener.php
@@ -16,14 +16,14 @@ namespace App\Search\Application;
  * the natural filterable scalar per shape and emits it next to the
  * envelope. Keys colliding with reserved doc fields (`id`, `code`,
  * `kind`, `tenantId`, `status`, `enabled`, `parentId`, `path`,
- * `attributesIndexed`, `completeness`, `createdAt`, `updatedAt`) are
- * dropped to avoid overwriting indexer-owned metadata.
+ * `attributesIndexed`, `completeness`, `completeness_pct`, `createdAt`,
+ * `updatedAt`) are dropped to avoid overwriting indexer-owned metadata.
  */
 final class DocumentFlattener
 {
     private const array RESERVED_KEYS = [
         'id', 'code', 'kind', 'tenantId', 'objectTypeId', 'status', 'enabled',
-        'parentId', 'path', 'attributesIndexed', 'completeness',
+        'parentId', 'path', 'attributesIndexed', 'completeness', 'completeness_pct',
         'createdAt', 'updatedAt',
     ];
 

--- a/apps/api/tests/Api/Search/SearchEndpointsApiTest.php
+++ b/apps/api/tests/Api/Search/SearchEndpointsApiTest.php
@@ -91,6 +91,53 @@ final class SearchEndpointsApiTest extends CatalogApiTestCase
         }
     }
 
+    /**
+     * #2310 — the dashboard completeness drill-downs deep-link to
+     * `/products?filter[completeness_pct][op]=gte&value=80`, which the list
+     * compiles into a Meili `completeness_pct >= 80` filter. That returned 0
+     * because the indexer never emitted `completeness_pct` onto the document
+     * (only the non-filterable `completeness` JSONB blob), so the reserved
+     * filterable attribute matched nothing. Assert the field is now indexed
+     * and the range filter actually partitions the catalog.
+     */
+    #[Test]
+    public function searchHonoursCompletenessRangeFilter(): void
+    {
+        $this->seedProduct('COMPLETE-90', completenessPct: 90);
+        $this->seedProduct('COMPLETE-95', completenessPct: 95);
+        $this->seedProduct('INCOMPLETE-20', completenessPct: 20);
+        $this->forceReindex(ObjectKind::Product);
+
+        // The FE serialises the dashboard's `op=gte` shorthand into the
+        // canonical DSL operator `>=` before base64-encoding the blob into
+        // `?q=`; mirror that exact shape here.
+        $blob = base64_encode(json_encode(
+            ['attr' => 'completeness_pct', 'op' => '>=', 'value' => 80],
+            JSON_THROW_ON_ERROR,
+        ));
+
+        $client = $this->authenticatedClient();
+        $body = $client->request('GET', '/api/search/products?q='.$blob)->toArray();
+
+        self::assertGreaterThanOrEqual(2, $body['totalHits'] ?? 0, 'both >= 80 products must match');
+
+        $hits = $body['hits'] ?? [];
+        \assert(\is_array($hits));
+        $codes = [];
+        foreach ($hits as $hit) {
+            \assert(\is_array($hit));
+            $codes[] = $hit['code'] ?? null;
+            // The reserved filterable attribute must ride on the document
+            // itself, not just the settings whitelist.
+            self::assertArrayHasKey('completeness_pct', $hit);
+            self::assertGreaterThanOrEqual(80, $hit['completeness_pct']);
+        }
+
+        self::assertContains('COMPLETE-90', $codes);
+        self::assertContains('COMPLETE-95', $codes);
+        self::assertNotContains('INCOMPLETE-20', $codes, 'a 20% product must fall outside the >= 80 window');
+    }
+
     #[Test]
     public function unauthenticatedSearchReturns401(): void
     {
@@ -351,7 +398,7 @@ final class SearchEndpointsApiTest extends CatalogApiTestCase
     /**
      * @param array<string, scalar> $attributes
      */
-    private function seedProduct(string $code, array $attributes = [], bool $enabled = true): void
+    private function seedProduct(string $code, array $attributes = [], bool $enabled = true, ?int $completenessPct = null): void
     {
         $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
         \assert($tenant instanceof Tenant);
@@ -374,6 +421,9 @@ final class SearchEndpointsApiTest extends CatalogApiTestCase
                 $wrapped[$key] = $value;
             }
             $object->updateAttributeIndex($wrapped);
+        }
+        if (null !== $completenessPct) {
+            $object->recordCompleteness(['global' => $completenessPct]);
         }
         $repo->save($object);
     }


### PR DESCRIPTION
## Summary
Kliknięcie bloczków kompletności na Pulpicie („Gotowe do publikacji ≥80%", „Średnia kompletność", „Kompletność katalogu") przenosiło na listę produktów z **0 wyników**. Kafle są klikalne (deep-link `?filter[completeness_pct][op]=gte&value=80`) — problemem było to, że indeks Meili nie zawierał wartości `completeness_pct`.

## Root cause
`completeness_pct` jest zarezerwowanym atrybutem *filterable* w `IndexSettingsTemplate`, ale żadna z dwóch metod `toDocument` (single `CatalogObjectIndexer`, bulk `BulkCatalogObjectIndexer`) go nie emitowała — zapisywały tylko niefilterowalny blob JSONB `completeness`. `completeness_pct >= 80` matchowało 0 dokumentów (potwierdzone na żywym Meili).

## Backend changes
- `CatalogObjectIndexer::toDocument` — emituje `completeness_pct`.
- `BulkCatalogObjectIndexer::toDocument` — to samo (zduplikowana ścieżka reindex/import).
- `DocumentFlattener` — `completeness_pct` w `RESERVED_KEYS`.

## Frontend changes
Brak — łańcuch FE poprawny (URL `op=gte` → DSL `>=` → `?q=<blob>`).

## Quality gates
- PHPStan max: 0. php-cs-fixer: 0.
- PHPUnit: nowy `searchHonoursCompletenessRangeFilter` (real Meili) — zielony, 11 asercji.

## Smoke test
Na żywym stacku: przed fiksem `completeness_pct >= 80` = 0 dokumentów; po re-pushu jednego produktu licznik 0 → 1. **Backfill istniejących dokumentów wymaga `pim:search:reindex`.**

## Świadome odejścia
- Backfill przez reindex po deployu. W dev CLI `pim:search:reindex` zwraca 0 (brak tenant contextu w CLI) — osobny pre-existing quirk.

Closes #2310

🤖 Generated with [Claude Code](https://claude.com/claude-code)