### PR TITLE
fix(admin): biome-ignore zamiast eslint-disable w use-smart-presets

### DIFF
--- a/apps/admin/src/lib/filters/use-smart-presets.ts
+++ b/apps/admin/src/lib/filters/use-smart-presets.ts
@@ -82,9 +82,11 @@ export function useSmartPresets({
     }
   };
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `load` is
+  // recreated every render; the effect intentionally re-runs only when the
+  // scope (withCounts / resource) changes, not on every render.
   useEffect(() => {
     void load();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [withCounts, resource]);
 
   const create: UseSmartPresetsResult['create'] = async (input) => {


### PR DESCRIPTION
## Summary
`biome check src e2e` (frontend gate) failał na **każdym** PR dotykającym admina z powodu pre-existing błędu: `use-smart-presets.ts` używał `// eslint-disable-next-line react-hooks/exhaustive-deps`, którego biome 2.5.x nie honoruje → `lint/correctness/useExhaustiveDependencies` jako **error**.

## Fix
Zamiana na równoważną supresję biome: `// biome-ignore lint/correctness/useExhaustiveDependencies: …` (intencja bez zmian — `load` jest tworzony co render, efekt celowo re-runuje tylko przy zmianie scope).

## Quality gates
- `biome check src e2e`: 0 errorów (wcześniej 1 error).
- Zero zmian zachowania — tylko komentarz supresji.

Odblokowuje frontendowe PR-y (m.in. #2349, #2350) — bez tego fixa ich gate „Frontend checks" jest czerwony niezależnie od zawartości.