### PR TITLE
feat(catalogs-pdf): CPDF-P5-01 — obszar /catalogs-pdf (shell + PillTabs)

### DIFF
--- a/apps/admin/e2e/cpdf-shell.spec.ts
+++ b/apps/admin/e2e/cpdf-shell.spec.ts
@@ -1,0 +1,54 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * CPDF-P5-01 (#2372) — PDF catalogs area shell: the `/catalogs-pdf` route now
+ * renders a self-contained PillTabs hub (Katalogi / Szablony) replacing the
+ * ComingSoonPlaceholder. The catalogs tab lands on the empty state + "Nowy
+ * katalog" CTA (wizard is P5-02); the templates tab lists the built-in `sheet`
+ * archetype as available with `grid`/`pricelist` as "Wkrótce".
+ *
+ * `GET /api/catalogs` is mocked to `{ items: [] }` so the shell is
+ * deterministic and offline. The known DNS/lang gotcha: the app renders EN
+ * from the user profile unless `i18nextLng=pl` is seeded before the app boots.
+ */
+
+test('CPDF-P5-01 — catalogs shell: tabs, empty state, templates, a11y', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('i18nextLng', 'pl');
+  });
+  await page.route('**/api/catalogs', (route) => route.fulfill({ json: { items: [] } }));
+
+  await loginAsAdmin(page);
+  await page.goto('/catalogs-pdf');
+
+  // Header + both pill tabs render (bilingual-tolerant).
+  await expect(page.getByRole('heading', { name: /katalogi pdf|pdf catalogs/i })).toBeVisible();
+  const catalogsTab = page.getByRole('tab', { name: /^katalogi$|^catalogs$/i });
+  const templatesTab = page.getByRole('tab', { name: /^szablony$|^templates$/i });
+  await expect(catalogsTab).toBeVisible();
+  await expect(templatesTab).toBeVisible();
+
+  // Catalogs tab (default): empty state + "Nowy katalog" CTA.
+  await expect(page.getByText(/brak katalogów|no catalogs yet/i)).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: /nowy katalog|new catalog/i }).first(),
+  ).toBeVisible();
+
+  // Switch to the Szablony tab — the sheet archetype is available.
+  await templatesTab.click();
+  await expect(page.getByRole('radio', { name: /karta produktu|product sheet/i })).toBeVisible();
+  // The grid/pricelist archetypes are disabled "Wkrótce" cards.
+  await expect(
+    page.getByRole('radio', { name: /katalog \(grid\)|catalog \(grid\)/i }),
+  ).toHaveAttribute('aria-disabled', 'true');
+
+  // a11y — no serious/critical violations on the shell's main content.
+  const axe = await new AxeBuilder({ page }).include('main').analyze();
+  const blocking = axe.violations.filter(
+    (violation) => violation.impact === 'serious' || violation.impact === 'critical',
+  );
+  expect(blocking).toEqual([]);
+});

--- a/apps/admin/src/components/ui-v2/pill-tabs.tsx
+++ b/apps/admin/src/components/ui-v2/pill-tabs.tsx
@@ -49,7 +49,7 @@ export function PillTabs({ items, activeId, onChange, ariaLabel, className }: Pi
             className={cn(
               'focus-ring inline-flex h-9 items-center gap-1.5 rounded-xl px-3.5 text-[13px] font-medium transition',
               active && 'bg-zinc-900 text-white',
-              !active && !item.disabled && 'text-zinc-500 hover:bg-zinc-100 hover:text-ink',
+              !active && !item.disabled && 'text-zinc-600 hover:bg-zinc-100 hover:text-ink',
               item.disabled && 'cursor-not-allowed text-zinc-300',
             )}
           >

--- a/apps/admin/src/features/catalogs-pdf/CatalogsTab.tsx
+++ b/apps/admin/src/features/catalogs-pdf/CatalogsTab.tsx
@@ -1,0 +1,67 @@
+import { useQuery } from '@tanstack/react-query';
+import { FileText } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { EmptyState } from '@/components/ui-v2/empty-state';
+import { jsonFetch } from '@/lib/http';
+
+/** One row of `GET /api/catalogs` — only the fields the shell reads. */
+interface CatalogProfileRow {
+  id: string;
+  name: string;
+  template_kind: string;
+  status: string;
+}
+
+/** `GET /api/catalogs` returns `{ items: [...] }` (CatalogProfileController::list). */
+interface CatalogsResponse {
+  items: CatalogProfileRow[];
+}
+
+interface CatalogsTabProps {
+  /** CTA that opens the create wizard (owned by CPDF-P5-02). */
+  onNewCatalog: () => void;
+}
+
+/**
+ * CPDF-P5-01 — Catalogs hub tab. For the shell ticket this is a lightweight
+ * hub: it fetches `GET /api/catalogs` and, until CPDF-P5-02 ships the wizard
+ * and the card grid, renders an empty state with the "Nowy katalog" CTA. A
+ * non-empty list still lands on the empty-state copy plus a count badge —
+ * the real card grid is P5-02/P5-03 scope.
+ */
+export function CatalogsTab({ onNewCatalog }: CatalogsTabProps) {
+  const { t } = useTranslation();
+
+  const catalogsQuery = useQuery<CatalogsResponse>({
+    queryKey: ['catalogs-pdf', 'profiles'],
+    queryFn: () => jsonFetch<CatalogsResponse>('/api/catalogs', { accept: 'application/json' }),
+    staleTime: 30_000,
+  });
+
+  const count = catalogsQuery.data?.items.length ?? 0;
+
+  return (
+    <div className="space-y-4">
+      {count > 0 && (
+        <p className="text-[12.5px] font-medium text-zinc-500">
+          {t('catalogs_pdf.catalogs_count', { count })}
+        </p>
+      )}
+      <EmptyState
+        icon={<FileText className="size-5" aria-hidden />}
+        title={t('catalogs_pdf.catalogs_empty_title')}
+        description={t('catalogs_pdf.catalogs_empty_description')}
+        action={
+          <button
+            type="button"
+            onClick={onNewCatalog}
+            className="focus-ring inline-flex h-9 items-center gap-1.5 rounded-xl bg-cta px-3.5 text-[13px] font-semibold text-cta-foreground transition hover:bg-accent-hover"
+          >
+            {t('catalogs_pdf.new_cta')}
+          </button>
+        }
+      />
+    </div>
+  );
+}

--- a/apps/admin/src/features/catalogs-pdf/TemplatesTab.tsx
+++ b/apps/admin/src/features/catalogs-pdf/TemplatesTab.tsx
@@ -1,0 +1,52 @@
+import { LayoutGrid, LayoutTemplate, Table } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { SelectableCard, SelectableCardGroup } from '@/components/ui-v2/selectable-card';
+import { StatusPill } from '@/components/ui-v2/status-pill';
+
+/**
+ * CPDF-P5-01 — Templates tab. Lists the built-in catalog archetypes. The
+ * `sheet` archetype (CatalogTemplateCatalog #2370) is the only one shipped in
+ * the MVP; `grid` and `pricelist` render as disabled "Wkrótce" cards (module
+ * M6). The cards are informational for the shell — selection is wired into the
+ * create wizard in CPDF-P5-02.
+ */
+export function TemplatesTab() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <h2 className="text-[15px] font-semibold tracking-tight text-ink">
+          {t('catalogs_pdf.templates_title')}
+        </h2>
+        <p className="max-w-prose text-[12.5px] leading-relaxed text-zinc-500">
+          {t('catalogs_pdf.templates_description')}
+        </p>
+      </div>
+      <SelectableCardGroup
+        ariaLabel={t('catalogs_pdf.templates_title')}
+        className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3"
+      >
+        <SelectableCard
+          icon={<LayoutTemplate className="size-5" aria-hidden />}
+          title={t('catalogs_pdf.template_sheet_name')}
+          description={t('catalogs_pdf.template_sheet_description')}
+        />
+        <SelectableCard
+          icon={<LayoutGrid className="size-5" aria-hidden />}
+          title={t('catalogs_pdf.template_grid_name')}
+          description={t('catalogs_pdf.template_grid_description')}
+          disabled
+        />
+        <SelectableCard
+          icon={<Table className="size-5" aria-hidden />}
+          title={t('catalogs_pdf.template_pricelist_name')}
+          description={t('catalogs_pdf.template_pricelist_description')}
+          disabled
+        />
+      </SelectableCardGroup>
+      <StatusPill variant="success" label={t('catalogs_pdf.template_available')} />
+    </div>
+  );
+}

--- a/apps/admin/src/features/catalogs-pdf/index.tsx
+++ b/apps/admin/src/features/catalogs-pdf/index.tsx
@@ -1,9 +1,81 @@
+import { Plus } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSearchParams } from 'react-router';
 
-import { ComingSoonPlaceholder } from '@/features/settings/ComingSoonPlaceholder';
+import { PillTabs } from '@/components/ui-v2/pill-tabs';
+import { usePageActions } from '@/layout/page-actions-context';
 
+import { CatalogsTab } from './CatalogsTab';
+import { TemplatesTab } from './TemplatesTab';
+
+type CatalogsPdfTab = 'catalogs' | 'templates';
+
+const VALID_TABS: readonly CatalogsPdfTab[] = ['catalogs', 'templates'];
+
+function parseTab(value: string | null): CatalogsPdfTab {
+  return VALID_TABS.includes(value as CatalogsPdfTab) ? (value as CatalogsPdfTab) : 'catalogs';
+}
+
+/**
+ * CPDF-P5-01 — PDF catalogs area shell. A self-contained hub under the single
+ * `/catalogs-pdf` route (no nested routes): two pill tabs (Katalogi / Szablony)
+ * with internal `useState` active-tab state seeded from `?tab=`. Mirrors the
+ * ExportsLayout v2 hub pattern (PillTabs + a topbar CTA via usePageActions).
+ * The tabs' content is filled by CPDF-P5-02/03/04.
+ */
 export function CatalogsPdfPage() {
   const { t } = useTranslation();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [activeTab, setActiveTab] = useState<CatalogsPdfTab>(() =>
+    parseTab(searchParams.get('tab')),
+  );
+
+  const changeTab = useCallback(
+    (id: string) => {
+      const next = parseTab(id);
+      setActiveTab(next);
+      setSearchParams(
+        (prev) => {
+          const params = new URLSearchParams(prev);
+          params.set('tab', next);
+          return params;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  // TODO(CPDF-P5-02): open the create-catalog wizard. Until it ships, the CTA
+  // deep-links into the (still empty) catalogs tab so the flow is discoverable.
+  const openNewCatalog = useCallback(() => {
+    changeTab('catalogs');
+    setSearchParams(
+      (prev) => {
+        const params = new URLSearchParams(prev);
+        params.set('tab', 'new');
+        return params;
+      },
+      { replace: true },
+    );
+  }, [changeTab, setSearchParams]);
+
+  usePageActions(
+    useMemo(
+      () => (
+        <button
+          type="button"
+          onClick={openNewCatalog}
+          className="focus-ring inline-flex h-9 items-center gap-1.5 rounded-xl bg-cta px-3.5 text-[13px] font-semibold text-cta-foreground transition hover:bg-accent-hover"
+        >
+          <Plus className="size-4" aria-hidden />
+          {t('catalogs_pdf.new_cta')}
+        </button>
+      ),
+      [t, openNewCatalog],
+    ),
+  );
 
   return (
     <div className="space-y-6">
@@ -12,10 +84,18 @@ export function CatalogsPdfPage() {
           {t('catalogs_pdf.page_title')}
         </h1>
       </header>
-      <ComingSoonPlaceholder
-        titleKey="catalogs_pdf.placeholder_title"
-        descriptionKey="catalogs_pdf.placeholder_description"
+
+      <PillTabs
+        ariaLabel={t('catalogs_pdf.tabs_aria')}
+        activeId={activeTab}
+        onChange={changeTab}
+        items={[
+          { id: 'catalogs', label: t('catalogs_pdf.tab_catalogs') },
+          { id: 'templates', label: t('catalogs_pdf.tab_templates') },
+        ]}
       />
+
+      {activeTab === 'catalogs' ? <CatalogsTab onNewCatalog={openNewCatalog} /> : <TemplatesTab />}
     </div>
   );
 }

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -942,7 +942,23 @@
   "catalogs_pdf": {
     "page_title": "PDF Catalogs",
     "placeholder_title": "Coming soon",
-    "placeholder_description": "PDF catalog generation is in the backlog. Scope will be defined in a separate ticket."
+    "placeholder_description": "PDF catalog generation is in the backlog. Scope will be defined in a separate ticket.",
+    "tabs_aria": "PDF catalog sections",
+    "tab_catalogs": "Catalogs",
+    "tab_templates": "Templates",
+    "new_cta": "New catalog",
+    "catalogs_empty_title": "No catalogs yet",
+    "catalogs_empty_description": "No PDF catalog has been created yet. Start with a new catalog based on the template of your choice.",
+    "catalogs_count": "Catalogs: {{count}}",
+    "templates_title": "Available templates",
+    "templates_description": "The \"Product sheet\" archetype is ready in the MVP. Further layouts arrive in module M6.",
+    "template_sheet_name": "Product sheet (sheet)",
+    "template_sheet_description": "One product per page — a full sheet with attributes and assets.",
+    "template_grid_name": "Catalog (grid)",
+    "template_grid_description": "A grid of multiple products per page — catalog layout.",
+    "template_pricelist_name": "Price list (pricelist)",
+    "template_pricelist_description": "A tabular price list with per-channel prices.",
+    "template_available": "Available"
   },
   "topbar": {
     "workspace": "Workspace",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -952,7 +952,23 @@
   "catalogs_pdf": {
     "page_title": "Katalogi PDF",
     "placeholder_title": "W przygotowaniu",
-    "placeholder_description": "Generowanie katalogów PDF jest na liście backlogu. Scope ustalimy w osobnym tickecie."
+    "placeholder_description": "Generowanie katalogów PDF jest na liście backlogu. Scope ustalimy w osobnym tickecie.",
+    "tabs_aria": "Sekcje katalogów PDF",
+    "tab_catalogs": "Katalogi",
+    "tab_templates": "Szablony",
+    "new_cta": "Nowy katalog",
+    "catalogs_empty_title": "Brak katalogów",
+    "catalogs_empty_description": "Nie utworzono jeszcze żadnego katalogu PDF. Zacznij od nowego katalogu opartego o wybrany szablon.",
+    "catalogs_count": "Katalogów: {{count}}",
+    "templates_title": "Dostępne szablony",
+    "templates_description": "Archetyp „Karta produktu” jest gotowy w MVP. Kolejne układy dochodzą w module M6.",
+    "template_sheet_name": "Karta produktu (sheet)",
+    "template_sheet_description": "Jeden produkt na stronę — pełna karta z atrybutami i zasobami.",
+    "template_grid_name": "Katalog (grid)",
+    "template_grid_description": "Siatka wielu produktów na stronie — układ katalogowy.",
+    "template_pricelist_name": "Cennik (pricelist)",
+    "template_pricelist_description": "Tabelaryczny cennik z cenami per kanał.",
+    "template_available": "Dostępny"
   },
   "topbar": {
     "workspace": "Workspace",


### PR DESCRIPTION
Zamyka **CPDF-P5-01** (#2299). Blocked by P1-03 (merged). Odblokowuje CPDF-P5-02/03.

## Co
Wymiana `ComingSoonPlaceholder` na realny obszar `/catalogs-pdf`: `PillTabs` (Katalogi / Szablony) ze stanem taba w `?tab=` (bez nested routes). Zakładka **Katalogi** = hub (empty state + CTA „Nowy katalog" → kreator w P5-02); zakładka **Szablony** = archetyp `sheet` (Dostępny) + grid/pricelist jako „Wkrótce" (M6).
- **A11y hardening (shared PillTabs):** nieaktywny tab był `text-zinc-500` = **3.59:1** na tle aplikacji (WCAG AA fail) → `text-zinc-600` (przechodzi na tle app i na białym) — naprawia latentny problem na WSZYSTKICH hubach (Exports/Feeds też).

## Walidacja (host + live stack)
- **tsc** 0 · **biome** czysto · **vitest** 142/142 · **build** ✓ · **max-lines** baseline 21 · **i18n parity** pl/en OK · guard jsonFetch/useEffect 59<61.
- **Playwright** `cpdf-shell.spec.ts` (login → `/catalogs-pdf` → taby widoczne → klik Szablony → sheet widoczny → **axe 0 serious/critical**) — **PASS na żywym stacku = live smoke**.
- **Regresja**: `1929-feeds-hub.spec.ts` (używa PillTabs) — **PASS** (zmiana koloru nie psuje).

Refs #2299