### PR TITLE
i18n(products): PL dla operatorów filtrów + labelki akcji zbiorczych

### DIFF
--- a/apps/admin/src/components/catalog/advanced-filter-panel.tsx
+++ b/apps/admin/src/components/catalog/advanced-filter-panel.tsx
@@ -102,6 +102,37 @@ function toFilterType(attrType: string | undefined): keyof typeof FILTER_OPERATO
   return (attrType !== undefined ? FILTER_TYPE_BY_ATTR_TYPE[attrType] : undefined) ?? 'text';
 }
 
+/**
+ * #2312 — Polish labels for the comparison operators. The select used to
+ * render the raw canonical tokens (`after`, `IS EMPTY`, `contains`…), which
+ * were English. Comparison symbols (`=`, `!=`, `<`, `>=`) are universal and
+ * stay as-is; only the word operators are translated.
+ */
+const OPERATOR_I18N: Record<string, { key: string; pl: string }> = {
+  between: { key: 'op_between', pl: 'pomiędzy' },
+  'IS EMPTY': { key: 'op_is_empty', pl: 'puste' },
+  'IS NOT EMPTY': { key: 'op_is_not_empty', pl: 'niepuste' },
+  'starts with': { key: 'op_starts_with', pl: 'zaczyna się od' },
+  'ends with': { key: 'op_ends_with', pl: 'kończy się na' },
+  contains: { key: 'op_contains', pl: 'zawiera' },
+  'not contains': { key: 'op_not_contains', pl: 'nie zawiera' },
+  IN: { key: 'op_in', pl: 'jest jednym z' },
+  'NOT IN': { key: 'op_not_in', pl: 'nie jest żadnym z' },
+  after: { key: 'op_after', pl: 'po' },
+  before: { key: 'op_before', pl: 'przed' },
+  '= TRUE': { key: 'op_is_true', pl: '= Tak' },
+  '= FALSE': { key: 'op_is_false', pl: '= Nie' },
+};
+
+function operatorLabel(
+  op: string,
+  t: (key: string, options?: { defaultValue?: string }) => string,
+): string {
+  const entry = OPERATOR_I18N[op];
+  if (entry === undefined) return op;
+  return t(`products.advanced_filter.${entry.key}`, { defaultValue: entry.pl });
+}
+
 interface AttributeApiRow {
   id: string;
   code: string;
@@ -347,7 +378,7 @@ export function AdvancedFilterPanel({
                 >
                   {ops.map((o) => (
                     <option key={o} value={o}>
-                      {o}
+                      {operatorLabel(o, t)}
                     </option>
                   ))}
                 </select>

--- a/apps/admin/src/components/catalog/bulk-wizard/bulk-wizard.tsx
+++ b/apps/admin/src/components/catalog/bulk-wizard/bulk-wizard.tsx
@@ -192,7 +192,7 @@ export function BulkWizard({ open, selectedIds, onClose, onApplied }: BulkWizard
             </div>
           </div>
           <div className="ml-auto inline-flex items-center gap-1">
-            {(['Wybór akcji', 'Konfiguracja', 'Preview diff'] as const).map((label, i) => {
+            {(['Wybór akcji', 'Konfiguracja', 'Podgląd zmian'] as const).map((label, i) => {
               const stepNo = (i + 1) as 1 | 2 | 3;
               const active = stepNo === step;
               const done = stepNo < step;


### PR DESCRIPTION
## Summary
Tłumaczy na polski angielskie stringi w filtrach zaawansowanych i kreatorze akcji zbiorczych.

## Frontend changes
- `advanced-filter-panel.tsx` — select operatorów porównania renderował surowe angielskie tokeny (`after`, `before`, `IS EMPTY`, `contains`, `IN`…). Dodano `operatorLabel()` z mapą PL (`po`, `przed`, `puste`, `zawiera`, `jest jednym z`…). Symbole (`=`, `!=`, `<`, `>=`) zostają.
- `bulk-wizard.tsx` — krok „Preview diff" → „Podgląd zmian".

## Quality gates
- tsc: 0. `biome check src e2e`: 0.

## Smoke test plan
1. Login → `/products` → Filtr zaawansowany → rozwiń select operatora: etykiety po polsku (po/przed/puste/zawiera…).
2. Akcja zbiorcza „Ustaw atrybut" → trzeci krok chip „Podgląd zmian".
3. Console — brak errorów.

Closes #2312

🤖 Generated with [Claude Code](https://claude.com/claude-code)