### PR TITLE
feat(export): CPDF-P3-03 — generate dispatch + monitor runów + KPI

### DIFF
--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -352,10 +352,14 @@ services:
     App\Export\Feed\Presentation\Controller\FeedRegenerateController:
         arguments:
             $topicBase: '%env(MERCURE_TOPIC_BASE)%'
-    # CPDF-P3-01 — catalog regeneration progress topic
+    # CPDF-P3-01/P3-03 — catalog regeneration progress topic
     # (tenant/{tid}/catalogs/{id}/runs); built from the same public origin the
-    # SPA subscribes on so the tenant-scoped subscribe claim matches.
+    # SPA subscribes on so the tenant-scoped subscribe claim matches. The manual
+    # "Generuj teraz" endpoint returns the same topic as `mercure_topic`.
     App\Export\Catalog\Application\Async\CatalogProgressPublisher:
+        arguments:
+            $topicBase: '%env(MERCURE_TOPIC_BASE)%'
+    App\Export\Catalog\Presentation\Controller\CatalogRegenerateController:
         arguments:
             $topicBase: '%env(MERCURE_TOPIC_BASE)%'
     # AUD-001 (#1573) — Catalog + permission publishers and the cookie

--- a/apps/api/src/Export/Catalog/Presentation/Controller/CatalogRegenerateController.php
+++ b/apps/api/src/Export/Catalog/Presentation/Controller/CatalogRegenerateController.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Presentation\Controller;
+
+use App\Export\Catalog\Domain\Entity\CatalogProfile;
+use App\Export\Catalog\Domain\Entity\CatalogRun;
+use App\Export\Catalog\Domain\Enum\CatalogRunTrigger;
+use App\Export\Catalog\Domain\Message\RunCatalogMessage;
+use App\Export\Catalog\Domain\Repository\CatalogProfileRepositoryInterface;
+use App\Export\Catalog\Domain\Repository\CatalogRunRepositoryInterface;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\TenantContext;
+use App\Shared\Application\UserIdentityAware;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Mercure\MercureSubscribeTopics;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+use const DATE_ATOM;
+
+/**
+ * Manual PDF catalog generation (ADR-0027 §6.3, CPDF-P3-03) — the "Generuj
+ * teraz" trigger, the catalog-world analogue of {@see \App\Export\Feed\Presentation\Controller\FeedRegenerateController}.
+ * Creates a pending {@see CatalogRun}, assigns the tenant and dispatches a
+ * {@see RunCatalogMessage} onto the shared `import` queue;
+ * {@see \App\Export\Catalog\Application\Async\GenerateCatalogHandler} drives the
+ * regeneration out-of-band and streams progress over Mercure (`mercure_topic`
+ * in the response — the monitor subscribes there).
+ *
+ * In dev/prod the response is a true 202 (run pending, worker picks it up);
+ * in the test env the `import` transport is sync://, so the run completes inline
+ * and the serialized state already reflects the terminal status — which is also
+ * why the response reloads the run before serializing. Auto-registered into
+ * OpenAPI by CustomRouteOpenApiFactory (ADR-0020).
+ */
+final class CatalogRegenerateController
+{
+    public function __construct(
+        private readonly CatalogProfileRepositoryInterface $catalogs,
+        private readonly CatalogRunRepositoryInterface $runs,
+        private readonly MessageBusInterface $bus,
+        private readonly TenantContext $tenantContext,
+        private readonly Security $security,
+        private readonly string $topicBase,
+    ) {
+    }
+
+    #[Route(path: '/api/catalogs/{id}/generate', name: 'pim_catalogs_generate', methods: ['POST'], requirements: ['id' => '[0-9a-fA-F-]{36}'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'integration', action: 'admin')]
+    public function generate(string $id): JsonResponse
+    {
+        $tenant = $this->resolveTenant();
+        $catalog = $this->loadOrFail($id);
+
+        $run = new CatalogRun($catalog->getId(), CatalogRunTrigger::Manual);
+        $run->assignTenant($tenant);
+        $this->runs->save($run);
+
+        $this->bus->dispatch(new RunCatalogMessage($run->getId(), $tenant->getId()));
+
+        // Sync transport (test env) completes the run inside dispatch() and
+        // the handler's EM clear detaches our reference — reload the run so the
+        // response reflects the actual current state.
+        $freshRun = $this->runs->findById($run->getId()) ?? $run;
+
+        return new JsonResponse(
+            [
+                'run' => [
+                    'id' => $freshRun->getId()->toRfc4122(),
+                    'catalog_id' => $freshRun->getCatalogProfileId()->toRfc4122(),
+                    'status' => $freshRun->getStatus()->value,
+                    'trigger' => $freshRun->getTrigger()->value,
+                    'page_count' => $freshRun->getPageCount(),
+                    'byte_size' => $freshRun->getByteSize(),
+                    'item_count' => $freshRun->getItemCount(),
+                    'error_message' => $freshRun->getErrorMessage(),
+                    'started_at' => $freshRun->getStartedAt()?->format(DATE_ATOM),
+                    'completed_at' => $freshRun->getCompletedAt()?->format(DATE_ATOM),
+                ],
+                // The monitor subscribes here for live progress/status (P3-03).
+                'mercure_topic' => MercureSubscribeTopics::catalogRuns(
+                    $tenant->getId(),
+                    $this->topicBase,
+                    $catalog->getId()->toRfc4122(),
+                ),
+            ],
+            Response::HTTP_ACCEPTED,
+        );
+    }
+
+    private function resolveTenant(): Tenant
+    {
+        if (!$this->security->getUser() instanceof UserIdentityAware) {
+            throw new AccessDeniedHttpException('Authenticated user identity required.');
+        }
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new AccessDeniedHttpException('Tenant context required.');
+        }
+
+        return $tenant;
+    }
+
+    private function loadOrFail(string $id): CatalogProfile
+    {
+        $catalog = $this->catalogs->findById(Uuid::fromString($id));
+        if (null === $catalog) {
+            // Tenant isolation via RLS/TenantFilter; a miss is a 404 either way.
+            throw new NotFoundHttpException(sprintf('Catalog "%s" was not found.', $id));
+        }
+
+        return $catalog;
+    }
+}

--- a/apps/api/src/Export/Catalog/Presentation/Controller/CatalogRunCancelController.php
+++ b/apps/api/src/Export/Catalog/Presentation/Controller/CatalogRunCancelController.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Presentation\Controller;
+
+use App\Export\Catalog\Domain\Entity\CatalogRun;
+use App\Export\Catalog\Domain\Repository\CatalogRunRepositoryInterface;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\TenantContext;
+use App\Shared\Application\UserIdentityAware;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+use const DATE_ATOM;
+
+/**
+ * CPDF-P3-03 — user-requested cancellation of a PDF catalog generation, the
+ * catalog-world mirror of
+ * {@see \App\Export\Feed\Presentation\Controller\FeedRunCancelController}.
+ *
+ * Persists the terminal status; the async worker polls it between chunks
+ * ({@see \App\Export\Catalog\Application\Async\GenerateCatalogHandler} onChunk)
+ * and stops gracefully — partial temp file removed, previous cached artifact
+ * untouched, no error state. Auto-registered into OpenAPI (ADR-0020).
+ */
+final class CatalogRunCancelController
+{
+    public function __construct(
+        private readonly CatalogRunRepositoryInterface $runs,
+        private readonly TenantContext $tenantContext,
+        private readonly Security $security,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/catalog-runs/{id}/cancel',
+        name: 'pim_catalog_runs_cancel',
+        methods: ['POST'],
+        requirements: ['id' => '[0-9a-fA-F-]{36}'],
+    )]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'integration', action: 'admin')]
+    public function cancel(string $id): JsonResponse
+    {
+        $this->assertTenantUser();
+
+        $run = $this->runs->findById(Uuid::fromString($id));
+        if (!$run instanceof CatalogRun) {
+            // Tenant isolation via RLS/TenantFilter; a miss is a 404 either way.
+            throw new NotFoundHttpException(sprintf('Catalog run "%s" was not found.', $id));
+        }
+
+        if ($run->getStatus()->isTerminal()) {
+            throw new ConflictHttpException(sprintf(
+                'Catalog run is already %s and cannot be cancelled.',
+                $run->getStatus()->value,
+            ));
+        }
+
+        $run->markCancelled();
+        $this->runs->save($run);
+
+        return new JsonResponse([
+            'id' => $run->getId()->toRfc4122(),
+            'catalog_id' => $run->getCatalogProfileId()->toRfc4122(),
+            'status' => $run->getStatus()->value,
+            'completed_at' => $run->getCompletedAt()?->format(DATE_ATOM),
+        ]);
+    }
+
+    private function assertTenantUser(): void
+    {
+        if (!$this->security->getUser() instanceof UserIdentityAware) {
+            throw new AccessDeniedHttpException('Authenticated user identity required.');
+        }
+        if (null === $this->tenantContext->get()) {
+            throw new AccessDeniedHttpException('Tenant context required.');
+        }
+    }
+}

--- a/apps/api/src/Export/Catalog/Presentation/Controller/CatalogRunHistoryController.php
+++ b/apps/api/src/Export/Catalog/Presentation/Controller/CatalogRunHistoryController.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Presentation\Controller;
+
+use App\Export\Catalog\Domain\Entity\CatalogProfile;
+use App\Export\Catalog\Domain\Entity\CatalogRun;
+use App\Export\Catalog\Domain\Repository\CatalogProfileRepositoryInterface;
+use App\Export\Catalog\Domain\Repository\CatalogRunRepositoryInterface;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\TenantContext;
+use App\Shared\Application\UserIdentityAware;
+use DateTimeInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Per-catalog run history (CPDF-P3-03, ADR-0027 §6.3) — the read side behind
+ * the catalog detail screen: the recent runs of one catalog, newest first. The
+ * catalog-world analogue of
+ * {@see \App\Export\Feed\Presentation\Controller\FeedRunHistoryController}.
+ * Read-only projection; auto-registered into OpenAPI (ADR-0020).
+ */
+final class CatalogRunHistoryController
+{
+    private const int DEFAULT_LIMIT = 25;
+    private const int MAX_LIMIT = 100;
+
+    public function __construct(
+        private readonly CatalogProfileRepositoryInterface $catalogs,
+        private readonly CatalogRunRepositoryInterface $runs,
+        private readonly TenantContext $tenantContext,
+        private readonly Security $security,
+    ) {
+    }
+
+    #[Route(path: '/api/catalogs/{id}/runs', name: 'pim_catalog_runs_history', methods: ['GET'], requirements: ['id' => '[0-9a-fA-F-]{36}'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'exports', action: 'view_all')]
+    public function list(string $id, Request $request): JsonResponse
+    {
+        $this->assertTenantUser();
+        $catalog = $this->loadCatalogOrFail($id);
+
+        $limit = max(1, min(self::MAX_LIMIT, $request->query->getInt('limit', self::DEFAULT_LIMIT)));
+
+        $runs = $this->runs->findByCatalogProfile($catalog->getId(), $limit);
+
+        return new JsonResponse([
+            'items' => array_map($this->serializeRun(...), $runs),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializeRun(CatalogRun $run): array
+    {
+        return [
+            'id' => $run->getId()->toRfc4122(),
+            'catalog_id' => $run->getCatalogProfileId()->toRfc4122(),
+            'trigger' => $run->getTrigger()->value,
+            'status' => $run->getStatus()->value,
+            'health' => CatalogRunMonitorController::health($run),
+            'page_count' => $run->getPageCount(),
+            'byte_size' => $run->getByteSize(),
+            'item_count' => $run->getItemCount(),
+            'duration_ms' => $run->getDurationMs(),
+            'error_message' => $run->getErrorMessage(),
+            'started_at' => $run->getStartedAt()?->format(DateTimeInterface::ATOM),
+            'completed_at' => $run->getCompletedAt()?->format(DateTimeInterface::ATOM),
+        ];
+    }
+
+    private function loadCatalogOrFail(string $id): CatalogProfile
+    {
+        $catalog = $this->catalogs->findById(Uuid::fromString($id));
+        if (null === $catalog) {
+            // Tenant isolation via RLS/TenantFilter; a miss is a 404 either way.
+            throw new NotFoundHttpException(sprintf('Catalog "%s" was not found.', $id));
+        }
+
+        return $catalog;
+    }
+
+    private function assertTenantUser(): void
+    {
+        if (!$this->security->getUser() instanceof UserIdentityAware) {
+            throw new AccessDeniedHttpException('Authenticated user identity required.');
+        }
+        if (null === $this->tenantContext->get()) {
+            throw new AccessDeniedHttpException('Tenant context required.');
+        }
+    }
+}

--- a/apps/api/src/Export/Catalog/Presentation/Controller/CatalogRunMonitorController.php
+++ b/apps/api/src/Export/Catalog/Presentation/Controller/CatalogRunMonitorController.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Presentation\Controller;
+
+use App\Export\Catalog\Domain\Entity\CatalogProfile;
+use App\Export\Catalog\Domain\Entity\CatalogRun;
+use App\Export\Catalog\Domain\Enum\CatalogRunStatus;
+use App\Export\Catalog\Domain\Enum\CatalogStatus;
+use App\Export\Catalog\Domain\Repository\CatalogProfileRepositoryInterface;
+use App\Export\Catalog\Domain\Repository\CatalogRunRepositoryInterface;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\TenantContext;
+use App\Shared\Application\UserIdentityAware;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Global catalog monitor (CPDF-P3-03, ADR-0027 §6.3) — the read side behind the
+ * catalog monitor screen: the tenant-wide run history (RunsTable) and the health
+ * KPI tiles (Regeneracje 24h / Strony wygenerowane / Błędy 24h). Read-only
+ * projections; the catalog-world analogue of
+ * {@see \App\Export\Feed\Presentation\Controller\FeedRunMonitorController}.
+ * Auto-registered into OpenAPI (ADR-0020).
+ *
+ * Runs are keyset-paginated over the UUIDv7 id (== started_at order); the
+ * `cursor` query param round-trips the last item's id. `status` filters the
+ * DISPLAY health: success (done) | error.
+ */
+final class CatalogRunMonitorController
+{
+    private const int DEFAULT_LIMIT = 25;
+    private const int MAX_LIMIT = 100;
+
+    public function __construct(
+        private readonly CatalogRunRepositoryInterface $runs,
+        private readonly CatalogProfileRepositoryInterface $catalogs,
+        private readonly TenantContext $tenantContext,
+        private readonly Security $security,
+    ) {
+    }
+
+    #[Route(path: '/api/catalog-runs', name: 'pim_catalog_runs_list', methods: ['GET'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'exports', action: 'view_all')]
+    public function list(Request $request): JsonResponse
+    {
+        $tenant = $this->resolveTenant();
+        [$health, $cursor, $limit] = $this->readListParams($request);
+
+        $page = $this->runs->findPage(null, $health, $cursor, $limit);
+
+        // Names for the global table — one indexed load for the whole page
+        // (a tenant has dozens of catalogs, not thousands).
+        $profiles = [];
+        foreach ($this->catalogs->findByTenant($tenant) as $profile) {
+            $profiles[$profile->getId()->toRfc4122()] = $profile;
+        }
+
+        $items = array_map(
+            fn (CatalogRun $run): array => $this->serializeRun($run, $profiles[$run->getCatalogProfileId()->toRfc4122()] ?? null),
+            $page,
+        );
+
+        return new JsonResponse([
+            'items' => $items,
+            'next_cursor' => [] !== $page && \count($page) === $limit
+                ? $page[\count($page) - 1]->getId()->toRfc4122()
+                : null,
+        ]);
+    }
+
+    #[Route(path: '/api/catalog-runs/kpi', name: 'pim_catalog_runs_kpi', methods: ['GET'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'exports', action: 'view_all')]
+    public function kpi(): JsonResponse
+    {
+        $tenant = $this->resolveTenant();
+
+        $kpi = $this->runs->kpi24h($tenant, new DateTimeImmutable());
+
+        // Current publication snapshot: what the public URLs serve right now
+        // (design tile "Strony syndykowane" — inventory, not a 24h flow).
+        $pagesPublished = 0;
+        $lastRegeneratedAt = null;
+        $statusCounts = ['active' => 0, 'paused' => 0, 'error' => 0];
+        foreach ($this->catalogs->findByTenant($tenant) as $profile) {
+            $pagesPublished += $profile->getCachedPageCount() ?? 0;
+            $cachedAt = $profile->getCachedAt();
+            if (null !== $cachedAt && (null === $lastRegeneratedAt || $cachedAt > $lastRegeneratedAt)) {
+                $lastRegeneratedAt = $cachedAt;
+            }
+            $key = match ($profile->getStatus()) {
+                CatalogStatus::Active => 'active',
+                CatalogStatus::Paused => 'paused',
+                CatalogStatus::Error => 'error',
+            };
+            ++$statusCounts[$key];
+        }
+
+        return new JsonResponse([
+            ...$kpi,
+            'pages_published' => $pagesPublished,
+            'last_regenerated_at' => $lastRegeneratedAt?->format(DateTimeInterface::ATOM),
+            'catalogs' => $statusCounts,
+        ]);
+    }
+
+    /**
+     * @return array{0: string|null, 1: Uuid|null, 2: int}
+     */
+    private function readListParams(Request $request): array
+    {
+        $status = $request->query->get('status');
+        $health = \in_array($status, ['success', 'error'], true) ? $status : null;
+
+        $cursorRaw = $request->query->get('cursor');
+        // An invalid cursor serves the first page — stale URLs never 500.
+        $cursor = (\is_string($cursorRaw) && Uuid::isValid($cursorRaw)) ? Uuid::fromString($cursorRaw) : null;
+
+        $limit = max(1, min(self::MAX_LIMIT, $request->query->getInt('limit', self::DEFAULT_LIMIT)));
+
+        return [$health, $cursor, $limit];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializeRun(CatalogRun $run, ?CatalogProfile $profile): array
+    {
+        return [
+            'id' => $run->getId()->toRfc4122(),
+            'catalog_id' => $run->getCatalogProfileId()->toRfc4122(),
+            'catalog_name' => $profile?->getName(),
+            'catalog_code' => $profile?->getCode(),
+            'template_kind' => $profile?->getTemplateKind()->value,
+            'trigger' => $run->getTrigger()->value,
+            'status' => $run->getStatus()->value,
+            'health' => self::health($run),
+            'page_count' => $run->getPageCount(),
+            'byte_size' => $run->getByteSize(),
+            'item_count' => $run->getItemCount(),
+            'duration_ms' => $run->getDurationMs(),
+            'error_message' => $run->getErrorMessage(),
+            'started_at' => $run->getStartedAt()?->format(DateTimeInterface::ATOM),
+            'completed_at' => $run->getCompletedAt()?->format(DateTimeInterface::ATOM),
+        ];
+    }
+
+    /**
+     * Display status for the monitor chips.
+     */
+    public static function health(CatalogRun $run): string
+    {
+        return match ($run->getStatus()) {
+            CatalogRunStatus::Done => 'success',
+            CatalogRunStatus::Error => 'error',
+            CatalogRunStatus::Pending => 'pending',
+            CatalogRunStatus::Running => 'running',
+            CatalogRunStatus::Cancelled => 'cancelled',
+        };
+    }
+
+    private function resolveTenant(): Tenant
+    {
+        if (!$this->security->getUser() instanceof UserIdentityAware) {
+            throw new AccessDeniedHttpException('Authenticated user identity required.');
+        }
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new AccessDeniedHttpException('Tenant context required.');
+        }
+
+        return $tenant;
+    }
+}

--- a/apps/api/tests/Api/Export/Catalog/CatalogRunMonitorApiTest.php
+++ b/apps/api/tests/Api/Export/Catalog/CatalogRunMonitorApiTest.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Export\Catalog;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Export\Catalog\Domain\Entity\CatalogProfile;
+use App\Export\Catalog\Domain\Enum\CatalogTemplateKind;
+use App\Export\Catalog\Domain\Repository\CatalogProfileRepositoryInterface;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * CPDF-P3-03 — catalog generate dispatch + run monitor + KPI endpoints.
+ *
+ * Mirrors the Feed monitor coverage: the manual "Generuj teraz" trigger
+ * (202 create + dispatch), the tenant-wide run list (keyset), the 24h KPI
+ * tiles and the per-catalog run history, plus the RBAC boundary cases
+ * (`integration.admin` on generate/cancel, `exports.view_all` on reads,
+ * 401 anonymous, 404 unknown id).
+ *
+ * The `import` transport is sync:// under test, so `POST /generate` runs the
+ * {@see \App\Export\Catalog\Application\Async\GenerateCatalogHandler} inline;
+ * the fixtures below (Product type + sku/name/description attributes + two
+ * objects with values + a matching CatalogProfile) let the render reach a real
+ * `%PDF-` artifact, so the run terminates `done` and the monitor/KPI/history
+ * endpoints have a genuine terminal run to report.
+ */
+final class CatalogRunMonitorApiTest extends CatalogApiTestCase
+{
+    private const string MARKETING_EMAIL = 'marketing-cpdf-monitor@demo.localhost';
+
+    #[Test]
+    public function generateDispatchesARunAndTheMonitorReportsIt(): void
+    {
+        $catalogId = $this->seedRenderableCatalog();
+        $client = $this->authenticatedClient();
+
+        // Manual "Generuj teraz" — sync transport renders inline, so the run
+        // reaches a terminal state before the response is serialized.
+        $generated = $client->request('POST', '/api/catalogs/'.$catalogId.'/generate');
+        self::assertSame(202, $generated->getStatusCode());
+        $body = $generated->toArray(false);
+        self::assertIsArray($body['run']);
+        $run = $body['run'];
+        self::assertIsString($run['id']);
+        $runId = $run['id'];
+        self::assertSame($catalogId, $run['catalog_id']);
+        self::assertIsString($body['mercure_topic']);
+        self::assertStringContainsString('/catalogs/'.$catalogId.'/runs', $body['mercure_topic']);
+
+        // Global run list — the fresh run is present.
+        $list = $client->request('GET', '/api/catalog-runs');
+        self::assertSame(200, $list->getStatusCode());
+        $listBody = $list->toArray(false);
+        self::assertIsArray($listBody['items']);
+        self::assertNotEmpty($listBody['items']);
+        self::assertContains($runId, array_column($listBody['items'], 'id'));
+        self::assertArrayHasKey('next_cursor', $listBody);
+
+        // KPI tiles — at least this one regeneration in the last 24h.
+        $kpi = $client->request('GET', '/api/catalog-runs/kpi');
+        self::assertSame(200, $kpi->getStatusCode());
+        $kpiBody = $kpi->toArray(false);
+        self::assertArrayHasKey('regenerations_24h', $kpiBody);
+        self::assertGreaterThanOrEqual(1, $kpiBody['regenerations_24h']);
+        self::assertArrayHasKey('errors_24h', $kpiBody);
+        self::assertArrayHasKey('items_24h', $kpiBody);
+        self::assertArrayHasKey('pages_published', $kpiBody);
+
+        // Per-catalog run history — lists the run we just triggered.
+        $history = $client->request('GET', '/api/catalogs/'.$catalogId.'/runs');
+        self::assertSame(200, $history->getStatusCode());
+        $historyBody = $history->toArray(false);
+        self::assertIsArray($historyBody['items']);
+        self::assertNotEmpty($historyBody['items']);
+        self::assertContains($runId, array_column($historyBody['items'], 'id'));
+    }
+
+    #[Test]
+    public function generateOnAnUnknownCatalogIsA404(): void
+    {
+        $client = $this->authenticatedClient();
+
+        self::assertSame(
+            404,
+            $client->request('POST', '/api/catalogs/00000000-0000-7000-8000-000000000000/generate')->getStatusCode(),
+        );
+    }
+
+    #[Test]
+    public function aPersonaWithoutTheGrantsIsForbidden(): void
+    {
+        $catalogId = $this->seedRenderableCatalog();
+        $marketingJwt = $this->seedMarketingUser();
+        $client = static::createClient();
+
+        // Marketing lacks integration.admin → generate refuses with 403.
+        $client->request('POST', '/api/catalogs/'.$catalogId.'/generate', [
+            'headers' => ['authorization' => 'Bearer '.$marketingJwt],
+        ]);
+        self::assertResponseStatusCodeSame(403);
+
+        // Marketing lacks exports.view_all → monitor reads refuse with 403.
+        $client->request('GET', '/api/catalog-runs', [
+            'headers' => ['authorization' => 'Bearer '.$marketingJwt],
+        ]);
+        self::assertResponseStatusCodeSame(403);
+
+        $client->request('GET', '/api/catalog-runs/kpi', [
+            'headers' => ['authorization' => 'Bearer '.$marketingJwt],
+        ]);
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    #[Test]
+    public function anonymousRequestsAre401(): void
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/api/catalog-runs');
+        self::assertResponseStatusCodeSame(401);
+
+        $client->request('GET', '/api/catalog-runs/kpi');
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    /**
+     * Seeds sku/name/description attributes onto the demo tenant's built-in
+     * Product ObjectType, two products with values and a CatalogProfile whose
+     * field mappings match — so the sync generate renders a real PDF.
+     */
+    private function seedRenderableCatalog(): string
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($type instanceof ObjectType);
+        $typeId = $type->getId();
+
+        $sku = new Attribute('sku', ['en' => 'SKU'], AttributeType::Text);
+        $name = new Attribute('name', ['en' => 'Name'], AttributeType::Text);
+        $description = new Attribute('description', ['en' => 'Description'], AttributeType::Wysiwyg);
+        $em->persist($sku);
+        $em->persist($name);
+        $em->persist($description);
+        $em->persist(new ObjectTypeAttribute($type, $sku, false, 1));
+        $em->persist(new ObjectTypeAttribute($type, $name, false, 2));
+        $em->persist(new ObjectTypeAttribute($type, $description, false, 3));
+        $em->flush();
+
+        $tenantId = $tenant->getId()->toRfc4122();
+        $conn = $em->getConnection();
+
+        $conn->executeStatement(
+            <<<'SQL'
+                INSERT INTO objects (id, tenant_id, object_type_id, kind, code, enabled, status, completeness, attributes_indexed, created_at, updated_at, completeness_pct, sync_status_aggregate, version, schema_drift)
+                SELECT gen_random_uuid(), :t, :ot, 'product', 'CPDF-'||g, true, 'published', '{}'::jsonb, '{}'::jsonb, now(), now(), 0, 'gray', 1, false
+                FROM generate_series(1, 2) g
+                SQL,
+            ['t' => $tenantId, 'ot' => $typeId->toRfc4122()],
+        );
+
+        foreach ([$sku->getId()->toRfc4122(), $name->getId()->toRfc4122()] as $attrId) {
+            $conn->executeStatement(
+                <<<'SQL'
+                    INSERT INTO object_values (id, tenant_id, object_id, attribute_id, value, provenance, provenance_meta)
+                    SELECT gen_random_uuid(), :t, o.id, :a, jsonb_build_object('value', o.code), 'import', '{}'::jsonb
+                    FROM objects o WHERE o.tenant_id = :t
+                    SQL,
+                ['t' => $tenantId, 'a' => $attrId],
+            );
+        }
+        $conn->executeStatement(
+            <<<'SQL'
+                INSERT INTO object_values (id, tenant_id, object_id, attribute_id, value, provenance, provenance_meta)
+                SELECT gen_random_uuid(), :t, o.id, :a, jsonb_build_object('value', :d::text), 'import', '{}'::jsonb
+                FROM objects o WHERE o.tenant_id = :t
+                SQL,
+            ['t' => $tenantId, 'a' => $description->getId()->toRfc4122(), 'd' => '<strong>Opis produktu</strong>'],
+        );
+
+        $profile = new CatalogProfile(
+            'monitor-cat',
+            'Monitor Catalog',
+            CatalogTemplateKind::Sheet,
+            $typeId,
+            branding: ['color' => '#0ea5e9', 'company_name' => 'ACME'],
+            fieldMappings: [
+                ['slot' => 'title', 'source' => ['kind' => 'attribute', 'ref' => 'name']],
+                ['slot' => 'sku', 'source' => ['kind' => 'attribute', 'ref' => 'sku']],
+                ['slot' => 'description', 'source' => ['kind' => 'attribute', 'ref' => 'description']],
+            ],
+        );
+        $profile->assignTenant($tenant);
+        self::getContainer()->get(CatalogProfileRepositoryInterface::class)->save($profile);
+
+        $em->clear();
+
+        // Re-establish tenant scope + RLS GUC after the clear so the follow-up
+        // API requests (which boot their own request scope) see the fixtures.
+        $reloaded = $em->getRepository(Tenant::class)->find($tenant->getId());
+        \assert($reloaded instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($reloaded);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+
+        return $profile->getId()->toRfc4122();
+    }
+
+    private function seedMarketingUser(): string
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $marketing = self::getContainer()->get(RoleRepositoryInterface::class)
+            ->findByCode('marketing', $tenant);
+        \assert(null !== $marketing, 'marketing role must be seeded per tenant');
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $stub = new User($tenant, self::MARKETING_EMAIL, '', ['ROLE_USER']);
+        $user = new User($tenant, self::MARKETING_EMAIL, $hasher->hashPassword($stub, 'changeme'), ['ROLE_USER']);
+        $user->addRole($marketing);
+        $em->persist($user);
+        $em->flush();
+
+        return self::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -11879,6 +11879,97 @@
                 "x-cortex-permission": "products.bulk_operations"
             }
         },
+        "/api/catalog-runs": {
+            "get": {
+                "operationId": "api_catalog_runs_get",
+                "tags": [
+                    "catalog-runs"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api catalog runs",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "exports.view_all"
+            }
+        },
+        "/api/catalog-runs/kpi": {
+            "get": {
+                "operationId": "api_catalog_runs_kpi_get",
+                "tags": [
+                    "catalog-runs"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api catalog runs kpi",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "exports.view_all"
+            }
+        },
+        "/api/catalog-runs/{id}/cancel": {
+            "post": {
+                "operationId": "api_catalog_runs_id_cancel_post",
+                "tags": [
+                    "catalog-runs"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api catalog runs id cancel",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "integration.admin"
+            }
+        },
         "/api/catalogs": {
             "get": {
                 "operationId": "api_catalogs_get",
@@ -12091,6 +12182,84 @@
                 ],
                 "x-pim-source": "custom-route",
                 "x-cortex-permission": "integration.admin"
+            }
+        },
+        "/api/catalogs/{id}/generate": {
+            "post": {
+                "operationId": "api_catalogs_id_generate_post",
+                "tags": [
+                    "catalogs"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api catalogs id generate",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "integration.admin"
+            }
+        },
+        "/api/catalogs/{id}/runs": {
+            "get": {
+                "operationId": "api_catalogs_id_runs_get",
+                "tags": [
+                    "catalogs"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api catalogs id runs",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "exports.view_all"
             }
         },
         "/api/catalogs/{id}/token": {


### PR DESCRIPTION
Zamyka **CPDF-P3-03** (#2295). Blocked by P3-01 (merged). Odblokowuje CPDF-P5-03/P5-04 (FE lista+progres).

## Co
Powierzchnia operatorska generacji + monitoringu (kalka kontrolerów Feed):
- `POST /api/catalogs/{id}/generate` (`integration.admin`) → tworzy pending run, dispatch `RunCatalogMessage` na `import`, **202** + Mercure topic runów.
- `GET /api/catalog-runs` (`exports.view_all`) — keyset + filtr statusu; `GET /api/catalog-runs/kpi` — kafle 24h (regenerations/errors/items + inwentarz katalogów).
- `GET /api/catalogs/{id}/runs` — historia per katalog; `POST /api/catalog-runs/{id}/cancel` (`integration.admin`) — flip non-terminal → cancelled (async onChunk go pollingu).

## Walidacja (kontener `pim-api-1`, real Postgres + MinIO)
- **ApiTest** `CatalogRunMonitorApiTest`: **4 testy, 28 asercji** — generate 202/403(marketing)/404, keyset list zawiera run, KPI regenerations_24h≥1 (realna regeneracja), historia, 401 anon.
- **PHPStan max** (2G, fresh cache) 0 · **Deptrac** 0 · **php-cs-fixer** czysto · **OpenAPI** v0.json z pełnym zestawem tras katalogów (generate/runs/kpi/cancel + pull/token/CRUD).

## Uwaga (lokalna walidacja)
`import` transport w kontenerze = `doctrine://` (dev), więc lokalnie test odpalany z `-e MESSENGER_IMPORT_TRANSPORT_DSN=sync://` by odtworzyć CI (gdzie import=sync:// → handler inline). Na CI przechodzi natywnie.

Refs #2295