### PR TITLE
fix(catalog): usuń koncept Aktywny/nieaktywny produktu z listy i akcji zbiorczych

### DIFF
--- a/apps/admin/src/components/catalog/bulk-bar.tsx
+++ b/apps/admin/src/components/catalog/bulk-bar.tsx
@@ -1,5 +1,4 @@
 import { Copy, Download, FolderTree, MoreHorizontal, Pencil, Sparkles, Trash2 } from 'lucide-react';
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { PermissionGate } from '@/components/identity';
@@ -10,17 +9,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { toast } from '@/components/ui/toast';
-import { jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
-
-interface BulkEditJobResponse {
-  id: string;
-  status: string;
-  total: number;
-  processed: number;
-  errors_count: number;
-  first_errors: Array<{ objectId: string; message: string }>;
-}
 
 interface BulkBarProps {
   selectedIds: string[];
@@ -51,7 +40,6 @@ interface BulkBarProps {
 export function BulkBar({
   selectedIds,
   onClear,
-  onApplied,
   onOpenWizard,
   onOpenCategoryModal,
   onOpenDeleteModal,
@@ -60,7 +48,6 @@ export function BulkBar({
   onOpenExportModal,
 }: BulkBarProps) {
   const { t } = useTranslation();
-  const [isPending, setIsPending] = useState(false);
 
   if (selectedIds.length === 0) return null;
 
@@ -71,37 +58,6 @@ export function BulkBar({
         defaultValue: 'W przygotowaniu — {{followUp}}',
       }),
     );
-  };
-
-  const runToggleEnabled = async (enabled: boolean): Promise<void> => {
-    setIsPending(true);
-    try {
-      const job = await jsonFetch<BulkEditJobResponse>('/api/products/bulk-edit', {
-        method: 'POST',
-        body: { operation: 'toggle_enabled', product_ids: selectedIds, payload: { enabled } },
-      });
-      if (job.errors_count === 0) {
-        toast.success(
-          t('products.bulk.toggle_done', {
-            count: job.processed,
-            defaultValue: 'Zaktualizowano {{count}} produktów',
-          }),
-        );
-        onApplied();
-      } else {
-        toast.error(
-          t('products.bulk.toggle_partial', {
-            errors: job.errors_count,
-            processed: job.processed,
-            defaultValue: 'Zaktualizowano {{processed}}, błędów: {{errors}}',
-          }),
-        );
-      }
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'unknown');
-    } finally {
-      setIsPending(false);
-    }
   };
 
   // RBAC-P6-005 (#717) — bulk action surface is gated behind
@@ -168,27 +124,12 @@ export function BulkBar({
               <button
                 type="button"
                 aria-label={t('products.bulk.more_actions', { defaultValue: 'Więcej akcji' })}
-                disabled={isPending}
                 className="text-white/70 hover:text-white inline-flex items-center justify-center size-7 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 disabled:opacity-50"
               >
                 <MoreHorizontal className="size-4" aria-hidden="true" />
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuItem
-                onSelect={() => {
-                  void runToggleEnabled(true);
-                }}
-              >
-                {t('products.bulk.enable', { defaultValue: 'Włącz' })}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => {
-                  void runToggleEnabled(false);
-                }}
-              >
-                {t('products.bulk.disable', { defaultValue: 'Wyłącz' })}
-              </DropdownMenuItem>
               {onOpenDuplicateModal ? (
                 <DropdownMenuItem
                   onSelect={() => {

--- a/apps/admin/src/components/catalog/product-row-actions.tsx
+++ b/apps/admin/src/components/catalog/product-row-actions.tsx
@@ -1,4 +1,4 @@
-import { Copy, History, MoreVertical, PencilLine, Power, PowerOff, Trash2 } from 'lucide-react';
+import { Copy, History, MoreVertical, PencilLine, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
@@ -33,26 +33,15 @@ interface AuditEntry {
  */
 export function ProductRowActions({
   productId,
-  enabled,
   onChanged,
 }: {
   productId: string;
-  enabled: boolean;
   onChanged: () => void;
 }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [showDuplicate, setShowDuplicate] = useState(false);
   const [showAudit, setShowAudit] = useState(false);
-
-  const toggleEnabled = async (): Promise<void> => {
-    await jsonFetch(`/api/products/${productId}`, {
-      method: 'PATCH',
-      body: { enabled: !enabled },
-      contentType: 'application/merge-patch+json',
-    });
-    onChanged();
-  };
 
   const handleDelete = async (): Promise<void> => {
     if (
@@ -93,20 +82,6 @@ export function ProductRowActions({
           <DropdownMenuItem onSelect={() => setShowDuplicate(true)}>
             <Copy className="mr-2 size-4" />
             {t('products.actions.duplicate', { defaultValue: 'Duplicate' })}
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={() => void toggleEnabled()}>
-            {enabled ? (
-              <>
-                <PowerOff className="mr-2 size-4" />
-                {t('products.actions.disable', { defaultValue: 'Disable' })}
-              </>
-            ) : (
-              <>
-                <Power className="mr-2 size-4" />
-                {t('products.actions.enable', { defaultValue: 'Enable' })}
-              </>
-            )}
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onSelect={() => setShowAudit(true)}>

--- a/apps/admin/src/components/catalog/products-grid.tsx
+++ b/apps/admin/src/components/catalog/products-grid.tsx
@@ -30,7 +30,6 @@ interface ProductsGridProps {
   expandedMasters: Set<string>;
   onToggleExpand: (id: string) => void;
   variantsByMasterCount: Map<string, number>;
-  onToggleEnabled: (id: string, next: boolean) => void;
   onChangedRow: () => void;
   isLoading: boolean;
   /**
@@ -50,8 +49,7 @@ interface ProductsGridProps {
   detailPathFor?: (id: string) => string;
 }
 
-const GRID_TPL =
-  '44px 52px 150px minmax(260px,1.6fr) minmax(160px,1fr) 170px 150px 120px 70px 44px';
+const GRID_TPL = '44px 52px 150px minmax(260px,1.6fr) minmax(160px,1fr) 170px 150px 120px 44px';
 
 const COL_KEYS = [
   'sel',
@@ -62,7 +60,6 @@ const COL_KEYS = [
   'compl',
   'channels',
   'price',
-  'enabled',
   'more',
 ] as const;
 
@@ -92,7 +89,6 @@ export function ProductsGrid({
   expandedMasters,
   onToggleExpand,
   variantsByMasterCount,
-  onToggleEnabled,
   onChangedRow,
   isLoading,
   alwaysShowChevronOnMasters = false,
@@ -155,7 +151,6 @@ export function ProductsGrid({
               onToggleExpand={onToggleExpand}
               variantsCount={variantsByMasterCount.get(row.id) ?? 0}
               forceExpandable={alwaysShowChevronOnMasters && row.parentId === null}
-              onToggleEnabled={onToggleEnabled}
               onChangedRow={onChangedRow}
               detailPathFor={detailPathFor}
             />
@@ -184,8 +179,6 @@ function defaultLabelFor(key: (typeof COL_KEYS)[number]): string {
       return 'Kanały';
     case 'price':
       return 'Cena';
-    case 'enabled':
-      return 'Aktywny';
   }
 }
 
@@ -201,7 +194,6 @@ interface RowViewProps {
   onToggleExpand: (id: string) => void;
   variantsCount: number;
   forceExpandable?: boolean;
-  onToggleEnabled: (id: string, next: boolean) => void;
   onChangedRow: () => void;
   detailPathFor: (id: string) => string;
 }
@@ -214,7 +206,6 @@ function ProductsGridRowView({
   onToggleExpand,
   variantsCount,
   forceExpandable = false,
-  onToggleEnabled,
   onChangedRow,
   detailPathFor,
 }: RowViewProps) {
@@ -364,41 +355,8 @@ function ProductsGridRowView({
         )}
       </div>
 
-      <div className="px-3 py-2">
-        {variant ? (
-          <span className="inline-block size-5" />
-        ) : (
-          <button
-            type="button"
-            role="switch"
-            aria-checked={row.enabled}
-            aria-label={t('products.row.toggle_enabled_aria', {
-              sku: row.sku,
-              defaultValue: 'Przełącz aktywność produktu {{sku}}',
-            })}
-            onClick={() => {
-              onToggleEnabled(row.id, !row.enabled);
-            }}
-            className={cn(
-              'inline-flex items-center h-5 w-9 rounded-full p-0.5 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900',
-              row.enabled ? 'bg-emerald-500' : 'bg-zinc-200',
-            )}
-          >
-            <span
-              className={cn(
-                'h-4 w-4 bg-white rounded-full shadow transition',
-                row.enabled && 'translate-x-4',
-              )}
-              aria-hidden="true"
-            />
-          </button>
-        )}
-      </div>
-
       <div className="px-3 py-2 text-zinc-500 hover:text-zinc-900 opacity-0 group-hover:opacity-100 focus-within:opacity-100">
-        {variant ? null : (
-          <ProductRowActions productId={row.id} enabled={row.enabled} onChanged={onChangedRow} />
-        )}
+        {variant ? null : <ProductRowActions productId={row.id} onChanged={onChangedRow} />}
       </div>
     </div>
   );

--- a/apps/admin/src/components/objects/universal-list-page.tsx
+++ b/apps/admin/src/components/objects/universal-list-page.tsx
@@ -120,8 +120,8 @@ interface ListResponse {
 
 type ExcelObjectRow = ProductsGridRow & Record<string, unknown>;
 
-const DEFAULT_FACETS = ['enabled', 'status'];
-const PRODUCT_FACETS = ['enabled', 'status', 'brand'];
+const DEFAULT_FACETS = ['status'];
+const PRODUCT_FACETS = ['status', 'brand'];
 
 const DEFAULT_EXCEL_COLUMNS: ExcelColumn<ExcelObjectRow>[] = [
   { key: 'sku', label: 'Kod', type: 'text', width: 160, readOnly: true },
@@ -560,18 +560,6 @@ export function UniversalListPage({
     if (mode === 'tree' || mode === 'flat') setVariantsMode(mode);
   };
 
-  const handleToggleEnabled = (id: string, next: boolean): void => {
-    void jsonFetch(`/api/objects/${id}`, {
-      method: 'PATCH',
-      body: { enabled: next },
-      contentType: 'application/merge-patch+json',
-    })
-      .then(() => refetch())
-      .catch((err: unknown) => {
-        toast.error(err instanceof Error ? err.message : 'unknown');
-      });
-  };
-
   const handleExcelCommit = async (
     row: ProductsGridRow,
     colKey: string,
@@ -944,7 +932,6 @@ export function UniversalListPage({
           expandedMasters={expandedMasters}
           onToggleExpand={toggleExpand}
           variantsByMasterCount={variantsByMasterCount}
-          onToggleEnabled={handleToggleEnabled}
           onChangedRow={refetch}
           isLoading={isLoading}
           alwaysShowChevronOnMasters={hasVariants && variantsMode === 'tree' && !isSearchActive}


### PR DESCRIPTION
## Summary
Nie ma czegoś takiego jak aktywny/nieaktywny produkt — widocznością steruje kanał/eksport, nie flaga `enabled`. Usuwa wszystkie UI-surface tego konceptu.

## Frontend changes
- `products-grid.tsx` — usunięto kolumnę „Aktywny" z per-wierszowym togglem (COL_KEYS + GRID_TPL + komórka + label + prop `onToggleEnabled`).
- `product-row-actions.tsx` — usunięto pozycję „Włącz/Wyłącz" z menu „…".
- `bulk-bar.tsx` — usunięto akcje „Włącz"/„Wyłącz" + wywołanie `toggle_enabled`.
- `universal-list-page.tsx` — usunięto facet `enabled` (filtr Aktywny) + handler `handleToggleEnabled`.

Kolumna Excel „Aktywny" została już usunięta w #2319.

## Backend
Bez zmian. Endpoint `toggle_enabled` w bulk-edit pozostaje (nieużywany z UI) — do ewentualnego wygaszenia osobnym ticketem.

## Quality gates
- tsc: 0. `biome check src e2e`: 0. Brak e2e zależnych od togglea.

## Smoke test plan
1. Login → `/products` (widok siatki): brak kolumny „Aktywny"/togglea; menu „…" wiersza bez „Włącz/Wyłącz".
2. Zaznacz produkty → pasek akcji „…": brak „Włącz/Wyłącz".
3. Filtry: brak facetu „Aktywny".
4. Console — brak errorów.

Closes #2316

🤖 Generated with [Claude Code](https://claude.com/claude-code)