### PR TITLE
fix(catalog): szczegóły produktu — Anuluj wraca do listy + guard niezapisanych zmian

### DIFF
--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -101,6 +101,9 @@ export function ProductDetailPage({
   // "Zapisz i wróć do listy" action saves + returns to the list.
   const isEditing = true;
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<boolean>(false);
+  // #2318 — "Anuluj" returns to the list without saving; if there are unsaved
+  // edits it asks for confirmation first.
+  const [showCancelConfirm, setShowCancelConfirm] = useState<boolean>(false);
 
   // #891 create-mode category selection. POST `/api/products` carries
   // this so the product + assignments land atomically — the previous
@@ -381,7 +384,14 @@ export function ProductDetailPage({
         locales={locales}
         channels={channels}
         onSave={(returnToList) => void handleSave(returnToList)}
-        onCancel={cancelEdit}
+        onCancel={() => {
+          // #2318 — guard unsaved edits before leaving to the list.
+          if (Object.keys(dirtyFields).length > 0) {
+            setShowCancelConfirm(true);
+          } else {
+            cancelEdit();
+          }
+        }}
         onRequestDelete={() => setShowDeleteConfirm(true)}
         onFieldChange={setFieldValue}
         onSelectTab={setActiveTab}
@@ -485,6 +495,36 @@ export function ProductDetailPage({
               {isDeleting
                 ? t('products.detail.delete.deleting', { defaultValue: 'Usuwanie…' })
                 : t('products.detail.delete.confirm_submit', { defaultValue: 'Usuń produkt' })}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showCancelConfirm} onOpenChange={setShowCancelConfirm}>
+        <DialogContent>
+          <div className="space-y-2">
+            <DialogTitle>
+              {t('products.detail.cancel.confirm_title', { defaultValue: 'Anulować zmiany?' })}
+            </DialogTitle>
+            <DialogDescription>
+              {t('products.detail.cancel.confirm_body', {
+                defaultValue:
+                  'Masz niezapisane zmiany. Czy na pewno chcesz anulować i wrócić do listy bez zapisu?',
+              })}
+            </DialogDescription>
+          </div>
+          <div className="mt-4 flex justify-end gap-2">
+            <Button variant="ghost" onClick={() => setShowCancelConfirm(false)}>
+              {t('products.detail.cancel.keep_editing', { defaultValue: 'Wróć do edycji' })}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                setShowCancelConfirm(false);
+                cancelEdit();
+              }}
+            >
+              {t('products.detail.cancel.discard', { defaultValue: 'Anuluj bez zapisu' })}
             </Button>
           </div>
         </DialogContent>

--- a/apps/admin/src/features/catalog/products/components/use-product-detail-form.ts
+++ b/apps/admin/src/features/catalog/products/components/use-product-detail-form.ts
@@ -273,10 +273,12 @@ export function useProductDetailForm({
   };
 
   const cancelEdit = (): void => {
-    // #1351 — no read-only mode anymore; "Anuluj" just discards unsaved
-    // edits and restores the persisted values.
+    // #2318 — "Anuluj" discards any unsaved edits and returns to the list
+    // without saving. The unsaved-changes confirmation is enforced by the
+    // caller (product-detail-page) before this runs, so here we just drop the
+    // dirty buffer and navigate back.
     setDirtyFields({});
-    void productQuery.refetch();
+    navigate(backHref);
   };
 
   const handleDelete = async (onDone: () => void): Promise<void> => {


### PR DESCRIPTION
## Summary
Przycisk „Anuluj" na szczegółach produktu wcześniej tylko czyścił bufor zmian i robił refetch — nie robił tego, na co wskazuje nazwa. Teraz wraca do listy produktów bez zapisu; przy niezapisanych zmianach najpierw pyta o potwierdzenie.

## Frontend changes
- `use-product-detail-form.ts` — `cancelEdit` nawiguje do `backHref` (lista) zamiast czyścić+refetch.
- `product-detail-page.tsx` — przycisk „Anuluj": jeśli są niezapisane zmiany (`dirtyFields`), otwiera dialog potwierdzenia („Wróć do edycji" / „Anuluj bez zapisu"); w przeciwnym razie od razu wraca do listy.

## Quality gates
- tsc: 0. `biome check src e2e`: 0.

## Smoke test plan
1. Login → `/products/{id}`.
2. Bez zmian → „Anuluj" → wraca do `/products`.
3. Zmień pole → „Anuluj" → dialog; „Wróć do edycji" zostaje; „Anuluj bez zapisu" → wraca do listy bez zapisu.
4. Console — brak errorów.

Closes #2318

🤖 Generated with [Claude Code](https://claude.com/claude-code)