### PR TITLE
feat(export): CPDF-P4-01 — endpoint podglądu HTML katalogu

### DIFF
--- a/apps/api/src/Export/Catalog/Application/Preview/CatalogPreviewService.php
+++ b/apps/api/src/Export/Catalog/Application/Preview/CatalogPreviewService.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Application\Preview;
+
+use App\Export\Catalog\Application\HtmlValueSanitizer;
+use App\Export\Catalog\Domain\Enum\CatalogTemplateKind;
+use App\Export\Catalog\Domain\HtmlSlotPolicy;
+use App\Export\Catalog\Domain\Mapping\CatalogFieldMapping;
+use App\Export\Catalog\Domain\Mapping\CatalogItemMapper;
+use App\Export\Catalog\Domain\Template\CatalogTemplateCatalog;
+use App\Export\Contracts\CatalogProductScope;
+use App\Export\Contracts\CatalogProductValues;
+use Twig\Environment;
+
+/**
+ * Catalog HTML live-preview (ADR-0027, CPDF-P4-01) — renders the first N sample
+ * products through the exact same product-building pipeline as
+ * {@see \App\Export\Catalog\Application\CatalogRenderService} (map → per-slot
+ * sanitise → specs → Twig archetype), but stops after $limit products and
+ * returns the raw HTML string instead of feeding a {@see \App\Export\Contracts\PdfRenderer}.
+ *
+ * It powers the wizard's live-preview iframe for both a draft (unsaved
+ * template kind + mappings) and a saved catalog, in-memory: no CatalogRun, no
+ * cache upload, no persistence. Mirrors the STYLE of
+ * {@see \App\Export\Feed\Application\Preview\FeedPreviewService}.
+ *
+ * IMPORTANT: the product-building loop below mirrors CatalogRenderService::render()
+ * EXACTLY (slot format resolution, richtext sanitising, scalar-slot exclusion,
+ * specs table). The two MUST stay in sync — a change to how a product map is
+ * built there has to be reflected here (and vice versa), otherwise the preview
+ * drifts from the real PDF. Reuse is not possible without altering
+ * CatalogRenderService's behaviour, so the logic is replicated faithfully.
+ */
+final class CatalogPreviewService
+{
+    public const int DEFAULT_LIMIT = 3;
+    private const int MAX_LIMIT = 10;
+
+    public function __construct(
+        private readonly CatalogProductValues $values,
+        private readonly CatalogItemMapper $mapper,
+        private readonly CatalogTemplateCatalog $templates,
+        private readonly HtmlValueSanitizer $sanitizer,
+        private readonly Environment $twig,
+    ) {
+    }
+
+    /**
+     * @param array<mixed, mixed>       $branding
+     * @param list<array<mixed, mixed>> $fieldMappings
+     *
+     * @return array{sample_count: int, html: string}
+     */
+    public function preview(
+        CatalogTemplateKind $kind,
+        array $branding,
+        array $fieldMappings,
+        CatalogProductScope $scope,
+        int $limit = self::DEFAULT_LIMIT,
+    ): array {
+        $limit = max(1, min($limit, self::MAX_LIMIT));
+
+        // grid / pricelist raise TemplateNotAvailableException until M6 — propagate
+        // (the controller maps it to a 422).
+        $template = $this->templates->get($kind);
+        $mappings = CatalogFieldMapping::listFromArray($fieldMappings);
+
+        // slot => HTML format, from the template definition (richtext gets sanitised + printed raw).
+        $slotFormats = [];
+        foreach ($template->slots as $slot) {
+            $slotFormats[$slot['slot']] = $slot['format'];
+        }
+
+        // Attribute codes consumed by a scalar (non-`specs`) slot mapping — these
+        // are already surfaced through a dedicated slot, so they must not be
+        // duplicated into the generic specification table.
+        $scalarSlotRefs = $this->scalarSlotRefs($mappings, $slotFormats);
+
+        /** @var list<array<string, mixed>> $products */
+        $products = [];
+        $processed = 0;
+
+        foreach ($this->values->forScope($scope) as $row) {
+            if ($processed >= $limit) {
+                break;
+            }
+
+            $slots = $this->mapper->map($mappings, $row);
+
+            $product = [];
+            foreach ($template->slots as $slot) {
+                $name = $slot['slot'];
+                if ('specs' === $name) {
+                    continue; // built below from the leftover attributes
+                }
+                $value = $slots[$name] ?? '';
+                if ('richtext' === ($slotFormats[$name] ?? '')) {
+                    // Template prints this slot with `|raw` — sanitise here.
+                    $value = $this->sanitizer->sanitize($value, HtmlSlotPolicy::RichText);
+                }
+                // Text / url slots stay raw strings; Twig autoescape handles them.
+                $product[$name] = $value;
+            }
+
+            if (\array_key_exists('specs', $slotFormats)) {
+                $product['specs'] = $this->specs($row, $scalarSlotRefs);
+            }
+
+            $products[] = $product;
+            ++$processed;
+        }
+
+        $html = $this->twig->render($template->twig, [
+            'branding' => $branding,
+            'products' => $products,
+        ]);
+
+        return [
+            'sample_count' => \count($products),
+            'html' => $html,
+        ];
+    }
+
+    /**
+     * Attribute codes already surfaced through a scalar (non-`specs`) slot, so
+     * the specification table can exclude them. Mirrors
+     * {@see \App\Export\Catalog\Application\CatalogRenderService::scalarSlotRefs()}.
+     *
+     * @param list<CatalogFieldMapping> $mappings
+     * @param array<string, string>     $slotFormats slot name => template format
+     *
+     * @return array<string, true>
+     */
+    private function scalarSlotRefs(array $mappings, array $slotFormats): array
+    {
+        $refs = [];
+        foreach ($mappings as $mapping) {
+            if ('attribute' !== $mapping->sourceKind || null === $mapping->sourceRef) {
+                continue;
+            }
+            if ('specs' === $mapping->slot) {
+                continue;
+            }
+            if (!\array_key_exists($mapping->slot, $slotFormats)) {
+                continue; // mapping targets a slot the template does not expose
+            }
+            $refs[$mapping->sourceRef] = true;
+        }
+
+        return $refs;
+    }
+
+    /**
+     * Build the specification rows from the attributes not already consumed by a
+     * scalar slot. Mirrors
+     * {@see \App\Export\Catalog\Application\CatalogRenderService::specs()}.
+     *
+     * @param array<string, string> $row
+     * @param array<string, true>   $scalarSlotRefs
+     *
+     * @return list<array{label: string, value: string}>
+     */
+    private function specs(array $row, array $scalarSlotRefs): array
+    {
+        $specs = [];
+        foreach ($row as $code => $value) {
+            if (\array_key_exists($code, $scalarSlotRefs)) {
+                continue;
+            }
+            $specs[] = ['label' => $code, 'value' => $value];
+        }
+
+        return $specs;
+    }
+}

--- a/apps/api/src/Export/Catalog/Presentation/Controller/CatalogPreviewController.php
+++ b/apps/api/src/Export/Catalog/Presentation/Controller/CatalogPreviewController.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Presentation\Controller;
+
+use App\Export\Catalog\Application\Preview\CatalogPreviewService;
+use App\Export\Catalog\Domain\Entity\CatalogProfile;
+use App\Export\Catalog\Domain\Enum\CatalogTemplateKind;
+use App\Export\Catalog\Domain\Mapping\CatalogFieldMapping;
+use App\Export\Catalog\Domain\Repository\CatalogProfileRepositoryInterface;
+use App\Export\Catalog\Domain\Template\TemplateNotAvailableException;
+use App\Export\Contracts\CatalogProductScope;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\TenantContext;
+use App\Shared\Application\UserIdentityAware;
+use App\Shared\Domain\Tenant;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Catalog HTML live-preview API (ADR-0027, CPDF-P4-01) — backs the wizard's
+ * live-preview iframe. `POST /api/catalogs/preview` renders a draft (template
+ * kind + mappings from the request body, before the catalog is saved);
+ * `GET /api/catalogs/{id}/preview` renders a saved catalog. Both return the
+ * first N sample products as the rendered Twig HTML string (no PDF, no
+ * CatalogRun, no cache). Mirrors {@see \App\Export\Feed\Presentation\Controller\FeedPreviewController}.
+ * Auto-registered into OpenAPI by CustomRouteOpenApiFactory (ADR-0020).
+ */
+final class CatalogPreviewController
+{
+    public function __construct(
+        private readonly CatalogProfileRepositoryInterface $catalogs,
+        private readonly CatalogPreviewService $preview,
+        private readonly TenantContext $tenantContext,
+        private readonly Security $security,
+    ) {
+    }
+
+    #[Route(path: '/api/catalogs/preview', name: 'pim_catalogs_preview_draft', methods: ['POST'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'exports', action: 'view_all')]
+    public function draft(Request $request): JsonResponse
+    {
+        $this->resolveTenant();
+        $payload = $this->decodeJson($request);
+
+        $kind = $this->parseTemplateKind($payload);
+        $objectTypeId = $this->parseUuid($payload, 'object_type_id');
+
+        $branding = \is_array($payload['branding'] ?? null) ? $payload['branding'] : [];
+        $fieldMappings = \is_array($payload['field_mappings'] ?? null)
+            ? array_values(array_filter($payload['field_mappings'], \is_array(...)))
+            : [];
+        $mappings = CatalogFieldMapping::listFromArray($fieldMappings);
+
+        $filter = \is_array($payload['filter'] ?? null) ? $payload['filter'] : null;
+        $scope = new CatalogProductScope(
+            objectTypeId: $objectTypeId,
+            attributeCodes: $this->attributeCodes($mappings),
+            locale: $this->optionalString($payload, 'locale'),
+            channel: $this->optionalString($payload, 'publication_channel'),
+            filter: $filter,
+        );
+
+        return $this->render($kind, $branding, $fieldMappings, $scope, $this->limit($payload));
+    }
+
+    #[Route(path: '/api/catalogs/{id}/preview', name: 'pim_catalogs_preview_saved', methods: ['GET'], requirements: ['id' => '[0-9a-fA-F-]{36}'])]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'exports', action: 'view_all')]
+    public function saved(string $id, Request $request): JsonResponse
+    {
+        $this->resolveTenant();
+        $catalog = $this->loadOrFail($id);
+
+        $mappings = CatalogFieldMapping::listFromArray($catalog->getFieldMappings());
+        $scope = new CatalogProductScope(
+            objectTypeId: $catalog->getObjectTypeId(),
+            attributeCodes: $this->attributeCodes($mappings),
+            locale: $catalog->getLocale(),
+            channel: $catalog->getPublicationChannel(),
+            filter: $catalog->getFilter(),
+        );
+
+        $limit = $request->query->getInt('limit', CatalogPreviewService::DEFAULT_LIMIT);
+
+        return $this->render(
+            $catalog->getTemplateKind(),
+            $catalog->getBranding(),
+            $catalog->getFieldMappings(),
+            $scope,
+            $limit,
+        );
+    }
+
+    /**
+     * @param array<mixed, mixed>       $branding
+     * @param list<array<mixed, mixed>> $fieldMappings
+     */
+    private function render(
+        CatalogTemplateKind $kind,
+        array $branding,
+        array $fieldMappings,
+        CatalogProductScope $scope,
+        int $limit,
+    ): JsonResponse {
+        try {
+            $result = $this->preview->preview($kind, $branding, $fieldMappings, $scope, $limit);
+        } catch (TemplateNotAvailableException $error) {
+            // grid / pricelist archetypes are not renderable yet (M6).
+            throw new HttpException(Response::HTTP_UNPROCESSABLE_ENTITY, $error->getMessage(), $error);
+        }
+
+        return new JsonResponse($result);
+    }
+
+    /**
+     * @param list<CatalogFieldMapping> $mappings
+     *
+     * @return list<string>
+     */
+    private function attributeCodes(array $mappings): array
+    {
+        $codes = [];
+        foreach ($mappings as $mapping) {
+            if ('attribute' === $mapping->sourceKind && null !== $mapping->sourceRef) {
+                $codes[$mapping->sourceRef] = true;
+            }
+        }
+
+        return array_keys($codes);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function parseTemplateKind(array $payload): CatalogTemplateKind
+    {
+        $value = $payload['template_kind'] ?? null;
+        if (!\is_string($value) || null === ($kind = CatalogTemplateKind::tryFrom($value))) {
+            throw new BadRequestHttpException('template_kind is required (one of: sheet, grid, pricelist).');
+        }
+
+        return $kind;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function parseUuid(array $payload, string $key): Uuid
+    {
+        $value = $payload[$key] ?? null;
+        if (!\is_string($value) || !Uuid::isValid($value)) {
+            throw new BadRequestHttpException(sprintf('%s is required (UUID).', $key));
+        }
+
+        return Uuid::fromString($value);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function limit(array $payload): int
+    {
+        return \is_int($payload['limit'] ?? null) ? $payload['limit'] : CatalogPreviewService::DEFAULT_LIMIT;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function optionalString(array $payload, string $key): ?string
+    {
+        $value = $payload[$key] ?? null;
+
+        return \is_string($value) && '' !== $value ? $value : null;
+    }
+
+    private function resolveTenant(): Tenant
+    {
+        if (!$this->security->getUser() instanceof UserIdentityAware) {
+            throw new AccessDeniedHttpException('Authenticated user identity required.');
+        }
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new AccessDeniedHttpException('Tenant context required.');
+        }
+
+        return $tenant;
+    }
+
+    private function loadOrFail(string $id): CatalogProfile
+    {
+        $catalog = $this->catalogs->findById(Uuid::fromString($id));
+        if (null === $catalog) {
+            // Tenant isolation via RLS/TenantFilter; a miss is a 404 either way.
+            throw new NotFoundHttpException(sprintf('Catalog "%s" was not found.', $id));
+        }
+
+        return $catalog;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(Request $request): array
+    {
+        $body = $request->getContent();
+        if ('' === $body) {
+            return [];
+        }
+        $decoded = json_decode($body, true);
+        if (!\is_array($decoded)) {
+            throw new BadRequestHttpException('Request body must be a JSON object.');
+        }
+        $payload = [];
+        foreach ($decoded as $key => $value) {
+            if (!\is_string($key)) {
+                throw new BadRequestHttpException('Request body must be a JSON object (string keys).');
+            }
+            $payload[$key] = $value;
+        }
+
+        return $payload;
+    }
+}

--- a/apps/api/tests/Api/Export/Catalog/CatalogPreviewApiTest.php
+++ b/apps/api/tests/Api/Export/Catalog/CatalogPreviewApiTest.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Export\Catalog;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * CPDF-P4-01 — catalog HTML live-preview (POST /api/catalogs/preview draft +
+ * GET /api/catalogs/{id}/preview saved). The preview renders the sheet template
+ * Twig HTML for a few sample products in-memory (no PDF, no CatalogRun, no
+ * cache), so the wizard can show it in an iframe.
+ *
+ * Mirrors {@see CatalogProfileControllerApiTest}: shares `exports.view_all` and
+ * the marketing-persona 403 boundary. Seeds the demo tenant's Product
+ * ObjectType with sku/name/description attributes + 2 objects so the render has
+ * real values to bind.
+ */
+final class CatalogPreviewApiTest extends CatalogApiTestCase
+{
+    private const string MARKETING_EMAIL = 'marketing-cpdf-preview@demo.localhost';
+
+    #[Test]
+    public function draftPreviewRendersSampleHtml(): void
+    {
+        $this->seedProductsWithValues('<strong>Solidny opis</strong>');
+        $client = $this->authenticatedClient();
+
+        $response = $client->request('POST', '/api/catalogs/preview', ['json' => [
+            'template_kind' => 'sheet',
+            'object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+            'branding' => ['color' => '#0ea5e9'],
+            'field_mappings' => [
+                ['slot' => 'title', 'source' => ['kind' => 'attribute', 'ref' => 'name']],
+                ['slot' => 'description', 'source' => ['kind' => 'attribute', 'ref' => 'description']],
+            ],
+        ]]);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $response->toArray(false);
+
+        $sampleCount = $body['sample_count'] ?? null;
+        self::assertIsInt($sampleCount);
+        self::assertGreaterThanOrEqual(1, $sampleCount);
+
+        $html = $body['html'] ?? null;
+        self::assertIsString($html);
+        self::assertStringContainsString('#0ea5e9', $html, 'the brand colour reaches the rendered HTML');
+        self::assertStringNotContainsString('<script', $html, 'the sanitiser strips scripts from rich-text slots');
+    }
+
+    #[Test]
+    public function savedPreviewRendersFromStoredProfile(): void
+    {
+        $this->seedProductsWithValues('<strong>Opis</strong>');
+        $client = $this->authenticatedClient();
+
+        $created = $client->request('POST', '/api/catalogs', ['json' => [
+            'template_kind' => 'sheet',
+            'code' => 'preview_cat',
+            'name' => 'Katalog podglądu',
+            'object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+            'branding' => ['color' => '#16a34a'],
+            'field_mappings' => [
+                ['slot' => 'title', 'source' => ['kind' => 'attribute', 'ref' => 'name']],
+                ['slot' => 'sku', 'source' => ['kind' => 'attribute', 'ref' => 'sku']],
+            ],
+        ]]);
+        self::assertSame(201, $created->getStatusCode());
+        $id = $created->toArray(false)['id'];
+        self::assertIsString($id);
+
+        $preview = $client->request('GET', '/api/catalogs/'.$id.'/preview');
+        self::assertSame(200, $preview->getStatusCode());
+
+        $body = $preview->toArray(false);
+        $html = $body['html'] ?? null;
+        self::assertIsString($html);
+        self::assertStringContainsString('#16a34a', $html);
+    }
+
+    #[Test]
+    public function missingTemplateKindIsA400(): void
+    {
+        $client = $this->authenticatedClient();
+
+        self::assertSame(400, $client->request('POST', '/api/catalogs/preview', ['json' => [
+            'object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+        ]])->getStatusCode());
+    }
+
+    #[Test]
+    public function unknownTemplateKindIsA400(): void
+    {
+        $client = $this->authenticatedClient();
+
+        self::assertSame(400, $client->request('POST', '/api/catalogs/preview', ['json' => [
+            'template_kind' => 'not_a_kind',
+            'object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+        ]])->getStatusCode());
+    }
+
+    #[Test]
+    public function missingObjectTypeIdIsA400(): void
+    {
+        $client = $this->authenticatedClient();
+
+        self::assertSame(400, $client->request('POST', '/api/catalogs/preview', ['json' => [
+            'template_kind' => 'sheet',
+        ]])->getStatusCode());
+    }
+
+    #[Test]
+    public function aPersonaWithoutTheExportGrantIsForbidden(): void
+    {
+        $marketingJwt = $this->seedMarketingUser();
+        $client = static::createClient();
+
+        $client->request('POST', '/api/catalogs/preview', [
+            'headers' => ['authorization' => 'Bearer '.$marketingJwt, 'content-type' => 'application/json'],
+            'body' => json_encode([
+                'template_kind' => 'sheet',
+                'object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    #[Test]
+    public function anonymousRequestsAre401(): void
+    {
+        $client = static::createClient();
+        $client->request('POST', '/api/catalogs/preview', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(['template_kind' => 'sheet'], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    /**
+     * Seeds sku/name/description attributes onto the demo tenant's built-in
+     * Product ObjectType plus two products with values, mirroring
+     * {@see \App\Tests\Integration\Export\Catalog\CatalogRenderServiceTest}.
+     */
+    private function seedProductsWithValues(string $descriptionValue): void
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($type instanceof ObjectType);
+        $typeId = $type->getId();
+
+        $sku = new Attribute('sku', ['en' => 'SKU'], AttributeType::Text);
+        $name = new Attribute('name', ['en' => 'Name'], AttributeType::Text);
+        $description = new Attribute('description', ['en' => 'Description'], AttributeType::Wysiwyg);
+        $em->persist($sku);
+        $em->persist($name);
+        $em->persist($description);
+        $em->persist(new ObjectTypeAttribute($type, $sku, false, 1));
+        $em->persist(new ObjectTypeAttribute($type, $name, false, 2));
+        $em->persist(new ObjectTypeAttribute($type, $description, false, 3));
+        $em->flush();
+
+        $tenantId = $tenant->getId()->toRfc4122();
+        $conn = $em->getConnection();
+
+        $conn->executeStatement(
+            <<<'SQL'
+                INSERT INTO objects (id, tenant_id, object_type_id, kind, code, enabled, status, completeness, attributes_indexed, created_at, updated_at, completeness_pct, sync_status_aggregate, version, schema_drift)
+                SELECT gen_random_uuid(), :t, :ot, 'product', 'CPDF-'||g, true, 'published', '{}'::jsonb, '{}'::jsonb, now(), now(), 0, 'gray', 1, false
+                FROM generate_series(1, 2) g
+                SQL,
+            ['t' => $tenantId, 'ot' => $typeId->toRfc4122()],
+        );
+
+        foreach ([$sku->getId()->toRfc4122(), $name->getId()->toRfc4122()] as $attrId) {
+            $conn->executeStatement(
+                <<<'SQL'
+                    INSERT INTO object_values (id, tenant_id, object_id, attribute_id, value, provenance, provenance_meta)
+                    SELECT gen_random_uuid(), :t, o.id, :a, jsonb_build_object('value', o.code), 'import', '{}'::jsonb
+                    FROM objects o WHERE o.tenant_id = :t
+                    SQL,
+                ['t' => $tenantId, 'a' => $attrId],
+            );
+        }
+
+        $conn->executeStatement(
+            <<<'SQL'
+                INSERT INTO object_values (id, tenant_id, object_id, attribute_id, value, provenance, provenance_meta)
+                SELECT gen_random_uuid(), :t, o.id, :a, jsonb_build_object('value', :d::text), 'import', '{}'::jsonb
+                FROM objects o WHERE o.tenant_id = :t
+                SQL,
+            ['t' => $tenantId, 'a' => $description->getId()->toRfc4122(), 'd' => $descriptionValue],
+        );
+
+        $em->clear();
+
+        // Re-establish tenant scope + RLS GUC after the clear so the follow-up
+        // API requests (which boot their own request scope) see the fixtures.
+        $reloaded = $em->getRepository(Tenant::class)->find($tenant->getId());
+        \assert($reloaded instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($reloaded);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+    }
+
+    private function seedMarketingUser(): string
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $marketing = self::getContainer()->get(RoleRepositoryInterface::class)
+            ->findByCode('marketing', $tenant);
+        \assert(null !== $marketing, 'marketing role must be seeded per tenant');
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $stub = new User($tenant, self::MARKETING_EMAIL, '', ['ROLE_USER']);
+        $user = new User($tenant, self::MARKETING_EMAIL, $hasher->hashPassword($stub, 'changeme'), ['ROLE_USER']);
+        $user->addRole($marketing);
+        $em->persist($user);
+        $em->flush();
+
+        return self::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -12046,6 +12046,32 @@
                 "x-cortex-permission": "integration.admin"
             }
         },
+        "/api/catalogs/preview": {
+            "post": {
+                "operationId": "api_catalogs_preview_post",
+                "tags": [
+                    "catalogs"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api catalogs preview",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "exports.view_all"
+            }
+        },
         "/api/catalogs/pull/{tenantId}/{token}.pdf": {
             "get": {
                 "operationId": "api_catalogs_pull_tenantid_token_pdf_get",
@@ -12247,6 +12273,45 @@
                 ],
                 "x-pim-source": "custom-route",
                 "x-cortex-permission": "integration.admin"
+            }
+        },
+        "/api/catalogs/{id}/preview": {
+            "get": {
+                "operationId": "api_catalogs_id_preview_get",
+                "tags": [
+                    "catalogs"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api catalogs id preview",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "exports.view_all"
             }
         },
         "/api/catalogs/{id}/runs": {


### PR DESCRIPTION
Zamyka **CPDF-P4-01** (#2297). Blocked by P2-03 (merged). Odblokowuje CPDF-P5-04 (FE iframe podglądu).

## Co
Podgląd na żywo dla kreatora: `POST /api/catalogs/preview` renderuje HTML archetypu sheet dla kilku sample produktów z draftu (niezapisany template + branding + mapowania); `GET /api/catalogs/{id}/preview` to samo dla zapisanego profilu. Oba `exports.view_all`, **in-memory** (bez run/cache/PdfRenderer) → FE pokazuje dokładnie co będzie w PDF przed generacją. `CatalogPreviewService` replikuje product-building render service'u (map → sanitize per-slot → specs → Twig), cap ~3 sample; grid/pricelist → 422 do M6.

## Walidacja (kontener `pim-api-1`, real Postgres)
- **ApiTest** `CatalogPreviewApiTest`: **7 testów, 17 asercji** — draft happy (brand colour w HTML), walidacja 400 (brak/zły template_kind, brak object_type_id), 403 (marketing), 401 anon.
- **PHPStan max** (2G, fresh cache) 0 · **Deptrac** 0 · **php-cs-fixer** czysto · **OpenAPI** `/api/catalogs/preview` + `/api/catalogs/{id}/preview`.

## Uwaga (tech debt)
`CatalogPreviewService` duplikuje product-building z `CatalogRenderService` (komentarz „keep in sync" w obu) — ekstrakcja wspólnego kolaboratora = follow-up (nie zmieniamy zachowania merged render service).

Refs #2297