### PR TITLE
feat(export): CPDF-P2-03 — CatalogRenderService (sheet → PDF end-to-end)

### DIFF
--- a/apps/api/src/Export/Catalog/Application/CatalogRenderResult.php
+++ b/apps/api/src/Export/Catalog/Application/CatalogRenderResult.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Application;
+
+/**
+ * Outcome of one catalog render (ADR-0027, CPDF-P2-03): the page count, the
+ * byte size of the produced PDF, and how many products were rendered. Immutable
+ * value object handed back to the caller so it can record the cache metadata on
+ * the {@see \App\Export\Catalog\Domain\Entity\CatalogProfile} / CatalogRun.
+ */
+final class CatalogRenderResult
+{
+    public function __construct(
+        public readonly int $pageCount,
+        public readonly int $byteSize,
+        public readonly int $itemCount,
+    ) {
+    }
+}

--- a/apps/api/src/Export/Catalog/Application/CatalogRenderService.php
+++ b/apps/api/src/Export/Catalog/Application/CatalogRenderService.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Application;
+
+use App\Export\Catalog\Domain\Entity\CatalogProfile;
+use App\Export\Catalog\Domain\HtmlSlotPolicy;
+use App\Export\Catalog\Domain\Mapping\CatalogFieldMapping;
+use App\Export\Catalog\Domain\Mapping\CatalogItemMapper;
+use App\Export\Catalog\Domain\Template\CatalogTemplateCatalog;
+use App\Export\Contracts\CatalogProductScope;
+use App\Export\Contracts\CatalogProductValues;
+use App\Export\Contracts\PdfRenderer;
+use App\Export\Contracts\PdfRenderOptions;
+use Closure;
+use Twig\Environment;
+
+/**
+ * Orchestrates one catalog regeneration for the `sheet` archetype (ADR-0027,
+ * CPDF-P2-03): resolves the profile's template, streams the memory-bounded
+ * product value maps ({@see CatalogProductValues}), applies the field mappings
+ * ({@see CatalogItemMapper}), sanitises rich-text slots ({@see HtmlValueSanitizer}),
+ * renders the Twig archetype to HTML, then to a PDF binary through the
+ * {@see PdfRenderer} port, and writes it to $targetPath. Mirrors the STYLE of
+ * {@see \App\Export\Feed\Application\Generator\FeedGenerator}, but produces a PDF
+ * document instead of streaming XML.
+ *
+ * Memory: the value source is memory-bounded (chunked ExportBuilder +
+ * EntityManager::clear()), but Dompdf accumulates the whole document in memory,
+ * so large catalogs are capped/chunked in CPDF-P6-04 (decision A). Image
+ * embedding as a data-URI is refined in CPDF-P6-03 (decision B) — for now the
+ * resolved image value is passed straight through.
+ */
+final class CatalogRenderService
+{
+    /** Progress-callback cadence — a coarse hook for the async run (CPDF-P3-01). */
+    private const int PROGRESS_EVERY = 50;
+
+    public function __construct(
+        private readonly CatalogProductValues $values,
+        private readonly CatalogItemMapper $mapper,
+        private readonly CatalogTemplateCatalog $templates,
+        private readonly HtmlValueSanitizer $sanitizer,
+        private readonly Environment $twig,
+        private readonly PdfRenderer $renderer,
+    ) {
+    }
+
+    /**
+     * @param Closure(int): void|null $onChunk invoked with the processed-product count every
+     *                                         PROGRESS_EVERY products when provided
+     */
+    public function render(CatalogProfile $profile, string $targetPath, ?Closure $onChunk = null): CatalogRenderResult
+    {
+        // grid / pricelist raise TemplateNotAvailableException until M6 — propagate.
+        $template = $this->templates->get($profile->getTemplateKind());
+        $mappings = CatalogFieldMapping::listFromArray($profile->getFieldMappings());
+        $scope = $this->scope($profile, $mappings);
+
+        // slot => HTML format, from the template definition (richtext gets sanitised + printed raw).
+        $slotFormats = [];
+        foreach ($template->slots as $slot) {
+            $slotFormats[$slot['slot']] = $slot['format'];
+        }
+
+        // Attribute codes consumed by a scalar (non-`specs`) slot mapping — these
+        // are already surfaced through a dedicated slot, so they must not be
+        // duplicated into the generic specification table.
+        $scalarSlotRefs = $this->scalarSlotRefs($mappings, $slotFormats);
+
+        /** @var list<array<string, mixed>> $products */
+        $products = [];
+        $processed = 0;
+
+        foreach ($this->values->forScope($scope) as $row) {
+            $slots = $this->mapper->map($mappings, $row);
+
+            $product = [];
+            foreach ($template->slots as $slot) {
+                $name = $slot['slot'];
+                if ('specs' === $name) {
+                    continue; // built below from the leftover attributes
+                }
+                $value = $slots[$name] ?? '';
+                if ('richtext' === ($slotFormats[$name] ?? '')) {
+                    // Template prints this slot with `|raw` — sanitise here.
+                    $value = $this->sanitizer->sanitize($value, HtmlSlotPolicy::RichText);
+                }
+                // Text / url slots stay raw strings; Twig autoescape handles them.
+                $product[$name] = $value;
+            }
+
+            if (\array_key_exists('specs', $slotFormats)) {
+                $product['specs'] = $this->specs($row, $scalarSlotRefs);
+            }
+
+            $products[] = $product;
+            ++$processed;
+            $this->tickProgress($onChunk, $processed);
+        }
+
+        $html = $this->twig->render($template->twig, [
+            'branding' => $profile->getBranding(),
+            'products' => $products,
+        ]);
+
+        $pdf = $this->renderer->render($html, new PdfRenderOptions());
+        file_put_contents($targetPath, $pdf);
+
+        return new CatalogRenderResult(
+            pageCount: $this->countPages($pdf, \count($products)),
+            byteSize: \strlen($pdf),
+            itemCount: \count($products),
+        );
+    }
+
+    /**
+     * The attribute codes the values adapter must fetch: the distinct
+     * `sourceRef` of every mapping whose source is a PIM attribute (mirrors the
+     * FeedGenerator scope logic).
+     *
+     * @param list<CatalogFieldMapping> $mappings
+     */
+    private function scope(CatalogProfile $profile, array $mappings): CatalogProductScope
+    {
+        $codes = [];
+        foreach ($mappings as $mapping) {
+            if ('attribute' === $mapping->sourceKind && null !== $mapping->sourceRef) {
+                $codes[$mapping->sourceRef] = true;
+            }
+        }
+
+        return new CatalogProductScope(
+            objectTypeId: $profile->getObjectTypeId(),
+            attributeCodes: array_keys($codes),
+            locale: $profile->getLocale(),
+            channel: $profile->getPublicationChannel(),
+            filter: $profile->getFilter(),
+        );
+    }
+
+    /**
+     * Attribute codes already surfaced through a scalar (non-`specs`) slot, so
+     * the specification table can exclude them.
+     *
+     * @param list<CatalogFieldMapping> $mappings
+     * @param array<string, string>     $slotFormats slot name => template format
+     *
+     * @return array<string, true>
+     */
+    private function scalarSlotRefs(array $mappings, array $slotFormats): array
+    {
+        $refs = [];
+        foreach ($mappings as $mapping) {
+            if ('attribute' !== $mapping->sourceKind || null === $mapping->sourceRef) {
+                continue;
+            }
+            if ('specs' === $mapping->slot) {
+                continue;
+            }
+            if (!\array_key_exists($mapping->slot, $slotFormats)) {
+                continue; // mapping targets a slot the template does not expose
+            }
+            $refs[$mapping->sourceRef] = true;
+        }
+
+        return $refs;
+    }
+
+    /**
+     * Build the specification rows from the attributes not already consumed by a
+     * scalar slot. Label is the attribute code; the raw serialized value is left
+     * for Twig to escape in the specs table.
+     *
+     * @param array<string, string> $row
+     * @param array<string, true>   $scalarSlotRefs
+     *
+     * @return list<array{label: string, value: string}>
+     */
+    private function specs(array $row, array $scalarSlotRefs): array
+    {
+        $specs = [];
+        foreach ($row as $code => $value) {
+            if (\array_key_exists($code, $scalarSlotRefs)) {
+                continue;
+            }
+            $specs[] = ['label' => $code, 'value' => $value];
+        }
+
+        return $specs;
+    }
+
+    /**
+     * @param Closure(int): void|null $onChunk
+     */
+    private function tickProgress(?Closure $onChunk, int $processed): void
+    {
+        if (null !== $onChunk && $processed > 0 && 0 === $processed % self::PROGRESS_EVERY) {
+            $onChunk($processed);
+        }
+    }
+
+    /**
+     * Lightweight page-count heuristic: Dompdf emits one `/Type /Page` object per
+     * page and a single `/Type /Pages` tree node, so the page count is the number
+     * of `/Type /Page` occurrences minus the `/Type /Pages` node. If the count
+     * comes out 0 (e.g. an unexpected PDF structure), fall back to the item count
+     * (one sheet per product), never below 1.
+     */
+    private function countPages(string $pdf, int $itemCount): int
+    {
+        $pages = substr_count($pdf, '/Type /Page') - substr_count($pdf, '/Type /Pages');
+        if ($pages < 1) {
+            return max(1, $itemCount);
+        }
+
+        return $pages;
+    }
+}

--- a/apps/api/tests/Integration/Export/Catalog/CatalogRenderServiceTest.php
+++ b/apps/api/tests/Integration/Export/Catalog/CatalogRenderServiceTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Export\Catalog;
+
+use App\Catalog\Application\Filter\FilterDslResolver;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Export\Application\Builder\ExportBuilder;
+use App\Export\Application\Catalog\ExportBuilderCatalogValues;
+use App\Export\Catalog\Application\CatalogRenderResult;
+use App\Export\Catalog\Application\CatalogRenderService;
+use App\Export\Catalog\Application\HtmlValueSanitizer;
+use App\Export\Catalog\Domain\Entity\CatalogProfile;
+use App\Export\Catalog\Domain\Enum\CatalogTemplateKind;
+use App\Export\Catalog\Domain\Mapping\CatalogItemMapper;
+use App\Export\Catalog\Domain\Template\CatalogTemplateCatalog;
+use App\Export\Catalog\Infrastructure\Renderer\DompdfRenderer;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * CPDF-P2-03 — the sheet archetype end-to-end: a CatalogProfile renders through
+ * the real value source (ExportBuilder), mapper, sanitiser, Twig archetype and
+ * the Dompdf PdfRenderer to a `%PDF-` binary on disk. Same set-based seeding as
+ * {@see ExportBuilderCatalogValuesTest}.
+ */
+final class CatalogRenderServiceTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function rendersSheetCatalogToPdf(): void
+    {
+        [, $typeId] = $this->seedObjects(2, '<strong>Opis produktu</strong>');
+
+        $service = $this->service();
+        $profile = $this->profile($typeId);
+
+        $target = tempnam(sys_get_temp_dir(), 'cpdf-');
+        self::assertNotFalse($target);
+        $result = $service->render($profile, $target);
+
+        self::assertInstanceOf(CatalogRenderResult::class, $result);
+        self::assertSame(2, $result->itemCount, 'every seeded product becomes one sheet');
+        self::assertGreaterThan(0, $result->byteSize);
+        self::assertGreaterThanOrEqual(1, $result->pageCount);
+
+        $pdf = (string) file_get_contents($target);
+        self::assertStringStartsWith('%PDF-', $pdf, 'the render produced a valid PDF file');
+
+        @unlink($target);
+    }
+
+    #[Test]
+    public function renderSurvivesMaliciousDescriptionValue(): void
+    {
+        [, $typeId] = $this->seedObjects(1, '<script>alert(1)</script>');
+
+        $service = $this->service();
+        $profile = $this->profile($typeId);
+
+        $target = tempnam(sys_get_temp_dir(), 'cpdf-');
+        self::assertNotFalse($target);
+        // Garbage data must not break the render — the sanitiser neutralises it.
+        $service->render($profile, $target);
+
+        $pdf = (string) file_get_contents($target);
+        self::assertStringStartsWith('%PDF-', $pdf);
+
+        @unlink($target);
+    }
+
+    private function service(): CatalogRenderService
+    {
+        // No consumer wires CatalogRenderService yet, so the DI compiler may
+        // inline/remove it — build it directly from its (retained) deps, the
+        // ExportBuilderCatalogValuesTest pattern. Twig is fetched by the 'twig'
+        // service id used across the Catalog tests.
+        $container = self::getContainer();
+        $em = $container->get(EntityManagerInterface::class);
+
+        $values = new ExportBuilderCatalogValues(
+            $container->get(ExportBuilder::class),
+            $container->get(CatalogObjectRepositoryInterface::class),
+            $container->get(ObjectTypeRepositoryInterface::class),
+            $container->get(FilterDslResolver::class),
+            $em->getConnection(),
+            $em,
+            $container->get(TenantContext::class),
+        );
+
+        $twig = $container->get('twig');
+
+        return new CatalogRenderService(
+            $values,
+            new CatalogItemMapper(),
+            new CatalogTemplateCatalog(),
+            new HtmlValueSanitizer(),
+            $twig,
+            // PdfRenderer alias has no consumer yet (DI removes it) — the default
+            // in-process Dompdf adapter is constructor-less, use it directly.
+            new DompdfRenderer(),
+        );
+    }
+
+    private function profile(Uuid $objectTypeId): CatalogProfile
+    {
+        return new CatalogProfile(
+            'sheet-cat',
+            'Sheet',
+            CatalogTemplateKind::Sheet,
+            $objectTypeId,
+            branding: ['color' => '#0ea5e9', 'company_name' => 'ACME'],
+            fieldMappings: [
+                ['slot' => 'title', 'source' => ['kind' => 'attribute', 'ref' => 'name']],
+                ['slot' => 'sku', 'source' => ['kind' => 'attribute', 'ref' => 'sku']],
+                ['slot' => 'description', 'source' => ['kind' => 'attribute', 'ref' => 'description']],
+            ],
+        );
+    }
+
+    /**
+     * @return array{0: Tenant, 1: Uuid}
+     */
+    private function seedObjects(int $count, string $descriptionValue): array
+    {
+        $em = $this->em();
+        $tenant = new Tenant('cpdf', 'CPDF Tenant');
+        $em->persist($tenant);
+        $em->flush();
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $type = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $type->markBuiltIn();
+        $em->persist($type);
+        $sku = new Attribute('sku', ['en' => 'SKU'], AttributeType::Text);
+        $name = new Attribute('name', ['en' => 'Name'], AttributeType::Text);
+        $description = new Attribute('description', ['en' => 'Description'], AttributeType::Wysiwyg);
+        $em->persist($sku);
+        $em->persist($name);
+        $em->persist($description);
+        $em->persist(new ObjectTypeAttribute($type, $sku, false, 1));
+        $em->persist(new ObjectTypeAttribute($type, $name, false, 2));
+        $em->persist(new ObjectTypeAttribute($type, $description, false, 3));
+        $em->flush();
+
+        $tenantId = $tenant->getId()->toRfc4122();
+        $typeId = $type->getId();
+        $conn = $em->getConnection();
+
+        $conn->executeStatement(
+            <<<'SQL'
+                INSERT INTO objects (id, tenant_id, object_type_id, kind, code, enabled, status, completeness, attributes_indexed, created_at, updated_at, completeness_pct, sync_status_aggregate, version, schema_drift)
+                SELECT gen_random_uuid(), :t, :ot, 'product', 'CPDF-'||g, true, 'published', '{}'::jsonb, '{}'::jsonb, now(), now(), 0, 'gray', 1, false
+                FROM generate_series(1, :n) g
+                SQL,
+            ['t' => $tenantId, 'ot' => $typeId->toRfc4122(), 'n' => $count],
+        );
+
+        foreach ([$sku->getId()->toRfc4122(), $name->getId()->toRfc4122()] as $attrId) {
+            $conn->executeStatement(
+                <<<'SQL'
+                    INSERT INTO object_values (id, tenant_id, object_id, attribute_id, value, provenance, provenance_meta)
+                    SELECT gen_random_uuid(), :t, o.id, :a, jsonb_build_object('value', o.code), 'import', '{}'::jsonb
+                    FROM objects o WHERE o.tenant_id = :t
+                    SQL,
+                ['t' => $tenantId, 'a' => $attrId],
+            );
+        }
+
+        $conn->executeStatement(
+            <<<'SQL'
+                INSERT INTO object_values (id, tenant_id, object_id, attribute_id, value, provenance, provenance_meta)
+                SELECT gen_random_uuid(), :t, o.id, :a, jsonb_build_object('value', :d::text), 'import', '{}'::jsonb
+                FROM objects o WHERE o.tenant_id = :t
+                SQL,
+            ['t' => $tenantId, 'a' => $description->getId()->toRfc4122(), 'd' => $descriptionValue],
+        );
+        $em->clear();
+
+        $reloaded = $em->getRepository(Tenant::class)->find($tenantId);
+        \assert($reloaded instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($reloaded);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+
+        return [$reloaded, $typeId];
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}


### PR DESCRIPTION
Zamyka **CPDF-P2-03** (#2292). Blocked by P0-03/P0-04/P2-01/P2-02 (merged). **Domyka M2.** Odblokowuje CPDF-P3-01 (async), CPDF-P4-01 (preview).

## Co
`CatalogRenderService` — jedna orkiestracja renderu (analog `FeedGenerator`): strumień produktów z memory-bounded value source → mapper (row → sloty) → sanityzacja opisu (`HtmlValueSanitizer` RichText) → render archetypu `sheet` Twig z brand tokens → port `PdfRenderer` → PDF. Zwraca `CatalogRenderResult` (page_count / byte_size / item_count).

## Walidacja (kontener `pim-api-1`, real Postgres + Dompdf)
- **2 testy integracyjne renderujące REALNE PDF-y** (9 asercji): (1) sheet dla 2 produktów → plik `%PDF-` na dysku, `itemCount=2`, `byteSize>0`, `pageCount≥1`; (2) produkt z `<script>alert(1)</script>` w opisie → render **nie wywala się**, PDF poprawny (sanitizer neutralizuje).
- **PHPStan max** (2G) 0 · **Deptrac** 0 · **php-cs-fixer** czysto.

## Świadome odejścia (udokumentowane w klasie)
- Dompdf trzyma cały dokument w pamięci → cap/chunk dużych katalogów w **CPDF-P6-04** (decyzja A).
- Osadzanie zdjęć jako data-URI → **CPDF-P6-03** (decyzja B); teraz wartość image przechodzi as-is.

Refs #2292