### PR TITLE
feat(export): CPDF-P3-04 — bulk generate katalogów

### DIFF
--- a/apps/api/src/Export/Catalog/Presentation/Controller/CatalogBulkGenerateController.php
+++ b/apps/api/src/Export/Catalog/Presentation/Controller/CatalogBulkGenerateController.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Presentation\Controller;
+
+use App\Export\Catalog\Domain\Entity\CatalogRun;
+use App\Export\Catalog\Domain\Enum\CatalogRunTrigger;
+use App\Export\Catalog\Domain\Message\RunCatalogMessage;
+use App\Export\Catalog\Domain\Repository\CatalogProfileRepositoryInterface;
+use App\Export\Catalog\Domain\Repository\CatalogRunRepositoryInterface;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\TenantContext;
+use App\Shared\Application\UserIdentityAware;
+use App\Shared\Domain\Tenant;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Bulk PDF catalog generation (ADR-0027 §5, CPDF-P3-04) — "Generuj wszystkie":
+ * the Plytix-parity trigger that regenerates a set of catalogs in one call
+ * (e.g. every collection sheet after a price update). It is the batch analogue
+ * of {@see CatalogRegenerateController}: for each requested catalog it creates a
+ * pending {@see CatalogRun} and dispatches a {@see RunCatalogMessage} onto the
+ * shared `import` queue, so the same {@see \App\Export\Catalog\Application\Async\GenerateCatalogHandler}
+ * drives every run out-of-band.
+ *
+ * Gated on the SINGLE-item permission (`integration.admin`), so the bulk route
+ * can never widen authority beyond generating one catalog (the bulk-endpoint
+ * escalation guard). Unknown ids / catalogs of another tenant are silently
+ * skipped (RLS/TenantFilter scopes the lookup); the response reports what was
+ * dispatched and what was skipped. Auto-registered into OpenAPI by
+ * CustomRouteOpenApiFactory (ADR-0020).
+ */
+final class CatalogBulkGenerateController
+{
+    /** A single request may not fan out to more than this many runs. */
+    private const int MAX_CATALOGS = 100;
+
+    public function __construct(
+        private readonly CatalogProfileRepositoryInterface $catalogs,
+        private readonly CatalogRunRepositoryInterface $runs,
+        private readonly MessageBusInterface $bus,
+        private readonly TenantContext $tenantContext,
+        private readonly Security $security,
+    ) {
+    }
+
+    #[Route(path: '/api/catalogs/bulk-generate', name: 'pim_catalogs_bulk_generate', methods: ['POST'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'integration', action: 'admin')]
+    public function bulkGenerate(Request $request): JsonResponse
+    {
+        $tenant = $this->resolveTenant();
+        $ids = $this->parseCatalogIds($request);
+
+        $dispatched = [];
+        $skipped = [];
+        foreach ($ids as $id) {
+            $catalog = $this->catalogs->findById($id);
+            if (null === $catalog) {
+                // RLS/TenantFilter already scoped the lookup — a miss (unknown
+                // or another tenant's catalog) is skipped, never leaked.
+                $skipped[] = $id->toRfc4122();
+
+                continue;
+            }
+
+            $run = new CatalogRun($catalog->getId(), CatalogRunTrigger::Manual);
+            $run->assignTenant($tenant);
+            $this->runs->save($run);
+            $this->bus->dispatch(new RunCatalogMessage($run->getId(), $tenant->getId()));
+
+            $dispatched[] = [
+                'catalog_id' => $catalog->getId()->toRfc4122(),
+                'run_id' => $run->getId()->toRfc4122(),
+            ];
+        }
+
+        return new JsonResponse(
+            [
+                'dispatched' => $dispatched,
+                'skipped' => $skipped,
+            ],
+            Response::HTTP_ACCEPTED,
+        );
+    }
+
+    /**
+     * @return list<Uuid>
+     */
+    private function parseCatalogIds(Request $request): array
+    {
+        $payload = json_decode($request->getContent(), true);
+        $rawIds = \is_array($payload) ? ($payload['catalog_ids'] ?? null) : null;
+        if (!\is_array($rawIds) || [] === $rawIds) {
+            throw new BadRequestHttpException('Field "catalog_ids" must be a non-empty array of catalog UUIDs.');
+        }
+        if (\count($rawIds) > self::MAX_CATALOGS) {
+            throw new BadRequestHttpException(sprintf('At most %d catalogs can be generated per request.', self::MAX_CATALOGS));
+        }
+
+        $ids = [];
+        foreach ($rawIds as $raw) {
+            if (!\is_string($raw) || !Uuid::isValid($raw)) {
+                throw new BadRequestHttpException('Every "catalog_ids" entry must be a valid UUID.');
+            }
+            $ids[] = Uuid::fromString($raw);
+        }
+
+        return $ids;
+    }
+
+    private function resolveTenant(): Tenant
+    {
+        if (!$this->security->getUser() instanceof UserIdentityAware) {
+            throw new AccessDeniedHttpException('Authenticated user identity required.');
+        }
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new AccessDeniedHttpException('Tenant context required.');
+        }
+
+        return $tenant;
+    }
+}

--- a/apps/api/tests/Api/Export/Catalog/CatalogBulkGenerateApiTest.php
+++ b/apps/api/tests/Api/Export/Catalog/CatalogBulkGenerateApiTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Export\Catalog;
+
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Catalog\Domain\ObjectKind;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * CPDF-P3-04 — bulk catalog generation. One call fans out to one run per
+ * requested catalog (Plytix parity); unknown/other-tenant ids are skipped,
+ * gating is the same single-item integration.admin (no bulk escalation).
+ */
+final class CatalogBulkGenerateApiTest extends CatalogApiTestCase
+{
+    private const string MARKETING_EMAIL = 'marketing-cpdf-bulk@demo.localhost';
+
+    #[Test]
+    public function bulkGenerateDispatchesOneRunPerKnownCatalog(): void
+    {
+        $client = $this->authenticatedClient();
+        $first = $this->createCatalog($client, 'bulk-a');
+        $second = $this->createCatalog($client, 'bulk-b');
+        $unknown = Uuid::v7()->toRfc4122();
+
+        $response = $client->request('POST', '/api/catalogs/bulk-generate', [
+            'json' => ['catalog_ids' => [$first, $second, $unknown]],
+        ]);
+
+        self::assertSame(202, $response->getStatusCode());
+        $body = $response->toArray(false);
+        self::assertIsArray($body['dispatched']);
+        self::assertCount(2, $body['dispatched'], 'every known catalog gets one run');
+        $dispatchedIds = array_column($body['dispatched'], 'catalog_id');
+        self::assertContains($first, $dispatchedIds);
+        self::assertContains($second, $dispatchedIds);
+        self::assertSame([$unknown], $body['skipped'], 'the unknown catalog is skipped, not leaked');
+    }
+
+    #[Test]
+    public function emptyPayloadIsA400(): void
+    {
+        $client = $this->authenticatedClient();
+
+        self::assertSame(400, $client->request('POST', '/api/catalogs/bulk-generate', ['json' => []])->getStatusCode());
+        self::assertSame(400, $client->request('POST', '/api/catalogs/bulk-generate', [
+            'json' => ['catalog_ids' => []],
+        ])->getStatusCode());
+        self::assertSame(400, $client->request('POST', '/api/catalogs/bulk-generate', [
+            'json' => ['catalog_ids' => ['not-a-uuid']],
+        ])->getStatusCode());
+    }
+
+    #[Test]
+    public function aPersonaWithoutIntegrationAdminIsForbidden(): void
+    {
+        $admin = $this->authenticatedClient();
+        $catalogId = $this->createCatalog($admin, 'bulk-rbac');
+
+        $marketingJwt = $this->seedMarketingUser();
+        $client = static::createClient();
+        $client->request('POST', '/api/catalogs/bulk-generate', [
+            'headers' => ['authorization' => 'Bearer '.$marketingJwt],
+            'json' => ['catalog_ids' => [$catalogId]],
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    #[Test]
+    public function anonymousRequestIs401(): void
+    {
+        static::createClient()->request('POST', '/api/catalogs/bulk-generate', [
+            'json' => ['catalog_ids' => [Uuid::v7()->toRfc4122()]],
+        ]);
+
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    private function createCatalog(Client $client, string $code): string
+    {
+        $created = $client->request('POST', '/api/catalogs', [
+            'json' => [
+                'code' => $code,
+                'name' => 'Bulk '.$code,
+                'template_kind' => 'sheet',
+                'object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                'field_mappings' => [],
+            ],
+        ]);
+        self::assertSame(201, $created->getStatusCode());
+        $id = $created->toArray(false)['id'];
+        self::assertIsString($id);
+
+        return $id;
+    }
+
+    private function seedMarketingUser(): string
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $marketing = self::getContainer()->get(RoleRepositoryInterface::class)
+            ->findByCode('marketing', $tenant);
+        \assert(null !== $marketing, 'marketing role must be seeded per tenant');
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $stub = new User($tenant, self::MARKETING_EMAIL, '', ['ROLE_USER']);
+        $user = new User($tenant, self::MARKETING_EMAIL, $hasher->hashPassword($stub, 'changeme'), ['ROLE_USER']);
+        $user->addRole($marketing);
+        $em->persist($user);
+        $em->flush();
+
+        return self::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -12020,6 +12020,32 @@
                 "x-cortex-permission": "integration.admin"
             }
         },
+        "/api/catalogs/bulk-generate": {
+            "post": {
+                "operationId": "api_catalogs_bulk_generate_post",
+                "tags": [
+                    "catalogs"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api catalogs bulk generate",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "integration.admin"
+            }
+        },
         "/api/catalogs/pull/{tenantId}/{token}.pdf": {
             "get": {
                 "operationId": "api_catalogs_pull_tenantid_token_pdf_get",


### PR DESCRIPTION
Zamyka **CPDF-P3-04** (#2296). Blocked by P3-01 (merged). **Domyka M3.**

## Co
Plytix-parity „Generuj wszystkie": `POST /api/catalogs/bulk-generate` z listą catalog_ids → per znany katalog tworzy pending `CatalogRun` + dispatch `RunCatalogMessage` (ten sam async handler). Gated na **single-item `integration.admin`** (bulk nie poszerza uprawnień — lekcja bulk-endpoint escalation); nieznane/cross-tenant id skipped (RLS), cap 100/request. Response: `dispatched [{catalog_id, run_id}]` + `skipped`.

## Walidacja (kontener `pim-api-1`, real Postgres)
- **ApiTest** `CatalogBulkGenerateApiTest`: **4 testy, 17 asercji** — 202 fan-out (2 known + 1 unknown→skipped), 400 (empty/bad-uuid payload), 403 (marketing bez integration.admin), 401 anon.
- **PHPStan max** (2G, fresh cache) 0 · **Deptrac** 0 · **php-cs-fixer** czysto · **OpenAPI** `/api/catalogs/bulk-generate` w v0.json.

Refs #2296