### PR TITLE
feat(export): CPDF-P3-02 — publiczny pull katalogu PDF (token URL, cache-and-serve) [SEC]

### DIFF
--- a/apps/api/config/packages/framework.yaml
+++ b/apps/api/config/packages/framework.yaml
@@ -145,6 +145,14 @@ framework:
             policy: 'sliding_window'
             limit: 120
             interval: '1 hour'
+        # CPDF-P3-02 [SEC] — public catalog PDF URL pulls, keyed per catalog (one
+        # active token per catalog, so per-catalog == per-token). The endpoint only
+        # ever streams the cached PDF (the real anti-DoS), so this limiter guards
+        # MinIO read bandwidth, not CPU. Same 120/h budget as feed_pull.
+        catalog_pull:
+            policy: 'sliding_window'
+            limit: 120
+            interval: '1 hour'
 
 when@test:
     framework:
@@ -156,6 +164,12 @@ when@test:
         # feed and every test mints a fresh feed, so tests never interfere.
         rate_limiter:
             feed_pull:
+                policy: 'sliding_window'
+                limit: 5
+                interval: '1 hour'
+            # Keep the catalog-pull 429 path testable — buckets are keyed per
+            # catalog and every test mints a fresh catalog, so tests never interfere.
+            catalog_pull:
                 policy: 'sliding_window'
                 limit: 5
                 interval: '1 hour'

--- a/apps/api/config/packages/security.yaml
+++ b/apps/api/config/packages/security.yaml
@@ -114,6 +114,12 @@ security:
         # magic-link routes). The controller only streams the cached artifact —
         # it never generates — so PUBLIC_ACCESS here cannot trigger heavy work.
         - { path: '^/api/feeds/pull/[0-9a-fA-F-]{36}/[A-Za-z0-9_-]+\.xml$', roles: PUBLIC_ACCESS }
+        # CPDF-P3-02 — public catalog PDF URL handed to partners/print shops. No
+        # session: the 192-bit token in the path IS the credential and the
+        # tenantId scopes RLS before the lookup (same "token IS the auth factor"
+        # model as the feed pull above). The controller only streams the cached
+        # PDF — it never generates — so PUBLIC_ACCESS here cannot trigger heavy work.
+        - { path: '^/api/catalogs/pull/[0-9a-fA-F-]{36}/[A-Za-z0-9_-]+\.pdf$', roles: PUBLIC_ACCESS }
         # `IS_AUTHENTICATED_FULLY` covers BOTH a logged-in user (ROLE_USER
         # + tenant context) and an API key principal (ROLE_API_KEY). The
         # voter chain enforces row-level access on top.

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -482,6 +482,13 @@ services:
         arguments:
             $secret: '%env(APP_SECRET)%'
 
+    # CPDF-P3-02 — catalog PDF URL token HMAC. Keyed with the app secret so the
+    # stored token_hash cannot be forged without the server key; the plaintext
+    # token is shown once at mint/rotate and never persisted.
+    App\Export\Catalog\Application\Delivery\CatalogTokenService:
+        arguments:
+            $secret: '%env(APP_SECRET)%'
+
     # XMLF-P3-06 [SEC] — the pull URL carries the feed credential in the path,
     # and the framework logs request paths (RouterListener route_parameters,
     # ErrorListener "No route found for …"). Decorating the single `logger`

--- a/apps/api/src/Export/Catalog/Application/Delivery/CatalogTokenService.php
+++ b/apps/api/src/Export/Catalog/Application/Delivery/CatalogTokenService.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Application\Delivery;
+
+use App\Export\Catalog\Domain\Entity\CatalogProfile;
+
+/**
+ * Catalog URL token lifecycle (ADR-0027 §6.5, CPDF-P3-02 [SEC]). Each catalog's
+ * public PDF URL carries an unguessable token (>=128-bit); we persist only its
+ * keyed HMAC on the profile (never the plaintext), so the public endpoint
+ * (CPDF-P3-02) can resolve the catalog by a single indexed lookup on the hash.
+ * The token is shown once at mint/rotate; it is NOT the tenant API key (separate
+ * lifecycle, read-only, revocable per catalog). Mirrors {@see \App\Export\Feed\Application\Delivery\FeedTokenService}.
+ */
+final class CatalogTokenService
+{
+    /** 24 random bytes → 32-char base64url token (192-bit, > the 128-bit floor). */
+    private const int TOKEN_BYTES = 24;
+
+    public function __construct(private readonly string $secret)
+    {
+    }
+
+    /**
+     * Mint a new token, store its HMAC on the catalog, and return the plaintext
+     * (shown to the user once).
+     */
+    public function mint(CatalogProfile $catalog): string
+    {
+        $token = rtrim(strtr(base64_encode(random_bytes(self::TOKEN_BYTES)), '+/', '-_'), '=');
+        $catalog->setTokenHash($this->hash($token));
+
+        return $token;
+    }
+
+    public function rotate(CatalogProfile $catalog): string
+    {
+        return $this->mint($catalog);
+    }
+
+    public function revoke(CatalogProfile $catalog): void
+    {
+        $catalog->setTokenHash(null);
+    }
+
+    /**
+     * Deterministic keyed hash used both to store the token and to resolve a
+     * catalog from an incoming URL token.
+     */
+    public function hash(string $token): string
+    {
+        return hash_hmac('sha256', $token, $this->secret);
+    }
+
+    public function matches(CatalogProfile $catalog, string $token): bool
+    {
+        $stored = $catalog->getTokenHash();
+
+        return null !== $stored && hash_equals($stored, $this->hash($token));
+    }
+}

--- a/apps/api/src/Export/Catalog/Presentation/Controller/CatalogPullController.php
+++ b/apps/api/src/Export/Catalog/Presentation/Controller/CatalogPullController.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Presentation\Controller;
+
+use App\Export\Catalog\Application\Delivery\CatalogCacheStorage;
+use App\Export\Catalog\Application\Delivery\CatalogEtag;
+use App\Export\Catalog\Application\Delivery\CatalogTokenService;
+use App\Export\Catalog\Domain\Entity\CatalogProfile;
+use App\Export\Catalog\Domain\Repository\CatalogProfileRepositoryInterface;
+use App\Identity\Contracts\Attribute\NoPermissionRequired;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Repository\TenantRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Public catalog PDF URL — cache-and-serve (ADR-0027 §6.5, CPDF-P3-02 [SEC]).
+ *
+ * The URL an operator hands to a partner/print shop:
+ * `GET /api/catalogs/pull/{tenantId}/{token}.pdf`. It is PUBLIC_ACCESS (no
+ * session) and NEVER generates — it only streams the last cached artifact
+ * (anti-DoS: a flood cannot trigger a 50k-SKU regeneration).
+ *
+ * Tenant isolation is closed by construction, not by an RLS bypass: the
+ * tenantId in the path establishes the RLS scope (GUC + TenantFilter) BEFORE
+ * the catalog lookup, and the 192-bit token is the credential. A token from
+ * tenant A therefore can never resolve a catalog of tenant B, and an unknown
+ * token/tenant yields a flat 404 (no enumeration signal). This mirrors a
+ * presigned URL: the tenantId is not a secret (it lives in the shared URL); the
+ * token is. Mirrors {@see \App\Export\Feed\Presentation\Controller\FeedPullController}.
+ */
+final class CatalogPullController
+{
+    public function __construct(
+        private readonly CatalogProfileRepositoryInterface $catalogs,
+        private readonly CatalogTokenService $tokens,
+        private readonly CatalogCacheStorage $cache,
+        private readonly TenantRepositoryInterface $tenants,
+        private readonly TenantContext $tenantContext,
+        private readonly TenantFilterConfigurator $tenantFilter,
+        private readonly Connection $connection,
+        private readonly RateLimiterFactoryInterface $catalogPullLimiter,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/catalogs/pull/{tenantId}/{token}.pdf',
+        name: 'pim_catalogs_pull',
+        methods: ['GET'],
+        requirements: ['tenantId' => '[0-9a-fA-F-]{36}', 'token' => '[A-Za-z0-9_-]+'],
+    )]
+    #[NoPermissionRequired(reason: 'Public catalog PDF URL for external pullers (partners/print shops). The 192-bit URL token is the credential and the path tenantId scopes RLS before any lookup; no session/RBAC applies. Streams the cached artifact only — never generates.')]
+    public function pull(string $tenantId, string $token, Request $request): Response
+    {
+        if (!Uuid::isValid($tenantId)) {
+            throw $this->notFound();
+        }
+        $this->scopeToTenant(Uuid::fromString($tenantId));
+
+        $catalog = $this->catalogs->findByTokenHash($this->tokens->hash($token));
+        // Constant-time re-check + guards. A miss (wrong token, revoked token,
+        // cross-tenant token) is indistinguishable from any other 404.
+        if (null === $catalog || !$this->tokens->matches($catalog, $token)) {
+            throw $this->notFound();
+        }
+
+        // Per-token budget (one active token per catalog → keyed by catalog id).
+        // After token verification so unauthenticated probes cannot exhaust a
+        // catalog's budget, before any storage read so a hammering loop cannot
+        // saturate MinIO bandwidth (CPDF-P3-02 [SEC]).
+        $this->enforceRateLimit($catalog);
+
+        $key = $catalog->getCachedFilePath();
+        if (null === $key || !$this->cache->exists($key)) {
+            // Never regenerated (or cache swept) — do not generate on pull.
+            throw $this->notFound();
+        }
+
+        // CPDF: pull telemetry deferred (no catalog_pull_stats table in MVP).
+
+        $etag = CatalogEtag::forCache($catalog->getCachedAt(), $catalog->getCachedFileSize(), $catalog->getCachedPageCount());
+        if ($this->matchesIfNoneMatch($request, $etag)) {
+            return new Response(status: Response::HTTP_NOT_MODIFIED, headers: $this->cacheHeaders($etag));
+        }
+
+        return $this->stream($catalog, $key, $etag);
+    }
+
+    private function enforceRateLimit(CatalogProfile $catalog): void
+    {
+        $limiter = $this->catalogPullLimiter->create('catalog-pull:'.$catalog->getId()->toRfc4122());
+        $consumed = $limiter->consume();
+        if ($consumed->isAccepted()) {
+            return;
+        }
+
+        $secondsUntilReset = max(1, $consumed->getRetryAfter()->getTimestamp() - time());
+
+        throw new TooManyRequestsHttpException(
+            $secondsUntilReset,
+            'Catalog pull rate limit exceeded. Try again later.',
+            null,
+            0,
+            ['Retry-After' => (string) $secondsUntilReset],
+        );
+    }
+
+    private function scopeToTenant(Uuid $tenantId): void
+    {
+        $tenant = $this->tenants->findById($tenantId);
+        if (!$tenant instanceof Tenant) {
+            throw $this->notFound();
+        }
+        // Establish the RLS scope from the URL before any TenantScoped query:
+        // the Postgres GUC (row-level security) + the Doctrine TenantFilter.
+        // tenant-safe: infrastructure (establishes the tenant_id RLS policies read from the URL path; this IS the tenant boundary the token then gates, not a bypass — mirrors RlsContextListener)
+        $this->connection->executeStatement(
+            "SELECT set_config('app.current_tenant', :tenant, false)",
+            ['tenant' => $tenantId->toRfc4122()],
+        );
+        $this->tenantContext->set($tenant);
+        // Re-apply the Doctrine tenant filter to the context we just set.
+        // Without this the filter keeps whatever the previous request on this
+        // worker configured — an enabled filter for tenant X would AND
+        // `tenant_id = X` into the token lookup below and turn a perfectly
+        // valid pull for tenant Y into a 404.
+        $this->tenantFilter->apply();
+    }
+
+    private function stream(CatalogProfile $catalog, string $key, string $etag): StreamedResponse
+    {
+        $headers = $this->cacheHeaders($etag);
+        $headers['Content-Type'] = 'application/pdf';
+        $headers['Content-Disposition'] = sprintf('inline; filename="%s.pdf"', $catalog->getCode());
+        $size = $catalog->getCachedFileSize();
+        if (null !== $size) {
+            $headers['Content-Length'] = (string) $size;
+        }
+
+        $storage = $this->cache;
+
+        return new StreamedResponse(static function () use ($storage, $key): void {
+            $stream = $storage->read($key);
+            $out = fopen('php://output', 'w');
+            if (false !== $out) {
+                stream_copy_to_stream($stream, $out);
+                fclose($out);
+            }
+            if (\is_resource($stream)) {
+                fclose($stream);
+            }
+        }, Response::HTTP_OK, $headers);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function cacheHeaders(string $etag): array
+    {
+        return [
+            'ETag' => $etag,
+            // Pullers poll on a schedule; allow a short shared cache + revalidation.
+            'Cache-Control' => 'public, max-age=300, must-revalidate',
+            'Vary' => 'Accept-Encoding',
+        ];
+    }
+
+    private function matchesIfNoneMatch(Request $request, string $etag): bool
+    {
+        $header = $request->headers->get('If-None-Match');
+        if (null === $header) {
+            return false;
+        }
+        foreach (array_map(trim(...), explode(',', $header)) as $candidate) {
+            if ($candidate === $etag || $candidate === 'W/'.$etag) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function notFound(): NotFoundHttpException
+    {
+        return new NotFoundHttpException('Catalog not found.');
+    }
+}

--- a/apps/api/src/Export/Catalog/Presentation/Controller/CatalogTokenController.php
+++ b/apps/api/src/Export/Catalog/Presentation/Controller/CatalogTokenController.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Presentation\Controller;
+
+use App\Export\Catalog\Application\Delivery\CatalogTokenService;
+use App\Export\Catalog\Domain\Entity\CatalogProfile;
+use App\Export\Catalog\Domain\Repository\CatalogProfileRepositoryInterface;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\TenantContext;
+use App\Shared\Application\UserIdentityAware;
+use App\Shared\Domain\Tenant;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Catalog PDF URL token lifecycle (ADR-0027 §6.5, CPDF-P3-02).
+ *
+ * `POST /api/catalogs/{id}/token` mints (or rotates) the token — the plaintext
+ * is returned ONCE together with the public pull URL; only its HMAC is
+ * persisted. `DELETE /api/catalogs/{id}/token` revokes it (the public URL
+ * immediately 404s). Reuses the export/integration RBAC (`integration.admin`,
+ * same grant as the catalog CRUD writes). Auto-registered into OpenAPI by
+ * CustomRouteOpenApiFactory (ADR-0020). Mirrors {@see \App\Export\Feed\Presentation\Controller\FeedTokenController}.
+ */
+final class CatalogTokenController
+{
+    public function __construct(
+        private readonly CatalogProfileRepositoryInterface $catalogs,
+        private readonly CatalogTokenService $tokens,
+        private readonly TenantContext $tenantContext,
+        private readonly Security $security,
+    ) {
+    }
+
+    #[Route(path: '/api/catalogs/{id}/token', name: 'pim_catalogs_token_mint', methods: ['POST'], requirements: ['id' => '[0-9a-fA-F-]{36}'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'integration', action: 'admin')]
+    public function mint(string $id): JsonResponse
+    {
+        $tenant = $this->resolveTenant();
+        $catalog = $this->loadOrFail($id);
+
+        $token = $this->tokens->mint($catalog);
+        $this->catalogs->save($catalog);
+
+        return new JsonResponse([
+            'token' => $token, // shown once — only its HMAC is stored
+            'url' => $this->pullUrl($tenant, $token),
+        ], Response::HTTP_CREATED);
+    }
+
+    #[Route(path: '/api/catalogs/{id}/token', name: 'pim_catalogs_token_revoke', methods: ['DELETE'], requirements: ['id' => '[0-9a-fA-F-]{36}'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'integration', action: 'admin')]
+    public function revoke(string $id): Response
+    {
+        $this->resolveTenant();
+        $catalog = $this->loadOrFail($id);
+
+        $this->tokens->revoke($catalog);
+        $this->catalogs->save($catalog);
+
+        return new Response(status: Response::HTTP_NO_CONTENT);
+    }
+
+    private function pullUrl(Tenant $tenant, string $token): string
+    {
+        return sprintf('/api/catalogs/pull/%s/%s.pdf', $tenant->getId()->toRfc4122(), $token);
+    }
+
+    private function resolveTenant(): Tenant
+    {
+        if (!$this->security->getUser() instanceof UserIdentityAware) {
+            throw new AccessDeniedHttpException('Authenticated user identity required.');
+        }
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new AccessDeniedHttpException('Tenant context required.');
+        }
+
+        return $tenant;
+    }
+
+    private function loadOrFail(string $id): CatalogProfile
+    {
+        $catalog = $this->catalogs->findById(Uuid::fromString($id));
+        if (null === $catalog) {
+            throw new NotFoundHttpException(sprintf('Catalog "%s" was not found.', $id));
+        }
+
+        return $catalog;
+    }
+}

--- a/apps/api/tests/Api/Export/Catalog/CatalogPullApiTest.php
+++ b/apps/api/tests/Api/Export/Catalog/CatalogPullApiTest.php
@@ -1,0 +1,277 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Export\Catalog;
+
+use App\Catalog\Domain\ObjectKind;
+use App\Export\Catalog\Application\Delivery\CatalogTokenService;
+use App\Export\Catalog\Domain\Entity\CatalogProfile;
+use App\Export\Catalog\Domain\Enum\CatalogTemplateKind;
+use App\Export\Catalog\Domain\Repository\CatalogProfileRepositoryInterface;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use DateTimeImmutable;
+use League\Flysystem\FilesystemOperator;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * CPDF-P3-02 [SEC] — public catalog PDF pull via token URL (cache-and-serve).
+ *
+ * Pins the security contract of `GET /api/catalogs/pull/{tenantId}/{token}.pdf`:
+ * an unknown token, a bad tenantId and a cross-tenant token all yield a flat
+ * 404 (no enumeration signal); the endpoint streams the cached PDF only (never
+ * generates); ETag drives a `304`; and the token mint/revoke lifecycle is gated
+ * by `integration.admin` (403 for the `marketing` persona). Mirrors the feed
+ * pull contract but for the PDF catalog surface.
+ */
+final class CatalogPullApiTest extends CatalogApiTestCase
+{
+    private const string MARKETING_EMAIL = 'marketing-cpdf-pull@demo.localhost';
+    private const string PDF_BLOB = "%PDF-1.4\n1 0 obj<<>>endobj\ntrailer<<>>\n%%EOF\n";
+
+    #[Test]
+    public function unknownTokenIsAFlat404WithoutEnumeration(): void
+    {
+        $tenantId = $this->demoTenant()->getId()->toRfc4122();
+        $randomToken = rtrim(strtr(base64_encode(random_bytes(24)), '+/', '-_'), '=');
+
+        $anon = static::createClient();
+        self::assertSame(
+            404,
+            $anon->request('GET', '/api/catalogs/pull/'.$tenantId.'/'.$randomToken.'.pdf')->getStatusCode(),
+        );
+    }
+
+    #[Test]
+    public function badTenantIdIsA404(): void
+    {
+        $unknownTenant = Uuid::v4()->toRfc4122();
+        $randomToken = rtrim(strtr(base64_encode(random_bytes(24)), '+/', '-_'), '=');
+
+        $anon = static::createClient();
+        self::assertSame(
+            404,
+            $anon->request('GET', '/api/catalogs/pull/'.$unknownTenant.'/'.$randomToken.'.pdf')->getStatusCode(),
+        );
+    }
+
+    #[Test]
+    public function happyPathStreamsTheCachedPdfWithAnEtag(): void
+    {
+        $tenant = $this->demoTenant();
+        [$token, $catalogId] = $this->seedCachedCatalog($tenant, 'happy_catalog');
+        $url = '/api/catalogs/pull/'.$tenant->getId()->toRfc4122().'/'.$token.'.pdf';
+        \assert('' !== $catalogId);
+
+        $anon = static::createClient();
+        $response = $anon->request('GET', $url);
+        self::assertSame(200, $response->getStatusCode());
+
+        $headers = $response->getHeaders(throw: false);
+        self::assertSame('application/pdf', $headers['content-type'][0] ?? null);
+        $etag = $headers['etag'][0] ?? null;
+        self::assertNotNull($etag);
+
+        self::assertStringStartsWith('%PDF-', $response->getContent(false));
+    }
+
+    #[Test]
+    public function aMatchingIfNoneMatchReturns304(): void
+    {
+        $tenant = $this->demoTenant();
+        [$token] = $this->seedCachedCatalog($tenant, 'revalidated_catalog');
+        $url = '/api/catalogs/pull/'.$tenant->getId()->toRfc4122().'/'.$token.'.pdf';
+
+        $anon = static::createClient();
+        $first = $anon->request('GET', $url);
+        self::assertSame(200, $first->getStatusCode());
+        $etag = $first->getHeaders(throw: false)['etag'][0] ?? null;
+        self::assertNotNull($etag);
+
+        $revalidated = $anon->request('GET', $url, ['headers' => ['If-None-Match' => $etag]]);
+        self::assertSame(304, $revalidated->getStatusCode());
+    }
+
+    #[Test]
+    public function aTokenMintedForTenantACannotPullUnderTenantB(): void
+    {
+        $tenantA = $this->demoTenant();
+        [$token] = $this->seedCachedCatalog($tenantA, 'cross_tenant_catalog');
+
+        // A different (real) tenant id in the path → the token's HMAC cannot
+        // resolve under B's RLS scope, so this is a flat 404.
+        $tenantB = new Tenant('other-cpdf', 'Other Tenant');
+        $this->em()->persist($tenantB);
+        $this->em()->flush();
+
+        $anon = static::createClient();
+        self::assertSame(
+            404,
+            $anon->request('GET', '/api/catalogs/pull/'.$tenantB->getId()->toRfc4122().'/'.$token.'.pdf')->getStatusCode(),
+        );
+    }
+
+    #[Test]
+    public function aCatalogWithATokenButNoCachedFileIs404NeverGenerates(): void
+    {
+        $tenant = $this->demoTenant();
+        $this->scopeToTenant($tenant);
+        // Mint a token but DO NOT write a cache blob / set the cache pointer.
+        $catalog = new CatalogProfile(
+            'uncached_catalog',
+            'Uncached',
+            CatalogTemplateKind::Sheet,
+            Uuid::fromString($this->objectTypeIdFor(ObjectKind::Product)),
+        );
+        $catalog->assignTenant($tenant);
+        $token = self::getContainer()->get(CatalogTokenService::class)->mint($catalog);
+        $this->catalogRepo()->save($catalog);
+
+        $url = '/api/catalogs/pull/'.$tenant->getId()->toRfc4122().'/'.$token.'.pdf';
+        $anon = static::createClient();
+        self::assertSame(404, $anon->request('GET', $url)->getStatusCode());
+    }
+
+    #[Test]
+    public function tokenMintIsAdminOnlyAndRevocable(): void
+    {
+        $admin = $this->authenticatedClient();
+
+        $created = $admin->request('POST', '/api/catalogs', ['json' => [
+            'template_kind' => 'sheet',
+            'code' => 'token_lifecycle_catalog',
+            'name' => 'Token lifecycle',
+            'object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+            'field_mappings' => [['slot' => 'title', 'source' => ['kind' => 'attribute', 'ref' => 'name']]],
+            'locale' => 'pl',
+        ]]);
+        self::assertSame(201, $created->getStatusCode());
+        $id = $created->toArray(false)['id'];
+        \assert(\is_string($id));
+
+        // Admin (super_admin + tenant_owner → integration.admin) can mint.
+        $minted = $admin->request('POST', '/api/catalogs/'.$id.'/token');
+        self::assertSame(201, $minted->getStatusCode());
+        $mintedBody = $minted->toArray(false);
+        self::assertIsString($mintedBody['token']);
+        self::assertIsString($mintedBody['url']);
+        self::assertStringContainsString('/api/catalogs/pull/', $mintedBody['url']);
+        self::assertStringEndsWith('.pdf', $mintedBody['url']);
+
+        // The marketing persona lacks integration.admin → 403 on mint + revoke.
+        $marketingJwt = $this->seedMarketingUser();
+        $client = static::createClient();
+        $client->request('POST', '/api/catalogs/'.$id.'/token', [
+            'headers' => ['authorization' => 'Bearer '.$marketingJwt],
+        ]);
+        self::assertResponseStatusCodeSame(403);
+
+        $client->request('DELETE', '/api/catalogs/'.$id.'/token', [
+            'headers' => ['authorization' => 'Bearer '.$marketingJwt],
+        ]);
+        self::assertResponseStatusCodeSame(403);
+
+        // Admin revokes.
+        self::assertSame(204, $admin->request('DELETE', '/api/catalogs/'.$id.'/token')->getStatusCode());
+    }
+
+    /**
+     * Seed a tenant-scoped CatalogProfile with a minted token AND a cached PDF
+     * blob written directly to the exports storage under the CPDF cache key.
+     *
+     * @return array{0: string, 1: string} [plaintext token, catalog id rfc4122]
+     */
+    private function seedCachedCatalog(Tenant $tenant, string $code): array
+    {
+        $this->scopeToTenant($tenant);
+        $catalog = new CatalogProfile(
+            $code,
+            'Cached catalog',
+            CatalogTemplateKind::Sheet,
+            Uuid::fromString($this->objectTypeIdFor(ObjectKind::Product)),
+        );
+        $catalog->assignTenant($tenant);
+
+        $key = sprintf(
+            'catalogs/%s/%s.pdf',
+            $tenant->getId()->toRfc4122(),
+            $catalog->getId()->toRfc4122(),
+        );
+        $blob = self::PDF_BLOB;
+        $this->exportsStorage()->write($key, $blob);
+
+        $catalog->recordCache($key, \strlen($blob), 1, new DateTimeImmutable());
+        $token = self::getContainer()->get(CatalogTokenService::class)->mint($catalog);
+        $this->catalogRepo()->save($catalog);
+
+        return [$token, $catalog->getId()->toRfc4122()];
+    }
+
+    private function demoTenant(): Tenant
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        return $tenant;
+    }
+
+    /**
+     * Establish the RLS scope (GUC + TenantContext + Doctrine filter) so a
+     * direct repository save of a CatalogProfile passes row-level security —
+     * the same context the public controller sets from the URL path.
+     */
+    private function scopeToTenant(Tenant $tenant): void
+    {
+        $this->em()->getConnection()->executeStatement(
+            "SELECT set_config('app.current_tenant', :tenant, false)",
+            ['tenant' => $tenant->getId()->toRfc4122()],
+        );
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+    }
+
+    private function catalogRepo(): CatalogProfileRepositoryInterface
+    {
+        $repo = self::getContainer()->get(CatalogProfileRepositoryInterface::class);
+
+        return $repo;
+    }
+
+    private function exportsStorage(): FilesystemOperator
+    {
+        $storage = self::getContainer()->get('exports.storage');
+
+        return $storage;
+    }
+
+    private function seedMarketingUser(): string
+    {
+        $em = $this->em();
+        $tenant = $this->demoTenant();
+
+        $marketing = self::getContainer()->get(RoleRepositoryInterface::class)
+            ->findByCode('marketing', $tenant);
+        \assert(null !== $marketing, 'marketing role must be seeded per tenant');
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $stub = new User($tenant, self::MARKETING_EMAIL, '', ['ROLE_USER']);
+        $user = new User($tenant, self::MARKETING_EMAIL, $hasher->hashPassword($stub, 'changeme'), ['ROLE_USER']);
+        $user->addRole($marketing);
+        $em->persist($user);
+        $em->flush();
+
+        $existing = self::getContainer()->get(UserRepositoryInterface::class)->findByEmail(self::MARKETING_EMAIL);
+        \assert($existing instanceof User);
+
+        return self::getContainer()->get(JWTTokenManagerInterface::class)->create($existing);
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -11929,6 +11929,57 @@
                 "x-cortex-permission": "integration.admin"
             }
         },
+        "/api/catalogs/pull/{tenantId}/{token}.pdf": {
+            "get": {
+                "operationId": "api_catalogs_pull_tenantid_token_pdf_get",
+                "tags": [
+                    "catalogs"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api catalogs pull tenantId token pdf",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "tenantId",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    },
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": false
+            }
+        },
         "/api/catalogs/{id}": {
             "get": {
                 "operationId": "api_catalogs_id_get",
@@ -12018,6 +12069,82 @@
                     }
                 },
                 "summary": "Api catalogs id",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "integration.admin"
+            }
+        },
+        "/api/catalogs/{id}/token": {
+            "post": {
+                "operationId": "api_catalogs_id_token_post",
+                "tags": [
+                    "catalogs"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api catalogs id token",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "integration.admin"
+            },
+            "delete": {
+                "operationId": "api_catalogs_id_token_delete",
+                "tags": [
+                    "catalogs"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api catalogs id token",
                 "description": "Custom controller route.",
                 "parameters": [
                     {


### PR DESCRIPTION
Zamyka **CPDF-P3-02** (#2294). Blocked by P1-01/P1-04 (merged). Odblokowuje CPDF-P5-03 (FE share-link). Kalka 1:1 security-flow `FeedPullController`.

## Co
Publiczny URL PDF: `GET /api/catalogs/pull/{tenantId}/{token}.pdf` — **PUBLIC_ACCESS, NIGDY nie generuje** (tylko streamuje cache; anti-DoS). Izolacja tenantów **domknięta konstrukcyjnie**: tenantId ze ścieżki ustawia RLS GUC + TenantFilter **przed** lookupem, 192-bit token (persystowany tylko HMAC) = credential, porównanie const-time; nieznany/cross-tenant token → **płaskie 404 bez enumeration signal**. ETag/304, rate-limit per-katalog, Content-Disposition. `CatalogTokenService` (mint/rotate/revoke), `CatalogTokenController` (mint/revoke gated `integration.admin`).

## Walidacja (kontener `pim-api-1`, real Postgres + MinIO)
- **[SEC] ApiTest** `CatalogPullApiTest`: **7 testów, 20 asercji** — unknown-token 404, bad-tenant 404, **cross-tenant token 404**, **cache-only 404** (nie generuje), happy 200 `application/pdf` `%PDF-` + ETag, **304** z If-None-Match, mint/revoke gated (admin 201, marketing 403). Test uderza w realny kernel (PUBLIC_ACCESS 401-vs-404) na realnym Postgres+MinIO.
- **PHPStan max** (2G) 0 · **Deptrac** 0 · **php-cs-fixer** czysto · **OpenAPI** `/api/catalogs/pull/...` + `/api/catalogs/{id}/token` w v0.json.

## Świadome odejścia
- Telemetria pobrań (`catalog_pull_stats`) odłożona (brak tabeli w MVP) — komentarz w miejscu, gdzie Feed rejestruje stat.
- **Live curl smoke publicznego URL** odłożony do integracji end-to-end (wymaga wygenerowanego katalogu z cache PDF + tokenem — pełny łańcuch generate+FE dojdzie w P5); ApiTest pokrywa security-flow przeciw realnemu kernelowi. Nie twierdzę „działa end-to-end" bez tego smoke.

Refs #2294