### PR TITLE
feat(export): CPDF-P3-01 — async GenerateCatalogHandler + Mercure progress

### DIFF
--- a/apps/api/config/packages/messenger.yaml
+++ b/apps/api/config/packages/messenger.yaml
@@ -178,6 +178,13 @@ framework:
             # tenant context on the worker before the handler loads the run.
             App\Export\Feed\Domain\Message\RunFeedMessage: import
 
+            # CPDF-P3-01 — async PDF catalog generation. Same import/export
+            # worker split as RunFeedMessage: a catalog renders to the cache
+            # out-of-band (GenerateCatalogHandler) with progress over Mercure.
+            # TenantAwareMessage so the rebinding + RLS-GUC middleware restore
+            # tenant context on the worker before the handler loads the run.
+            App\Export\Catalog\Domain\Message\RunCatalogMessage: import
+
             # APIC-P4-05 — producer webhook delivery. Async so the originating
             # write never blocks on a slow integrator; the `async` retry strategy
             # (5×, exponential) backs off failures and dead-letters to `failed`.

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -352,6 +352,12 @@ services:
     App\Export\Feed\Presentation\Controller\FeedRegenerateController:
         arguments:
             $topicBase: '%env(MERCURE_TOPIC_BASE)%'
+    # CPDF-P3-01 — catalog regeneration progress topic
+    # (tenant/{tid}/catalogs/{id}/runs); built from the same public origin the
+    # SPA subscribes on so the tenant-scoped subscribe claim matches.
+    App\Export\Catalog\Application\Async\CatalogProgressPublisher:
+        arguments:
+            $topicBase: '%env(MERCURE_TOPIC_BASE)%'
     # AUD-001 (#1573) — Catalog + permission publishers and the cookie
     # mint endpoint must build topics from the same public origin the SPA
     # subscribes on, so the tenant-scoped subscribe claim matches the

--- a/apps/api/src/Export/Catalog/Application/Async/CatalogCancelledException.php
+++ b/apps/api/src/Export/Catalog/Application/Async/CatalogCancelledException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Application\Async;
+
+use RuntimeException;
+
+/**
+ * CPDF-P3-01 — thrown by the per-chunk progress callback when the persisted
+ * {@see \App\Export\Catalog\Domain\Entity\CatalogRun} status flips to
+ * `cancelled` (the cancel endpoint writes it; the worker polls it between
+ * chunks).
+ *
+ * Mirrors {@see \App\Export\Feed\Application\Async\FeedCancelledException}: the
+ * regenerator lets it pass through and records `cancelled` on the run WITHOUT
+ * marking it as error, and the handler treats it as a graceful stop, not a
+ * failure.
+ */
+final class CatalogCancelledException extends RuntimeException
+{
+}

--- a/apps/api/src/Export/Catalog/Application/Async/CatalogProgressPublisher.php
+++ b/apps/api/src/Export/Catalog/Application/Async/CatalogProgressPublisher.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Application\Async;
+
+use App\Export\Catalog\Domain\Entity\CatalogRun;
+use App\Shared\Infrastructure\Mercure\MercureSubscribeTopics;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Mercure\HubInterface;
+use Symfony\Component\Mercure\Update;
+use Throwable;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * CPDF-P3-01 — Mercure SSE publisher for PDF catalog generation runs, the
+ * catalog-world mirror of
+ * {@see \App\Export\Feed\Application\Async\FeedProgressPublisher}.
+ *
+ * Publishes lifecycle events to the tenant-scoped, private per-catalog topic
+ * `tenant/{tid}/catalogs/{catalog_id}/runs`
+ * ({@see MercureSubscribeTopics::catalogRuns()} — AUD-001: the tenant prefix +
+ * `private: true` + the subscriber-JWT claim minted by forTenant() close the
+ * cross-tenant leak class).
+ *
+ * One topic per catalog (not per run): the monitor screen subscribes when the
+ * catalog detail opens, so a run started later still streams into the open
+ * view. Events carry `run_id` for the FE to demultiplex.
+ *
+ * Hub failures are logged but never abort the regeneration — the cache write is
+ * the source of truth; Mercure is a notification channel.
+ */
+final class CatalogProgressPublisher
+{
+    private readonly LoggerInterface $logger;
+
+    public function __construct(
+        private readonly HubInterface $hub,
+        private readonly string $topicBase,
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    /**
+     * Per-chunk progress tick. `itemsTotal` is the best-effort expected size
+     * (the previous successful run's item count) — null on a first run, in
+     * which case `progress_pct`/`eta` stay null and the FE renders an
+     * indeterminate bar with a live counter.
+     */
+    public function progress(CatalogRun $run, int $itemsDone, ?int $itemsTotal, ?int $estimatedSecondsRemaining): void
+    {
+        $pct = (null !== $itemsTotal && $itemsTotal > 0)
+            ? min(100, (int) floor($itemsDone / $itemsTotal * 100))
+            : null;
+
+        $this->publish($run, 'progress', [
+            'items_done' => $itemsDone,
+            'items_total' => $itemsTotal,
+            'progress_pct' => $pct,
+            'estimated_seconds_remaining' => $estimatedSecondsRemaining,
+        ]);
+    }
+
+    /**
+     * Status transition (pending → running → done / error / cancelled).
+     * Drives the monitor pipeline stages + the hub tile badge.
+     */
+    public function status(CatalogRun $run): void
+    {
+        $this->publish($run, 'status', [
+            'status' => $run->getStatus()->value,
+            'page_count' => $run->getPageCount(),
+            'byte_size' => $run->getByteSize(),
+            'item_count' => $run->getItemCount(),
+            'duration_ms' => $run->getDurationMs(),
+            'error_message' => $run->getErrorMessage(),
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function publish(CatalogRun $run, string $eventType, array $payload): void
+    {
+        $tenant = $run->getTenant();
+        if (null === $tenant) {
+            // Runs are tenant-stamped on persist; a null here is a
+            // misconfiguration. Skip rather than emit an un-scoped topic.
+            $this->logger->warning('Catalog progress publish skipped: run has no tenant', [
+                'run_id' => $run->getId()->toRfc4122(),
+                'event' => $eventType,
+            ]);
+
+            return;
+        }
+
+        $message = [
+            'event' => $eventType,
+            'run_id' => $run->getId()->toRfc4122(),
+            'catalog_id' => $run->getCatalogProfileId()->toRfc4122(),
+            ...$payload,
+        ];
+        $encoded = json_encode($message, JSON_THROW_ON_ERROR);
+
+        $topic = MercureSubscribeTopics::catalogRuns(
+            $tenant->getId(),
+            $this->topicBase,
+            $run->getCatalogProfileId()->toRfc4122(),
+        );
+
+        try {
+            $this->hub->publish(new Update($topic, $encoded, private: true));
+        } catch (Throwable $error) {
+            $this->logger->warning('Catalog progress publish failed', [
+                'run_id' => $run->getId()->toRfc4122(),
+                'event' => $eventType,
+                'error' => $error->getMessage(),
+            ]);
+        }
+    }
+}

--- a/apps/api/src/Export/Catalog/Application/Async/GenerateCatalogHandler.php
+++ b/apps/api/src/Export/Catalog/Application/Async/GenerateCatalogHandler.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Application\Async;
+
+use App\Export\Catalog\Application\Generator\CatalogRegenerator;
+use App\Export\Catalog\Domain\Entity\CatalogProfile;
+use App\Export\Catalog\Domain\Entity\CatalogRun;
+use App\Export\Catalog\Domain\Enum\CatalogRunStatus;
+use App\Export\Catalog\Domain\Message\RunCatalogMessage;
+use App\Export\Catalog\Domain\Repository\CatalogProfileRepositoryInterface;
+use App\Export\Catalog\Domain\Repository\CatalogRunRepositoryInterface;
+use App\Shared\Application\AbstractBatchHandler;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * CPDF-P3-01 — async PDF catalog generation worker, the catalog-world mirror of
+ * {@see \App\Export\Feed\Application\Async\FeedRunHandler}. The flow:
+ *
+ *   1. Load the persisted CatalogRun (state survives retries) + idempotency
+ *      guard: only a `pending` run is processed — a duplicate delivery or a
+ *      pre-cancelled run is skipped with an info log, never an exception.
+ *   2. Rebind TenantContext from the run's tenant (the request listener never
+ *      fires on a worker boot; the messenger middleware already restored the
+ *      RLS GUC from the TenantAwareMessage). Like FeedRunHandler, the tenant is
+ *      read straight off the persisted run's relation — the message's tenantId
+ *      only feeds the rebinding middleware.
+ *   3. markRunning + publish `status` so the monitor pipeline lights up.
+ *   4. Drive {@see CatalogRegenerator} — the same engine the sync endpoint uses
+ *      (render → cache upload → cache pointer on the profile) — with a per-chunk
+ *      callback that publishes progress + ETA and polls the PERSISTED run status
+ *      for cancellation (the in-memory entity is stale inside the long loop; the
+ *      cancel endpoint writes straight to the row).
+ *   5. Publish the terminal `status` (done / error / cancelled) off the run the
+ *      regenerator returns (it owns the terminal transition).
+ *
+ * Memory safety: the render's value source pages products keyset-style and
+ * clears the EntityManager every chunk (IMP2 reuse), so a large catalog stays
+ * flat; this class extends {@see AbstractBatchHandler} so any future batch write
+ * it grows funnels through flushAndClear() (CLAUDE.md §3.10).
+ *
+ * Failures are captured in run state (markError inside the regenerator) and
+ * published — NOT re-thrown. Mirrors the feed handler: in dev/test the transport
+ * is sync://, so a re-throw would surface a 500 on the dispatching request even
+ * though the failure is already recorded and visible in the monitor.
+ * Cancellation is a graceful stop, not a failure.
+ */
+#[AsMessageHandler]
+final class GenerateCatalogHandler extends AbstractBatchHandler
+{
+    private readonly LoggerInterface $logger;
+
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        private readonly CatalogRunRepositoryInterface $runs,
+        private readonly CatalogProfileRepositoryInterface $profiles,
+        private readonly CatalogRegenerator $regenerator,
+        private readonly CatalogProgressPublisher $progress,
+        private readonly TenantContext $tenantContext,
+        ?LoggerInterface $logger = null,
+        int $batchSize = 1000,
+    ) {
+        parent::__construct($entityManager, $batchSize);
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    public function __invoke(RunCatalogMessage $message): void
+    {
+        $run = $this->runs->findById($message->catalogRunId);
+        if (!$run instanceof CatalogRun) {
+            $this->logger->info('Catalog run handler skipped — run not found', [
+                'run_id' => $message->catalogRunId->toRfc4122(),
+            ]);
+
+            return;
+        }
+
+        // Idempotency guard — duplicate delivery (sync transport + retries)
+        // or a run cancelled before the worker picked it up.
+        if (CatalogRunStatus::Pending !== $run->getStatus()) {
+            $this->logger->info('Catalog run handler skipped — run not pending', [
+                'run_id' => $run->getId()->toRfc4122(),
+                'status' => $run->getStatus()->value,
+            ]);
+
+            return;
+        }
+
+        $tenant = $run->getTenant();
+        if (!$tenant instanceof Tenant) {
+            $run->markError('Catalog run has no tenant assignment.');
+            $this->runs->save($run);
+
+            return;
+        }
+        $this->tenantContext->set($tenant);
+
+        $profile = $this->profiles->findById($run->getCatalogProfileId());
+        if (!$profile instanceof CatalogProfile) {
+            $run->markError('Catalog profile no longer exists.');
+            $this->runs->save($run);
+            $this->progress->status($run);
+
+            return;
+        }
+
+        $run->markRunning();
+        $this->runs->save($run);
+        $this->progress->status($run);
+
+        $runId = $run->getId();
+        // No cached assortment size on the profile, so total/ETA stay null and
+        // the FE renders an indeterminate progress bar with a live counter until
+        // a first run establishes the size (parity with a feed's first run).
+        $onChunk = function (int $processed) use ($runId, $run): void {
+            $this->progress->progress($run, $processed, null, null);
+
+            // The in-memory run is stale inside the long render loop; the cancel
+            // endpoint writes straight to the row — poll the persisted status.
+            $current = $this->runs->findById($runId);
+            if (null !== $current && CatalogRunStatus::Cancelled === $current->getStatus()) {
+                throw new CatalogCancelledException('Catalog generation cancelled by the user.');
+            }
+        };
+
+        // The regenerator owns the terminal transition (done / cancelled / error)
+        // and returns the managed run — publish its terminal status. It never
+        // re-throws; failures are recorded on the run.
+        $terminal = $this->regenerator->regenerate($profile, $run, $onChunk);
+        $this->progress->status($terminal);
+
+        if (CatalogRunStatus::Cancelled === $terminal->getStatus()) {
+            $this->logger->info('Catalog run cancelled by user', [
+                'run_id' => $terminal->getId()->toRfc4122(),
+            ]);
+        } elseif (CatalogRunStatus::Error === $terminal->getStatus()) {
+            $this->logger->error('Catalog run failed', [
+                'run_id' => $terminal->getId()->toRfc4122(),
+                'error' => $terminal->getErrorMessage(),
+            ]);
+        }
+    }
+}

--- a/apps/api/src/Export/Catalog/Application/Generator/CatalogRegenerator.php
+++ b/apps/api/src/Export/Catalog/Application/Generator/CatalogRegenerator.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Application\Generator;
+
+use App\Export\Catalog\Application\Async\CatalogCancelledException;
+use App\Export\Catalog\Application\CatalogRenderService;
+use App\Export\Catalog\Application\Delivery\CatalogCacheStorage;
+use App\Export\Catalog\Domain\Entity\CatalogProfile;
+use App\Export\Catalog\Domain\Entity\CatalogRun;
+use App\Export\Catalog\Domain\Repository\CatalogProfileRepositoryInterface;
+use App\Export\Catalog\Domain\Repository\CatalogRunRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use Closure;
+use DateTimeImmutable;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Regeneration orchestrator (ADR-0027, CPDF-P3-01) — the shared core the
+ * manual "Generuj teraz" endpoint and the async worker
+ * ({@see \App\Export\Catalog\Application\Async\GenerateCatalogHandler}) both
+ * drive, the catalog-world mirror of
+ * {@see \App\Export\Feed\Application\Generator\FeedRegenerator}.
+ *
+ * DESIGN DIVERGENCE from the Feed engine: {@see CatalogRenderService} is a PURE
+ * renderer — it maps the profile to HTML, renders a PDF binary to a temp path
+ * and returns a {@see \App\Export\Catalog\Application\CatalogRenderResult}
+ * (counters only). It does NOT own the {@see CatalogRun} lifecycle. So this
+ * regenerator owns the run state transitions (markDone / markCancelled /
+ * markError) AND the cache pointer on the profile — the pieces the
+ * FeedGenerator handled internally.
+ *
+ * It renders through the service into a local temp file, uploads a successful
+ * run to the tenant-scoped cache key (`catalogs/<tenant>/<catalog>.pdf`,
+ * {@see CatalogCacheStorage}) and records the cache pointer on the
+ * {@see CatalogProfile} so the public URL (CPDF-P3-02) can serve it.
+ *
+ * EM-clear reload guard: the render's value source pages products keyset-style
+ * and clears the EntityManager between chunks to stay memory-flat (IMP2 reuse),
+ * which detaches `$profile` and `$run`. This class reloads a managed instance
+ * of each (`findById(...) ?? $original`) before saving so the write hits a
+ * tracked entity, the same guard the export/feed handlers use.
+ *
+ * Failures are captured in run state (markError) and returned — NOT re-thrown,
+ * mirroring the Feed handler: the terminal state is visible in the monitor
+ * pipeline instead of surfacing a 500 on the sync (dev/test) transport.
+ */
+final class CatalogRegenerator
+{
+    public function __construct(
+        private readonly CatalogRenderService $renderer,
+        private readonly CatalogCacheStorage $cache,
+        private readonly CatalogProfileRepositoryInterface $profiles,
+        private readonly CatalogRunRepositoryInterface $runs,
+        private readonly TenantContext $tenantContext,
+    ) {
+    }
+
+    /**
+     * @param Closure(int): void|null $onChunk progress callback forwarded to the render service;
+     *                                         may throw CatalogCancelledException to stop gracefully
+     */
+    public function regenerate(CatalogProfile $profile, CatalogRun $run, ?Closure $onChunk = null): CatalogRun
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new RuntimeException('Catalog regeneration requires a tenant context.');
+        }
+
+        $temp = tempnam(sys_get_temp_dir(), 'pim-catalog-');
+        if (false === $temp) {
+            throw new RuntimeException('Unable to allocate a temp file for catalog generation.');
+        }
+
+        $startedAt = microtime(true);
+
+        try {
+            // May throw CatalogCancelledException (propagated from onChunk).
+            $result = $this->renderer->render($profile, $temp, $onChunk);
+
+            $key = sprintf(
+                'catalogs/%s/%s.pdf',
+                $tenant->getId()->toRfc4122(),
+                $profile->getId()->toRfc4122(),
+            );
+            $this->cache->put($key, $temp);
+
+            $durationMs = (int) round((microtime(true) - $startedAt) * 1000);
+
+            // The render's value source cleared the EM mid-run (IMP2 reuse),
+            // detaching $profile / $run — reload managed instances before saving.
+            $managedProfile = $this->profiles->findById($profile->getId()) ?? $profile;
+            $managedProfile->recordCache($key, $result->byteSize, $result->pageCount, new DateTimeImmutable());
+            $this->profiles->save($managedProfile);
+
+            $managedRun = $this->runs->findById($run->getId()) ?? $run;
+            $managedRun->markDone($result->pageCount, $result->byteSize, $result->itemCount, $durationMs);
+            $this->runs->save($managedRun);
+
+            return $managedRun;
+        } catch (CatalogCancelledException) {
+            // The cancel endpoint already persisted `cancelled`; record it on the
+            // managed run so the terminal publish reads a graceful stop.
+            $managedRun = $this->runs->findById($run->getId()) ?? $run;
+            $managedRun->markCancelled();
+            $this->runs->save($managedRun);
+
+            return $managedRun;
+        } catch (Throwable $error) {
+            $managedRun = $this->runs->findById($run->getId()) ?? $run;
+            $managedRun->markError($error->getMessage());
+            $this->runs->save($managedRun);
+
+            return $managedRun;
+        } finally {
+            @unlink($temp);
+        }
+    }
+}

--- a/apps/api/src/Export/Catalog/Domain/Message/RunCatalogMessage.php
+++ b/apps/api/src/Export/Catalog/Domain/Message/RunCatalogMessage.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Domain\Message;
+
+use App\Shared\Application\TenantAwareMessage;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * CPDF-P3-01 — Symfony Messenger envelope for async PDF catalog generation.
+ *
+ * Dispatched by the manual "Generuj teraz" endpoint (and later the cron
+ * scheduler) onto the shared `import` queue. Carries the
+ * {@see \App\Export\Catalog\Domain\Entity\CatalogRun} UUID — the handler loads
+ * the persisted run so the message is replay-safe (a retry resumes from
+ * recorded state instead of re-reading stale config).
+ *
+ * Implements {@see TenantAwareMessage} so the
+ * {@see \App\Shared\Infrastructure\Messenger\TenantContextRebindingMiddleware}
+ * rebinds tenant + RLS GUC on the worker before the handler touches any
+ * tenant-scoped row (HIGH-002).
+ */
+final class RunCatalogMessage implements TenantAwareMessage
+{
+    public function __construct(
+        public readonly Uuid $catalogRunId,
+        public readonly Uuid $tenantId,
+    ) {
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenantId;
+    }
+}

--- a/apps/api/src/Shared/Infrastructure/Mercure/MercureSubscribeTopics.php
+++ b/apps/api/src/Shared/Infrastructure/Mercure/MercureSubscribeTopics.php
@@ -82,6 +82,17 @@ final class MercureSubscribeTopics
     }
 
     /**
+     * Live regeneration progress of one PDF catalog (CPDF-P3-01) — every run of
+     * the catalog publishes progress + status here; the monitor screen
+     * subscribes per catalog, so a new run appears on the already-open detail
+     * view.
+     */
+    public static function catalogRuns(Uuid $tenantId, string $base, string $catalogId): string
+    {
+        return self::tenantPrefix($tenantId, $base).'/catalogs/'.$catalogId.'/runs';
+    }
+
+    /**
      * Live phases of one agent run (AGENT-P1-05 #1957): planning /
      * tool-call / materializing / awaiting_approval / committing / done
      * / error / rolled_back — the chat panel + inbox subscribe per run.
@@ -133,6 +144,8 @@ final class MercureSubscribeTopics
             $prefix.'/exports/{id}',
             // Feed regeneration progress (XMLF-P4-02, per-feed run stream).
             $prefix.'/feeds/{id}/runs',
+            // Catalog regeneration progress (CPDF-P3-01, per-catalog run stream).
+            $prefix.'/catalogs/{id}/runs',
             // Agent run phases + per-user history refresh (AGENT-P1-05).
             $prefix.'/agent-runs/{id}',
             $prefix.'/agent-runs/user/{id}',

--- a/apps/api/tests/Integration/Export/Catalog/GenerateCatalogHandlerTest.php
+++ b/apps/api/tests/Integration/Export/Catalog/GenerateCatalogHandlerTest.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Export\Catalog;
+
+use App\Catalog\Application\Filter\FilterDslResolver;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Export\Application\Builder\ExportBuilder;
+use App\Export\Application\Catalog\ExportBuilderCatalogValues;
+use App\Export\Catalog\Application\Async\CatalogProgressPublisher;
+use App\Export\Catalog\Application\Async\GenerateCatalogHandler;
+use App\Export\Catalog\Application\CatalogRenderService;
+use App\Export\Catalog\Application\Generator\CatalogRegenerator;
+use App\Export\Catalog\Application\HtmlValueSanitizer;
+use App\Export\Catalog\Domain\Entity\CatalogProfile;
+use App\Export\Catalog\Domain\Entity\CatalogRun;
+use App\Export\Catalog\Domain\Enum\CatalogRunStatus;
+use App\Export\Catalog\Domain\Enum\CatalogRunTrigger;
+use App\Export\Catalog\Domain\Enum\CatalogTemplateKind;
+use App\Export\Catalog\Domain\Mapping\CatalogItemMapper;
+use App\Export\Catalog\Domain\Message\RunCatalogMessage;
+use App\Export\Catalog\Domain\Repository\CatalogProfileRepositoryInterface;
+use App\Export\Catalog\Domain\Repository\CatalogRunRepositoryInterface;
+use App\Export\Catalog\Domain\Template\CatalogTemplateCatalog;
+use App\Export\Catalog\Infrastructure\Delivery\FlysystemCatalogCacheStorage;
+use App\Export\Catalog\Infrastructure\Renderer\DompdfRenderer;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use App\Tests\Support\InMemoryMercureHub;
+use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * CPDF-P3-01 — the async catalog generation worker end-to-end: a pending
+ * CatalogRun drives the real render service → Regenerator → MinIO-backed cache,
+ * lands the run in `done`, records the cache pointer on the profile and leaves a
+ * `%PDF-` object at the tenant-scoped cache key. Same set-based seeding as
+ * {@see CatalogRenderServiceTest}.
+ */
+final class GenerateCatalogHandlerTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function generatesCatalogToDoneWithCachedPdf(): void
+    {
+        [$tenant, $typeId] = $this->seedObjects(2, '<strong>Opis produktu</strong>');
+
+        $profile = new CatalogProfile(
+            'sheet-cat',
+            'Sheet',
+            CatalogTemplateKind::Sheet,
+            $typeId,
+            branding: ['color' => '#0ea5e9', 'company_name' => 'ACME'],
+            fieldMappings: [
+                ['slot' => 'title', 'source' => ['kind' => 'attribute', 'ref' => 'name']],
+                ['slot' => 'sku', 'source' => ['kind' => 'attribute', 'ref' => 'sku']],
+                ['slot' => 'description', 'source' => ['kind' => 'attribute', 'ref' => 'description']],
+            ],
+        );
+        $profile->assignTenant($tenant);
+        $this->profiles()->save($profile);
+
+        $run = new CatalogRun($profile->getId(), CatalogRunTrigger::Manual);
+        $run->assignTenant($tenant);
+        $this->runs()->save($run);
+
+        $runId = $run->getId();
+        $cacheKey = sprintf(
+            'catalogs/%s/%s.pdf',
+            $tenant->getId()->toRfc4122(),
+            $profile->getId()->toRfc4122(),
+        );
+
+        $handler = $this->handler();
+        $handler(new RunCatalogMessage($runId, $tenant->getId()));
+
+        // Re-scope after the render's EM clear before reading tenant-scoped rows
+        // (the handler cleared the EM mid-run, detaching the seed's tenant).
+        $this->rebind($this->reloadTenant($tenant->getId()->toRfc4122()));
+
+        $reloadedRun = $this->runs()->findById($runId);
+        self::assertInstanceOf(CatalogRun::class, $reloadedRun);
+        self::assertSame(CatalogRunStatus::Done, $reloadedRun->getStatus(), $reloadedRun->getErrorMessage() ?? '');
+        self::assertSame(2, $reloadedRun->getItemCount(), 'every seeded product becomes one sheet');
+        self::assertNotNull($reloadedRun->getPageCount());
+        self::assertGreaterThanOrEqual(1, $reloadedRun->getPageCount());
+
+        $reloadedProfile = $this->profiles()->findById($profile->getId());
+        self::assertInstanceOf(CatalogProfile::class, $reloadedProfile);
+        self::assertSame($cacheKey, $reloadedProfile->getCachedFilePath());
+
+        $operator = self::getContainer()->get('exports.storage');
+        self::assertInstanceOf(FilesystemOperator::class, $operator);
+        self::assertTrue($operator->fileExists($cacheKey), 'the generated PDF is cached under the tenant-scoped key');
+
+        // Cleanup the cache artifact so repeat runs stay hermetic.
+        $operator->delete($cacheKey);
+    }
+
+    private function handler(): GenerateCatalogHandler
+    {
+        $container = self::getContainer();
+
+        // The handler's dependency chain reaches CatalogRenderService, whose
+        // PdfRenderer alias the DI compiler inlines/removes (no other consumer),
+        // so the handler is not resolvable from the test container — build the
+        // chain directly (the CatalogRenderServiceTest pattern).
+        $em = $container->get(EntityManagerInterface::class);
+        $values = new ExportBuilderCatalogValues(
+            $container->get(ExportBuilder::class),
+            $container->get(CatalogObjectRepositoryInterface::class),
+            $container->get(ObjectTypeRepositoryInterface::class),
+            $container->get(FilterDslResolver::class),
+            $em->getConnection(),
+            $em,
+            $container->get(TenantContext::class),
+        );
+
+        $renderer = new CatalogRenderService(
+            $values,
+            new CatalogItemMapper(),
+            new CatalogTemplateCatalog(),
+            new HtmlValueSanitizer(),
+            $container->get('twig'),
+            new DompdfRenderer(),
+        );
+
+        $regenerator = new CatalogRegenerator(
+            $renderer,
+            new FlysystemCatalogCacheStorage($container->get('exports.storage')),
+            $this->profiles(),
+            $this->runs(),
+            $container->get(TenantContext::class),
+        );
+
+        return new GenerateCatalogHandler(
+            $em,
+            $this->runs(),
+            $this->profiles(),
+            $regenerator,
+            new CatalogProgressPublisher(new InMemoryMercureHub(), 'https://pim.localhost'),
+            $container->get(TenantContext::class),
+        );
+    }
+
+    private function profiles(): CatalogProfileRepositoryInterface
+    {
+        return self::getContainer()->get(CatalogProfileRepositoryInterface::class);
+    }
+
+    private function runs(): CatalogRunRepositoryInterface
+    {
+        return self::getContainer()->get(CatalogRunRepositoryInterface::class);
+    }
+
+    /**
+     * @return array{0: Tenant, 1: Uuid}
+     */
+    private function seedObjects(int $count, string $descriptionValue): array
+    {
+        $em = $this->em();
+        $tenant = new Tenant('cpdf', 'CPDF Tenant');
+        $em->persist($tenant);
+        $em->flush();
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $type = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $type->markBuiltIn();
+        $em->persist($type);
+        $sku = new Attribute('sku', ['en' => 'SKU'], AttributeType::Text);
+        $name = new Attribute('name', ['en' => 'Name'], AttributeType::Text);
+        $description = new Attribute('description', ['en' => 'Description'], AttributeType::Wysiwyg);
+        $em->persist($sku);
+        $em->persist($name);
+        $em->persist($description);
+        $em->persist(new ObjectTypeAttribute($type, $sku, false, 1));
+        $em->persist(new ObjectTypeAttribute($type, $name, false, 2));
+        $em->persist(new ObjectTypeAttribute($type, $description, false, 3));
+        $em->flush();
+
+        $tenantId = $tenant->getId()->toRfc4122();
+        $typeId = $type->getId();
+        $conn = $em->getConnection();
+
+        $conn->executeStatement(
+            <<<'SQL'
+                INSERT INTO objects (id, tenant_id, object_type_id, kind, code, enabled, status, completeness, attributes_indexed, created_at, updated_at, completeness_pct, sync_status_aggregate, version, schema_drift)
+                SELECT gen_random_uuid(), :t, :ot, 'product', 'CPDF-'||g, true, 'published', '{}'::jsonb, '{}'::jsonb, now(), now(), 0, 'gray', 1, false
+                FROM generate_series(1, :n) g
+                SQL,
+            ['t' => $tenantId, 'ot' => $typeId->toRfc4122(), 'n' => $count],
+        );
+
+        foreach ([$sku->getId()->toRfc4122(), $name->getId()->toRfc4122()] as $attrId) {
+            $conn->executeStatement(
+                <<<'SQL'
+                    INSERT INTO object_values (id, tenant_id, object_id, attribute_id, value, provenance, provenance_meta)
+                    SELECT gen_random_uuid(), :t, o.id, :a, jsonb_build_object('value', o.code), 'import', '{}'::jsonb
+                    FROM objects o WHERE o.tenant_id = :t
+                    SQL,
+                ['t' => $tenantId, 'a' => $attrId],
+            );
+        }
+
+        $conn->executeStatement(
+            <<<'SQL'
+                INSERT INTO object_values (id, tenant_id, object_id, attribute_id, value, provenance, provenance_meta)
+                SELECT gen_random_uuid(), :t, o.id, :a, jsonb_build_object('value', :d::text), 'import', '{}'::jsonb
+                FROM objects o WHERE o.tenant_id = :t
+                SQL,
+            ['t' => $tenantId, 'a' => $description->getId()->toRfc4122(), 'd' => $descriptionValue],
+        );
+        $em->clear();
+
+        $reloaded = $this->rebind($this->reloadTenant($tenantId));
+
+        return [$reloaded, $typeId];
+    }
+
+    private function reloadTenant(string $tenantId): Tenant
+    {
+        $reloaded = $this->em()->getRepository(Tenant::class)->find($tenantId);
+        \assert($reloaded instanceof Tenant);
+
+        return $reloaded;
+    }
+
+    private function rebind(Tenant $tenant): Tenant
+    {
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+
+        return $tenant;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}


### PR DESCRIPTION
Zamyka **CPDF-P3-01** (#2293). Blocked by M1/M2 (merged). Odblokowuje CPDF-P3-03 (regenerate/monitor).

## Co
Async generacja katalogu (mirror wzorca Feed):
- `RunCatalogMessage` (TenantAwareMessage, transport `import`) → `GenerateCatalogHandler` (`AbstractBatchHandler`): load run, idempotency (pending guard), tenant rebind, markRunning + publish, drive `CatalogRegenerator` z callbackiem progresu (Mercure) + poll persisted run na cancel; terminal status bez re-throw.
- `CatalogRegenerator` **owns run lifecycle** (render service jest czysty): render→temp → upload MinIO `catalogs/<tenant>/<id>.pdf` → recordCache na reloaded managed profile → markDone/markError/markCancelled.
- `CatalogProgressPublisher` (Mercure, per-catalog topic `catalogRuns`) + `catalogRuns()` w `MercureSubscribeTopics` + routing w `messenger.yaml`.

## Walidacja (kontener `pim-api-1`, real Postgres + MinIO)
- **Integration test** `GenerateCatalogHandlerTest` (1 test, 10 asercji): dispatch `RunCatalogMessage` → handler → run **Done**, itemCount 2, pageCount≥1, cache pointer ustawiony, **PDF w MinIO** (`catalogs/{tenant}/{id}.pdf` istnieje).
- **PHPStan max** (2G) 0 · **Deptrac** 0 · **php-cs-fixer** czysto.

## Świadome odejście
Run lifecycle w `CatalogRegenerator` (nie w render service) — divergence od Feed (gdzie `FeedGenerator` zarządza runem wewnętrznie); `CatalogRenderService` pozostaje czystym rendererem (testowalnym w izolacji, P2-03).

Refs #2293