### PR TITLE
feat(export): CPDF-P0-03 — port PdfRenderer + adapter DompdfRenderer + POC

### DIFF
--- a/apps/api/.env
+++ b/apps/api/.env
@@ -93,6 +93,10 @@ APP_DEFAULT_TENANT_CODE=demo
 # /api/object_types POST + the modeling UI Create button (Faza 1
 # ADR-013 will tie this to per-role permissions).
 CATALOG_ENABLE_CUSTOM_OBJECT_TYPES=true
+# CPDF-P0-03 (ADR-0027) — PDF renderer selection for Catalog PDF. `dompdf`
+# is the in-process default (zero infra); `gotenberg` (CPDF-P6-03) needs a
+# GOTENBERG_URL sidecar. Consumed by the renderer switch from CPDF-P6-03.
+CATALOG_PDF_RENDERER=dompdf
 # AGENT-P0-08 (#1951) — global agent kill-switch (open-core: a deploy
 # without the agent sets 0 and every /api/agent/* endpoint refuses with
 # a 403 problem document). Per-tenant availability additionally

--- a/apps/api/composer.json
+++ b/apps/api/composer.json
@@ -17,6 +17,7 @@
         "doctrine/doctrine-bundle": "^2.18.2",
         "doctrine/doctrine-migrations-bundle": "^3.7",
         "doctrine/orm": "^3.6.3",
+        "dompdf/dompdf": "^3.1",
         "dragonmantank/cron-expression": "^3.6",
         "ezyang/htmlpurifier": "^4.19",
         "league/csv": "^9.28",

--- a/apps/api/composer.lock
+++ b/apps/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b5ab2a5990494949eaa6c89c941d899",
+    "content-hash": "b11a6a8755986849a1cf96a725af1ad4",
     "packages": [
         {
             "name": "anthropic-ai/sdk",
@@ -2881,6 +2881,161 @@
             "time": "2026-02-08T16:21:46+00:00"
         },
         {
+            "name": "dompdf/dompdf",
+            "version": "v3.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/dompdf.git",
+                "reference": "f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496",
+                "reference": "f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496",
+                "shasum": ""
+            },
+            "require": {
+                "dompdf/php-font-lib": "^1.0.0",
+                "dompdf/php-svg-lib": "^1.0.0",
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "masterminds/html5": "^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "ext-gd": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "mockery/mockery": "^1.3",
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.4 || ^5.4 || ^6.2 || ^7.0"
+            },
+            "suggest": {
+                "ext-gd": "Needed to process images",
+                "ext-gmagick": "Improves image processing performance",
+                "ext-imagick": "Improves image processing performance",
+                "ext-zlib": "Needed for pdf stream compression"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dompdf\\": "src/"
+                },
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "The Dompdf Community",
+                    "homepage": "https://github.com/dompdf/dompdf/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
+            "homepage": "https://github.com/dompdf/dompdf",
+            "support": {
+                "issues": "https://github.com/dompdf/dompdf/issues",
+                "source": "https://github.com/dompdf/dompdf/tree/v3.1.5"
+            },
+            "time": "2026-03-03T13:54:37+00:00"
+        },
+        {
+            "name": "dompdf/php-font-lib",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-font-lib.git",
+                "reference": "a6e9a688a2a80016ac080b97be73d3e10c444c9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-font-lib/zipball/a6e9a688a2a80016ac080b97be73d3e10c444c9a",
+                "reference": "a6e9a688a2a80016ac080b97be73d3e10c444c9a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11 || ^12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FontLib\\": "src/FontLib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The FontLib Community",
+                    "homepage": "https://github.com/dompdf/php-font-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse, export and make subsets of different types of font files.",
+            "homepage": "https://github.com/dompdf/php-font-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-font-lib/issues",
+                "source": "https://github.com/dompdf/php-font-lib/tree/1.0.2"
+            },
+            "time": "2026-01-20T14:10:26+00:00"
+        },
+        {
+            "name": "dompdf/php-svg-lib",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-svg-lib.git",
+                "reference": "8259ffb930817e72b1ff1caef5d226501f3dfeb1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-svg-lib/zipball/8259ffb930817e72b1ff1caef5d226501f3dfeb1",
+                "reference": "8259ffb930817e72b1ff1caef5d226501f3dfeb1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0",
+                "sabberworm/php-css-parser": "^8.4 || ^9.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Svg\\": "src/Svg"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The SvgLib Community",
+                    "homepage": "https://github.com/dompdf/php-svg-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse and export to PDF SVG files.",
+            "homepage": "https://github.com/dompdf/php-svg-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-svg-lib/issues",
+                "source": "https://github.com/dompdf/php-svg-lib/tree/1.0.2"
+            },
+            "time": "2026-01-02T16:01:13+00:00"
+        },
+        {
             "name": "dragonmantank/cron-expression",
             "version": "v3.6.0",
             "source": {
@@ -4300,6 +4455,73 @@
                 "source": "https://github.com/MarkBaker/PHPMatrix/tree/3.0.1"
             },
             "time": "2022-12-02T22:17:43+00:00"
+        },
+        {
+            "name": "masterminds/html5",
+            "version": "2.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Masterminds/html5-php.git",
+                "reference": "fd5018f6815fff903946d0564977b44ce8010e29"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fd5018f6815fff903946d0564977b44ce8010e29",
+                "reference": "fd5018f6815fff903946d0564977b44ce8010e29",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9 || ^10"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Masterminds\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Butcher",
+                    "email": "technosophos@gmail.com"
+                },
+                {
+                    "name": "Matt Farina",
+                    "email": "matt@mattfarina.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "An HTML5 parser and serializer.",
+            "homepage": "http://masterminds.github.io/html5-php",
+            "keywords": [
+                "HTML5",
+                "dom",
+                "html",
+                "parser",
+                "querypath",
+                "serializer",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/Masterminds/html5-php/issues",
+                "source": "https://github.com/Masterminds/html5-php/tree/2.10.1"
+            },
+            "time": "2026-06-23T18:43:15+00:00"
         },
         {
             "name": "meilisearch/meilisearch-php",
@@ -5737,6 +5959,86 @@
                 }
             ],
             "time": "2023-12-12T12:06:11+00:00"
+        },
+        {
+            "name": "sabberworm/php-css-parser",
+            "version": "v9.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MyIntervals/PHP-CSS-Parser.git",
+                "reference": "fd3bf9fb173e0df649bc4e3e0d088a1b2417c08f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MyIntervals/PHP-CSS-Parser/zipball/fd3bf9fb173e0df649bc4e3e0d088a1b2417c08f",
+                "reference": "fd3bf9fb173e0df649bc4e3e0d088a1b2417c08f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": "^7.2.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "thecodingmachine/safe": "^1.3 || ^2.5 || ^3.4"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "1.4.0",
+                "phpstan/extension-installer": "1.4.3",
+                "phpstan/phpstan": "1.12.33 || 2.2.2",
+                "phpstan/phpstan-phpunit": "1.4.2 || 2.0.16",
+                "phpstan/phpstan-strict-rules": "1.6.2 || 2.0.11",
+                "phpunit/phpunit": "8.5.52",
+                "rawr/phpunit-data-provider": "3.3.1",
+                "rector/rector": "1.2.10 || 2.4.6",
+                "rector/type-perfect": "1.0.0 || 2.1.3",
+                "squizlabs/php_codesniffer": "4.0.1",
+                "thecodingmachine/phpstan-safe-rule": "1.2.0 || 1.4.3"
+            },
+            "suggest": {
+                "ext-mbstring": "for parsing UTF-8 CSS"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.5.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Rule/Rule.php",
+                    "src/RuleSet/RuleContainer.php"
+                ],
+                "psr-4": {
+                    "Sabberworm\\CSS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Raphael Schweikert"
+                },
+                {
+                    "name": "Oliver Klee",
+                    "email": "github@oliverklee.de"
+                },
+                {
+                    "name": "Jake Hotson",
+                    "email": "jake.github@qzdesign.co.uk"
+                }
+            ],
+            "description": "Parser for CSS Files written in PHP",
+            "homepage": "https://www.sabberworm.com/blog/2010/6/10/php-css-parser",
+            "keywords": [
+                "css",
+                "parser",
+                "stylesheet"
+            ],
+            "support": {
+                "issues": "https://github.com/MyIntervals/PHP-CSS-Parser/issues",
+                "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v9.4.0"
+            },
+            "time": "2026-06-18T15:10:53+00:00"
         },
         {
             "name": "spomky-labs/otphp",
@@ -11525,6 +11827,149 @@
             "time": "2026-06-08T20:24:16+00:00"
         },
         {
+            "name": "thecodingmachine/safe",
+            "version": "v3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thecodingmachine/safe.git",
+                "reference": "705683a25bacf0d4860c7dea4d7947bfd09eea19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/705683a25bacf0d4860c7dea4d7947bfd09eea19",
+                "reference": "705683a25bacf0d4860c7dea4d7947bfd09eea19",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpstan/phpstan": "^2",
+                "phpunit/phpunit": "^10",
+                "squizlabs/php_codesniffer": "^3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/special_cases.php",
+                    "generated/apache.php",
+                    "generated/apcu.php",
+                    "generated/array.php",
+                    "generated/bzip2.php",
+                    "generated/calendar.php",
+                    "generated/classobj.php",
+                    "generated/com.php",
+                    "generated/cubrid.php",
+                    "generated/curl.php",
+                    "generated/datetime.php",
+                    "generated/dir.php",
+                    "generated/eio.php",
+                    "generated/errorfunc.php",
+                    "generated/exec.php",
+                    "generated/fileinfo.php",
+                    "generated/filesystem.php",
+                    "generated/filter.php",
+                    "generated/fpm.php",
+                    "generated/ftp.php",
+                    "generated/funchand.php",
+                    "generated/gettext.php",
+                    "generated/gmp.php",
+                    "generated/gnupg.php",
+                    "generated/hash.php",
+                    "generated/ibase.php",
+                    "generated/ibmDb2.php",
+                    "generated/iconv.php",
+                    "generated/image.php",
+                    "generated/imap.php",
+                    "generated/info.php",
+                    "generated/inotify.php",
+                    "generated/json.php",
+                    "generated/ldap.php",
+                    "generated/libxml.php",
+                    "generated/lzf.php",
+                    "generated/mailparse.php",
+                    "generated/mbstring.php",
+                    "generated/misc.php",
+                    "generated/mysql.php",
+                    "generated/mysqli.php",
+                    "generated/network.php",
+                    "generated/oci8.php",
+                    "generated/opcache.php",
+                    "generated/openssl.php",
+                    "generated/outcontrol.php",
+                    "generated/pcntl.php",
+                    "generated/pcre.php",
+                    "generated/pgsql.php",
+                    "generated/posix.php",
+                    "generated/ps.php",
+                    "generated/pspell.php",
+                    "generated/readline.php",
+                    "generated/rnp.php",
+                    "generated/rpminfo.php",
+                    "generated/rrd.php",
+                    "generated/sem.php",
+                    "generated/session.php",
+                    "generated/shmop.php",
+                    "generated/sockets.php",
+                    "generated/sodium.php",
+                    "generated/solr.php",
+                    "generated/spl.php",
+                    "generated/sqlsrv.php",
+                    "generated/ssdeep.php",
+                    "generated/ssh2.php",
+                    "generated/stream.php",
+                    "generated/strings.php",
+                    "generated/swoole.php",
+                    "generated/uodbc.php",
+                    "generated/uopz.php",
+                    "generated/url.php",
+                    "generated/var.php",
+                    "generated/xdiff.php",
+                    "generated/xml.php",
+                    "generated/xmlrpc.php",
+                    "generated/yaml.php",
+                    "generated/yaz.php",
+                    "generated/zip.php",
+                    "generated/zlib.php"
+                ],
+                "classmap": [
+                    "lib/DateTime.php",
+                    "lib/DateTimeImmutable.php",
+                    "lib/Exceptions/",
+                    "generated/Exceptions/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
+            "support": {
+                "issues": "https://github.com/thecodingmachine/safe/issues",
+                "source": "https://github.com/thecodingmachine/safe/tree/v3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/OskarStark",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/shish",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/silasjoisten",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-04T18:08:13+00:00"
+        },
+        {
             "name": "twig/extra-bundle",
             "version": "v3.24.0",
             "source": {
@@ -12709,73 +13154,6 @@
                 "type"
             ],
             "time": "2026-02-19T20:12:01+00:00"
-        },
-        {
-            "name": "masterminds/html5",
-            "version": "2.10.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Masterminds/html5-php.git",
-                "reference": "fd5018f6815fff903946d0564977b44ce8010e29"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fd5018f6815fff903946d0564977b44ce8010e29",
-                "reference": "fd5018f6815fff903946d0564977b44ce8010e29",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9 || ^10"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Masterminds\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Matt Butcher",
-                    "email": "technosophos@gmail.com"
-                },
-                {
-                    "name": "Matt Farina",
-                    "email": "matt@mattfarina.com"
-                },
-                {
-                    "name": "Asmir Mustafic",
-                    "email": "goetas@gmail.com"
-                }
-            ],
-            "description": "An HTML5 parser and serializer.",
-            "homepage": "http://masterminds.github.io/html5-php",
-            "keywords": [
-                "HTML5",
-                "dom",
-                "html",
-                "parser",
-                "querypath",
-                "serializer",
-                "xml"
-            ],
-            "support": {
-                "issues": "https://github.com/Masterminds/html5-php/issues",
-                "source": "https://github.com/Masterminds/html5-php/tree/2.10.1"
-            },
-            "time": "2026-06-23T18:43:15+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -84,6 +84,12 @@ services:
             # (supersedes the narrower P1-01 migrations-only exclude).
             - '../src/Agent/'
 
+    # CPDF-P0-03 (ADR-0027) — the PdfRenderer port defaults to the in-process
+    # Dompdf adapter so a stock install renders catalogs with zero extra infra.
+    # CPDF-P6-03 adds GotenbergRenderer and the CATALOG_PDF_RENDERER switch;
+    # until then this alias is the only adapter (no GOTENBERG_URL ⇒ Dompdf).
+    App\Export\Contracts\PdfRenderer: '@App\Export\Catalog\Infrastructure\Renderer\DompdfRenderer'
+
     # W2-7 / AUD-042 — single RFC 7807 contract for custom controllers.
     # `$debug` is bound to the kernel flag so the listener can keep the
     # real exception message in `detail` for 5xx locally while collapsing

--- a/apps/api/src/Export/Catalog/Infrastructure/Renderer/DompdfRenderer.php
+++ b/apps/api/src/Export/Catalog/Infrastructure/Renderer/DompdfRenderer.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Infrastructure\Renderer;
+
+use App\Export\Contracts\PdfRenderer;
+use App\Export\Contracts\PdfRenderException;
+use App\Export\Contracts\PdfRenderOptions;
+use Dompdf\Dompdf;
+use Dompdf\Options;
+use Throwable;
+
+/**
+ * In-process PDF renderer backed by dompdf/dompdf (ADR-0027, CPDF-P0-03).
+ *
+ * The default adapter: pure PHP, no sidecar, so a stock Cortex install renders
+ * catalogs without any extra infrastructure. It is the only class in the repo
+ * that touches {@see Dompdf}. Remote asset fetching stays off — the
+ * catalog render service streams product images as data URIs upstream
+ * (decision B). Note (decision A, CPDF-P6-04): Dompdf builds the whole document
+ * in memory, so large catalogs are capped/chunked upstream.
+ */
+final class DompdfRenderer implements PdfRenderer
+{
+    public function render(string $html, PdfRenderOptions $options): string
+    {
+        $dompdfOptions = new Options();
+        $dompdfOptions->set('isRemoteEnabled', false);
+        $dompdfOptions->set('isHtml5ParserEnabled', true);
+        if ($options->basePath !== null) {
+            $dompdfOptions->set('chroot', $options->basePath);
+        }
+
+        $dompdf = new Dompdf($dompdfOptions);
+        $dompdf->setPaper($options->paperSize, $options->orientation);
+        $dompdf->loadHtml($html);
+
+        try {
+            $dompdf->render();
+            $output = $dompdf->output();
+        } catch (Throwable $e) {
+            throw new PdfRenderException('Dompdf failed to render the document.', 0, $e);
+        }
+
+        if (!str_starts_with($output, '%PDF-')) {
+            throw new PdfRenderException('Dompdf produced an invalid PDF document.');
+        }
+
+        return $output;
+    }
+}

--- a/apps/api/src/Export/Contracts/PdfRenderException.php
+++ b/apps/api/src/Export/Contracts/PdfRenderException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Contracts;
+
+use RuntimeException;
+
+/**
+ * Thrown when a {@see PdfRenderer} cannot turn HTML into a valid PDF
+ * (ADR-0027, CPDF-P0-03).
+ */
+final class PdfRenderException extends RuntimeException
+{
+}

--- a/apps/api/src/Export/Contracts/PdfRenderOptions.php
+++ b/apps/api/src/Export/Contracts/PdfRenderOptions.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Contracts;
+
+/**
+ * Renderer-agnostic options passed to a {@see PdfRenderer} (ADR-0027, CPDF-P0-03).
+ *
+ * Primitive by design so both the in-process Dompdf adapter and the future
+ * Gotenberg sidecar (CPDF-P6-03) read the same shape. `basePath` is the local
+ * root a renderer may resolve relative asset paths against.
+ */
+final class PdfRenderOptions
+{
+    public function __construct(
+        public readonly string $paperSize = 'A4',
+        public readonly string $orientation = 'portrait',
+        public readonly ?string $basePath = null,
+    ) {
+    }
+}

--- a/apps/api/src/Export/Contracts/PdfRenderer.php
+++ b/apps/api/src/Export/Contracts/PdfRenderer.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Contracts;
+
+/**
+ * Renders an HTML document to a PDF binary (ADR-0027, CPDF-P0-03).
+ *
+ * The port keeps the renderer swappable so a stock Cortex install needs no
+ * extra infrastructure:
+ *   - {@see \App\Export\Catalog\Infrastructure\Renderer\DompdfRenderer} —
+ *     in-process, pure PHP, the default (zero infra);
+ *   - `GotenbergRenderer` (CPDF-P6-03) — headless Chromium sidecar, opt-in
+ *     behind `GOTENBERG_URL`, for high-fidelity / premium layouts;
+ *   - PDFreactor — a future CMYK adapter (Faza 2).
+ *
+ * Callers (the catalog render service) depend only on this contract.
+ */
+interface PdfRenderer
+{
+    /**
+     * @return string the rendered PDF as a binary string (starts with `%PDF-`)
+     *
+     * @throws PdfRenderException when the document cannot be rendered
+     */
+    public function render(string $html, PdfRenderOptions $options): string;
+}

--- a/apps/api/tests/Unit/Export/Catalog/DompdfRendererTest.php
+++ b/apps/api/tests/Unit/Export/Catalog/DompdfRendererTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export\Catalog;
+
+use App\Export\Catalog\Infrastructure\Renderer\DompdfRenderer;
+use App\Export\Contracts\PdfRenderOptions;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * CPDF-P0-03 — POC that the PdfRenderer port + Dompdf adapter turn HTML into a
+ * valid PDF binary in-process.
+ */
+final class DompdfRendererTest extends TestCase
+{
+    public function testRendersHtmlToPdfBinary(): void
+    {
+        $renderer = new DompdfRenderer();
+        $html = '<html><body><h1>Karta produktu</h1>'
+            .'<table><tr><td>SKU</td><td>ABC-1</td></tr></table></body></html>';
+
+        $pdf = $renderer->render($html, new PdfRenderOptions());
+
+        self::assertStringStartsWith('%PDF-', $pdf);
+        self::assertStringContainsString('%%EOF', $pdf);
+    }
+
+    public function testRendersLandscapeLetter(): void
+    {
+        $renderer = new DompdfRenderer();
+
+        $pdf = $renderer->render(
+            '<p>hello</p>',
+            new PdfRenderOptions(paperSize: 'letter', orientation: 'landscape'),
+        );
+
+        self::assertStringStartsWith('%PDF-', $pdf);
+    }
+}


### PR DESCRIPTION
Zamyka **CPDF-P0-03** (#2284). Blocked by CPDF-P0-01/P0-02 (merged). Odblokowuje CPDF-P2-03 (render service) i CPDF-P6-03 (Gotenberg).

## Co

Fundament renderowania: pojedynczy **port `PdfRenderer`** (`src/Export/Contracts/`), przez który przechodzi każdy bajt PDF.

- `PdfRenderer::render(string $html, PdfRenderOptions): string` (+ `PdfRenderOptions` VO, `PdfRenderException`).
- **`DompdfRenderer`** — domyślny adapter in-process (czysty PHP, `dompdf/dompdf` ^3.1 = v3.1.5), **zero nowej infry**; jedyna klasa dotykająca `\Dompdf\Dompdf`.
- DI: port aliasowany do Dompdf; env `CATALOG_PDF_RENDERER=dompdf` (runtime-switch do opcjonalnego Gotenberga dochodzi w CPDF-P6-03 — bez `GOTENBERG_URL` zawsze Dompdf).
- POC unit test: HTML → poprawny binarny `%PDF-`.

## Walidacja (uruchomiona w kontenerze `pim-api-1`, PHP 8.4)

- **PHPUnit** `DompdfRendererTest`: **2/2** (renders `%PDF-` + `%%EOF`; A4 portrait + Letter landscape).
- **PHPStan max**: `No errors`.
- **php-cs-fixer** (dist): czysto.
- **Deptrac**: 0 violations (DompdfRenderer w `Export_Catalog_Internals` sięga tylko `Export_Contracts` + Vendor).
- **DI**: `debug:container` potwierdza `PdfRenderer` → private alias na `DompdfRenderer`.

## Uwaga

Osadzanie zdjęć: `isRemoteEnabled=false` — render service (CPDF-P2-02/03) strumieniuje obrazy jako data-URI (decyzja B). Dompdf trzyma dokument w pamięci → cap/chunk dużych katalogów w CPDF-P6-04 (decyzja A).

Refs #2284