### PR TITLE
fix(admin): single-line biome-ignore w use-smart-presets (naprawa #2351)

### DIFF
--- a/apps/admin/src/lib/filters/use-smart-presets.ts
+++ b/apps/admin/src/lib/filters/use-smart-presets.ts
@@ -82,9 +82,7 @@ export function useSmartPresets({
     }
   };
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: `load` is
-  // recreated every render; the effect intentionally re-runs only when the
-  // scope (withCounts / resource) changes, not on every render.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — load re-runs only on scope (withCounts/resource) change
   useEffect(() => {
     void load();
   }, [withCounts, resource]);


### PR DESCRIPTION
## Summary
Poprawka do #2351: poprzedni `biome-ignore` był rozbity na 3 linie komentarza. Biome 2.5.x honoruje supresję tylko gdy dyrektywa jest w **jednej** linii bezpośrednio nad diagnostyką — stąd zgłaszał zarówno niesupresowany `useExhaustiveDependencies` error, jak i `suppressions/unused` error. Zwinięto do jednej linii (wzorzec jak w `product-detail-page.tsx:196`).

## Weryfikacja
- `biome check src e2e` (dokładna komenda CI): **exit 0, 0 errorów**.

Bez tego gate „Frontend checks" był czerwony na każdym froncie mimo #2351.