### PR TITLE
feat(export): CPDF-P1-02 — repozytoria Doctrine CatalogProfile/CatalogRun

### DIFF
--- a/apps/api/src/Export/Catalog/Domain/Repository/CatalogProfileRepositoryInterface.php
+++ b/apps/api/src/Export/Catalog/Domain/Repository/CatalogProfileRepositoryInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Domain\Repository;
+
+use App\Export\Catalog\Domain\Entity\CatalogProfile;
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
+
+interface CatalogProfileRepositoryInterface
+{
+    public function save(CatalogProfile $profile): void;
+
+    public function remove(CatalogProfile $profile): void;
+
+    public function findById(Uuid $id): ?CatalogProfile;
+
+    /**
+     * Resolve a catalog by its stored token HMAC (CPDF public URL). The caller
+     * MUST have already established the tenant context / RLS scope from the URL,
+     * so this only returns a hit inside the current tenant — a token from tenant
+     * A can never resolve a catalog of tenant B.
+     */
+    public function findByTokenHash(string $tokenHash): ?CatalogProfile;
+
+    public function findByTenantAndCode(Tenant $tenant, string $code): ?CatalogProfile;
+
+    /**
+     * @return list<CatalogProfile>
+     */
+    public function findByTenant(Tenant $tenant): array;
+}

--- a/apps/api/src/Export/Catalog/Domain/Repository/CatalogRunRepositoryInterface.php
+++ b/apps/api/src/Export/Catalog/Domain/Repository/CatalogRunRepositoryInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Domain\Repository;
+
+use App\Export\Catalog\Domain\Entity\CatalogRun;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+interface CatalogRunRepositoryInterface
+{
+    public function save(CatalogRun $run): void;
+
+    public function findById(Uuid $id): ?CatalogRun;
+
+    /**
+     * Most recent runs of a catalog, newest first.
+     *
+     * @return list<CatalogRun>
+     */
+    public function findByCatalogProfile(Uuid $catalogProfileId, int $limit = 50): array;
+
+    /**
+     * Keyset page of runs, newest first (CPDF monitor). CatalogRun ids are
+     * UUIDv7, so ordering by id IS ordering by started_at — the cursor is the
+     * last-seen run id. `$health` filters the DISPLAY status: success (done),
+     * error; null = everything.
+     *
+     * @return list<CatalogRun>
+     */
+    public function findPage(?Uuid $catalogProfileId, ?string $health, ?Uuid $cursor, int $limit): array;
+
+    /**
+     * Tenant-wide 24h health KPI for the monitor tiles (CPDF): regeneration
+     * count, item sum, error count + the most recent error.
+     *
+     * @return array{regenerations_24h: int, items_24h: int, errors_24h: int, last_error: array{run_id: string, catalog_id: string, message: string|null}|null}
+     */
+    public function kpi24h(Tenant $tenant, DateTimeImmutable $now): array;
+}

--- a/apps/api/src/Export/Catalog/Infrastructure/Doctrine/Repository/DoctrineCatalogProfileRepository.php
+++ b/apps/api/src/Export/Catalog/Infrastructure/Doctrine/Repository/DoctrineCatalogProfileRepository.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Infrastructure\Doctrine\Repository;
+
+use App\Export\Catalog\Domain\Entity\CatalogProfile;
+use App\Export\Catalog\Domain\Repository\CatalogProfileRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<CatalogProfile>
+ */
+class DoctrineCatalogProfileRepository extends ServiceEntityRepository implements CatalogProfileRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, CatalogProfile::class);
+    }
+
+    public function save(CatalogProfile $profile): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($profile);
+        $em->flush();
+    }
+
+    public function remove(CatalogProfile $profile): void
+    {
+        $em = $this->getEntityManager();
+        $em->remove($profile);
+        $em->flush();
+    }
+
+    public function findById(Uuid $id): ?CatalogProfile
+    {
+        return parent::find($id->toRfc4122());
+    }
+
+    public function findByTokenHash(string $tokenHash): ?CatalogProfile
+    {
+        // Tenant scoping is enforced upstream (RLS GUC + TenantFilter set by the
+        // public controller from the URL); this is a plain indexed lookup that
+        // only sees the current tenant's rows.
+        return $this->findOneBy(['tokenHash' => $tokenHash]);
+    }
+
+    public function findByTenantAndCode(Tenant $tenant, string $code): ?CatalogProfile
+    {
+        return $this->findOneBy(['tenant' => $tenant, 'code' => $code]);
+    }
+
+    /**
+     * @return list<CatalogProfile>
+     */
+    public function findByTenant(Tenant $tenant): array
+    {
+        $qb = $this->createQueryBuilder('c')
+            ->where('c.tenant = :tenant')
+            ->orderBy('c.updatedAt', 'DESC')
+            ->setParameter('tenant', $tenant);
+
+        /** @var list<CatalogProfile> $result */
+        $result = $qb->getQuery()->getResult();
+
+        return $result;
+    }
+}

--- a/apps/api/src/Export/Catalog/Infrastructure/Doctrine/Repository/DoctrineCatalogRunRepository.php
+++ b/apps/api/src/Export/Catalog/Infrastructure/Doctrine/Repository/DoctrineCatalogRunRepository.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Infrastructure\Doctrine\Repository;
+
+use App\Export\Catalog\Domain\Entity\CatalogRun;
+use App\Export\Catalog\Domain\Enum\CatalogRunStatus;
+use App\Export\Catalog\Domain\Repository\CatalogRunRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use DateTimeZone;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<CatalogRun>
+ */
+class DoctrineCatalogRunRepository extends ServiceEntityRepository implements CatalogRunRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, CatalogRun::class);
+    }
+
+    public function save(CatalogRun $run): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($run);
+        $em->flush();
+    }
+
+    public function findById(Uuid $id): ?CatalogRun
+    {
+        return parent::find($id->toRfc4122());
+    }
+
+    /**
+     * @return list<CatalogRun>
+     */
+    public function findByCatalogProfile(Uuid $catalogProfileId, int $limit = 50): array
+    {
+        $qb = $this->createQueryBuilder('r')
+            ->where('r.catalogProfileId = :cid')
+            ->orderBy('r.startedAt', 'DESC')
+            ->setMaxResults($limit)
+            ->setParameter('cid', $catalogProfileId->toRfc4122());
+
+        /** @var list<CatalogRun> $result */
+        $result = $qb->getQuery()->getResult();
+
+        return $result;
+    }
+
+    /**
+     * @return list<CatalogRun>
+     */
+    public function findPage(?Uuid $catalogProfileId, ?string $health, ?Uuid $cursor, int $limit): array
+    {
+        // UUIDv7 ids are time-ordered, so id DESC == started_at DESC and the
+        // keyset cursor is a plain id comparison (stable under concurrent
+        // inserts, unlike OFFSET).
+        $qb = $this->createQueryBuilder('r')
+            ->orderBy('r.id', 'DESC')
+            ->setMaxResults($limit);
+
+        if (null !== $catalogProfileId) {
+            $qb->andWhere('r.catalogProfileId = :cid')
+                ->setParameter('cid', $catalogProfileId->toRfc4122());
+        }
+        if (null !== $cursor) {
+            $qb->andWhere('r.id < :cursor')
+                ->setParameter('cursor', $cursor->toRfc4122());
+        }
+
+        // Display-status filter: `success` is a completed run (`done`); `error`
+        // is the raw error status. CatalogRun has no warning count, so unlike
+        // FeedRun there is no warning split of `done`.
+        match ($health) {
+            'success' => $qb->andWhere('r.status = :st')
+                ->setParameter('st', CatalogRunStatus::Done->value),
+            'error' => $qb->andWhere('r.status = :st')
+                ->setParameter('st', CatalogRunStatus::Error->value),
+            default => null,
+        };
+
+        /** @var list<CatalogRun> $result */
+        $result = $qb->getQuery()->getResult();
+
+        return $result;
+    }
+
+    public function kpi24h(Tenant $tenant, DateTimeImmutable $now): array
+    {
+        $since = $now->setTimezone(new DateTimeZone('UTC'))->modify('-24 hours')->format('Y-m-d H:i:s');
+        $params = ['tenant' => $tenant->getId()->toRfc4122(), 'since' => $since];
+
+        // tenant-safe: explicit tenant_id filter (monitor KPI scoped to the authenticated tenant; RLS GUC active as defence in depth)
+        $row = $this->getEntityManager()->getConnection()->executeQuery(
+            'SELECT COUNT(*) AS regenerations,'
+            .' COALESCE(SUM(item_count), 0) AS items,'
+            ." COUNT(*) FILTER (WHERE status = 'error') AS errors"
+            .' FROM catalog_runs WHERE tenant_id = :tenant AND started_at >= :since',
+            $params,
+        )->fetchAssociative();
+
+        // tenant-safe: explicit tenant_id filter (single most-recent error row for the monitor tile)
+        $lastError = $this->getEntityManager()->getConnection()->executeQuery(
+            'SELECT id, catalog_profile_id, error_message FROM catalog_runs'
+            ." WHERE tenant_id = :tenant AND status = 'error' AND started_at >= :since"
+            .' ORDER BY id DESC LIMIT 1',
+            $params,
+        )->fetchAssociative();
+
+        $counters = \is_array($row) ? $row : [];
+
+        $lastErrorOut = null;
+        if (\is_array($lastError)
+            && \is_string($lastError['id'] ?? null)
+            && \is_string($lastError['catalog_profile_id'] ?? null)
+        ) {
+            $lastErrorOut = [
+                'run_id' => $lastError['id'],
+                'catalog_id' => $lastError['catalog_profile_id'],
+                'message' => \is_string($lastError['error_message'] ?? null) ? $lastError['error_message'] : null,
+            ];
+        }
+
+        return [
+            'regenerations_24h' => self::toInt($counters['regenerations'] ?? 0),
+            'items_24h' => self::toInt($counters['items'] ?? 0),
+            'errors_24h' => self::toInt($counters['errors'] ?? 0),
+            'last_error' => $lastErrorOut,
+        ];
+    }
+
+    private static function toInt(mixed $value): int
+    {
+        return is_numeric($value) ? (int) $value : 0;
+    }
+}


### PR DESCRIPTION
Zamyka **CPDF-P1-02** (#2287). Blocked by CPDF-P1-01 (merged). Odblokowuje CPDF-P1-03 (CRUD), CPDF-P3-01 (async).

## Co

Kalka repozytoriów Feed dla modelu Catalog:
- `CatalogProfileRepositoryInterface` + `DoctrineCatalogProfileRepository`: `save`/`remove`/`findById`/`findByTokenHash`/`findByTenantAndCode`/`findByTenant`.
- `CatalogRunRepositoryInterface` + `DoctrineCatalogRunRepository`: `findByCatalogProfile`, `findPage` (keyset `id DESC`, UUIDv7), `kpi24h`.
- Interfejsy w Domain, impl w Infrastructure, **autowire-by-implements** (jak Feed — bez jawnego bindingu; potwierdzone `debug:container` = private alias na impl).

## Adaptacje vs Feed (CatalogRun nie ma skipped/warning counters)

- `kpi24h`: `regenerations_24h` (COUNT), `errors_24h` (FILTER status='error'), **`items_24h`** (SUM `item_count`, zamiast Feed `skipped_24h`); `last_error` z `catalog_id` (zamiast `feed_id`).
- `findPage` health: collapse do `done`/`error`/`null` (brak `warning` bo brak `warning_count`).

## Walidacja (kontener `pim-api-1`, PHP 8.4)

- **PHPStan max** (pełny, 2G): No errors. **Deptrac**: 0 violations. **php-cs-fixer**: czysto. **DI**: interfejsy → impl (private alias).

## Coverage

Zgodnie z precedensem Feed (brak dedykowanego repo Integration testu — repo pokryte przez ApiTestCase kontrolera): repozytoria będą pokryte end-to-end (real Postgres + RLS z auth) w **CPDF-P1-03** ApiTestCase (401/403/404/happy path na CRUD `/api/catalogs`). Standalone repo Integration test duplikowałby to pokrycie i jest nieuruchamialny lokalnie (kernel test-env).

Refs #2287