### PR TITLE
chore(deptrac): CPDF-P0-02 — warstwy Export_Catalog + seam Export_Contracts

### DIFF
--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -253,11 +253,12 @@ parameters:
           collectors:
               - type: directory
                 value: 'src/Import/Contracts/.*'
-        # ─── Export core + Feed sub-area (ADR-0023, epik XMLF) ─────────
-        # Feed (src/Export/Feed) is a sub-area of the Export BC: it may reach
-        # the whole Export core (ExportBuilder reuse) and the Export_Contracts
-        # seam, but talks to other BCs (Channel/Catalog/Asset) only through
-        # their *_Contracts. Core Export must NOT reach Feed.
+        # ─── Export core + Feed / Catalog sub-areas (ADR-0023 XMLF, ADR-0027 CPDF) ─
+        # Feed (src/Export/Feed) and Catalog (src/Export/Catalog) are sub-areas of
+        # the Export BC: each may reach the whole Export core (ExportBuilder reuse)
+        # and the Export_Contracts seam (e.g. the PdfRenderer port), but talks to
+        # other BCs (Channel/Catalog/Asset) only through their *_Contracts. Core
+        # Export must NOT reach Feed or Catalog.
         - name: Export
           collectors:
               - type: bool
@@ -267,6 +268,8 @@ parameters:
                 must_not:
                     - type: directory
                       value: 'src/Export/Feed/.*'
+                    - type: directory
+                      value: 'src/Export/Catalog/.*'
                     - type: directory
                       value: 'src/Export/Contracts/.*'
         - name: Export_Contracts
@@ -287,6 +290,20 @@ parameters:
           collectors:
               - type: directory
                 value: 'src/Export/Feed/Contracts/.*'
+        - name: Export_Catalog_Internals
+          collectors:
+              - type: directory
+                value: 'src/Export/Catalog/Domain/.*'
+              - type: directory
+                value: 'src/Export/Catalog/Application/.*'
+              - type: directory
+                value: 'src/Export/Catalog/Infrastructure/.*'
+              - type: directory
+                value: 'src/Export/Catalog/Presentation/.*'
+        - name: Export_Catalog_Contracts
+          collectors:
+              - type: directory
+                value: 'src/Export/Catalog/Contracts/.*'
 
         # ─── Tooling — fixtures, benchmarks, foundry stories, PHPStan rules ───
         - name: Tooling
@@ -390,6 +407,19 @@ parameters:
             - Shared
             - Vendor
         Export_Feed_Contracts:
+            - Shared
+            - Vendor
+        Export_Catalog_Internals:
+            - Export
+            - Export_Contracts
+            - Export_Catalog_Contracts
+            - Catalog_Contracts
+            - Channel_Contracts
+            - Asset_Contracts
+            - Identity_Contracts
+            - Shared
+            - Vendor
+        Export_Catalog_Contracts:
             - Shared
             - Vendor
 


### PR DESCRIPTION
Zamyka **CPDF-P0-02** (#2283). Blocked by CPDF-P0-01 (ADR-0027, merged #2361). Odblokowuje CPDF-P0-03.

## Co

Egzekwuje granicę z ADR-0027 CI-owo od dnia 1: pod-obszar Katalogów PDF (`src/Export/Catalog`) sięga rdzenia Export + seamu `Export_Contracts` (port `PdfRenderer`), ale do innych BC (Channel/Catalog/Asset) tylko przez `*\Contracts\*`.

- Nowe warstwy `Export_Catalog_Internals` (Domain/Application/Infrastructure/Presentation) + `Export_Catalog_Contracts` — kalka pod-obszaru Feed.
- `src/Export/Catalog/*` wykluczone z płaskiej warstwy `Export` (bool must/must_not, jak Feed).
- Ruleset: `Export_Catalog_Internals` → [`Export`, `Export_Contracts`, `Export_Catalog_Contracts`, `{Catalog,Channel,Asset,Identity}_Contracts`, `Shared`, `Vendor`]; `Export_Catalog_Contracts` → [`Shared`, `Vendor`].
- **Zero nowych `skip_violations`.**

## Uwaga

`src/Export/Catalog/` jeszcze nie istnieje — warstwy dołożone „na przyszłość" (kolekcjonują 0 klas do czasu CPDF-P0-03). Deptrac toleruje puste warstwy → 0 violations.

## Smoke

- Walidacja YAML (python): 32 warstwy, wszystkie referencje ruleset zdefiniowane, `Export` must_not zawiera `src/Export/Catalog/.*`, `Export_Catalog_Internals` nie sięga `Catalog_Internals`/`Channel_Internals`.
- Deptrac analyse (CI): oczekiwane 0 violations.

Refs #2283