### PR TITLE
feat(export): CPDF-P1-03 — CRUD CatalogProfile (/api/catalogs) + ApiTest

### DIFF
--- a/apps/api/src/Export/Catalog/Domain/Entity/CatalogProfile.php
+++ b/apps/api/src/Export/Catalog/Domain/Entity/CatalogProfile.php
@@ -156,6 +156,12 @@ class CatalogProfile extends AggregateRoot implements TenantScoped
         return CatalogTemplateKind::from($this->templateKind);
     }
 
+    public function changeTemplateKind(CatalogTemplateKind $templateKind): void
+    {
+        $this->templateKind = $templateKind->value;
+        $this->touch();
+    }
+
     public function getObjectTypeId(): Uuid
     {
         return $this->objectTypeId;

--- a/apps/api/src/Export/Catalog/Presentation/Controller/CatalogProfileController.php
+++ b/apps/api/src/Export/Catalog/Presentation/Controller/CatalogProfileController.php
@@ -1,0 +1,372 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Presentation\Controller;
+
+use App\Export\Catalog\Domain\Entity\CatalogProfile;
+use App\Export\Catalog\Domain\Enum\CatalogStatus;
+use App\Export\Catalog\Domain\Enum\CatalogTemplateKind;
+use App\Export\Catalog\Domain\Repository\CatalogProfileRepositoryInterface;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\TenantContext;
+use App\Shared\Application\UserIdentityAware;
+use App\Shared\Domain\Tenant;
+use DateTimeInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * CRUD for PDF catalog profiles (ADR-0027, CPDF-P1-03). Tenant-scoped custom
+ * routes (CQRS, ADR-0012) — the catalog-world analogue of
+ * {@see \App\Export\Feed\Presentation\Controller\FeedProfileController}, sharing
+ * its export RBAC surface (`exports.view_all` on reads, `integration.admin` on
+ * writes) so no new permission code is introduced. Auto-registered into OpenAPI
+ * by CustomRouteOpenApiFactory (ADR-0020).
+ *
+ * The URL token hash is never serialized (CPDF public URL, P3); publication
+ * config mints/rotates it via a dedicated endpoint outside this CRUD surface.
+ */
+final class CatalogProfileController
+{
+    public function __construct(
+        private readonly CatalogProfileRepositoryInterface $catalogs,
+        private readonly TenantContext $tenantContext,
+        private readonly Security $security,
+    ) {
+    }
+
+    #[Route(path: '/api/catalogs', name: 'pim_catalogs_list', methods: ['GET'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'exports', action: 'view_all')]
+    public function list(): JsonResponse
+    {
+        [$tenant] = $this->resolveTenant();
+
+        return new JsonResponse([
+            'items' => array_map($this->serialize(...), $this->catalogs->findByTenant($tenant)),
+        ]);
+    }
+
+    #[Route(path: '/api/catalogs', name: 'pim_catalogs_create', methods: ['POST'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'integration', action: 'admin')]
+    public function create(Request $request): JsonResponse
+    {
+        [$tenant] = $this->resolveTenant();
+        $payload = $this->decodeJson($request);
+
+        $kind = $this->parseKind($payload);
+        $code = $this->parseString($payload, 'code');
+        $name = $this->parseString($payload, 'name');
+        $objectTypeId = $this->parseUuid($payload, 'object_type_id');
+
+        if (null !== $this->catalogs->findByTenantAndCode($tenant, $code)) {
+            throw new BadRequestHttpException(sprintf('A catalog with code "%s" already exists.', $code));
+        }
+
+        $catalog = new CatalogProfile(
+            code: $code,
+            name: $name,
+            templateKind: $kind,
+            objectTypeId: $objectTypeId,
+            branding: $this->parseArray($payload, 'branding'),
+            fieldMappings: $this->parseMappings($payload),
+            filter: $this->parseOptionalArray($payload, 'filter'),
+            channelId: $this->parseOptionalUuid($payload, 'channel_id'),
+            publicationChannel: $this->parseOptionalString($payload, 'publication_channel'),
+            locale: $this->parseOptionalString($payload, 'locale'),
+            renderer: $this->parseRenderer($payload),
+        );
+        $catalog->assignTenant($tenant);
+        $this->catalogs->save($catalog);
+
+        return new JsonResponse($this->serialize($catalog), Response::HTTP_CREATED);
+    }
+
+    #[Route(path: '/api/catalogs/{id}', name: 'pim_catalogs_get', methods: ['GET'], requirements: ['id' => '[0-9a-fA-F-]{36}'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'exports', action: 'view_all')]
+    public function get(string $id): JsonResponse
+    {
+        return new JsonResponse($this->serialize($this->loadOrFail($id)));
+    }
+
+    #[Route(path: '/api/catalogs/{id}', name: 'pim_catalogs_patch', methods: ['PATCH'], requirements: ['id' => '[0-9a-fA-F-]{36}'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'integration', action: 'admin')]
+    public function patch(string $id, Request $request): JsonResponse
+    {
+        $catalog = $this->loadOrFail($id);
+        $payload = $this->decodeJson($request);
+
+        if (\array_key_exists('name', $payload)) {
+            $catalog->rename($this->parseString($payload, 'name'));
+        }
+        if (\array_key_exists('template_kind', $payload)) {
+            $catalog->changeTemplateKind($this->parseKind($payload));
+        }
+        if (\array_key_exists('branding', $payload) && \is_array($payload['branding'])) {
+            $catalog->updateBranding($payload['branding']);
+        }
+        if (\array_key_exists('field_mappings', $payload) && \is_array($payload['field_mappings'])) {
+            $catalog->updateFieldMappings(array_values(array_filter($payload['field_mappings'], \is_array(...))));
+        }
+        if (\array_key_exists('filter', $payload)) {
+            $catalog->updateFilter(\is_array($payload['filter']) ? $payload['filter'] : null);
+        }
+        if (\array_key_exists('renderer', $payload)) {
+            $catalog->setRenderer($this->parseRenderer($payload));
+        }
+        if (\array_key_exists('status', $payload)) {
+            $this->applyStatus($catalog, $payload);
+        }
+        // Scope block — channel drives per-channel value resolution (?channel=);
+        // absent keys keep their current values.
+        if (\array_key_exists('channel_id', $payload)
+            || \array_key_exists('publication_channel', $payload)
+            || \array_key_exists('locale', $payload)
+        ) {
+            $catalog->setScope(
+                \array_key_exists('channel_id', $payload) ? $this->parseOptionalUuid($payload, 'channel_id') : $catalog->getChannelId(),
+                \array_key_exists('publication_channel', $payload) ? $this->parseOptionalString($payload, 'publication_channel') : $catalog->getPublicationChannel(),
+                \array_key_exists('locale', $payload) ? $this->parseOptionalString($payload, 'locale') : $catalog->getLocale(),
+            );
+        }
+
+        $this->catalogs->save($catalog);
+
+        return new JsonResponse($this->serialize($catalog));
+    }
+
+    #[Route(path: '/api/catalogs/{id}', name: 'pim_catalogs_delete', methods: ['DELETE'], requirements: ['id' => '[0-9a-fA-F-]{36}'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'integration', action: 'admin')]
+    public function delete(string $id): Response
+    {
+        $this->catalogs->remove($this->loadOrFail($id));
+
+        return new Response(status: Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * @return array{Tenant}
+     */
+    private function resolveTenant(): array
+    {
+        if (!$this->security->getUser() instanceof UserIdentityAware) {
+            throw new AccessDeniedHttpException('Authenticated user identity required.');
+        }
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new AccessDeniedHttpException('Tenant context required.');
+        }
+
+        return [$tenant];
+    }
+
+    private function loadOrFail(string $id): CatalogProfile
+    {
+        $this->resolveTenant();
+        $catalog = $this->catalogs->findById(Uuid::fromString($id));
+        if (null === $catalog) {
+            // Tenant isolation via RLS/TenantFilter; a miss is a 404 either way.
+            throw new NotFoundHttpException(sprintf('Catalog "%s" was not found.', $id));
+        }
+
+        return $catalog;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function applyStatus(CatalogProfile $catalog, array $payload): void
+    {
+        $value = $payload['status'] ?? null;
+        $status = \is_string($value) ? CatalogStatus::tryFrom($value) : null;
+        if (null === $status) {
+            throw new BadRequestHttpException('status must be one of active|paused|error.');
+        }
+        match ($status) {
+            CatalogStatus::Paused => $catalog->pause(),
+            CatalogStatus::Active => $catalog->resume(),
+            CatalogStatus::Error => $catalog->markError(),
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function parseKind(array $payload): CatalogTemplateKind
+    {
+        $value = $payload['template_kind'] ?? null;
+        $kind = \is_string($value) ? CatalogTemplateKind::tryFrom($value) : null;
+        if (null === $kind) {
+            throw new BadRequestHttpException('template_kind is required (sheet|grid|pricelist).');
+        }
+
+        return $kind;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function parseRenderer(array $payload): string
+    {
+        $value = $payload['renderer'] ?? 'auto';
+
+        return \is_string($value) && '' !== $value ? $value : 'auto';
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<mixed, mixed>
+     */
+    private function parseArray(array $payload, string $key): array
+    {
+        $value = $payload[$key] ?? null;
+
+        return \is_array($value) ? $value : [];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<mixed, mixed>|null
+     */
+    private function parseOptionalArray(array $payload, string $key): ?array
+    {
+        $value = $payload[$key] ?? null;
+
+        return \is_array($value) ? $value : null;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return list<array<mixed, mixed>>
+     */
+    private function parseMappings(array $payload): array
+    {
+        $value = $payload['field_mappings'] ?? null;
+
+        return \is_array($value)
+            ? array_values(array_filter($value, \is_array(...)))
+            : [];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function parseString(array $payload, string $key): string
+    {
+        $value = $payload[$key] ?? null;
+        if (!\is_string($value) || '' === $value) {
+            throw new BadRequestHttpException(sprintf('%s is required (non-empty string).', $key));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function parseOptionalString(array $payload, string $key): ?string
+    {
+        $value = $payload[$key] ?? null;
+
+        return \is_string($value) && '' !== $value ? $value : null;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function parseUuid(array $payload, string $key): Uuid
+    {
+        $value = $payload[$key] ?? null;
+        if (!\is_string($value) || !Uuid::isValid($value)) {
+            throw new BadRequestHttpException(sprintf('%s is required (UUID).', $key));
+        }
+
+        return Uuid::fromString($value);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function parseOptionalUuid(array $payload, string $key): ?Uuid
+    {
+        $value = $payload[$key] ?? null;
+        if (null === $value || '' === $value) {
+            return null;
+        }
+        if (!\is_string($value) || !Uuid::isValid($value)) {
+            throw new BadRequestHttpException(sprintf('%s must be a UUID when provided.', $key));
+        }
+
+        return Uuid::fromString($value);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(Request $request): array
+    {
+        $body = $request->getContent();
+        if ('' === $body) {
+            return [];
+        }
+        $decoded = json_decode($body, true);
+        if (!\is_array($decoded)) {
+            throw new BadRequestHttpException('Request body must be a JSON object.');
+        }
+        $payload = [];
+        foreach ($decoded as $key => $value) {
+            if (!\is_string($key)) {
+                throw new BadRequestHttpException('Request body must be a JSON object (string keys).');
+            }
+            $payload[$key] = $value;
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serialize(CatalogProfile $catalog): array
+    {
+        return [
+            'id' => $catalog->getId()->toRfc4122(),
+            'code' => $catalog->getCode(),
+            'name' => $catalog->getName(),
+            'template_kind' => $catalog->getTemplateKind()->value,
+            'object_type_id' => $catalog->getObjectTypeId()->toRfc4122(),
+            'status' => $catalog->getStatus()->value,
+            'branding' => $catalog->getBranding(),
+            'field_mappings' => $catalog->getFieldMappings(),
+            'filter' => $catalog->getFilter(),
+            'channel_id' => $catalog->getChannelId()?->toRfc4122(),
+            'publication_channel' => $catalog->getPublicationChannel(),
+            'locale' => $catalog->getLocale(),
+            'renderer' => $catalog->getRenderer(),
+            'cached_file_size' => $catalog->getCachedFileSize(),
+            'cached_page_count' => $catalog->getCachedPageCount(),
+            'cached_at' => $catalog->getCachedAt()?->format(DateTimeInterface::ATOM),
+            // The plaintext token is never persisted; the hub only needs to know
+            // whether a URL exists to offer rotate vs mint copy.
+            'has_token' => null !== $catalog->getTokenHash(),
+            'created_at' => $catalog->getCreatedAt()->format(DateTimeInterface::ATOM),
+            'updated_at' => $catalog->getUpdatedAt()->format(DateTimeInterface::ATOM),
+        ];
+    }
+}

--- a/apps/api/tests/Api/Export/Catalog/CatalogProfileControllerApiTest.php
+++ b/apps/api/tests/Api/Export/Catalog/CatalogProfileControllerApiTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Export\Catalog;
+
+use App\Catalog\Domain\ObjectKind;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * CPDF-P1-03 — CatalogProfile CRUD (POST/GET/PATCH/DELETE /api/catalogs).
+ *
+ * Mirrors {@see \App\Tests\Api\Export\FeedProfileCrudApiTest} but for the PDF
+ * catalog surface, sharing the export RBAC (`exports.view_all` on reads,
+ * `integration.admin` on writes). Adds the auth-boundary cases the ticket
+ * requires: 401 (anonymous), 403 (a `marketing` persona that holds neither the
+ * read nor the write export grant), 404 (missing id) and body validation.
+ */
+final class CatalogProfileControllerApiTest extends CatalogApiTestCase
+{
+    private const string MARKETING_EMAIL = 'marketing-cpdf@demo.localhost';
+
+    /** @return array<string, mixed> */
+    private function payload(): array
+    {
+        return [
+            'template_kind' => 'sheet',
+            'code' => 'b2b_catalog',
+            'name' => 'Katalog B2B — Stalko',
+            'object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+            'branding' => ['palette' => ['primary' => '#0a0a0a']],
+            'field_mappings' => [['slot' => 'title', 'source' => ['kind' => 'attribute', 'ref' => 'name']]],
+            'filter' => ['op' => 'and', 'conditions' => []],
+            'locale' => 'pl',
+            'renderer' => 'auto',
+        ];
+    }
+
+    #[Test]
+    public function createsListsGetsPatchesAndDeletesACatalog(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $created = $client->request('POST', '/api/catalogs', ['json' => $this->payload()]);
+        self::assertSame(201, $created->getStatusCode());
+        $body = $created->toArray(false);
+        self::assertSame('b2b_catalog', $body['code']);
+        self::assertSame('sheet', $body['template_kind']);
+        self::assertSame('active', $body['status']);
+        self::assertSame('pl', $body['locale']);
+        self::assertFalse($body['has_token']);
+        self::assertArrayNotHasKey('token_hash', $body);
+        $id = $body['id'];
+        self::assertIsString($id);
+
+        $listResponse = $client->request('GET', '/api/catalogs');
+        self::assertSame(200, $listResponse->getStatusCode());
+        $items = $listResponse->toArray(false)['items'];
+        self::assertIsArray($items);
+        self::assertNotEmpty($items);
+        self::assertContains($id, array_column($items, 'id'));
+        self::assertStringNotContainsString('token_hash', $listResponse->getContent(false));
+
+        $get = $client->request('GET', '/api/catalogs/'.$id);
+        self::assertSame(200, $get->getStatusCode());
+
+        $patched = $client->request('PATCH', '/api/catalogs/'.$id, [
+            'json' => ['name' => 'Katalog B2B — v2', 'template_kind' => 'grid', 'status' => 'paused'],
+        ]);
+        self::assertSame(200, $patched->getStatusCode());
+        $patchedBody = $patched->toArray(false);
+        self::assertSame('Katalog B2B — v2', $patchedBody['name']);
+        self::assertSame('grid', $patchedBody['template_kind']);
+        self::assertSame('paused', $patchedBody['status']);
+        self::assertArrayNotHasKey('token_hash', $patchedBody);
+
+        self::assertSame(204, $client->request('DELETE', '/api/catalogs/'.$id)->getStatusCode());
+        self::assertSame(404, $client->request('GET', '/api/catalogs/'.$id)->getStatusCode());
+    }
+
+    #[Test]
+    public function rejectsAMissingCode(): void
+    {
+        $client = $this->authenticatedClient();
+        $payload = $this->payload();
+        unset($payload['code']);
+
+        self::assertSame(400, $client->request('POST', '/api/catalogs', ['json' => $payload])->getStatusCode());
+    }
+
+    #[Test]
+    public function rejectsAnUnknownTemplateKind(): void
+    {
+        $client = $this->authenticatedClient();
+        $payload = $this->payload();
+        $payload['code'] = 'bad_kind_catalog';
+        $payload['template_kind'] = 'not_a_kind';
+
+        self::assertSame(400, $client->request('POST', '/api/catalogs', ['json' => $payload])->getStatusCode());
+    }
+
+    #[Test]
+    public function unknownIdIsA404(): void
+    {
+        $client = $this->authenticatedClient();
+
+        self::assertSame(
+            404,
+            $client->request('GET', '/api/catalogs/00000000-0000-7000-8000-000000000000')->getStatusCode(),
+        );
+    }
+
+    #[Test]
+    public function anonymousRequestsAre401(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/api/catalogs');
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    #[Test]
+    public function aPersonaWithoutTheExportGrantsIsForbidden(): void
+    {
+        $marketingJwt = $this->seedMarketingUser();
+        // API Platform's test client only supports a single active kernel —
+        // swap the Bearer per request rather than calling createClient() twice.
+        $client = static::createClient();
+        $adminJwt = $this->jwtFor(self::ADMIN_EMAIL);
+
+        // Admin creates a catalog to target (super_admin holds every grant).
+        $created = $client->request('POST', '/api/catalogs', [
+            'headers' => ['authorization' => 'Bearer '.$adminJwt, 'content-type' => 'application/json'],
+            'body' => json_encode($this->payload(), JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(201);
+        $id = $created->toArray()['id'];
+        \assert(\is_string($id));
+
+        // Marketing lacks exports.view_all → read endpoints refuse with 403.
+        $client->request('GET', '/api/catalogs', [
+            'headers' => ['authorization' => 'Bearer '.$marketingJwt],
+        ]);
+        self::assertResponseStatusCodeSame(403);
+
+        $client->request('GET', '/api/catalogs/'.$id, [
+            'headers' => ['authorization' => 'Bearer '.$marketingJwt],
+        ]);
+        self::assertResponseStatusCodeSame(403);
+
+        // Marketing lacks integration.admin → write endpoints refuse with 403.
+        $writePayload = $this->payload();
+        $writePayload['code'] = 'marketing_denied';
+        $client->request('POST', '/api/catalogs', [
+            'headers' => ['authorization' => 'Bearer '.$marketingJwt, 'content-type' => 'application/json'],
+            'body' => json_encode($writePayload, JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(403);
+
+        $client->request('DELETE', '/api/catalogs/'.$id, [
+            'headers' => ['authorization' => 'Bearer '.$marketingJwt],
+        ]);
+        self::assertResponseStatusCodeSame(403);
+
+        // The denied write changed nothing — the admin still sees the catalog.
+        $client->request('GET', '/api/catalogs/'.$id, [
+            'headers' => ['authorization' => 'Bearer '.$adminJwt],
+        ]);
+        self::assertResponseStatusCodeSame(200);
+    }
+
+    private function jwtFor(string $email): string
+    {
+        $user = self::getContainer()->get(UserRepositoryInterface::class)->findByEmail($email);
+        \assert($user instanceof User);
+
+        return self::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+    }
+
+    private function seedMarketingUser(): string
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $marketing = self::getContainer()->get(RoleRepositoryInterface::class)
+            ->findByCode('marketing', $tenant);
+        \assert(null !== $marketing, 'marketing role must be seeded per tenant');
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $stub = new User($tenant, self::MARKETING_EMAIL, '', ['ROLE_USER']);
+        $user = new User($tenant, self::MARKETING_EMAIL, $hasher->hashPassword($stub, 'changeme'), ['ROLE_USER']);
+        $user->addRole($marketing);
+        $em->persist($user);
+        $em->flush();
+
+        return self::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -11879,6 +11879,169 @@
                 "x-cortex-permission": "products.bulk_operations"
             }
         },
+        "/api/catalogs": {
+            "get": {
+                "operationId": "api_catalogs_get",
+                "tags": [
+                    "catalogs"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api catalogs",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "exports.view_all"
+            },
+            "post": {
+                "operationId": "api_catalogs_post",
+                "tags": [
+                    "catalogs"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api catalogs",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "integration.admin"
+            }
+        },
+        "/api/catalogs/{id}": {
+            "get": {
+                "operationId": "api_catalogs_id_get",
+                "tags": [
+                    "catalogs"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api catalogs id",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "exports.view_all"
+            },
+            "delete": {
+                "operationId": "api_catalogs_id_delete",
+                "tags": [
+                    "catalogs"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api catalogs id",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "integration.admin"
+            },
+            "patch": {
+                "operationId": "api_catalogs_id_patch",
+                "tags": [
+                    "catalogs"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api catalogs id",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "integration.admin"
+            }
+        },
         "/api/categories/{id}/attribute_groups": {
             "get": {
                 "operationId": "api_categories_id_attribute_groups_get",


### PR DESCRIPTION
Zamyka **CPDF-P1-03** (#2288). Blocked by P1-01/P1-02 (merged). Odblokowuje CPDF-P4-02 (OpenAPI lockdown), CPDF-P5-02 (kreator FE).

## Co

- `CatalogProfileController` (custom `#[Route]`, `/api/catalogs`): list/create/get/patch/delete. Kalka `FeedProfileController`.
- Body create/patch w kształcie Catalog: `template_kind` (sheet/grid/pricelist), `branding`, `field_mappings`, `filter`, scope (`channel_id`/`publication_channel`/`locale`), `renderer`. Serializacja **bez `token_hash`** (zamiast tego `has_token` bool).
- Custom trasy dorzucone do `docs/api-spec/v0.json`.

## RBAC (świadoma decyzja — bez nowego modułu)

Read → `#[RequiresPermission(module:'exports', action:'view_all')]`, write → `(module:'integration', action:'admin')` — **dokładnie jak `FeedProfileController`**. Katalogi PDF żyją w rodzinie Export (`src/Export/Catalog`), więc gejtowanie pod `exports`/`integration` jest spójne i **nie wprowadza nowej powierzchni RBAC**. System uprawnień to kody per-rola (`PrdRoleTemplates`), bez centralnego rejestru modułów — dodanie kodu `catalogs_pdf.*` dotknęłoby role/fixtures/FE/testy (klasa zmian, przed którą przestrzega re-audit RBAC). Dedykowany moduł można dodać później (P4-02) jeśli operator chce granularnej separacji; menu-gate P5-05 zgejtuję na `exports.view_all`.

## Walidacja (kontener `pim-api-1`, PHP 8.4, real Postgres)

- **ApiTestCase** `CatalogProfileControllerApiTest`: **6 testów, 31 asercji** — 401 (brak auth), **403** (persona `marketing` bez `exports.view_all`/`integration.admin` na read i write), 404, walidacja (bad `template_kind`/brak `code`), happy path (create 201 → list → get → patch → delete 204). Asercja: `token_hash` nigdy w odpowiedzi.
- **PHPStan max** (pełny, 2G): No errors. **Deptrac**: 0. **php-cs-fixer**: czysto. **OpenAPI**: `/api/catalogs` + `/api/catalogs/{id}` w v0.json (regen `APP_DEBUG=0` jak CI).

Refs #2288