### PR TITLE
feat(export): CPDF-P2-01 — CatalogTemplateCatalog + archetyp sheet + brand tokens

### DIFF
--- a/apps/api/src/Export/Catalog/Application/CatalogBrandingGuard.php
+++ b/apps/api/src/Export/Catalog/Application/CatalogBrandingGuard.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Application;
+
+use App\Export\Catalog\Domain\Template\CatalogTemplate;
+
+/**
+ * Validates a catalog profile's branding and field mappings before they are
+ * persisted or used to render (ADR-0027, CPDF-P2-01). Brand colours are
+ * injected verbatim into the Twig `<style>` block, so a malformed colour must
+ * never reach the template; likewise mappings may only bind template slots.
+ */
+final class CatalogBrandingGuard
+{
+    private const string COLOR_PATTERN = '/^#[0-9a-fA-F]{6}$/';
+
+    /**
+     * @param array<string, mixed> $branding
+     *
+     * @throws InvalidBrandingException
+     */
+    public function assertValidBranding(array $branding): void
+    {
+        if (array_key_exists('color', $branding)) {
+            $color = $branding['color'];
+            if (!\is_string($color) || 1 !== preg_match(self::COLOR_PATTERN, $color)) {
+                throw new InvalidBrandingException('Branding "color" must be a #RRGGBB hex string.');
+            }
+        }
+
+        if (array_key_exists('logo', $branding)) {
+            $logo = $branding['logo'];
+            if (!\is_string($logo) || '' === $logo) {
+                throw new InvalidBrandingException('Branding "logo" must be a non-empty string.');
+            }
+        }
+
+        if (array_key_exists('company_name', $branding) && !\is_string($branding['company_name'])) {
+            throw new InvalidBrandingException('Branding "company_name" must be a string.');
+        }
+    }
+
+    /**
+     * @param list<array{slot: string, source: string}> $fieldMappings
+     *
+     * @throws InvalidBrandingException
+     */
+    public function assertMappingsMatchTemplate(array $fieldMappings, CatalogTemplate $template): void
+    {
+        $slotNames = $template->slotNames();
+
+        foreach ($fieldMappings as $mapping) {
+            if (!\in_array($mapping['slot'], $slotNames, true)) {
+                throw new InvalidBrandingException(sprintf(
+                    'Mapping slot "%s" is not exposed by template "%s".',
+                    $mapping['slot'],
+                    $template->kind->value,
+                ));
+            }
+        }
+    }
+}

--- a/apps/api/src/Export/Catalog/Application/InvalidBrandingException.php
+++ b/apps/api/src/Export/Catalog/Application/InvalidBrandingException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Application;
+
+use RuntimeException;
+
+/**
+ * Raised by {@see CatalogBrandingGuard} when a profile's branding or its
+ * field mappings are malformed (ADR-0027, CPDF-P2-01).
+ */
+final class InvalidBrandingException extends RuntimeException
+{
+}

--- a/apps/api/src/Export/Catalog/Domain/Template/CatalogTemplate.php
+++ b/apps/api/src/Export/Catalog/Domain/Template/CatalogTemplate.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Domain\Template;
+
+use App\Export\Catalog\Domain\Enum\CatalogTemplateKind;
+
+/**
+ * A built-in catalog PDF template (ADR-0027, CPDF-P2-01): the Twig archetype
+ * plus the named slots it exposes and the default slot->attribute bindings
+ * cloned into a CatalogProfile when a user creates a catalog from the template.
+ * Held in code (not a DB table) so predefs are versioned with the app, mirroring
+ * {@see \App\Export\Feed\Domain\Template\FeedTemplate}.
+ */
+final class CatalogTemplate
+{
+    /**
+     * @param list<array{slot: string, label: string, format: string}> $slots           the named slots the template exposes
+     * @param list<array{slot: string, source: string}>                $defaultMappings default slot->attribute-code bindings
+     */
+    public function __construct(
+        public readonly CatalogTemplateKind $kind,
+        public readonly string $twig,
+        public readonly array $slots,
+        public readonly array $defaultMappings,
+    ) {
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function slotNames(): array
+    {
+        return array_map(static fn (array $slot): string => $slot['slot'], $this->slots);
+    }
+}

--- a/apps/api/src/Export/Catalog/Domain/Template/CatalogTemplateCatalog.php
+++ b/apps/api/src/Export/Catalog/Domain/Template/CatalogTemplateCatalog.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Domain\Template;
+
+use App\Export\Catalog\Domain\Enum\CatalogTemplateKind;
+
+/**
+ * The built-in catalog PDF templates (ADR-0027, CPDF-P2-01). MVP ships the
+ * `sheet` archetype (one product per page); `grid` and `pricelist` arrive in
+ * M6 and raise {@see TemplateNotAvailableException} until then. Mirrors
+ * {@see \App\Export\Feed\Domain\Template\FeedTemplateCatalog}.
+ */
+final class CatalogTemplateCatalog
+{
+    public function get(CatalogTemplateKind $kind): CatalogTemplate
+    {
+        return match ($kind) {
+            CatalogTemplateKind::Sheet => $this->sheet(),
+            CatalogTemplateKind::Grid, CatalogTemplateKind::Pricelist => throw new TemplateNotAvailableException(
+                sprintf('Catalog template "%s" is not available yet; grid and pricelist archetypes arrive in M6.', $kind->value),
+            ),
+        };
+    }
+
+    /**
+     * @return list<CatalogTemplate>
+     */
+    public function all(): array
+    {
+        return [$this->sheet()];
+    }
+
+    private function sheet(): CatalogTemplate
+    {
+        $slots = [
+            ['slot' => 'title', 'label' => 'Product name', 'format' => 'text'],
+            ['slot' => 'sku', 'label' => 'SKU', 'format' => 'text'],
+            ['slot' => 'image', 'label' => 'Main image', 'format' => 'url'],
+            ['slot' => 'description', 'label' => 'Description', 'format' => 'richtext'],
+            ['slot' => 'price', 'label' => 'Price', 'format' => 'text'],
+            // Repeatable label/value rows rendered as a specification table.
+            ['slot' => 'specs', 'label' => 'Specification', 'format' => 'list'],
+        ];
+
+        $defaultMappings = [
+            ['slot' => 'title', 'source' => 'name'],
+            ['slot' => 'sku', 'source' => 'sku'],
+            ['slot' => 'image', 'source' => 'main_image'],
+            ['slot' => 'description', 'source' => 'description'],
+            ['slot' => 'price', 'source' => 'price'],
+        ];
+
+        return new CatalogTemplate(CatalogTemplateKind::Sheet, 'catalog/sheet.html.twig', $slots, $defaultMappings);
+    }
+}

--- a/apps/api/src/Export/Catalog/Domain/Template/TemplateNotAvailableException.php
+++ b/apps/api/src/Export/Catalog/Domain/Template/TemplateNotAvailableException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Domain\Template;
+
+use RuntimeException;
+
+/**
+ * Raised when a template kind is requested whose archetype is not yet shipped
+ * (ADR-0027, CPDF-P2-01): grid and pricelist archetypes arrive in M6.
+ */
+final class TemplateNotAvailableException extends RuntimeException
+{
+}

--- a/apps/api/templates/catalog/sheet.html.twig
+++ b/apps/api/templates/catalog/sheet.html.twig
@@ -1,0 +1,144 @@
+{#
+  Catalog PDF — "sheet" archetype (ADR-0027, CPDF-P2-01): one branded product
+  data sheet per page. Rendered to HTML here, then to PDF by the Dompdf-backed
+  PdfRenderer (CPDF-P2-03).
+
+  Dompdf-safe CSS only: CSS 2.1 subset — no flexbox, no grid, no CSS custom
+  properties (Dompdf does not resolve `var(--x)` reliably). Brand colours are
+  injected by interpolating Twig values straight into the <style> block below,
+  NOT via `var()`.
+
+  The template receives exactly two variables:
+    - branding: map (company_name?, logo?, color?)
+    - products: list of maps keyed by slot name (title/sku/image/description/price/specs)
+
+  strict_variables is ON in the test env, so every variable access is guarded
+  with `|default(...)` or `is defined`.
+#}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        body {
+            font-family: DejaVu Sans, sans-serif;
+            color: #111827;
+            margin: 0;
+        }
+        .sheet {
+            padding: 32px;
+            page-break-after: always;
+        }
+        .sheet-last {
+            page-break-after: auto;
+        }
+        .sheet-header {
+            border-bottom: 3px solid {{ branding.color|default('#1d4ed8') }};
+            padding-bottom: 12px;
+            margin-bottom: 20px;
+        }
+        .sheet-header .company {
+            font-size: 18px;
+            font-weight: bold;
+            color: {{ branding.color|default('#1d4ed8') }};
+        }
+        .sheet-header .logo {
+            max-height: 48px;
+        }
+        .product-image {
+            text-align: center;
+            margin-bottom: 20px;
+        }
+        .product-image img {
+            max-width: 100%;
+            max-height: 340px;
+        }
+        .product-title {
+            font-size: 24px;
+            font-weight: bold;
+            margin: 0 0 6px 0;
+        }
+        .product-sku {
+            font-size: 12px;
+            color: #6b7280;
+            margin-bottom: 12px;
+        }
+        .product-price {
+            font-size: 20px;
+            font-weight: bold;
+            color: {{ branding.color|default('#1d4ed8') }};
+            margin-bottom: 16px;
+        }
+        .product-description {
+            margin-bottom: 20px;
+            line-height: 1.5;
+        }
+        .specs {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        .specs td {
+            border-bottom: 1px solid #e5e7eb;
+            padding: 6px 8px;
+            font-size: 13px;
+        }
+        .specs td.spec-label {
+            font-weight: bold;
+            width: 40%;
+            color: #374151;
+        }
+        .sheet-footer {
+            border-top: 1px solid #e5e7eb;
+            margin-top: 24px;
+            padding-top: 8px;
+            font-size: 11px;
+            color: #9ca3af;
+        }
+    </style>
+</head>
+<body>
+    {% for product in products %}
+        <div class="sheet{% if loop.last %} sheet-last{% endif %}">
+            <div class="sheet-header">
+                {% if branding.logo is defined and branding.logo %}
+                    <img class="logo" src="{{ branding.logo }}" alt="">
+                {% endif %}
+                <span class="company">{{ branding.company_name|default('') }}</span>
+            </div>
+
+            {% if product.image is defined and product.image %}
+                <div class="product-image">
+                    <img src="{{ product.image }}" alt="">
+                </div>
+            {% endif %}
+
+            <h1 class="product-title">{{ product.title|default('') }}</h1>
+            <div class="product-sku">{{ product.sku|default('') }}</div>
+
+            {% if product.price is defined and product.price %}
+                <div class="product-price">{{ product.price }}</div>
+            {% endif %}
+
+            {% if product.description is defined and product.description %}
+                {# Already sanitised upstream by HtmlValueSanitizer — safe to print raw. #}
+                <div class="product-description">{{ product.description|raw }}</div>
+            {% endif %}
+
+            {% if product.specs is defined and product.specs %}
+                <table class="specs">
+                    {% for row in product.specs %}
+                        <tr>
+                            <td class="spec-label">{{ row.label|default('') }}</td>
+                            <td class="spec-value">{{ row.value|default('') }}</td>
+                        </tr>
+                    {% endfor %}
+                </table>
+            {% endif %}
+
+            <div class="sheet-footer">
+                {{ branding.company_name|default('') }} &mdash; {{ loop.index }} / {{ loop.length }}
+            </div>
+        </div>
+    {% endfor %}
+</body>
+</html>

--- a/apps/api/tests/Integration/Export/Catalog/SheetTemplateRenderTest.php
+++ b/apps/api/tests/Integration/Export/Catalog/SheetTemplateRenderTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Export\Catalog;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Twig\Environment;
+
+/**
+ * CPDF-P2-01 — renders the sheet archetype through the real Twig environment
+ * (strict_variables ON) to prove the template is valid and that brand tokens
+ * are injected into the <style> block. Deliberately does NOT touch the Dompdf
+ * PdfRenderer — that lands in CPDF-P2-03.
+ */
+final class SheetTemplateRenderTest extends KernelTestCase
+{
+    #[Test]
+    public function rendersSheetWithBrandColourAndSpecs(): void
+    {
+        self::bootKernel();
+        $twig = self::getContainer()->get('twig');
+        self::assertInstanceOf(Environment::class, $twig);
+
+        $html = $twig->render('catalog/sheet.html.twig', [
+            'branding' => [
+                'color' => '#0ea5e9',
+                'company_name' => 'ACME',
+                'logo' => null,
+            ],
+            'products' => [
+                [
+                    'title' => 'Wiertarka X1',
+                    'sku' => 'SKU-001',
+                    'image' => null,
+                    'description' => '<strong>Opis</strong>',
+                    'price' => '199,00 zł',
+                    'specs' => [
+                        ['label' => 'Waga', 'value' => '2kg'],
+                    ],
+                ],
+            ],
+        ]);
+
+        // Brand colour injected verbatim into the <style> block (not via CSS var).
+        self::assertStringContainsString('#0ea5e9', $html);
+        self::assertStringContainsString('Wiertarka X1', $html);
+        self::assertStringContainsString('Waga', $html);
+    }
+}

--- a/apps/api/tests/Unit/Export/Catalog/CatalogBrandingGuardTest.php
+++ b/apps/api/tests/Unit/Export/Catalog/CatalogBrandingGuardTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export\Catalog;
+
+use App\Export\Catalog\Application\CatalogBrandingGuard;
+use App\Export\Catalog\Application\InvalidBrandingException;
+use App\Export\Catalog\Domain\Enum\CatalogTemplateKind;
+use App\Export\Catalog\Domain\Template\CatalogTemplateCatalog;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * CPDF-P2-01 — the branding guard accepts well-formed branding and mappings and
+ * rejects a malformed brand colour or a mapping that targets an unknown slot.
+ */
+final class CatalogBrandingGuardTest extends TestCase
+{
+    #[Test]
+    public function acceptsValidBranding(): void
+    {
+        $guard = new CatalogBrandingGuard();
+
+        $guard->assertValidBranding([
+            'color' => '#0ea5e9',
+            'company_name' => 'ACME',
+            'logo' => 'https://cdn.example.test/logo.png',
+            'unknown_key' => 'ignored',
+        ]);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function rejectsNonHexColour(): void
+    {
+        $this->expectException(InvalidBrandingException::class);
+        new CatalogBrandingGuard()->assertValidBranding(['color' => 'notahex']);
+    }
+
+    #[Test]
+    public function rejectsEmptyLogo(): void
+    {
+        $this->expectException(InvalidBrandingException::class);
+        new CatalogBrandingGuard()->assertValidBranding(['logo' => '']);
+    }
+
+    #[Test]
+    public function rejectsMappingToUnknownSlot(): void
+    {
+        $template = new CatalogTemplateCatalog()->get(CatalogTemplateKind::Sheet);
+
+        $this->expectException(InvalidBrandingException::class);
+        new CatalogBrandingGuard()->assertMappingsMatchTemplate(
+            [['slot' => 'nope', 'source' => 'whatever']],
+            $template,
+        );
+    }
+
+    #[Test]
+    public function acceptsMappingToRealSlot(): void
+    {
+        $template = new CatalogTemplateCatalog()->get(CatalogTemplateKind::Sheet);
+
+        new CatalogBrandingGuard()->assertMappingsMatchTemplate(
+            [
+                ['slot' => 'title', 'source' => 'name'],
+                ['slot' => 'specs', 'source' => 'attributes'],
+            ],
+            $template,
+        );
+
+        $this->expectNotToPerformAssertions();
+    }
+}

--- a/apps/api/tests/Unit/Export/Catalog/CatalogTemplateCatalogTest.php
+++ b/apps/api/tests/Unit/Export/Catalog/CatalogTemplateCatalogTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export\Catalog;
+
+use App\Export\Catalog\Domain\Enum\CatalogTemplateKind;
+use App\Export\Catalog\Domain\Template\CatalogTemplateCatalog;
+use App\Export\Catalog\Domain\Template\TemplateNotAvailableException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * CPDF-P2-01 — the built-in catalog template catalog exposes the sheet
+ * archetype with its slots and default mappings, and rejects kinds whose
+ * archetype is not yet shipped.
+ */
+final class CatalogTemplateCatalogTest extends TestCase
+{
+    #[Test]
+    public function sheetExposesSixSlotsWithDefaultMappings(): void
+    {
+        $template = new CatalogTemplateCatalog()->get(CatalogTemplateKind::Sheet);
+
+        self::assertSame(CatalogTemplateKind::Sheet, $template->kind);
+        self::assertSame('catalog/sheet.html.twig', $template->twig);
+        self::assertSame(
+            ['title', 'sku', 'image', 'description', 'price', 'specs'],
+            $template->slotNames(),
+        );
+        self::assertCount(6, $template->slots);
+        self::assertCount(5, $template->defaultMappings);
+        self::assertContains(['slot' => 'title', 'source' => 'name'], $template->defaultMappings);
+        self::assertContains(['slot' => 'image', 'source' => 'main_image'], $template->defaultMappings);
+    }
+
+    #[Test]
+    public function allReturnsOnlyTheSheet(): void
+    {
+        $all = new CatalogTemplateCatalog()->all();
+
+        self::assertCount(1, $all);
+        self::assertSame(CatalogTemplateKind::Sheet, $all[0]->kind);
+    }
+
+    #[Test]
+    public function gridIsNotAvailableYet(): void
+    {
+        $this->expectException(TemplateNotAvailableException::class);
+        new CatalogTemplateCatalog()->get(CatalogTemplateKind::Grid);
+    }
+
+    #[Test]
+    public function pricelistIsNotAvailableYet(): void
+    {
+        $this->expectException(TemplateNotAvailableException::class);
+        new CatalogTemplateCatalog()->get(CatalogTemplateKind::Pricelist);
+    }
+}


### PR DESCRIPTION
Zamyka **CPDF-P2-01** (#2290). Blocked by P1-01 (merged). Odblokowuje CPDF-P2-02, CPDF-P2-03.

## Co
Jeden parametryzowalny silnik szablonu (decyzja #3): `CatalogTemplate` VO + `CatalogTemplateCatalog` (sheet built-in; grid/pricelist → `TemplateNotAvailableException` do M6); `templates/catalog/sheet.html.twig` (CSS 2.1 Dompdf-safe, brand colour wstrzyknięty prosto w `<style>` — Dompdf bez CSS custom properties; sloty title/sku/image/description/price/specs, wszystkie zmienne guarded pod `strict_variables`); `CatalogBrandingGuard` (hex/logo + field_mappings → realne sloty).

## Walidacja (kontener `pim-api-1`)
- **Testy 10/10** (18 asercji): template catalog, branding guard, oraz `SheetTemplateRenderTest` renderujący realny szablon przez `twig` service (HTML zawiera brand colour + slot).
- **PHPStan max** (2G) 0 · **Deptrac** 0 · **php-cs-fixer** czysto.

Refs #2290