### PR TITLE
feat(export): CPDF-P0-04 — HtmlValueSanitizer dla wartości produktowych [SEC]

### DIFF
--- a/apps/api/src/Export/Catalog/Application/HtmlValueSanitizer.php
+++ b/apps/api/src/Export/Catalog/Application/HtmlValueSanitizer.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Application;
+
+use App\Export\Catalog\Domain\HtmlSlotPolicy;
+use HTMLPurifier;
+use HTMLPurifier_Config;
+
+use const ENT_HTML5;
+use const ENT_QUOTES;
+use const ENT_SUBSTITUTE;
+
+/**
+ * Neutralises product values before they are bound into a catalog HTML template
+ * (ADR-0027, CPDF-P0-04). Every value a template slot renders passes through
+ * here, so garbage data (a name carrying `<script>`, a description with a
+ * `javascript:` href, a stray `\x0B`) can neither break the layout nor inject
+ * content into the rendered PDF — the same class of defect as CSV/XML formula
+ * injection.
+ *
+ * Mirrors the write-path {@see \App\Catalog\Application\HtmlSanitizer} config
+ * (cross-BC reuse is not allowed, so the HTMLPurifier setup is duplicated here
+ * behind the Export seam). Twig autoescape still guards the {@see HtmlSlotPolicy::Escape}
+ * path in the template; this class is the value-level defence and the single
+ * place the rich-text allow-list lives for catalogs.
+ */
+final class HtmlValueSanitizer
+{
+    /** Conservative rich-text allow-list — mirrors the wysiwyg write-path set. */
+    private const string ALLOWED_HTML =
+        'p,br,strong,b,em,i,u,s,sub,sup,'
+        .'ul,ol,li,'
+        .'a[href|title|target|rel],'
+        .'h1,h2,h3,h4,h5,h6,'
+        .'blockquote,pre,code,hr,'
+        .'table,thead,tbody,tr,th,td';
+
+    /** `javascript:` / `data:` are absent by design — the stored-XSS vectors. */
+    private const string ALLOWED_URI_SCHEMES = 'http,https,mailto';
+
+    private ?HTMLPurifier $purifier = null;
+
+    public function sanitize(string $value, HtmlSlotPolicy $policy): string
+    {
+        $value = $this->stripControlChars($value);
+
+        if ('' === $value) {
+            return '';
+        }
+
+        return match ($policy) {
+            HtmlSlotPolicy::Escape => htmlspecialchars(
+                $value,
+                ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5,
+                'UTF-8',
+            ),
+            HtmlSlotPolicy::RichText => $this->purifier()->purify($value),
+            HtmlSlotPolicy::Strip => trim(strip_tags($value)),
+        };
+    }
+
+    /**
+     * Remove XML/HTML-illegal C0 control chars (keep tab/newline/carriage
+     * return). Applied to every policy before anything else so a `\x0B` cannot
+     * survive into the layout.
+     */
+    private function stripControlChars(string $value): string
+    {
+        return preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F]/', '', $value) ?? $value;
+    }
+
+    private function purifier(): HTMLPurifier
+    {
+        if (null !== $this->purifier) {
+            return $this->purifier;
+        }
+
+        $config = HTMLPurifier_Config::createDefault();
+        $config->set('HTML.Allowed', self::ALLOWED_HTML);
+        $config->set('URI.AllowedSchemes', array_fill_keys(
+            explode(',', self::ALLOWED_URI_SCHEMES),
+            true,
+        ));
+        $config->set('Attr.AllowedRel', ['noopener', 'noreferrer', 'nofollow']);
+        $config->set('HTML.Nofollow', true);
+        // FrankenPHP worker mode: no on-disk serialiser cache. The definition is
+        // cheap to rebuild and the instance is reused for the worker lifetime.
+        $config->set('Cache.DefinitionImpl', null);
+
+        return $this->purifier = new HTMLPurifier($config);
+    }
+}

--- a/apps/api/src/Export/Catalog/Domain/HtmlSlotPolicy.php
+++ b/apps/api/src/Export/Catalog/Domain/HtmlSlotPolicy.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Domain;
+
+/**
+ * How a template slot treats an HTML/text product value before it reaches the
+ * catalog HTML (ADR-0027, CPDF-P0-04). Chosen per slot in the field mapping —
+ * never hard-coded — so a name/price/SKU is fully escaped while a description
+ * keeps a safe rich-text subset.
+ */
+enum HtmlSlotPolicy: string
+{
+    /** Full HTML-escape — the default for scalar slots (name, sku, price). */
+    case Escape = 'escape';
+
+    /** Keep a conservative rich-text allow-list — for description slots. */
+    case RichText = 'richtext';
+
+    /** Remove every tag, keep the text content. */
+    case Strip = 'strip';
+}

--- a/apps/api/tests/Unit/Export/Catalog/HtmlValueSanitizerTest.php
+++ b/apps/api/tests/Unit/Export/Catalog/HtmlValueSanitizerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export\Catalog;
+
+use App\Export\Catalog\Application\HtmlValueSanitizer;
+use App\Export\Catalog\Domain\HtmlSlotPolicy;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * CPDF-P0-04 [SEC] — failing-test-first: garbage product values must never
+ * break the catalog HTML or inject executable/layout-breaking content,
+ * whatever the slot policy.
+ */
+final class HtmlValueSanitizerTest extends TestCase
+{
+    private HtmlValueSanitizer $sanitizer;
+
+    protected function setUp(): void
+    {
+        $this->sanitizer = new HtmlValueSanitizer();
+    }
+
+    public function testEscapePolicyLeavesNoLiveMarkup(): void
+    {
+        $out = $this->sanitizer->sanitize(
+            'Kabel <script>alert(1)</script> <b>HDMI</b>',
+            HtmlSlotPolicy::Escape,
+        );
+
+        // Everything becomes inert text: no unescaped '<' survives.
+        self::assertStringNotContainsString('<', $out);
+        self::assertStringContainsString('&lt;script&gt;', $out);
+    }
+
+    public function testRichTextDropsScriptButKeepsAllowedTags(): void
+    {
+        $out = $this->sanitizer->sanitize(
+            '<p>Opis <strong>produktu</strong></p><script>alert(1)</script>',
+            HtmlSlotPolicy::RichText,
+        );
+
+        self::assertStringNotContainsString('<script', $out);
+        self::assertStringContainsString('<strong>', $out);
+    }
+
+    public function testRichTextBlocksJavascriptHref(): void
+    {
+        $out = $this->sanitizer->sanitize(
+            '<a href="javascript:alert(1)">klik</a>',
+            HtmlSlotPolicy::RichText,
+        );
+
+        self::assertStringNotContainsString('javascript:', $out);
+        self::assertStringContainsString('klik', $out);
+    }
+
+    public function testRichTextDropsDisallowedTags(): void
+    {
+        $out = $this->sanitizer->sanitize(
+            '<img src=x onerror="alert(1)"><iframe src="//evil"></iframe>ok',
+            HtmlSlotPolicy::RichText,
+        );
+
+        self::assertStringNotContainsString('<img', $out);
+        self::assertStringNotContainsString('<iframe', $out);
+        self::assertStringNotContainsString('onerror', $out);
+        self::assertStringContainsString('ok', $out);
+    }
+
+    public function testStripPolicyRemovesAllTags(): void
+    {
+        $out = $this->sanitizer->sanitize(
+            '<div onerror="x"><b>tekst</b></div>',
+            HtmlSlotPolicy::Strip,
+        );
+
+        self::assertStringNotContainsString('<', $out);
+        self::assertStringNotContainsString('onerror', $out);
+        self::assertStringContainsString('tekst', $out);
+    }
+
+    #[DataProvider('garbageProvider')]
+    public function testGarbageStaysWellFormedAndInert(string $garbage): void
+    {
+        foreach (HtmlSlotPolicy::cases() as $policy) {
+            $out = $this->sanitizer->sanitize($garbage, $policy);
+            $label = $policy->value;
+
+            // No executable <script> element survives in any policy.
+            self::assertStringNotContainsString('<script', $out, $label);
+            // Illegal C0 control chars are always stripped.
+            self::assertDoesNotMatchRegularExpression(
+                '/[\x00-\x08\x0B\x0C\x0E-\x1F]/',
+                $out,
+                $label,
+            );
+
+            if (HtmlSlotPolicy::Escape !== $policy) {
+                // Parsed policies additionally strip event handlers and js: URIs.
+                self::assertStringNotContainsString('javascript:', $out, $label);
+                self::assertStringNotContainsString('onerror', $out, $label);
+            } else {
+                // Escape leaves zero live markup — every '<' is entity-encoded.
+                self::assertStringNotContainsString('<', $out, $label);
+            }
+        }
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function garbageProvider(): iterable
+    {
+        yield 'script' => ['<script>alert(1)</script>'];
+        yield 'onerror img' => ['<img src=x onerror="alert(1)">'];
+        yield 'javascript href' => ['<a href="javascript:alert(1)">x</a>'];
+        yield 'control chars' => ["A\x00B\x0BC\x1FD"];
+        yield 'unclosed tag' => ['<div><span>oops'];
+        yield 'emoji + entity' => ['Cena 10€ 🚀 <b>&amp;</b>'];
+    }
+}


### PR DESCRIPTION
Zamyka **CPDF-P0-04** (#2285). Blocked by CPDF-P0-01 (merged). Odblokowuje CPDF-P2-03 (render service).

## Co

Współdzielony, bezpieczeństwo-krytyczny rdzeń: każda wartość produktowa, którą slot szablonu renderuje, przechodzi przez `HtmlValueSanitizer` — śmieciowe dane (nazwa z `<script>`, opis z `javascript:` href, `\x0B`) nie rozbiją layoutu ani nie wstrzykną treści do PDF (analog CSV/XML injection, lekcja #1552).

- `HtmlSlotPolicy` (enum, Domain): `escape` (default) / `richtext` (whitelista) / `strip` — wybierana per slot, nie hardkod.
- `HtmlValueSanitizer` (Application): mirror configu HTMLPurifier z write-path `wysiwyg` (cross-BC reuse zakazany przez Deptrac → config zduplikowany za seamem Export); C0 control-chars zawsze usuwane najpierw; `Cache.DefinitionImpl=null` pod worker mode.
- Twig autoescape nadal chroni ścieżkę `escape` w szablonie; ta klasa to obrona na poziomie wartości.

**Umiejscowienie:** sanitizer w `Application` (nie `Domain` z treści ticketu) — mirror istniejącego `Catalog\Application\HtmlSanitizer` i trzyma Domain wolne od vendora (HTMLPurifier). Enum polityki został w Domain.

## Walidacja (kontener `pim-api-1`, PHP 8.4) — failing-test-first [SEC]

- **PHPUnit** `HtmlValueSanitizerTest`: **11/11, 79 asercji** — fuzz suite (`<script>`, `onerror`, `javascript:` href, control-chars, niedomknięte tagi, emoji+entity) × 3 polityki: żadna nie przepuszcza wykonywalnego markupu; escape nie zostawia żywego `<`.
- **PHPStan max**: `No errors`.
- **Deptrac**: 0 violations (Application/Domain w `Export_Catalog_Internals`, HTMLPurifier = Vendor).
- **php-cs-fixer** (dist): czysto.

Refs #2285