### PR TITLE
feat(catalogs-pdf): CPDF-P5-03 — hub katalogów (KPI + karty + akcje)

### DIFF
--- a/apps/admin/e2e/cpdf-hub.spec.ts
+++ b/apps/admin/e2e/cpdf-hub.spec.ts
@@ -1,0 +1,137 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * CPDF-P5-03 — the catalogs hub under the /catalogs-pdf shell: KPI strip fed by
+ * /api/catalog-runs/kpi, catalog cards with their cache state, and the Pobierz /
+ * Regeneruj / Udostępnij / Usuń actions. All catalog endpoints are mocked so the
+ * spec is deterministic and offline.
+ */
+
+const CATALOGS = [
+  {
+    id: '019f0000-0000-7000-8000-0000000000a1',
+    code: 'spring_2026',
+    name: 'Katalog wiosna 2026',
+    template_kind: 'sheet',
+    status: 'active',
+    object_type_id: '019f0000-0000-7000-8000-0000000000ff',
+    branding: {},
+    field_mappings: [],
+    filter: null,
+    channel_id: null,
+    publication_channel: null,
+    locale: 'pl',
+    renderer: 'auto',
+    cached_file_size: 204800,
+    cached_page_count: 48,
+    cached_at: '2026-07-01T04:00:00+00:00',
+    has_token: true,
+    created_at: '2026-06-01T00:00:00+00:00',
+    updated_at: '2026-07-01T04:00:00+00:00',
+  },
+  {
+    id: '019f0000-0000-7000-8000-0000000000a2',
+    code: 'pricelist_b2b',
+    name: 'Cennik B2B',
+    template_kind: 'pricelist',
+    status: 'paused',
+    object_type_id: '019f0000-0000-7000-8000-0000000000ff',
+    branding: {},
+    field_mappings: [],
+    filter: null,
+    channel_id: null,
+    publication_channel: null,
+    locale: null,
+    renderer: 'auto',
+    cached_file_size: null,
+    cached_page_count: null,
+    cached_at: null,
+    has_token: false,
+    created_at: '2026-06-10T00:00:00+00:00',
+    updated_at: '2026-06-10T00:00:00+00:00',
+  },
+];
+
+const KPI = {
+  regenerations_24h: 6,
+  items_24h: 12408,
+  errors_24h: 0,
+  pages_published: 48,
+  last_regenerated_at: '2026-07-01T04:00:00+00:00',
+  catalogs: { active: 1, paused: 1, error: 0 },
+  last_error: null,
+};
+
+test('CPDF-P5-03 — catalogs hub: KPI, cards, actions, a11y', async ({ page }) => {
+  await loginAsAdmin(page);
+
+  await page.route('**/api/catalogs', (route) => {
+    if (route.request().method() !== 'GET') return route.continue();
+    return route.fulfill({ json: { items: CATALOGS } });
+  });
+  await page.route('**/api/catalog-runs/kpi', (route) => route.fulfill({ json: KPI }));
+
+  let generateCalled = false;
+  let tokenMintCalled = false;
+
+  await page.route('**/api/catalogs/*/generate', (route) => {
+    generateCalled = true;
+    return route.fulfill({ status: 202, json: { run: { id: 'r1', status: 'pending' } } });
+  });
+  await page.route('**/api/catalogs/*/token', (route) => {
+    tokenMintCalled = true;
+    return route.fulfill({
+      status: 201,
+      json: { token: 't', url: '/api/catalogs/pull/x/t.pdf' },
+    });
+  });
+  await page.route('**/api/catalogs/*', (route) => {
+    if (route.request().method() === 'DELETE') {
+      return route.fulfill({ status: 204, body: '' });
+    }
+    return route.continue();
+  });
+
+  await page.goto('/catalogs-pdf');
+
+  const main = page.getByRole('main');
+
+  // KPI strip renders the merged aggregates. pl-PL grouping starts at five
+  // digits (CLDR minimumGroupingDigits=2), so 12408 gets an NBSP separator;
+  // an optional whitespace matches both.
+  await expect(main.getByText(/12\s?408/)).toBeVisible();
+  await expect(main.getByText('Regeneracje 24h')).toBeVisible();
+
+  // Both catalog cards render.
+  await expect(page.getByRole('heading', { name: /Katalogi$/ })).toBeVisible();
+  await expect(page.getByText('Katalog wiosna 2026')).toBeVisible();
+  await expect(page.getByText('Cennik B2B')).toBeVisible();
+
+  const firstCard = page
+    .getByText('Katalog wiosna 2026')
+    .locator('xpath=ancestor::div[contains(@class,"rounded-3xl")][1]');
+
+  // Regeneruj fires the generate call.
+  await firstCard.getByRole('button', { name: /Regeneruj/ }).click();
+  await expect.poll(() => generateCalled).toBe(true);
+
+  // Udostępnij mints a token and surfaces the "Skopiowano" state.
+  await firstCard.getByRole('button', { name: /^Udostępnij$/ }).click();
+  await expect.poll(() => tokenMintCalled).toBe(true);
+  await expect(firstCard.getByText('Skopiowano')).toBeVisible();
+
+  // a11y — no serious/critical violations on the hub. Kill CSS
+  // transitions/animations so the scan does not read mid-animation colours.
+  await page.addStyleTag({
+    content: '*,*::before,*::after{transition:none!important;animation:none!important}',
+  });
+  await page.waitForTimeout(150);
+  const axe = await new AxeBuilder({ page }).include('main').analyze();
+  const blocking = axe.violations.filter(
+    (violation) => violation.impact === 'serious' || violation.impact === 'critical',
+  );
+  expect(blocking).toEqual([]);
+});

--- a/apps/admin/src/features/catalogs-pdf/CatalogsTab.tsx
+++ b/apps/admin/src/features/catalogs-pdf/CatalogsTab.tsx
@@ -1,22 +1,11 @@
-import { useQuery } from '@tanstack/react-query';
 import { FileText } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { EmptyState } from '@/components/ui-v2/empty-state';
-import { jsonFetch } from '@/lib/http';
 
-/** One row of `GET /api/catalogs` — only the fields the shell reads. */
-interface CatalogProfileRow {
-  id: string;
-  name: string;
-  template_kind: string;
-  status: string;
-}
-
-/** `GET /api/catalogs` returns `{ items: [...] }` (CatalogProfileController::list). */
-interface CatalogsResponse {
-  items: CatalogProfileRow[];
-}
+import { useCatalogKpi, useCatalogs } from './api/catalogs';
+import { CatalogCard } from './hub/CatalogCard';
+import { CatalogKpiStrip } from './hub/CatalogKpiStrip';
 
 interface CatalogsTabProps {
   /** CTA that opens the create wizard (owned by CPDF-P5-02). */
@@ -24,44 +13,54 @@ interface CatalogsTabProps {
 }
 
 /**
- * CPDF-P5-01 — Catalogs hub tab. For the shell ticket this is a lightweight
- * hub: it fetches `GET /api/catalogs` and, until CPDF-P5-02 ships the wizard
- * and the card grid, renders an empty state with the "Nowy katalog" CTA. A
- * non-empty list still lands on the empty-state copy plus a count badge —
- * the real card grid is P5-02/P5-03 scope.
+ * CPDF-P5-03 — the Catalogs hub tab: a KPI strip plus the catalog card grid.
+ * Each card surfaces the last cache state and the Pobierz / Regeneruj /
+ * Udostępnij / Usuń actions. With zero catalogs it falls back to the empty
+ * state + "Nowy katalog" CTA (kept from the P5-01 shell).
  */
 export function CatalogsTab({ onNewCatalog }: CatalogsTabProps) {
   const { t } = useTranslation();
+  const catalogsQuery = useCatalogs();
+  const kpiQuery = useCatalogKpi();
 
-  const catalogsQuery = useQuery<CatalogsResponse>({
-    queryKey: ['catalogs-pdf', 'profiles'],
-    queryFn: () => jsonFetch<CatalogsResponse>('/api/catalogs', { accept: 'application/json' }),
-    staleTime: 30_000,
-  });
-
-  const count = catalogsQuery.data?.items.length ?? 0;
+  const catalogs = catalogsQuery.data ?? [];
 
   return (
-    <div className="space-y-4">
-      {count > 0 && (
-        <p className="text-[12.5px] font-medium text-zinc-500">
-          {t('catalogs_pdf.catalogs_count', { count })}
-        </p>
+    <div className="space-y-6">
+      <CatalogKpiStrip kpi={kpiQuery.data} />
+
+      {catalogs.length > 0 ? (
+        <>
+          <div className="flex flex-wrap items-center gap-3">
+            <h2 className="font-display text-[16px] font-semibold tracking-tight">
+              {t('catalogs_pdf.hub_title')}
+            </h2>
+            <span className="text-[12px] text-zinc-500">
+              {t('catalogs_pdf.hub_subtitle', { count: catalogs.length })}
+            </span>
+          </div>
+          <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+            {catalogs.map((catalog) => (
+              <CatalogCard key={catalog.id} catalog={catalog} />
+            ))}
+          </div>
+        </>
+      ) : (
+        <EmptyState
+          icon={<FileText className="size-5" aria-hidden />}
+          title={t('catalogs_pdf.catalogs_empty_title')}
+          description={t('catalogs_pdf.catalogs_empty_description')}
+          action={
+            <button
+              type="button"
+              onClick={onNewCatalog}
+              className="focus-ring inline-flex h-9 items-center gap-1.5 rounded-xl bg-cta px-3.5 text-[13px] font-semibold text-cta-foreground transition hover:bg-accent-hover"
+            >
+              {t('catalogs_pdf.new_cta')}
+            </button>
+          }
+        />
       )}
-      <EmptyState
-        icon={<FileText className="size-5" aria-hidden />}
-        title={t('catalogs_pdf.catalogs_empty_title')}
-        description={t('catalogs_pdf.catalogs_empty_description')}
-        action={
-          <button
-            type="button"
-            onClick={onNewCatalog}
-            className="focus-ring inline-flex h-9 items-center gap-1.5 rounded-xl bg-cta px-3.5 text-[13px] font-semibold text-cta-foreground transition hover:bg-accent-hover"
-          >
-            {t('catalogs_pdf.new_cta')}
-          </button>
-        }
-      />
     </div>
   );
 }

--- a/apps/admin/src/features/catalogs-pdf/api/catalogs.ts
+++ b/apps/admin/src/features/catalogs-pdf/api/catalogs.ts
@@ -1,0 +1,132 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { jsonFetch } from '@/lib/http';
+
+/**
+ * CPDF-P5-03 — data layer for the catalogs hub. `/api/catalogs` +
+ * `/api/catalog-runs/*` are custom `#[Route]` surfaces (not API Platform
+ * resources), so the Refine dataProvider's hydra parsing does not apply —
+ * plain jsonFetch + react-query, the established pattern for custom endpoints
+ * (mirrors the feeds hub `api/feeds.ts`).
+ */
+
+export type CatalogStatus = 'active' | 'paused' | 'error';
+export type CatalogTemplateKind = 'sheet' | 'grid' | 'pricelist';
+
+/**
+ * One row of `GET /api/catalogs` — the fields the hub reads. Exact shape from
+ * {@link CatalogProfileController::serialize}. The plaintext token is never
+ * serialized; `has_token` tells the card whether a URL already exists.
+ */
+export interface CatalogProfileRow {
+  id: string;
+  code: string;
+  name: string;
+  template_kind: CatalogTemplateKind | string;
+  status: CatalogStatus | string;
+  object_type_id: string;
+  branding: Record<string, unknown>;
+  field_mappings: Array<Record<string, unknown>>;
+  filter: Record<string, unknown> | null;
+  channel_id: string | null;
+  publication_channel: string | null;
+  locale: string | null;
+  renderer: string;
+  cached_file_size: number | null;
+  cached_page_count: number | null;
+  cached_at: string | null;
+  has_token: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+/** `GET /api/catalog-runs/kpi` — {@link CatalogRunMonitorController::kpi}. */
+export interface CatalogKpi {
+  regenerations_24h: number;
+  items_24h: number;
+  errors_24h: number;
+  pages_published: number;
+  last_regenerated_at: string | null;
+  catalogs: { active: number; paused: number; error: number };
+  last_error: { run_id: string; catalog_id: string; message: string | null } | null;
+}
+
+/** Minted URL token — the plaintext URL is returned once (P3-02). */
+export interface MintedCatalogToken {
+  token: string;
+  url: string;
+}
+
+interface CatalogsResponse {
+  items: CatalogProfileRow[];
+}
+
+export const CATALOGS_QUERY_KEY = ['catalogs-pdf', 'profiles'] as const;
+export const CATALOG_KPI_QUERY_KEY = ['catalogs-pdf', 'kpi'] as const;
+
+export function useCatalogs() {
+  return useQuery({
+    queryKey: CATALOGS_QUERY_KEY,
+    queryFn: async () => (await jsonFetch<CatalogsResponse>('/api/catalogs')).items,
+    staleTime: 30_000,
+  });
+}
+
+export function useCatalogKpi() {
+  return useQuery({
+    queryKey: CATALOG_KPI_QUERY_KEY,
+    queryFn: () => jsonFetch<CatalogKpi>('/api/catalog-runs/kpi'),
+    staleTime: 30_000,
+  });
+}
+
+function invalidateCatalogs(queryClient: ReturnType<typeof useQueryClient>): void {
+  void queryClient.invalidateQueries({ queryKey: CATALOGS_QUERY_KEY });
+  void queryClient.invalidateQueries({ queryKey: CATALOG_KPI_QUERY_KEY });
+}
+
+/** Trigger a manual regeneration (202 + pending run). */
+export function useRegenerateCatalog() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) =>
+      jsonFetch<Record<string, unknown>>(`/api/catalogs/${id}/generate`, { method: 'POST' }),
+    onSettled: () => invalidateCatalogs(queryClient),
+  });
+}
+
+/** Mint/rotate the URL token — the plaintext URL is shown once (P3-02). */
+export function useMintCatalogToken() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) =>
+      jsonFetch<MintedCatalogToken>(`/api/catalogs/${id}/token`, { method: 'POST' }),
+    onSettled: () => invalidateCatalogs(queryClient),
+  });
+}
+
+/** Delete a catalog (204). */
+export function useDeleteCatalog() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => jsonFetch(`/api/catalogs/${id}`, { method: 'DELETE' }),
+    onSettled: () => invalidateCatalogs(queryClient),
+  });
+}
+
+/** Map a catalog `status` onto a `<StatusPill>` visual variant. */
+export function catalogStatusVariant(status: string): 'success' | 'warning' | 'error' {
+  switch (status) {
+    case 'paused':
+      return 'warning';
+    case 'error':
+      return 'error';
+    default:
+      return 'success';
+  }
+}
+
+/** Prefix a same-origin path with the current origin for share/download URLs. */
+export function absoluteUrl(path: string): string {
+  return path.startsWith('http') ? path : `${window.location.origin}${path}`;
+}

--- a/apps/admin/src/features/catalogs-pdf/hub/CatalogCard.tsx
+++ b/apps/admin/src/features/catalogs-pdf/hub/CatalogCard.tsx
@@ -1,0 +1,189 @@
+import { Check, Download, FileText, Link2, RefreshCw, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useToast } from '@/components/ui/toast';
+import { StatusPill } from '@/components/ui-v2/status-pill';
+import { httpErrorDetail } from '@/lib/http';
+import { cn } from '@/lib/utils';
+
+import {
+  absoluteUrl,
+  type CatalogProfileRow,
+  catalogStatusVariant,
+  useDeleteCatalog,
+  useMintCatalogToken,
+  useRegenerateCatalog,
+} from '../api/catalogs';
+
+const TEMPLATE_ICON_TONES: Record<string, string> = {
+  sheet: 'bg-sky-50 text-sky-600',
+  grid: 'bg-emerald-50 text-emerald-600',
+  pricelist: 'bg-violet-50 text-violet-600',
+};
+
+/**
+ * CPDF-P5-03 — one configured catalog (mirrors the feeds {@link FeedCard}):
+ * identity + template badge + status pill, a cache line (last regeneration /
+ * page count), and the action footer — Pobierz (mint token → open the pull
+ * URL), Regeneruj, Udostępnij (mint token → copy the pull URL, transient
+ * "Skopiowano"), Usuń (confirm → delete).
+ */
+export function CatalogCard({ catalog }: { catalog: CatalogProfileRow }) {
+  const { t } = useTranslation();
+  const toast = useToast();
+  const regenerate = useRegenerateCatalog();
+  const mintToken = useMintCatalogToken();
+  const remove = useDeleteCatalog();
+  const [copied, setCopied] = useState(false);
+
+  const iconTone =
+    catalog.status === 'error'
+      ? 'bg-brick-50 text-brick-600'
+      : catalog.status === 'paused'
+        ? 'bg-zinc-100 text-zinc-500'
+        : (TEMPLATE_ICON_TONES[catalog.template_kind] ?? 'bg-zinc-100 text-zinc-600');
+
+  function onRegenerate(): void {
+    regenerate.mutate(catalog.id, {
+      onSuccess: () => toast.success(t('catalogs_pdf.card.regenerate_started')),
+      onError: (error) =>
+        toast.error(httpErrorDetail(error) ?? t('catalogs_pdf.card.action_error')),
+    });
+  }
+
+  function onDownload(): void {
+    mintToken.mutate(catalog.id, {
+      onSuccess: (minted) => window.open(absoluteUrl(minted.url), '_blank', 'noopener,noreferrer'),
+      onError: (error) =>
+        toast.error(httpErrorDetail(error) ?? t('catalogs_pdf.card.action_error')),
+    });
+  }
+
+  function onShare(): void {
+    mintToken.mutate(catalog.id, {
+      onSuccess: (minted) => {
+        void navigator.clipboard?.writeText(absoluteUrl(minted.url)).catch(() => {
+          /* clipboard blocked — the toast below still confirms the mint */
+        });
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 2000);
+        toast.success(t('catalogs_pdf.card.share_copied'));
+      },
+      onError: (error) =>
+        toast.error(httpErrorDetail(error) ?? t('catalogs_pdf.card.action_error')),
+    });
+  }
+
+  function onDelete(): void {
+    if (!window.confirm(t('catalogs_pdf.card.delete_confirm', { name: catalog.name }))) {
+      return;
+    }
+    remove.mutate(catalog.id, {
+      onSuccess: () => toast.success(t('catalogs_pdf.card.delete_success')),
+      onError: (error) =>
+        toast.error(httpErrorDetail(error) ?? t('catalogs_pdf.card.action_error')),
+    });
+  }
+
+  const cacheLine =
+    catalog.cached_at !== null
+      ? t('catalogs_pdf.card.cache_line', {
+          date: new Date(catalog.cached_at).toLocaleString('pl-PL'),
+          count: catalog.cached_page_count ?? 0,
+        })
+      : t('catalogs_pdf.card.cache_none');
+
+  return (
+    <div className="group rounded-3xl bg-white p-5 soft-shadow transition hover:soft-shadow-lg">
+      <div className="flex items-start gap-3">
+        <div className={cn('grid h-11 w-11 shrink-0 place-items-center rounded-xl', iconTone)}>
+          <FileText className="h-5 w-5" aria-hidden />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="text-[15px] font-semibold tracking-tight">{catalog.name}</div>
+            <span className="rounded-md border border-zinc-200 px-1.5 py-0.5 font-mono text-[10.5px] uppercase text-zinc-600">
+              {t(`catalogs_pdf.template_kind.${catalog.template_kind}`, {
+                defaultValue: catalog.template_kind,
+              })}
+            </span>
+          </div>
+          <div className="mt-1 flex items-center gap-1.5 text-[11.5px] text-zinc-500">
+            <span className="font-mono">{catalog.code}</span>
+            {catalog.locale !== null && (
+              <>
+                <span className="text-zinc-300">·</span>
+                <span className="font-mono uppercase">{catalog.locale}</span>
+              </>
+            )}
+          </div>
+        </div>
+        <StatusPill
+          variant={catalogStatusVariant(catalog.status)}
+          label={t(`catalogs_pdf.status.${catalog.status}`, { defaultValue: catalog.status })}
+        />
+      </div>
+
+      <div className="mt-4 flex items-center gap-2 text-[12px] text-zinc-600">
+        <FileText className="h-4 w-4 shrink-0 text-zinc-400" aria-hidden />
+        <span className="min-w-0 truncate">{cacheLine}</span>
+        {catalog.has_token && (
+          <span
+            className="ml-auto inline-flex shrink-0 items-center gap-1 text-[11px] text-zinc-600"
+            title={t('catalogs_pdf.card.has_token')}
+          >
+            <Link2 className="h-3.5 w-3.5" aria-hidden />
+            {t('catalogs_pdf.card.has_token')}
+          </span>
+        )}
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-zinc-100 pt-3">
+        <button
+          type="button"
+          onClick={onDownload}
+          disabled={mintToken.isPending}
+          className="flex h-8 items-center gap-1.5 rounded-lg bg-zinc-900 px-3 text-[12px] font-medium text-white hover:bg-zinc-800 disabled:opacity-40"
+        >
+          <Download className="h-3.5 w-3.5" aria-hidden />
+          {t('catalogs_pdf.card.download')}
+        </button>
+        <button
+          type="button"
+          onClick={onRegenerate}
+          disabled={regenerate.isPending}
+          className="flex h-8 items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-2.5 text-[12px] font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-40"
+        >
+          <RefreshCw
+            className={cn('h-3.5 w-3.5', regenerate.isPending && 'animate-spin')}
+            aria-hidden
+          />
+          {t('catalogs_pdf.card.regenerate')}
+        </button>
+        <button
+          type="button"
+          onClick={onShare}
+          disabled={mintToken.isPending}
+          className="flex h-8 items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-2.5 text-[12px] font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-40"
+        >
+          {copied ? (
+            <Check className="h-3.5 w-3.5 text-emerald-600" aria-hidden />
+          ) : (
+            <Link2 className="h-3.5 w-3.5" aria-hidden />
+          )}
+          {copied ? t('catalogs_pdf.card.share_copied') : t('catalogs_pdf.card.share')}
+        </button>
+        <button
+          type="button"
+          onClick={onDelete}
+          disabled={remove.isPending}
+          aria-label={t('catalogs_pdf.card.delete')}
+          title={t('catalogs_pdf.card.delete')}
+          className="ml-auto grid h-8 w-8 place-items-center rounded-lg border border-zinc-200 bg-white text-zinc-500 transition hover:bg-brick-50 hover:text-brick-600 disabled:opacity-40"
+        >
+          <Trash2 className="h-3.5 w-3.5" aria-hidden />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/catalogs-pdf/hub/CatalogKpiStrip.tsx
+++ b/apps/admin/src/features/catalogs-pdf/hub/CatalogKpiStrip.tsx
@@ -1,0 +1,83 @@
+import { AlertTriangle, Files, FileText, RefreshCw } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import type { CatalogKpi } from '../api/catalogs';
+
+/**
+ * CPDF-P5-03 — the catalogs hub KPI strip (mirrors the feeds
+ * {@link FeedKpiStrip} styling): 24h regenerations, 24h errors, published
+ * pages inventory and 24h item throughput. Undefined KPI (loading / error)
+ * renders a graceful "—".
+ */
+export function CatalogKpiStrip({ kpi }: { kpi: CatalogKpi | undefined }) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+      <KpiTile
+        label={t('catalogs_pdf.kpi.regenerations')}
+        value={formatCount(kpi?.regenerations_24h)}
+        icon={<RefreshCw className="h-4.5 w-4.5" aria-hidden />}
+        hint={t('catalogs_pdf.kpi.regenerations_hint')}
+      />
+      <KpiTile
+        label={t('catalogs_pdf.kpi.errors')}
+        value={formatCount(kpi?.errors_24h)}
+        icon={<AlertTriangle className="h-4.5 w-4.5" aria-hidden />}
+        hint={t('catalogs_pdf.kpi.errors_hint')}
+        tone={kpi && kpi.errors_24h > 0 ? 'error' : 'default'}
+      />
+      <KpiTile
+        label={t('catalogs_pdf.kpi.pages')}
+        value={formatCount(kpi?.pages_published)}
+        icon={<FileText className="h-4.5 w-4.5" aria-hidden />}
+        hint={t('catalogs_pdf.kpi.pages_hint')}
+      />
+      <KpiTile
+        label={t('catalogs_pdf.kpi.items')}
+        value={formatCount(kpi?.items_24h)}
+        icon={<Files className="h-4.5 w-4.5" aria-hidden />}
+        hint={t('catalogs_pdf.kpi.items_hint')}
+      />
+    </div>
+  );
+}
+
+interface KpiTileProps {
+  label: string;
+  value: string;
+  icon: React.ReactNode;
+  hint: string;
+  tone?: 'default' | 'error';
+}
+
+function KpiTile({ label, value, icon, hint, tone = 'default' }: KpiTileProps) {
+  return (
+    <div className="rounded-2xl bg-white p-4 soft-shadow">
+      <div className="flex items-start justify-between">
+        <div className="min-w-0">
+          <div className="text-[10.5px] font-medium uppercase tracking-wider text-zinc-500">
+            {label}
+          </div>
+          <div className="num mt-1 font-display text-[28px] font-semibold tracking-tight">
+            {value}
+          </div>
+          <div className="mt-1.5 truncate text-[11px] text-zinc-500">{hint}</div>
+        </div>
+        <div
+          className={
+            tone === 'error'
+              ? 'grid h-10 w-10 shrink-0 place-items-center rounded-xl bg-brick-50 text-brick-600'
+              : 'grid h-10 w-10 shrink-0 place-items-center rounded-xl bg-zinc-900 text-white'
+          }
+        >
+          {icon}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function formatCount(value: number | undefined): string {
+  return value === undefined ? '—' : value.toLocaleString('pl-PL');
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -959,6 +959,42 @@
     "template_pricelist_name": "Price list (pricelist)",
     "template_pricelist_description": "A tabular price list with per-channel prices.",
     "template_available": "Available",
+    "hub_title": "Catalogs",
+    "hub_subtitle": "{{count}} catalogs",
+    "kpi": {
+      "regenerations": "Regenerations 24h",
+      "regenerations_hint": "Runs in the last day",
+      "errors": "Errors 24h",
+      "errors_hint": "Failed runs",
+      "pages": "Pages published",
+      "pages_hint": "Current cache state",
+      "items": "Items 24h",
+      "items_hint": "Rendered entries"
+    },
+    "status": {
+      "active": "Active",
+      "paused": "Paused",
+      "error": "Error"
+    },
+    "template_kind": {
+      "sheet": "Sheet",
+      "grid": "Grid",
+      "pricelist": "Pricelist"
+    },
+    "card": {
+      "download": "Download",
+      "regenerate": "Regenerate",
+      "share": "Share",
+      "share_copied": "Copied",
+      "delete": "Delete",
+      "has_token": "Public link",
+      "cache_line": "Generated {{date}} · {{count}} pages",
+      "cache_none": "Not generated",
+      "regenerate_started": "Regeneration started",
+      "delete_confirm": "Delete catalog “{{name}}”? This cannot be undone.",
+      "delete_success": "Catalog deleted",
+      "action_error": "Could not complete the action. Please try again."
+    },
     "wizard": {
       "title": "New PDF catalog",
       "lead": "Build and generate a catalog in six steps: scope, archetype, branding, field mapping, preview, generate.",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -969,6 +969,42 @@
     "template_pricelist_name": "Cennik (pricelist)",
     "template_pricelist_description": "Tabelaryczny cennik z cenami per kanał.",
     "template_available": "Dostępny",
+    "hub_title": "Katalogi",
+    "hub_subtitle": "{{count}} katalogów",
+    "kpi": {
+      "regenerations": "Regeneracje 24h",
+      "regenerations_hint": "Uruchomienia z ostatniej doby",
+      "errors": "Błędy 24h",
+      "errors_hint": "Nieudane uruchomienia",
+      "pages": "Strony opublikowane",
+      "pages_hint": "Aktualny stan cache",
+      "items": "Produkty 24h",
+      "items_hint": "Wyrenderowane pozycje"
+    },
+    "status": {
+      "active": "Aktywny",
+      "paused": "Wstrzymany",
+      "error": "Błąd"
+    },
+    "template_kind": {
+      "sheet": "Karta",
+      "grid": "Siatka",
+      "pricelist": "Cennik"
+    },
+    "card": {
+      "download": "Pobierz",
+      "regenerate": "Regeneruj",
+      "share": "Udostępnij",
+      "share_copied": "Skopiowano",
+      "delete": "Usuń",
+      "has_token": "Link publiczny",
+      "cache_line": "Wygenerowano {{date}} · {{count}} stron",
+      "cache_none": "Nie wygenerowano",
+      "regenerate_started": "Regeneracja uruchomiona",
+      "delete_confirm": "Usunąć katalog „{{name}}”? Tej operacji nie można cofnąć.",
+      "delete_success": "Katalog usunięty",
+      "action_error": "Nie udało się wykonać akcji. Spróbuj ponownie."
+    },
     "wizard": {
       "title": "Nowy katalog PDF",
       "lead": "Zbuduj i wygeneruj katalog w sześciu krokach: zakres, archetyp, branding, mapowanie pól, podgląd, generowanie.",


### PR DESCRIPTION
Zamyka **CPDF-P5-03** (#2301). Blocked by P5-01 (merged). 

## Co
Zakładka „Katalogi" z zaślepki → realny hub: **KPI strip** (regeneracje/errory/strony/itemy 24h z `/api/catalog-runs/kpi`) + **grid kart katalogów** — każda ze status-pillem, linią cache i akcjami **Pobierz / Regeneruj / Udostępnij / Usuń**. Warstwa react-query: list, KPI, regenerate (POST `/{id}/generate`), token mint (POST `/{id}/token` → `{token, url}`, użyty do download i kopiowanego share-linku), delete. Empty state + CTA „Nowy katalog" gdy brak katalogów.
- **A11y fix:** badge „Link publiczny" był `text-zinc-400` (3.3:1 na białym, WCAG AA fail) → `zinc-600`.

## Walidacja (host + LIVE stack)
- **tsc/biome/vitest 142/build/max-lines/i18n-parity** zielone.
- **Playwright** `cpdf-hub.spec.ts`: KPI tiles + 2 karty + Regeneruj (generate call) + Udostępnij (token mint + „Skopiowano") + axe 0 serious/critical (transitions killed). PASS.
- **LIVE smoke (pim.localhost, realny backend):** `GET /api/catalogs` → 2 katalogi; `GET /api/catalog-runs/kpi` → 200 (klucze regenerations_24h/errors_24h/items_24h/pages_published/catalogs/last_error/last_regenerated_at); `POST /api/catalogs/{id}/token` → **201** z `url=/api/catalogs/pull/{tenant}/{token}.pdf` (dokładnie to czego używa hub do share/download).

Refs #2301