### PR TITLE
feat(export): CPDF-P4-02 — lockdown RBAC + OpenAPI powierzchni katalogów

### DIFF
--- a/apps/api/tests/Api/Export/Catalog/CatalogApiLockdownTest.php
+++ b/apps/api/tests/Api/Export/Catalog/CatalogApiLockdownTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Export\Catalog;
+
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * CPDF-P4-02 — RBAC lockdown of the catalog PDF surface. Every catalog
+ * endpoint is gated (RequiresPermissionAnnotationRule enforces the attribute at
+ * static-analysis time; this test proves the runtime effect): an unauthenticated
+ * request to any catalog API route is refused with 401 — the SOLE exception is
+ * the public pull URL, whose 192-bit token is the credential (an unknown token
+ * yields a 404, never a 401). This guards against a future catalog endpoint
+ * accidentally shipping public.
+ */
+final class CatalogApiLockdownTest extends CatalogApiTestCase
+{
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function protectedRoutes(): iterable
+    {
+        $id = Uuid::v7()->toRfc4122();
+
+        yield 'list' => ['GET', '/api/catalogs'];
+        yield 'create' => ['POST', '/api/catalogs'];
+        yield 'get' => ['GET', '/api/catalogs/'.$id];
+        yield 'patch' => ['PATCH', '/api/catalogs/'.$id];
+        yield 'delete' => ['DELETE', '/api/catalogs/'.$id];
+        yield 'generate' => ['POST', '/api/catalogs/'.$id.'/generate'];
+        yield 'bulk-generate' => ['POST', '/api/catalogs/bulk-generate'];
+        yield 'preview-draft' => ['POST', '/api/catalogs/preview'];
+        yield 'preview-saved' => ['GET', '/api/catalogs/'.$id.'/preview'];
+        yield 'token-mint' => ['POST', '/api/catalogs/'.$id.'/token'];
+        yield 'token-revoke' => ['DELETE', '/api/catalogs/'.$id.'/token'];
+        yield 'run-history' => ['GET', '/api/catalogs/'.$id.'/runs'];
+        yield 'runs-list' => ['GET', '/api/catalog-runs'];
+        yield 'runs-kpi' => ['GET', '/api/catalog-runs/kpi'];
+        yield 'run-cancel' => ['POST', '/api/catalog-runs/'.$id.'/cancel'];
+    }
+
+    #[Test]
+    #[DataProvider('protectedRoutes')]
+    public function everyCatalogEndpointRequiresAuth(string $method, string $path): void
+    {
+        static::createClient()->request($method, $path);
+
+        self::assertResponseStatusCodeSame(401, sprintf('%s %s must be gated', $method, $path));
+    }
+
+    #[Test]
+    public function onlyThePublicPullIsUnauthenticated(): void
+    {
+        // The public pull is the single NoPermissionRequired route: no session,
+        // the token is the credential — an unknown token is a flat 404, not 401.
+        $tenantId = Uuid::v7()->toRfc4122();
+        static::createClient()->request('GET', '/api/catalogs/pull/'.$tenantId.'/deadbeeftoken.pdf');
+
+        self::assertResponseStatusCodeSame(404);
+    }
+}

--- a/docs/adr/0027-catalog-pdf-renderer-port.md
+++ b/docs/adr/0027-catalog-pdf-renderer-port.md
@@ -60,6 +60,10 @@ Rozstrzygnięcia (decyzje z planu §2/§6/§12):
 - **Generowanie na żądanie (bez cache)** — odrzucony: DoS na workera przy pobraniach z publicznego URL, tym bardziej że render PDF jest droższy niż strumień XML feedu.
 - **Autoryzacja kluczem tenanta** — odrzucony: klucz tenanta ma szerszy zakres; token dokumentu musi być read-only, per-dokument, rewokowalny bez wpływu na inne integracje.
 
+## RBAC — powierzchnia gejtowana (CPDF-P1-03/P3-*/P4-02)
+
+Endpointy katalogów **reużywają istniejące uprawnienia PRD** zamiast wprowadzać dedykowany moduł `catalogs_pdf` (plan §6.8 zakładał nowy moduł — świadomie odrzucone): odczyty (`list`/`get`/`preview`/monitor/KPI/historia) na `#[RequiresPermission(module: 'exports', action: 'view_all')]`, zapisy i akcje (`create`/`patch`/`delete`/`generate`/`bulk-generate`/`token`/`cancel`) na `#[RequiresPermission(module: 'integration', action: 'admin')]` — dokładnie jak siostrzany `Export/Feed`. Katalogi PDF żyją w rodzinie Export (`src/Export/Catalog/`), więc gejtowanie pod `exports`/`integration` jest spójne semantycznie i **nie tworzy nowej powierzchni RBAC** (nowy kod uprawnień dotyka `PrdRoleTemplates`/fixtures/FE/testów — klasa zmian, przed którą przestrzega re-audit RBAC). Publiczny pull to jedyny `#[NoPermissionRequired]` (token = credential). `RequiresPermissionAnnotationRule` (PHPStan) egzekwuje atrybut na każdej trasie; `CatalogApiLockdownTest` dowodzi runtime (401 na całej powierzchni poza pull → 404). Dedykowany moduł `catalogs_pdf` można dodać później jeśli operator zechce granularnej separacji — menu-gate FE (P5-05) gejtuje wtedy spójnie na `exports.view_all`.
+
 ## Links
 
 - Plan: `Project Plan/UI/feature-catalogs-pdf.md` §2 (decyzje), §6 (architektura), §7 (IN/OUT), §12 (mini-ADR szkic)


### PR DESCRIPTION
Zamyka **CPDF-P4-02** (#2298). **Domyka M4.**

## Co
Powierzchnia API katalogów w pełni zamknięta i udokumentowana:
- **OpenAPI**: wszystkie ~16 tras katalogów w `docs/api-spec/v0.json` (bramka spec-drift zielona — regenerowane inkrementalnie w M1-M4).
- **RBAC**: `RequiresPermissionAnnotationRule` (PHPStan) wymusza `#[RequiresPermission]`/`#[NoPermissionRequired]` na każdej trasie (zielony). **`CatalogApiLockdownTest`** dowodzi runtime: **16 testów** — 15 endpointów → **401** bez auth, publiczny pull → **404** (token = credential, jedyny `NoPermissionRequired`).
- **ADR-0027** dostaje sekcję RBAC: świadomy **reuse `exports.view_all` (read) / `integration.admin` (write)** zamiast modułu `catalogs_pdf` (jak `Export/Feed`), z uzasadnieniem (nowy kod uprawnień = klasa zmian przed którą przestrzega re-audit RBAC).

## Walidacja (kontener `pim-api-1`)
- **ApiTest** lockdown: **16/16** · **PHPStan max** (2G, fresh cache) 0 · **Deptrac** 0 · **cs-fixer** czysto. Bez zmian tras → v0.json bez zmian.

Refs #2298