### PR TITLE
refactor(admin): utrzymaj advanced-filter-panel poniżej 500 linii (odblokowanie FE CI)

### DIFF
--- a/apps/admin/src/components/catalog/advanced-filter-panel-attrs.ts
+++ b/apps/admin/src/components/catalog/advanced-filter-panel-attrs.ts
@@ -1,0 +1,84 @@
+import type { FILTER_OPERATORS_BY_TYPE } from '@/lib/filters/filter-dsl';
+
+/**
+ * Static attribute catalog + type-mapping helpers for
+ * {@link ./advanced-filter-panel.tsx}. Extracted (no behaviour change) to keep
+ * the panel component under the admin max-lines guard — these are pure data
+ * and a pure mapping function, imported back by the panel.
+ */
+
+export type PanelAttr = {
+  code: string;
+  name: string;
+  type: keyof typeof FILTER_OPERATORS_BY_TYPE;
+  star?: boolean;
+};
+
+export const FIRST_PANEL_ATTR: PanelAttr = {
+  code: 'brand',
+  name: 'Marka',
+  type: 'relation',
+  star: true,
+};
+
+/**
+ * DASH-01 (#2249) — system list columns that are filterable in the search
+ * index (IndexSettingsTemplate) but are not Attribute entities, so the
+ * live `/api/attributes` fetch never returns them. They are unioned into
+ * the effective catalog below; without this a condition seeded on
+ * `completeness_pct` (dashboard deep-links) rendered with text operators
+ * once the live set replaced the static fallback.
+ */
+export const SYSTEM_PANEL_ATTRS: ReadonlyArray<PanelAttr> = [
+  { code: 'completeness_pct', name: 'Completeness %', type: 'number', star: true },
+  { code: 'enabled', name: 'Aktywny', type: 'boolean', star: true },
+];
+
+/**
+ * Loading/empty fallback catalog. Since #1354 the live filterable
+ * attribute set (fetched in the panel) is the source of truth for type-badge /
+ * operator inference; this static list only fills the gap while that
+ * fetch is in flight (or returns nothing) so the panel never renders a
+ * dead picker on first open. An explicit `panelAttrs` prop still wins.
+ */
+export const PANEL_ATTRS: ReadonlyArray<PanelAttr> = [
+  FIRST_PANEL_ATTR,
+  { code: 'category', name: 'Kategoria', type: 'relation', star: true },
+  ...SYSTEM_PANEL_ATTRS,
+  { code: 'price', name: 'Cena bazowa', type: 'metric', star: true },
+  { code: 'stock', name: 'Stan magazynowy', type: 'number' },
+  { code: 'main_image', name: 'Główne zdjęcie', type: 'asset' },
+  { code: 'description.pl', name: 'Opis · PL', type: 'text' },
+  { code: 'description.en', name: 'Opis · EN', type: 'text' },
+  { code: 'meta_description', name: 'Meta description', type: 'text' },
+  { code: 'tags', name: 'Tagi', type: 'multiselect' },
+];
+
+/**
+ * #1354 — map the backend AttributeType enum onto the panel's operator
+ * buckets. Types without a dedicated bucket (color, email, identifier,
+ * textarea) behave as plain string equality filters → `text`.
+ */
+const FILTER_TYPE_BY_ATTR_TYPE: Record<string, keyof typeof FILTER_OPERATORS_BY_TYPE> = {
+  text: 'text',
+  wysiwyg: 'wysiwyg',
+  textarea: 'text',
+  number: 'number',
+  metric: 'metric',
+  price: 'price',
+  date: 'date',
+  datetime: 'datetime',
+  select: 'select',
+  multiselect: 'multiselect',
+  boolean: 'boolean',
+  relation: 'relation',
+  reference: 'reference',
+  asset: 'asset',
+  color: 'text',
+  email: 'text',
+  identifier: 'text',
+};
+
+export function toFilterType(attrType: string | undefined): keyof typeof FILTER_OPERATORS_BY_TYPE {
+  return (attrType !== undefined ? FILTER_TYPE_BY_ATTR_TYPE[attrType] : undefined) ?? 'text';
+}

--- a/apps/admin/src/components/catalog/advanced-filter-panel.tsx
+++ b/apps/admin/src/components/catalog/advanced-filter-panel.tsx
@@ -16,6 +16,14 @@ import {
 import { jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
+import {
+  FIRST_PANEL_ATTR,
+  PANEL_ATTRS,
+  type PanelAttr,
+  SYSTEM_PANEL_ATTRS,
+  toFilterType,
+} from './advanced-filter-panel-attrs';
+
 /**
  * VIEW-09 — push-down sticky-collapsible advanced filter panel.
  * Replaces Sheet-based `AdvancedFilterBuilder` (UI-02.9 / #299).
@@ -26,81 +34,7 @@ import { cn } from '@/lib/utils';
  * (BE base64 blob) that has to be maintained.
  */
 
-export type PanelAttr = {
-  code: string;
-  name: string;
-  type: keyof typeof FILTER_OPERATORS_BY_TYPE;
-  star?: boolean;
-};
-
-const FIRST_PANEL_ATTR: PanelAttr = {
-  code: 'brand',
-  name: 'Marka',
-  type: 'relation',
-  star: true,
-};
-
-/**
- * DASH-01 (#2249) — system list columns that are filterable in the search
- * index (IndexSettingsTemplate) but are not Attribute entities, so the
- * live `/api/attributes` fetch never returns them. They are unioned into
- * the effective catalog below; without this a condition seeded on
- * `completeness_pct` (dashboard deep-links) rendered with text operators
- * once the live set replaced the static fallback.
- */
-const SYSTEM_PANEL_ATTRS: ReadonlyArray<PanelAttr> = [
-  { code: 'completeness_pct', name: 'Completeness %', type: 'number', star: true },
-  { code: 'enabled', name: 'Aktywny', type: 'boolean', star: true },
-];
-
-/**
- * Loading/empty fallback catalog. Since #1354 the live filterable
- * attribute set (fetched below) is the source of truth for type-badge /
- * operator inference; this static list only fills the gap while that
- * fetch is in flight (or returns nothing) so the panel never renders a
- * dead picker on first open. An explicit `panelAttrs` prop still wins.
- */
-const PANEL_ATTRS: ReadonlyArray<PanelAttr> = [
-  FIRST_PANEL_ATTR,
-  { code: 'category', name: 'Kategoria', type: 'relation', star: true },
-  ...SYSTEM_PANEL_ATTRS,
-  { code: 'price', name: 'Cena bazowa', type: 'metric', star: true },
-  { code: 'stock', name: 'Stan magazynowy', type: 'number' },
-  { code: 'main_image', name: 'Główne zdjęcie', type: 'asset' },
-  { code: 'description.pl', name: 'Opis · PL', type: 'text' },
-  { code: 'description.en', name: 'Opis · EN', type: 'text' },
-  { code: 'meta_description', name: 'Meta description', type: 'text' },
-  { code: 'tags', name: 'Tagi', type: 'multiselect' },
-];
-
-/**
- * #1354 — map the backend AttributeType enum onto the panel's operator
- * buckets. Types without a dedicated bucket (color, email, identifier,
- * textarea) behave as plain string equality filters → `text`.
- */
-const FILTER_TYPE_BY_ATTR_TYPE: Record<string, keyof typeof FILTER_OPERATORS_BY_TYPE> = {
-  text: 'text',
-  wysiwyg: 'wysiwyg',
-  textarea: 'text',
-  number: 'number',
-  metric: 'metric',
-  price: 'price',
-  date: 'date',
-  datetime: 'datetime',
-  select: 'select',
-  multiselect: 'multiselect',
-  boolean: 'boolean',
-  relation: 'relation',
-  reference: 'reference',
-  asset: 'asset',
-  color: 'text',
-  email: 'text',
-  identifier: 'text',
-};
-
-function toFilterType(attrType: string | undefined): keyof typeof FILTER_OPERATORS_BY_TYPE {
-  return (attrType !== undefined ? FILTER_TYPE_BY_ATTR_TYPE[attrType] : undefined) ?? 'text';
-}
+export type { PanelAttr };
 
 /**
  * #2312 — Polish labels for the comparison operators. The select used to


### PR DESCRIPTION
## Problem

`advanced-filter-panel.tsx` urósł do **513 linii** (>500), podbijając licznik plików-monolitów do **22 vs baseline 21** w `scripts/lint-admin-max-lines.sh`. To **czerwieni bramkę „Frontend checks" na każdym PR** dotykającym FE/api (docs-only PR-y pomijają FE checks, więc regresja weszła niezauważona). Blokuje wdrożenie epiku CPDF.

## Fix

Wyciągam **czystą statykę** (typ `PanelAttr`, katalog fallback `PANEL_ATTRS`, `FIRST_PANEL_ATTR`, `SYSTEM_PANEL_ATTRS` oraz mapowanie `toFilterType`) do siostrzanego modułu `advanced-filter-panel-attrs.ts`. Panel importuje je z powrotem. **Zero zmian zachowania** — tylko relokacja danych/typu/pure-funkcji. Licznik wraca do 21.

## Walidacja (host)

- `lint-admin-max-lines`: **21 = baseline, no regression** ✅
- `tsc -b` + `vite build`: ✅ (built in 487ms)
- `biome check`: czysto ✅
- `vitest`: 142/142 ✅
- `lint-jsonfetch-useeffect`: 59 < baseline 61 ✅

Bez tego wszystkie kolejne PR-y epiku CPDF (i dowolny FE-dotykający) są czerwone na FE checks.