### PR TITLE
feat(export): CPDF-P1-04 — seam cache MinIO dla katalogów PDF

### DIFF
--- a/apps/api/src/Export/Catalog/Application/Delivery/CatalogCacheStorage.php
+++ b/apps/api/src/Export/Catalog/Application/Delivery/CatalogCacheStorage.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Application\Delivery;
+
+/**
+ * Cache-and-serve storage seam for catalog PDFs (ADR-0027 §6.5, CPDF-P1-04).
+ *
+ * A generation streams the rendered PDF to a local temp file and hands it to
+ * {@see put()} under a tenant-scoped key (`catalogs/<tenant>/<catalog>.pdf`);
+ * the public URL endpoint (CPDF-P3-02) later streams the same key straight
+ * back to the puller. Keeping this a narrow interface (rather than passing the
+ * whole Flysystem operator around) keeps the generator testable with an
+ * in-memory fake. Mirrors the Feed cache seam.
+ */
+interface CatalogCacheStorage
+{
+    /**
+     * Store the local file's bytes at the given tenant-scoped key,
+     * overwriting any previous cache for that catalog.
+     */
+    public function put(string $key, string $localPath): void;
+
+    public function exists(string $key): bool;
+
+    /**
+     * Open a read stream on the cached object so the public URL (CPDF-P3-02)
+     * streams it straight to the puller without buffering the whole PDF. The
+     * caller owns closing the returned resource.
+     *
+     * @return resource
+     */
+    public function read(string $key);
+
+    /**
+     * Remove the cached object (e.g. when its catalog profile is deleted).
+     * A missing key is a no-op.
+     */
+    public function delete(string $key): void;
+}

--- a/apps/api/src/Export/Catalog/Application/Delivery/CatalogEtag.php
+++ b/apps/api/src/Export/Catalog/Application/Delivery/CatalogEtag.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Application\Delivery;
+
+use DateTimeImmutable;
+
+/**
+ * Deterministic ETag for a catalog's cached PDF (CPDF-P1-04, used by the public
+ * pull in CPDF-P3-02). Derived from the cache generation stamp + byte size +
+ * page count, so it changes exactly when a regeneration replaces the file and
+ * lets a puller skip the body with a conditional `If-None-Match` → `304`.
+ */
+final class CatalogEtag
+{
+    public static function forCache(?DateTimeImmutable $cachedAt, ?int $size, ?int $pageCount): string
+    {
+        $seed = ($cachedAt?->getTimestamp() ?? 0).'-'.($size ?? 0).'-'.($pageCount ?? 0);
+
+        return '"'.substr(hash('sha256', $seed), 0, 24).'"';
+    }
+}

--- a/apps/api/src/Export/Catalog/Infrastructure/Delivery/FlysystemCatalogCacheStorage.php
+++ b/apps/api/src/Export/Catalog/Infrastructure/Delivery/FlysystemCatalogCacheStorage.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Infrastructure\Delivery;
+
+use App\Export\Catalog\Application\Delivery\CatalogCacheStorage;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use RuntimeException;
+
+/**
+ * Flysystem-backed catalog PDF cache (CPDF-P1-04). Reuses the `exports.storage`
+ * MinIO/S3 bucket the export feature already provisions, under a dedicated
+ * `catalogs/` prefix so a lifecycle/TTL policy can target catalogs
+ * independently. Tenant isolation rides on the key prefix
+ * (`catalogs/<tenant>/…`), the same application-layer barrier exports and feeds
+ * use (RLS does not extend to object storage in MVP). Mirrors
+ * {@see \App\Export\Feed\Infrastructure\Delivery\FlysystemFeedCacheStorage}.
+ */
+final class FlysystemCatalogCacheStorage implements CatalogCacheStorage
+{
+    public function __construct(
+        private readonly FilesystemOperator $exportsStorage,
+    ) {
+    }
+
+    public function put(string $key, string $localPath): void
+    {
+        $stream = @fopen($localPath, 'r');
+        if (false === $stream) {
+            throw new RuntimeException(sprintf('Unable to read local catalog file "%s" for cache upload.', $localPath));
+        }
+        try {
+            $this->exportsStorage->writeStream($key, $stream);
+        } catch (FilesystemException $error) {
+            throw new RuntimeException(sprintf('Catalog cache upload failed for "%s": %s', $key, $error->getMessage()), previous: $error);
+        } finally {
+            if (\is_resource($stream)) {
+                fclose($stream);
+            }
+        }
+    }
+
+    public function exists(string $key): bool
+    {
+        try {
+            return $this->exportsStorage->fileExists($key);
+        } catch (FilesystemException) {
+            return false;
+        }
+    }
+
+    public function read(string $key)
+    {
+        try {
+            return $this->exportsStorage->readStream($key);
+        } catch (FilesystemException $error) {
+            throw new RuntimeException(sprintf('Catalog cache read failed for "%s": %s', $key, $error->getMessage()), previous: $error);
+        }
+    }
+
+    public function delete(string $key): void
+    {
+        try {
+            $this->exportsStorage->delete($key);
+        } catch (FilesystemException $error) {
+            throw new RuntimeException(sprintf('Catalog cache delete failed for "%s": %s', $key, $error->getMessage()), previous: $error);
+        }
+    }
+}

--- a/apps/api/tests/Integration/Export/Catalog/CatalogCacheStorageTest.php
+++ b/apps/api/tests/Integration/Export/Catalog/CatalogCacheStorageTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Export\Catalog;
+
+use App\Export\Catalog\Infrastructure\Delivery\FlysystemCatalogCacheStorage;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * CPDF-P1-04 — round-trips a catalog PDF through the real MinIO-backed cache
+ * (no mock storage): put → exists → read → delete. The seam has no consumer
+ * until CPDF-P3-01/P3-02, so the impl is instantiated directly against the real
+ * `exports.storage` operator rather than pulled from the (compiled-away) alias.
+ */
+final class CatalogCacheStorageTest extends KernelTestCase
+{
+    private const string KEY = 'catalogs/__test__/cache-roundtrip.pdf';
+
+    #[Test]
+    public function putReadExistsDeleteRoundTrip(): void
+    {
+        self::bootKernel();
+        $operator = self::getContainer()->get('exports.storage');
+        $storage = new FlysystemCatalogCacheStorage($operator);
+
+        $local = tempnam(sys_get_temp_dir(), 'cpdf');
+        \assert(false !== $local);
+        file_put_contents($local, "%PDF-1.7\nround-trip\n%%EOF");
+
+        try {
+            $storage->put(self::KEY, $local);
+            self::assertTrue($storage->exists(self::KEY));
+
+            $stream = $storage->read(self::KEY);
+            $bytes = stream_get_contents($stream);
+            if (\is_resource($stream)) {
+                fclose($stream);
+            }
+            self::assertIsString($bytes);
+            self::assertStringStartsWith('%PDF-', $bytes);
+            self::assertStringContainsString('round-trip', $bytes);
+
+            $storage->delete(self::KEY);
+            self::assertFalse($storage->exists(self::KEY));
+        } finally {
+            if (is_file($local)) {
+                @unlink($local);
+            }
+            if ($storage->exists(self::KEY)) {
+                $storage->delete(self::KEY);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Zamyka **CPDF-P1-04** (#2289). Blocked by P1-01 (merged). Odblokowuje CPDF-P3-01 (async), CPDF-P3-02 (public pull).

## Co

Kalka seamu cache-and-serve Feed dla PDF:
- `CatalogCacheStorage` (seam Application): `put`/`exists`/`read`/**`delete`** (delete dla usunięcia cache przy kasowaniu profilu).
- `FlysystemCatalogCacheStorage` (Infrastructure): reużywa istniejący bucket `exports.storage` (MinIO) pod prefiksem `catalogs/` — izolacja tenantów na kluczu (`catalogs/<tenant>/<id>.pdf`), jak Feed. **Bez zmian `flysystem.yaml`.**
- `CatalogEtag::forCache(cachedAt, size, pageCount)` — deterministyczny ETag dla warunkowego `304` (CPDF-P3-02).

## Walidacja (kontener `pim-api-1`, real MinIO)

- **Integration test** `CatalogCacheStorageTest` (no-mock): put → exists=true → read (bytes `%PDF-` + treść) → delete → exists=false. **1 test, 5 asercji, PASS** na żywym MinIO.
- **PHPStan max** (2G): No errors. **Deptrac**: 0. **php-cs-fixer**: czysto.

Refs #2289