### PR TITLE
feat(export): CPDF-P2-02 — ExportBuilder rows → sloty szablonu (mapper + scope seam)

### DIFF
--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -663,6 +663,14 @@ parameters:
             - App\Catalog\Domain\Entity\ObjectType
             - App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface
             - App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface
+        # CPDF-P2-02 — catalog PDF values adapter, same Export-core → Catalog\Domain
+        # reach as the feed values adapter above (reuses ExportBuilder + id resolution).
+        App\Export\Application\Catalog\ExportBuilderCatalogValues:
+            - App\Catalog\Application\Filter\FilterDslResolver
+            - App\Catalog\Domain\Entity\CatalogObject
+            - App\Catalog\Domain\Entity\ObjectType
+            - App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface
+            - App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface
         # APIC-P3-06 — outbound-sync reader reuses the Export ValueSerializer +
         # iterates catalog objects; same Export → Catalog\Domain reach as the
         # serializer/runner above (the implementation is Catalog-data-bound).

--- a/apps/api/src/Export/Application/Catalog/ExportBuilderCatalogValues.php
+++ b/apps/api/src/Export/Application/Catalog/ExportBuilderCatalogValues.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Application\Catalog;
+
+use App\Catalog\Application\Filter\FilterDslResolver;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Export\Application\Builder\ExportBuilder;
+use App\Export\Contracts\CatalogProductScope;
+use App\Export\Contracts\CatalogProductValues;
+use App\Export\Domain\Entity\ExportSession;
+use App\Export\Domain\Enum\ExportEntityType;
+use App\Export\Domain\Enum\ExportFormat;
+use App\Export\Domain\Enum\ExportSource;
+use App\Export\Domain\Enum\ExportTargetScope;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Generator;
+use RuntimeException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Export-core adapter that streams a catalog's product values through the existing
+ * {@see ExportBuilder} (ADR-0023 §6.3, CPDF-P2-02). It lives in Export core (not
+ * the Catalog sub-area) so it can reuse the catalog id-resolution + value builder
+ * the way {@see \App\Export\Application\Sync\SyncExportRunner} does; the catalog
+ * generator depends only on the {@see CatalogProductValues} seam.
+ *
+ * The catalog's scope becomes an in-memory {@see ExportSession} (never persisted);
+ * products are paged in CLEAR_INTERVAL keyset chunks with EntityManager::clear()
+ * between pages, so a 50k catalog stays memory-flat. Column keys are requested both
+ * bare and locale-scoped, then collapsed back to attribute codes for the mapper.
+ */
+final class ExportBuilderCatalogValues implements CatalogProductValues
+{
+    private const int CLEAR_INTERVAL = 200;
+
+    public function __construct(
+        private readonly ExportBuilder $builder,
+        private readonly CatalogObjectRepositoryInterface $objects,
+        private readonly ObjectTypeRepositoryInterface $objectTypes,
+        private readonly FilterDslResolver $filterDsl,
+        private readonly Connection $connection,
+        private readonly EntityManagerInterface $em,
+        private readonly TenantContext $tenantContext,
+    ) {
+    }
+
+    public function forScope(CatalogProductScope $scope): iterable
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new RuntimeException('Catalog generation requires a tenant context.');
+        }
+        $tenantId = $tenant->getId();
+
+        $objectType = $this->objectTypes->findById($scope->objectTypeId);
+        if (null === $objectType) {
+            throw new RuntimeException(sprintf('ObjectType "%s" was not found.', $scope->objectTypeId->toRfc4122()));
+        }
+
+        $columns = $this->columnKeys($scope);
+        $session = $this->session($scope, $columns);
+        $session->assignTenant($tenant);
+
+        $ids = null === $scope->filter
+            ? $this->objects->findRootObjectIds($objectType, $tenant)
+            : $this->filterIds($scope, $tenant, $objectType);
+
+        // CPDF-P2-02 — flat variants (plan §6.6): a master WITH variants is
+        // represented by its variants (each becomes its own row, carrying
+        // the master's SKU in the `parent_sku` built-in for item_group_id);
+        // a master without variants stays a single item. One grouped id query
+        // for the whole scope — the sync runner's emit-id-plan pattern.
+        $childIdsByParent = $this->objects->findChildIdsByParentIds($ids, $tenant);
+        $emitIds = [];
+        foreach ($ids as $id) {
+            $children = $childIdsByParent[$id] ?? [];
+            foreach ([] === $children ? [$id] : $children as $emitId) {
+                $emitIds[] = $emitId;
+            }
+        }
+
+        foreach (array_chunk($emitIds, self::CLEAR_INTERVAL) as $page) {
+            $this->reattachTenant($session, $tenantId);
+            foreach ($this->builder->build($this->hydrateInOrder($page), $session) as $row) {
+                yield $this->toAttributeMap($row, $scope);
+            }
+            $this->em->clear();
+            // clear() detaches the Tenant the caller's TenantContext holds; the
+            // catalog generator persists run rows (TenantScoped) after us and
+            // TenantAssignmentListener would otherwise assign a detached Tenant →
+            // "new entity found through relationship". Rebind a managed instance
+            // so downstream persists stay in the identity map.
+            $this->rebindTenantContext($tenantId);
+        }
+    }
+
+    private function rebindTenantContext(Uuid $tenantId): void
+    {
+        $tenant = $this->em->find(Tenant::class, $tenantId->toRfc4122());
+        if ($tenant instanceof Tenant) {
+            $this->tenantContext->set($tenant);
+        }
+    }
+
+    /**
+     * @param list<string> $columns
+     */
+    private function session(CatalogProductScope $scope, array $columns): ExportSession
+    {
+        return new ExportSession(
+            userId: Uuid::v7(),
+            source: ExportSource::SavedProfileRun,
+            format: ExportFormat::Xml,
+            targetScope: null === $scope->filter ? ExportTargetScope::All : ExportTargetScope::Filter,
+            selectedColumns: $columns,
+            filterSnapshot: $this->stringKeyed($scope->filter),
+            locales: null !== $scope->locale ? [$scope->locale] : null,
+            channels: null !== $scope->channel ? [$scope->channel] : null,
+            includeVariants: true,
+            entityType: ExportEntityType::Product,
+            objectTypeId: $scope->objectTypeId,
+        );
+    }
+
+    /**
+     * Request each attribute both bare and locale-scoped so the mapper can prefer
+     * the localized value and fall back to the global one.
+     *
+     * @return list<string>
+     */
+    private function columnKeys(CatalogProductScope $scope): array
+    {
+        $keys = [];
+        foreach ($scope->attributeCodes as $code) {
+            $keys[$code] = true;
+            if (null !== $scope->locale) {
+                $keys[$code.'.'.$scope->locale] = true;
+            }
+        }
+
+        return array_keys($keys);
+    }
+
+    /**
+     * @param array<string, string> $row
+     *
+     * @return array<string, string>
+     */
+    private function toAttributeMap(array $row, CatalogProductScope $scope): array
+    {
+        $item = [];
+        foreach ($scope->attributeCodes as $code) {
+            $localized = null !== $scope->locale ? ($row[$code.'.'.$scope->locale] ?? '') : '';
+            $item[$code] = '' !== $localized ? $localized : ($row[$code] ?? '');
+        }
+
+        return $item;
+    }
+
+    /**
+     * @param list<string> $idPage
+     *
+     * @return list<CatalogObject>
+     */
+    private function hydrateInOrder(array $idPage): array
+    {
+        $byId = [];
+        foreach ($this->objects->findByIds($idPage) as $object) {
+            $byId[$object->getId()->toRfc4122()] = $object;
+        }
+
+        $ordered = [];
+        foreach ($idPage as $id) {
+            if (isset($byId[$id])) {
+                $ordered[] = $byId[$id];
+            }
+        }
+
+        return $ordered;
+    }
+
+    /**
+     * The filter snapshot is a JSON object (string-keyed at runtime); narrow it
+     * for the ExportSession / FilterDslResolver which type it as array<string,mixed>.
+     *
+     * @param array<mixed, mixed>|null $filter
+     *
+     * @return array<string, mixed>|null
+     */
+    private function stringKeyed(?array $filter): ?array
+    {
+        if (null === $filter) {
+            return null;
+        }
+        $out = [];
+        foreach ($filter as $key => $value) {
+            if (\is_string($key)) {
+                $out[$key] = $value;
+            }
+        }
+
+        return $out;
+    }
+
+    private function reattachTenant(ExportSession $session, Uuid $tenantId): void
+    {
+        $tenant = $this->em->find(Tenant::class, $tenantId->toRfc4122());
+        if ($tenant instanceof Tenant) {
+            $session->rebindTenant($tenant);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function filterIds(CatalogProductScope $scope, Tenant $tenant, ObjectType $objectType): array
+    {
+        $dsl = $this->stringKeyed($scope->filter);
+        if (null === $dsl || [] === $dsl) {
+            return [];
+        }
+        $whereClause = $this->filterDsl->toCountSql($dsl);
+        if (null === $whereClause) {
+            throw new RuntimeException('Invalid filter DSL in catalog scope.');
+        }
+
+        $sql = 'SELECT co.id FROM objects co WHERE co.tenant_id = :tenant AND co.object_type_id = :otid AND ('.$whereClause.')';
+        $rows = $this->connection->fetchFirstColumn($sql, [
+            'tenant' => $tenant->getId()->toRfc4122(),
+            'otid' => $objectType->getId()->toRfc4122(),
+        ]);
+
+        $ids = [];
+        foreach ($rows as $id) {
+            if (\is_string($id)) {
+                $ids[] = $id;
+            }
+        }
+
+        return $ids;
+    }
+}

--- a/apps/api/src/Export/Catalog/Domain/Mapping/CatalogFieldMapping.php
+++ b/apps/api/src/Export/Catalog/Domain/Mapping/CatalogFieldMapping.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Domain\Mapping;
+
+/**
+ * One slot mapping (ADR-0023 §6.4, CPDF-P2-02): which source feeds a catalog
+ * template slot. Source kinds: `attribute` (a PIM attribute code), `static` (a
+ * fixed value), `template` (interpolation of other fields). Transforms are a
+ * deferred hook (plan §7), out of MVP scope — so there is no `transform` field.
+ */
+final class CatalogFieldMapping
+{
+    public function __construct(
+        public readonly string $slot,
+        public readonly ?string $sourceKind,
+        public readonly ?string $sourceRef,
+        public readonly ?string $sourceValue,
+    ) {
+    }
+
+    /**
+     * @param array<mixed, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $slot = \is_string($data['slot'] ?? null) ? $data['slot'] : '';
+
+        $source = \is_array($data['source'] ?? null) ? $data['source'] : [];
+        $kind = \is_string($source['kind'] ?? null) ? $source['kind'] : null;
+        $ref = \is_string($source['ref'] ?? null) ? $source['ref'] : null;
+        $value = \is_string($source['value'] ?? null) ? $source['value'] : null;
+
+        return new self($slot, $kind, $ref, $value);
+    }
+
+    /**
+     * Parse a persisted `field_mappings` list.
+     *
+     * @param array<mixed, mixed> $raw
+     *
+     * @return list<self>
+     */
+    public static function listFromArray(array $raw): array
+    {
+        $out = [];
+        foreach ($raw as $entry) {
+            if (\is_array($entry)) {
+                $out[] = self::fromArray($entry);
+            }
+        }
+
+        return $out;
+    }
+}

--- a/apps/api/src/Export/Catalog/Domain/Mapping/CatalogItemMapper.php
+++ b/apps/api/src/Export/Catalog/Domain/Mapping/CatalogItemMapper.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Domain\Mapping;
+
+/**
+ * Builds the template item map (slot target => value) from a product's raw
+ * attribute values (ADR-0023 §6.4, CPDF-P2-02). For each mapping it resolves the
+ * source (attribute / static / template). Transforms are a deferred hook (plan
+ * §7), out of MVP scope — the mapper is pure and dependency-free. The catalog
+ * generator feeds the result into the template slots.
+ */
+final class CatalogItemMapper
+{
+    /**
+     * @param list<CatalogFieldMapping> $mappings
+     * @param array<string, string>     $attributes raw attribute values keyed by attribute code
+     *
+     * @return array<string, string> slot target => resolved value
+     */
+    public function map(array $mappings, array $attributes): array
+    {
+        $item = [];
+        foreach ($mappings as $mapping) {
+            $item[$mapping->slot] = $this->resolveSource($mapping, $attributes);
+        }
+
+        return $item;
+    }
+
+    /**
+     * @param array<string, string> $attributes
+     */
+    private function resolveSource(CatalogFieldMapping $mapping, array $attributes): string
+    {
+        return match ($mapping->sourceKind) {
+            'attribute' => $attributes[$mapping->sourceRef ?? ''] ?? '',
+            'static' => $mapping->sourceValue ?? '',
+            'template' => $this->interpolate($mapping->sourceValue ?? '', $attributes),
+            default => '',
+        };
+    }
+
+    /**
+     * @param array<string, string> $vars
+     */
+    private function interpolate(string $template, array $vars): string
+    {
+        return preg_replace_callback(
+            '/\{([a-z0-9_.]+)\}/i',
+            static fn (array $m): string => $vars[$m[1]] ?? $m[0],
+            $template,
+        ) ?? $template;
+    }
+}

--- a/apps/api/src/Export/Contracts/CatalogProductScope.php
+++ b/apps/api/src/Export/Contracts/CatalogProductScope.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Contracts;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * The scope a catalog projects, as primitives (ADR-0023 §6.6, CPDF-P2-02). Lives
+ * in the Export seam so the Export-core value adapter never depends on the
+ * Catalog sub-area: the catalog generator builds it from a template + object
+ * type and hands it to {@see CatalogProductValues}.
+ */
+final class CatalogProductScope
+{
+    /**
+     * @param list<string>             $attributeCodes attribute codes the mappings read
+     * @param array<mixed, mixed>|null $filter         filter-DSL snapshot (null = whole catalog)
+     */
+    public function __construct(
+        public readonly Uuid $objectTypeId,
+        public readonly array $attributeCodes,
+        public readonly ?string $locale = null,
+        public readonly ?string $channel = null,
+        public readonly ?array $filter = null,
+    ) {
+    }
+}

--- a/apps/api/src/Export/Contracts/CatalogProductValues.php
+++ b/apps/api/src/Export/Contracts/CatalogProductValues.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Contracts;
+
+/**
+ * Seam over the product value source a catalog projects (ADR-0023 §6.3,
+ * CPDF-P2-02). Yields one attribute-code-keyed map per product, memory-bounded
+ * (the implementation owns chunking + EntityManager::clear()). Lives in the
+ * Export seam: the Export-core adapter ({@see \App\Export\Application\Catalog\ExportBuilderCatalogValues})
+ * implements it over ExportBuilder; the catalog generator consumes it.
+ */
+interface CatalogProductValues
+{
+    /**
+     * @return iterable<array<string, string>> attribute code => serialized value, per product
+     */
+    public function forScope(CatalogProductScope $scope): iterable;
+}

--- a/apps/api/tests/Integration/Export/Catalog/ExportBuilderCatalogValuesTest.php
+++ b/apps/api/tests/Integration/Export/Catalog/ExportBuilderCatalogValuesTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Export\Catalog;
+
+use App\Catalog\Application\Filter\FilterDslResolver;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Export\Application\Builder\ExportBuilder;
+use App\Export\Application\Catalog\ExportBuilderCatalogValues;
+use App\Export\Contracts\CatalogProductScope;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * CPDF-P2-02 — the Export-core adapter resolves catalog product values through
+ * the existing {@see ExportBuilder}: a seeded product yields one attribute-code
+ * keyed row carrying the seeded values, so the catalog generator can feed those
+ * into template slots. Same set-based seeding as the Export/Feed benchmarks.
+ */
+final class ExportBuilderCatalogValuesTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function forScopeYieldsAttributeKeyedRowsForSeededProducts(): void
+    {
+        [, $typeId] = $this->seedObjects(2);
+
+        // The adapter has no consumer until CPDF-P2-03, so the DI compiler
+        // inlines/removes it — build it directly from the (retained) deps.
+        $container = self::getContainer();
+        $em = $container->get(EntityManagerInterface::class);
+        $adapter = new ExportBuilderCatalogValues(
+            $container->get(ExportBuilder::class),
+            $container->get(CatalogObjectRepositoryInterface::class),
+            $container->get(ObjectTypeRepositoryInterface::class),
+            $container->get(FilterDslResolver::class),
+            $em->getConnection(),
+            $em,
+            $container->get(TenantContext::class),
+        );
+
+        $scope = new CatalogProductScope($typeId, ['sku', 'name']);
+
+        $rows = [];
+        foreach ($adapter->forScope($scope) as $row) {
+            $rows[] = $row;
+        }
+
+        self::assertCount(2, $rows, 'every seeded root product becomes one row');
+        foreach ($rows as $row) {
+            self::assertArrayHasKey('sku', $row);
+            self::assertArrayHasKey('name', $row);
+        }
+
+        // Both attributes were seeded with the object code as value.
+        $skus = array_column($rows, 'sku');
+        $names = array_column($rows, 'name');
+        sort($skus);
+        sort($names);
+        self::assertSame(['CPDF-1', 'CPDF-2'], $skus);
+        self::assertSame($skus, $names, 'name mirrors sku (both seeded from the object code)');
+    }
+
+    /**
+     * @return array{0: Tenant, 1: Uuid}
+     */
+    private function seedObjects(int $count): array
+    {
+        $em = $this->em();
+        $tenant = new Tenant('cpdf', 'CPDF Tenant');
+        $em->persist($tenant);
+        $em->flush();
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $type = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $type->markBuiltIn();
+        $em->persist($type);
+        $sku = new Attribute('sku', ['en' => 'SKU'], AttributeType::Text);
+        $name = new Attribute('name', ['en' => 'Name'], AttributeType::Text);
+        $em->persist($sku);
+        $em->persist($name);
+        $em->persist(new ObjectTypeAttribute($type, $sku, false, 1));
+        $em->persist(new ObjectTypeAttribute($type, $name, false, 2));
+        $em->flush();
+
+        $tenantId = $tenant->getId()->toRfc4122();
+        $typeId = $type->getId();
+        $conn = $em->getConnection();
+
+        $conn->executeStatement(
+            <<<'SQL'
+                INSERT INTO objects (id, tenant_id, object_type_id, kind, code, enabled, status, completeness, attributes_indexed, created_at, updated_at, completeness_pct, sync_status_aggregate, version, schema_drift)
+                SELECT gen_random_uuid(), :t, :ot, 'product', 'CPDF-'||g, true, 'published', '{}'::jsonb, '{}'::jsonb, now(), now(), 0, 'gray', 1, false
+                FROM generate_series(1, :n) g
+                SQL,
+            ['t' => $tenantId, 'ot' => $typeId->toRfc4122(), 'n' => $count],
+        );
+
+        foreach ([$sku->getId()->toRfc4122(), $name->getId()->toRfc4122()] as $attrId) {
+            $conn->executeStatement(
+                <<<'SQL'
+                    INSERT INTO object_values (id, tenant_id, object_id, attribute_id, value, provenance, provenance_meta)
+                    SELECT gen_random_uuid(), :t, o.id, :a, jsonb_build_object('value', o.code), 'import', '{}'::jsonb
+                    FROM objects o WHERE o.tenant_id = :t
+                    SQL,
+                ['t' => $tenantId, 'a' => $attrId],
+            );
+        }
+        $em->clear();
+
+        $reloaded = $em->getRepository(Tenant::class)->find($tenantId);
+        \assert($reloaded instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($reloaded);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+
+        return [$reloaded, $typeId];
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}

--- a/apps/api/tests/Unit/Export/Catalog/CatalogItemMapperTest.php
+++ b/apps/api/tests/Unit/Export/Catalog/CatalogItemMapperTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export\Catalog;
+
+use App\Export\Catalog\Domain\Mapping\CatalogFieldMapping;
+use App\Export\Catalog\Domain\Mapping\CatalogItemMapper;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * CPDF-P2-02 — the pure slot mapper resolves attribute / static / template
+ * sources into slot => value, feeding catalog template slots from ExportBuilder
+ * attribute maps. Transforms are a deferred hook (plan §7) — no transform path.
+ */
+final class CatalogItemMapperTest extends TestCase
+{
+    #[Test]
+    public function mapsAttributeStaticAndTemplateSources(): void
+    {
+        $mappings = [
+            new CatalogFieldMapping('title', 'attribute', 'name', null),
+            new CatalogFieldMapping('brand', 'static', null, 'ACME'),
+            new CatalogFieldMapping('label', 'template', null, '{name} ({sku})'),
+        ];
+
+        $item = new CatalogItemMapper()->map($mappings, ['sku' => 'SKU-1', 'name' => 'Widget']);
+
+        self::assertSame('Widget', $item['title']);
+        self::assertSame('ACME', $item['brand']);
+        self::assertSame('Widget (SKU-1)', $item['label']);
+    }
+
+    #[Test]
+    public function unknownAttributeResolvesToEmptyString(): void
+    {
+        $mappings = [
+            new CatalogFieldMapping('title', 'attribute', 'ghost', null),
+            new CatalogFieldMapping('note', 'static', null, null),
+            new CatalogFieldMapping('other', 'unknown_kind', 'name', null),
+        ];
+
+        $item = new CatalogItemMapper()->map($mappings, ['name' => 'Widget']);
+
+        self::assertSame('', $item['title']);
+        self::assertSame('', $item['note']);
+        self::assertSame('', $item['other']);
+    }
+
+    #[Test]
+    public function mapsAListParsedFromArray(): void
+    {
+        $mappings = CatalogFieldMapping::listFromArray([
+            ['slot' => 'id', 'source' => ['kind' => 'attribute', 'ref' => 'sku']],
+            ['slot' => 'name', 'source' => ['kind' => 'attribute', 'ref' => 'name']],
+            ['slot' => 'currency', 'source' => ['kind' => 'static', 'value' => 'PLN']],
+            'not-an-array-is-skipped',
+        ]);
+
+        self::assertCount(3, $mappings);
+
+        $item = new CatalogItemMapper()->map($mappings, ['sku' => 'SKU-1', 'name' => 'Widget']);
+
+        self::assertSame(['id' => 'SKU-1', 'name' => 'Widget', 'currency' => 'PLN'], $item);
+    }
+}


### PR DESCRIPTION
Zamyka **CPDF-P2-02** (#2291). Blocked by P1-01/P2-01 (merged). Odblokowuje CPDF-P2-03 (render service).

## Co
Reuse silnika Export zamiast własnego selektora (decyzja §2/§4):
- `CatalogProductScope` + `CatalogProductValues` (seam Export/Contracts) + adapter **`ExportBuilderCatalogValues`** (Export core, kalka `ExportBuilderFeedValues`): chunking keyset 200 + `EntityManager::clear()`, filter DSL, warianty flat, kolaps kluczy locale → memory-flat dla dużych katalogów.
- `CatalogItemMapper` + `CatalogFieldMapping` (Domain/Mapping): wiersz atrybutów → sloty (źródła attribute/static/template; transformacje = hook §7).
- Deptrac baseline dla reachu adaptera do Catalog-core (jak feed adapter).

## Walidacja (kontener `pim-api-1`, real Postgres)
- **Testy 4/4** (15 asercji): `CatalogItemMapperTest` (attribute/static/template, nieznany atrybut→''), `ExportBuilderCatalogValuesTest` — 2 zaseedowane produkty → `forScope(sku,name)` daje 2 wiersze `CPDF-1`/`CPDF-2`.
- **PHPStan max** (2G) 0 · **Deptrac** 0 · **php-cs-fixer** czysto.

Refs #2291