### PR TITLE
fix(products): filtr zaawansowany renderuje kontrolkę wg typu atrybutu

### DIFF
--- a/apps/admin/src/components/catalog/advanced-filter-panel.tsx
+++ b/apps/admin/src/components/catalog/advanced-filter-panel.tsx
@@ -4,12 +4,13 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { AttributePicker } from '@/components/catalog/attribute-picker';
+import { BulkValueInput } from '@/components/catalog/bulk-wizard/bulk-value-input';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import {
   CORE_OPERATORS,
   FILTER_OPERATORS_BY_TYPE,
   type FilterCondition,
+  type FilterConditionValue,
   type FilterOperator,
 } from '@/lib/filters/filter-dsl';
 import { jsonFetch } from '@/lib/http';
@@ -276,7 +277,20 @@ export function AdvancedFilterPanel({
             const attrMeta =
               effectivePanelAttrs.find((a) => a.code === cond.attr) ?? firstPanelAttr;
             const ops = FILTER_OPERATORS_BY_TYPE[attrMeta.type] ?? CORE_OPERATORS;
-            const isEmpty = cond.op === 'IS EMPTY' || cond.op === 'IS NOT EMPTY';
+            // #2311 — the value control's shape follows the attribute type,
+            // not a bare text box. Operators that encode the value in the
+            // operator itself (empty checks, boolean truthiness) take no
+            // value input; `IN`/`NOT IN` collect several option codes, so the
+            // control switches to the multiselect variant regardless of the
+            // attribute's own single/multi flavour.
+            const noValueOp =
+              cond.op === 'IS EMPTY' ||
+              cond.op === 'IS NOT EMPTY' ||
+              cond.op === '= TRUE' ||
+              cond.op === '= FALSE';
+            const isEmpty = noValueOp;
+            const valueInputType =
+              cond.op === 'IN' || cond.op === 'NOT IN' ? 'multiselect' : attrMeta.type;
 
             return (
               // Index-based key is acceptable here: the editor mutates
@@ -339,45 +353,24 @@ export function AdvancedFilterPanel({
                 </select>
 
                 {!isEmpty && (
-                  <Input
-                    inputMode={
-                      attrMeta.type === 'number' || attrMeta.type === 'metric'
-                        ? 'decimal'
-                        : undefined
-                    }
-                    value={
-                      typeof cond.value === 'string' || typeof cond.value === 'number'
-                        ? String(cond.value)
-                        : Array.isArray(cond.value)
-                          ? cond.value.join(', ')
-                          : ''
-                    }
-                    onChange={(e) => {
-                      const raw = e.target.value;
-                      // Always keep the verbatim string in draft state.
-                      // `commitAndApply` is responsible for converting
-                      // numeric strings (including the Polish comma
-                      // decimal `101,99`) to numbers — keeping the
-                      // intermediate value as a string avoids the
-                      // round-trip `Number(...) -> String(...)` that
-                      // strips a trailing separator while the operator
-                      // is still typing.
-                      const next: string | string[] =
-                        cond.op === 'IN' || cond.op === 'NOT IN'
-                          ? raw
-                              .split(',')
-                              .map((s) => s.trim())
-                              .filter(Boolean)
-                          : raw;
-                      updateCondition(idx, { value: next });
-                    }}
-                    placeholder={
-                      attrMeta.type === 'number' || attrMeta.type === 'metric'
-                        ? 'np. 101,99'
-                        : 'wpisz wartość'
-                    }
-                    className="h-9 flex-1 text-[12.5px]"
-                  />
+                  <div className="flex-1">
+                    <BulkValueInput
+                      attrCode={cond.attr}
+                      attrType={valueInputType}
+                      value={cond.value}
+                      // BulkValueInput is generic (`unknown`) but only ever
+                      // emits string | number | boolean | string[] per the
+                      // attribute type — all valid FilterConditionValue.
+                      onChange={(next) =>
+                        updateCondition(idx, { value: next as FilterConditionValue })
+                      }
+                      placeholder={
+                        attrMeta.type === 'number' || attrMeta.type === 'metric'
+                          ? 'np. 101,99'
+                          : 'wpisz wartość'
+                      }
+                    />
+                  </div>
                 )}
                 {isEmpty && <div className="flex-1" />}
 

--- a/apps/admin/src/components/catalog/bulk-wizard/__tests__/bulk-value-input.test.tsx
+++ b/apps/admin/src/components/catalog/bulk-wizard/__tests__/bulk-value-input.test.tsx
@@ -18,14 +18,18 @@ describe('BulkValueInput typed controls', () => {
   });
 
   it('renders a datetime-local picker for a datetime attribute', () => {
-    render(<BulkValueInput attrCode="updated_at" attrType="datetime" value="" onChange={vi.fn()} />);
+    render(
+      <BulkValueInput attrCode="updated_at" attrType="datetime" value="" onChange={vi.fn()} />,
+    );
     const input = document.querySelector('input[type="datetime-local"]');
     expect(input).not.toBeNull();
   });
 
   it('renders a colour picker plus hex field for a color attribute', () => {
     const onChange = vi.fn();
-    render(<BulkValueInput attrCode="swatch" attrType="color" value="#ff0000" onChange={onChange} />);
+    render(
+      <BulkValueInput attrCode="swatch" attrType="color" value="#ff0000" onChange={onChange} />,
+    );
     const colorInput = document.querySelector('input[type="color"]');
     expect(colorInput).not.toBeNull();
     fireEvent.change(colorInput as HTMLInputElement, { target: { value: '#00ff00' } });
@@ -34,7 +38,9 @@ describe('BulkValueInput typed controls', () => {
 
   it('renders a Tak/Nie toggle for a boolean attribute and emits a boolean', () => {
     const onChange = vi.fn();
-    render(<BulkValueInput attrCode="in_stock" attrType="boolean" value={false} onChange={onChange} />);
+    render(
+      <BulkValueInput attrCode="in_stock" attrType="boolean" value={false} onChange={onChange} />,
+    );
     fireEvent.click(screen.getByText('Tak'));
     expect(onChange).toHaveBeenCalledWith(true);
   });

--- a/apps/admin/src/components/catalog/bulk-wizard/__tests__/bulk-value-input.test.tsx
+++ b/apps/admin/src/components/catalog/bulk-wizard/__tests__/bulk-value-input.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { BulkValueInput } from '@/components/catalog/bulk-wizard/bulk-value-input';
+
+/**
+ * #2311 — the shared typed value input renders a control matching the
+ * attribute type instead of a bare text box. These cases cover the
+ * fetch-free branches (date / datetime / color / boolean); select and
+ * multiselect are exercised end-to-end via the advanced filter panel and
+ * bulk wizard against the real options endpoint.
+ */
+describe('BulkValueInput typed controls', () => {
+  it('renders a native date picker for a date attribute', () => {
+    render(<BulkValueInput attrCode="release_date" attrType="date" value="" onChange={vi.fn()} />);
+    const input = document.querySelector('input[type="date"]');
+    expect(input).not.toBeNull();
+  });
+
+  it('renders a datetime-local picker for a datetime attribute', () => {
+    render(<BulkValueInput attrCode="updated_at" attrType="datetime" value="" onChange={vi.fn()} />);
+    const input = document.querySelector('input[type="datetime-local"]');
+    expect(input).not.toBeNull();
+  });
+
+  it('renders a colour picker plus hex field for a color attribute', () => {
+    const onChange = vi.fn();
+    render(<BulkValueInput attrCode="swatch" attrType="color" value="#ff0000" onChange={onChange} />);
+    const colorInput = document.querySelector('input[type="color"]');
+    expect(colorInput).not.toBeNull();
+    fireEvent.change(colorInput as HTMLInputElement, { target: { value: '#00ff00' } });
+    expect(onChange).toHaveBeenCalledWith('#00ff00');
+  });
+
+  it('renders a Tak/Nie toggle for a boolean attribute and emits a boolean', () => {
+    const onChange = vi.fn();
+    render(<BulkValueInput attrCode="in_stock" attrType="boolean" value={false} onChange={onChange} />);
+    fireEvent.click(screen.getByText('Tak'));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('falls back to a plain text input for an unknown type', () => {
+    render(<BulkValueInput attrCode="note" attrType={undefined} value="" onChange={vi.fn()} />);
+    const inputs = document.querySelectorAll('input');
+    expect(inputs.length).toBeGreaterThan(0);
+    expect(document.querySelector('input[type="color"]')).toBeNull();
+  });
+});

--- a/apps/admin/src/components/catalog/bulk-wizard/bulk-value-input.tsx
+++ b/apps/admin/src/components/catalog/bulk-wizard/bulk-value-input.tsx
@@ -6,13 +6,17 @@ import { jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
 /**
- * VIEW-25b (#556) — value input adapter dla BulkWizard.
+ * VIEW-25b (#556) — typed value input adapter.
  *
- * Renderuje odpowiedni picker zależnie od typu atrybutu:
+ * Współdzielony między BulkWizard (akcje zbiorcze) a AdvancedFilterPanel
+ * (#2311 — filtr zaawansowany honoruje typ atrybutu). Renderuje odpowiedni
+ * picker zależnie od typu atrybutu:
  *  - `text` → standardowy <Input>
- *  - `number` / `metric` → <Input type=number>
+ *  - `number` / `metric` → <Input inputMode=decimal>
  *  - `date` → <Input type=date>
+ *  - `datetime` → <Input type=datetime-local>
  *  - `boolean` → toggle Tak/Nie
+ *  - `color` → <input type=color> + hex <Input>
  *  - `select` → dropdown z `/api/attributes/{code}/options`
  *  - `multiselect` → chips picker z tej samej listy options
  *  - typ undefined → fallback do `text`
@@ -131,6 +135,38 @@ export function BulkValueInput({
         onChange={(e) => onChange(e.target.value)}
         className="font-mono"
       />
+    );
+  }
+
+  if (attrType === 'datetime') {
+    return (
+      <Input
+        type="datetime-local"
+        value={typeof value === 'string' ? value : ''}
+        onChange={(e) => onChange(e.target.value)}
+        className="font-mono"
+      />
+    );
+  }
+
+  if (attrType === 'color') {
+    const colorValue = typeof value === 'string' && value !== '' ? value : '#000000';
+    return (
+      <div className="inline-flex items-center gap-2">
+        <input
+          type="color"
+          aria-label={t('bulk_value.color_picker', { defaultValue: 'Wybierz kolor' })}
+          value={colorValue}
+          onChange={(e) => onChange(e.target.value)}
+          className="h-9 w-12 cursor-pointer rounded-lg border border-zinc-200 bg-white p-1"
+        />
+        <Input
+          value={typeof value === 'string' ? value : ''}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="#RRGGBB"
+          className="font-mono w-28"
+        />
+      </div>
     );
   }
 


### PR DESCRIPTION
## Summary
W filtrach zaawansowanych na liście produktów wybór atrybutu typu Select (np. `color`) dawał zwykłe pole tekstowe zamiast listy wartości. Teraz pole wartości dopasowuje kontrolkę do typu atrybutu.

## Root cause
Panel zawsze renderował `<Input>` tekstowy dla wartości warunku, niezależnie od typu atrybutu.

## Frontend changes
- Reużyto współdzielony `BulkValueInput` (adapter typu) w `advanced-filter-panel.tsx` zamiast surowego `<Input>`.
- Rozszerzono `BulkValueInput` o `datetime` (`<input type=datetime-local>`) i `color` (`<input type=color>` + pole hex) — korzysta z tego również BulkWizard.
- Panel przełącza kontrolkę na multiselect dla operatorów `IN`/`NOT IN` i pomija pole wartości dla operatorów bez wartości (`IS EMPTY`, `= TRUE`/`= FALSE`).

## Backend changes
Brak.

## Quality gates
- tsc: 0 błędów. biome (zmienione pliki): 0.
- vitest: nowy `bulk-value-input.test.tsx` — 5/5 zielone (date/datetime/color/boolean/fallback).

## Smoke test plan
1. Login (admin@demo.localhost / changeme).
2. `/products` → Filtr zaawansowany → wybierz atrybut Select (color) → pojawia się dropdown wartości (nie input).
3. Sprawdź: boolean → brak pola wartości (op `= TRUE`/`= FALSE`); date → date picker; multiselect / `IN` → lista checkboxów.
4. DevTools Console — brak errorów.

Wymaga manualnego smoke testu przed claim „działa" (kontrolki select/multiselect fetchują `/api/attributes/{code}/options`).

Closes #2311

🤖 Generated with [Claude Code](https://claude.com/claude-code)