### PR TITLE
feat(catalogs-pdf): CPDF-P5-04 — live progres runów (Mercure) + auto-refresh podglądu

### DIFF
--- a/apps/admin/e2e/cpdf-progress.spec.ts
+++ b/apps/admin/e2e/cpdf-progress.spec.ts
@@ -1,0 +1,108 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * CPDF-P5-04 — live regeneration progress on the catalogs hub. Clicking
+ * Regeneruj fires POST /api/catalogs/{id}/generate (202) and shows the live
+ * "Generowanie…" affordance driven by the Mercure run stream. Simulating a real
+ * SSE frame in Playwright is impractical (the EventSource opens against the hub
+ * origin), so this spec asserts the mutation-pending → live-progress transition
+ * and that the UI degrades gracefully with no EventSource events: the card must
+ * stay usable and pass a11y. All catalog endpoints are mocked → deterministic.
+ */
+
+const CATALOGS = [
+  {
+    id: '019f0000-0000-7000-8000-0000000000b1',
+    code: 'spring_2026',
+    name: 'Katalog wiosna 2026',
+    template_kind: 'sheet',
+    status: 'active',
+    object_type_id: '019f0000-0000-7000-8000-0000000000ff',
+    branding: {},
+    field_mappings: [],
+    filter: null,
+    channel_id: null,
+    publication_channel: null,
+    locale: 'pl',
+    renderer: 'auto',
+    cached_file_size: 204800,
+    cached_page_count: 48,
+    cached_at: '2026-07-01T04:00:00+00:00',
+    has_token: true,
+    created_at: '2026-06-01T00:00:00+00:00',
+    updated_at: '2026-07-01T04:00:00+00:00',
+  },
+];
+
+const KPI = {
+  regenerations_24h: 6,
+  items_24h: 12408,
+  errors_24h: 0,
+  pages_published: 48,
+  last_regenerated_at: '2026-07-01T04:00:00+00:00',
+  catalogs: { active: 1, paused: 0, error: 0 },
+  last_error: null,
+};
+
+test('CPDF-P5-04 — hub: Regeneruj shows live progress, degrades without SSE', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('i18nextLng', 'pl');
+  });
+
+  await loginAsAdmin(page);
+
+  await page.route('**/api/catalogs', (route) => {
+    if (route.request().method() !== 'GET') return route.continue();
+    return route.fulfill({ json: { items: CATALOGS } });
+  });
+  await page.route('**/api/catalog-runs/kpi', (route) => route.fulfill({ json: KPI }));
+
+  let generateCalled = false;
+  await page.route('**/api/catalogs/*/generate', (route) => {
+    generateCalled = true;
+    return route.fulfill({
+      status: 202,
+      json: {
+        run: { id: 'run-1', status: 'pending' },
+        mercure_topic: 'tenant/t/catalogs/019f0000-0000-7000-8000-0000000000b1/runs',
+      },
+    });
+  });
+  // The Mercure authorization mint + hub subscribe never emit an SSE frame in
+  // this harness — the card must fall back to the REST list refresh (no crash).
+  await page.route('**/api/mercure/authorization', (route) =>
+    route.fulfill({ status: 204, body: '' }),
+  );
+
+  await page.goto('/catalogs-pdf');
+
+  const card = page
+    .getByText('Katalog wiosna 2026')
+    .locator('xpath=ancestor::div[contains(@class,"rounded-3xl")][1]');
+  await expect(card).toBeVisible();
+
+  // Regeneruj fires the generate call and reveals the live progress line.
+  await card.getByRole('button', { name: /Regeneruj/ }).click();
+  await expect.poll(() => generateCalled).toBe(true);
+
+  // Live affordance: with no SSE frame the indeterminate "Generowanie…" status
+  // shows (progress_pct unknown). role=status, not raw text.
+  await expect(card.getByRole('status').filter({ hasText: 'Generowanie' })).toBeVisible();
+
+  // Graceful degradation — the card stays interactive (no crash without SSE).
+  await expect(card.getByRole('button', { name: /Pobierz/ })).toBeEnabled();
+
+  // a11y — no serious/critical violations while the progress line is live.
+  await page.addStyleTag({
+    content: '*,*::before,*::after{transition:none!important;animation:none!important}',
+  });
+  await page.waitForTimeout(150);
+  const axe = await new AxeBuilder({ page }).include('main').analyze();
+  const blocking = axe.violations.filter(
+    (violation) => violation.impact === 'serious' || violation.impact === 'critical',
+  );
+  expect(blocking).toEqual([]);
+});

--- a/apps/admin/src/features/catalogs-pdf/api/runs-stream.ts
+++ b/apps/admin/src/features/catalogs-pdf/api/runs-stream.ts
@@ -1,0 +1,92 @@
+import * as React from 'react';
+
+import { useIdentity } from '@/lib/identity';
+import { ensureMercureAuthorization, mercureSubscribeUrl, mercureTenantTopic } from '@/lib/mercure';
+
+/**
+ * CPDF-P5-04 — SSE subscriber for one catalog's run stream (P4 publisher).
+ * Split from api/catalogs.ts so the ADR-0021 transport-in-effect guard stays
+ * clean: this file owns the EventSource effect and carries no HTTP transport at
+ * all (mirrors the feeds api/runs-stream.ts split).
+ */
+
+export interface CatalogRunEvent {
+  event: 'progress' | 'status';
+  run_id: string;
+  catalog_id: string;
+  items_done?: number;
+  items_total?: number | null;
+  progress_pct?: number | null;
+  estimated_seconds_remaining?: number | null;
+  status?: string;
+  error_message?: string | null;
+}
+
+export interface CatalogRunsStream {
+  connected: boolean;
+  lastEvent: CatalogRunEvent | null;
+  topic: string | null;
+}
+
+/**
+ * SSE subscriber for one catalog's run stream. Mirrors the
+ * useFeedRunsStream pattern: mint the mercureAuthorization cookie, open the
+ * EventSource, surface the latest event; no-ops without EventSource and on hub
+ * errors (the REST catalogs/kpi refresh stays the fallback). Pass `null` while
+ * no run is active so idle hub cards never open a socket.
+ */
+export function useCatalogRunsStream(catalogId: string | null): CatalogRunsStream {
+  const [connected, setConnected] = React.useState(false);
+  const [lastEvent, setLastEvent] = React.useState<CatalogRunEvent | null>(null);
+  const { identity } = useIdentity();
+  const tenantId = identity?.tenant?.id ?? null;
+  const topic =
+    catalogId !== null && tenantId !== null
+      ? mercureTenantTopic(tenantId, 'catalogs', catalogId, 'runs')
+      : null;
+
+  React.useEffect(() => {
+    if (topic === null) {
+      setConnected(false);
+      setLastEvent(null);
+      return;
+    }
+    if (typeof window === 'undefined' || typeof EventSource === 'undefined') {
+      return;
+    }
+
+    const url = mercureSubscribeUrl(topic);
+    let source: EventSource | null = null;
+    let cancelled = false;
+
+    ensureMercureAuthorization()
+      .then(() => {
+        if (cancelled) {
+          return;
+        }
+        source = new EventSource(url, { withCredentials: true });
+        source.addEventListener('open', () => setConnected(true));
+        source.addEventListener('message', (event) => {
+          try {
+            setLastEvent(JSON.parse(event.data) as CatalogRunEvent);
+          } catch {
+            // Malformed payload — Mercure is enrichment, not source of truth.
+          }
+        });
+        source.addEventListener('error', () => setConnected(false));
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setConnected(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      source?.close();
+      setConnected(false);
+    };
+  }, [topic]);
+
+  return { connected, lastEvent, topic };
+}

--- a/apps/admin/src/features/catalogs-pdf/hub/CatalogCard.tsx
+++ b/apps/admin/src/features/catalogs-pdf/hub/CatalogCard.tsx
@@ -1,5 +1,6 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { Check, Download, FileText, Link2, RefreshCw, Trash2 } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useToast } from '@/components/ui/toast';
 import { StatusPill } from '@/components/ui-v2/status-pill';
@@ -8,12 +9,16 @@ import { cn } from '@/lib/utils';
 
 import {
   absoluteUrl,
+  CATALOG_KPI_QUERY_KEY,
+  CATALOGS_QUERY_KEY,
   type CatalogProfileRow,
   catalogStatusVariant,
   useDeleteCatalog,
   useMintCatalogToken,
   useRegenerateCatalog,
 } from '../api/catalogs';
+import { useCatalogRunsStream } from '../api/runs-stream';
+import { CatalogRunProgress, isTerminalRunEvent } from './CatalogRunProgress';
 
 const TEMPLATE_ICON_TONES: Record<string, string> = {
   sheet: 'bg-sky-50 text-sky-600',
@@ -31,10 +36,34 @@ const TEMPLATE_ICON_TONES: Record<string, string> = {
 export function CatalogCard({ catalog }: { catalog: CatalogProfileRow }) {
   const { t } = useTranslation();
   const toast = useToast();
+  const queryClient = useQueryClient();
   const regenerate = useRegenerateCatalog();
   const mintToken = useMintCatalogToken();
   const remove = useDeleteCatalog();
   const [copied, setCopied] = useState(false);
+
+  // Gate the EventSource: `null` until the user starts a regeneration, so idle
+  // hub cards never open a socket. Cleared when the run reaches a terminal
+  // status (or on mint/HTTP fallback via the REST refresh below).
+  const [runActive, setRunActive] = useState(false);
+  const stream = useCatalogRunsStream(runActive ? catalog.id : null);
+  const lastEvent = stream.lastEvent;
+
+  useEffect(() => {
+    if (!runActive || lastEvent === null) {
+      return;
+    }
+    if (isTerminalRunEvent(lastEvent)) {
+      // Terminal status — the catalog card + KPI aggregates are stale now.
+      setRunActive(false);
+      void queryClient.invalidateQueries({ queryKey: CATALOGS_QUERY_KEY });
+      void queryClient.invalidateQueries({ queryKey: CATALOG_KPI_QUERY_KEY });
+    }
+  }, [runActive, lastEvent, queryClient]);
+
+  // The regenerate mutation already refreshes the list on settle (fallback when
+  // there is no EventSource / the hub errors); the live line is enrichment.
+  const showProgress = runActive && !isTerminalRunEvent(lastEvent);
 
   const iconTone =
     catalog.status === 'error'
@@ -45,7 +74,10 @@ export function CatalogCard({ catalog }: { catalog: CatalogProfileRow }) {
 
   function onRegenerate(): void {
     regenerate.mutate(catalog.id, {
-      onSuccess: () => toast.success(t('catalogs_pdf.card.regenerate_started')),
+      onSuccess: () => {
+        setRunActive(true);
+        toast.success(t('catalogs_pdf.card.regenerate_started'));
+      },
       onError: (error) =>
         toast.error(httpErrorDetail(error) ?? t('catalogs_pdf.card.action_error')),
     });
@@ -137,6 +169,8 @@ export function CatalogCard({ catalog }: { catalog: CatalogProfileRow }) {
           </span>
         )}
       </div>
+
+      {(regenerate.isPending || showProgress) && <CatalogRunProgress lastEvent={lastEvent} />}
 
       <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-zinc-100 pt-3">
         <button

--- a/apps/admin/src/features/catalogs-pdf/hub/CatalogRunProgress.tsx
+++ b/apps/admin/src/features/catalogs-pdf/hub/CatalogRunProgress.tsx
@@ -1,0 +1,73 @@
+import { Loader2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import type { CatalogRunEvent } from '../api/runs-stream';
+
+/** Status values that end a run — progress stops and the card refreshes. */
+const TERMINAL_STATUSES = new Set(['done', 'error', 'cancelled']);
+
+/** True once the stream reports a terminal `status` event. */
+export function isTerminalRunEvent(event: CatalogRunEvent | null): boolean {
+  return (
+    event !== null &&
+    event.event === 'status' &&
+    typeof event.status === 'string' &&
+    TERMINAL_STATUSES.has(event.status)
+  );
+}
+
+interface CatalogRunProgressProps {
+  /** Latest streamed event, or `null` before the first frame arrives. */
+  lastEvent: CatalogRunEvent | null;
+}
+
+/**
+ * CPDF-P5-04 — the live regeneration line on a hub card. A determinate bar when
+ * `progress_pct` is known, otherwise an indeterminate "Generowanie…" pill. The
+ * caller renders this only while a run is active (non-terminal), so a terminal
+ * status collapses it and the card falls back to the refreshed REST state.
+ */
+export function CatalogRunProgress({ lastEvent }: CatalogRunProgressProps) {
+  const { t } = useTranslation();
+  const pct =
+    lastEvent !== null && typeof lastEvent.progress_pct === 'number'
+      ? Math.max(0, Math.min(100, Math.round(lastEvent.progress_pct)))
+      : null;
+
+  if (pct === null) {
+    return (
+      <div
+        className="mt-4 flex items-center gap-2 rounded-lg bg-zinc-50 px-3 py-2 text-[12px] text-zinc-600"
+        role="status"
+        aria-live="polite"
+      >
+        <Loader2 className="h-3.5 w-3.5 animate-spin text-zinc-400" aria-hidden />
+        {t('catalogs_pdf.card.progress_generating')}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-4" role="status" aria-live="polite">
+      <div className="flex items-center justify-between text-[11.5px] text-zinc-600">
+        <span>{t('catalogs_pdf.card.progress_generating')}</span>
+        <span className="font-mono tabular-nums">
+          {t('catalogs_pdf.card.progress_percent', { pct })}
+        </span>
+      </div>
+      <div
+        className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-zinc-100"
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={pct}
+        aria-label={t('catalogs_pdf.card.progress_generating')}
+      >
+        <div
+          className="h-full rounded-full bg-zinc-900 transition-[width]"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/catalogs-pdf/wizard/steps/StepPreview.tsx
+++ b/apps/admin/src/features/catalogs-pdf/wizard/steps/StepPreview.tsx
@@ -1,5 +1,5 @@
 import { RefreshCw } from 'lucide-react';
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { httpErrorDetail } from '@/lib/http';
@@ -7,6 +7,12 @@ import { cn } from '@/lib/utils';
 
 import { type PreviewResult, useGenerateCatalog } from '../use-generate-catalog';
 import { useCatalogWizard } from '../wizard-store';
+
+/** Step index at which this preview is mounted — guards the auto-refresh. */
+const PREVIEW_STEP = 4;
+
+/** Auto-refresh debounce — re-render ~500ms after the last input change. */
+const AUTO_REFRESH_DELAY_MS = 500;
 
 interface StepPreviewProps {
   /** Built-in product ObjectType id — required for the preview scope. */
@@ -17,8 +23,14 @@ interface StepPreviewProps {
  * CPDF-P5-02 step 5 — live HTML preview. A manual "Odśwież podgląd" button
  * POSTs the current draft to /api/catalogs/preview and renders the returned
  * HTML in a sandboxed iframe (srcDoc) for isolation — the BE sanitises it,
- * the sandbox stops any residual script/navigation. Auto-refresh + Mercure
- * progress polish lands in CPDF-P5-04; a manual refresh is enough here.
+ * the sandbox stops any residual script/navigation.
+ *
+ * CPDF-P5-04 — DEBOUNCED auto-refresh: when the branding / mapping / scope
+ * inputs change, the preview re-renders ~500ms later (a subtle "Odświeżanie…"
+ * state marks the in-flight auto-refresh). The manual button stays as the
+ * explicit escape hatch. The debounce is keyed on the serialized draft slice
+ * so only meaningful edits re-fetch; the `preview` HTTP call lives in
+ * use-generate-catalog.ts (no transport co-located with the effect — ADR-0021).
  */
 export function StepPreview({ objectTypeId }: StepPreviewProps) {
   const { t } = useTranslation();
@@ -27,8 +39,9 @@ export function StepPreview({ objectTypeId }: StepPreviewProps) {
   const [result, setResult] = useState<PreviewResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [autoRefreshing, setAutoRefreshing] = useState(false);
 
-  const refresh = async () => {
+  const refresh = useCallback(async () => {
     if (objectTypeId === null) {
       setError(t('catalogs_pdf.wizard.error_no_object_type'));
       return;
@@ -42,7 +55,42 @@ export function StepPreview({ objectTypeId }: StepPreviewProps) {
     } finally {
       setLoading(false);
     }
-  };
+  }, [objectTypeId, preview, state, t]);
+
+  // Keep the latest refresh closure in a ref so the debounce effect below can
+  // fire it without re-subscribing on every render (only the serialized draft
+  // slice should re-arm the timer).
+  const refreshRef = useRef(refresh);
+  refreshRef.current = refresh;
+
+  // The slice that should trigger an auto-refresh: branding, field mappings,
+  // scope (filter/locale/template). `step` and `name`/`dirty` are excluded so
+  // navigation and unrelated edits do not re-fetch.
+  const draftKey = JSON.stringify({
+    templateKind: state.templateKind,
+    locale: state.locale,
+    filterDsl: state.filterDsl,
+    branding: state.branding,
+    fieldMappings: state.fieldMappings,
+  });
+
+  const visible = state.step === PREVIEW_STEP;
+
+  // draftKey is the intended debounce trigger (re-arms on branding/mapping/scope change).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: draftKey is a change-trigger dependency, not read in the body.
+  useEffect(() => {
+    if (!visible || objectTypeId === null) {
+      return;
+    }
+    setAutoRefreshing(true);
+    const timer = window.setTimeout(() => {
+      void refreshRef.current().finally(() => setAutoRefreshing(false));
+    }, AUTO_REFRESH_DELAY_MS);
+    return () => {
+      window.clearTimeout(timer);
+      setAutoRefreshing(false);
+    };
+  }, [draftKey, visible, objectTypeId]);
 
   return (
     <div className="rounded-2xl border border-zinc-200 bg-surface p-7 shadow-card">
@@ -55,17 +103,24 @@ export function StepPreview({ objectTypeId }: StepPreviewProps) {
             {t('catalogs_pdf.wizard.preview_subtitle')}
           </p>
         </div>
-        <button
-          type="button"
-          onClick={() => void refresh()}
-          disabled={loading}
-          className={cn(
-            'focus-ring inline-flex h-10 items-center gap-2 rounded-xl border border-zinc-200 bg-surface px-4 text-[13px] font-medium text-zinc-700 transition enabled:hover:border-zinc-400 disabled:cursor-not-allowed disabled:text-zinc-300',
+        <div className="flex items-center gap-3">
+          {autoRefreshing && (
+            <span className="text-[12px] text-zinc-400" role="status" aria-live="polite">
+              {t('catalogs_pdf.wizard.preview_auto_refreshing')}
+            </span>
           )}
-        >
-          <RefreshCw className={cn('size-4', loading && 'animate-spin')} aria-hidden />
-          {t('catalogs_pdf.wizard.preview_refresh')}
-        </button>
+          <button
+            type="button"
+            onClick={() => void refresh()}
+            disabled={loading}
+            className={cn(
+              'focus-ring inline-flex h-10 items-center gap-2 rounded-xl border border-zinc-200 bg-surface px-4 text-[13px] font-medium text-zinc-700 transition enabled:hover:border-zinc-400 disabled:cursor-not-allowed disabled:text-zinc-300',
+            )}
+          >
+            <RefreshCw className={cn('size-4', loading && 'animate-spin')} aria-hidden />
+            {t('catalogs_pdf.wizard.preview_refresh')}
+          </button>
+        </div>
       </div>
 
       {error !== null && (

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -993,7 +993,9 @@
       "regenerate_started": "Regeneration started",
       "delete_confirm": "Delete catalog “{{name}}”? This cannot be undone.",
       "delete_success": "Catalog deleted",
-      "action_error": "Could not complete the action. Please try again."
+      "action_error": "Could not complete the action. Please try again.",
+      "progress_generating": "Generating…",
+      "progress_percent": "{{pct}}%"
     },
     "wizard": {
       "title": "New PDF catalog",
@@ -1063,7 +1065,8 @@
       "summary_filter_all": "All products",
       "summary_filter_set": "Filter active",
       "summary_mappings": "Mapped fields",
-      "error_no_object_type": "Could not resolve the \"product\" object type. Refresh the page and try again."
+      "error_no_object_type": "Could not resolve the \"product\" object type. Refresh the page and try again.",
+      "preview_auto_refreshing": "Refreshing…"
     }
   },
   "topbar": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1003,7 +1003,9 @@
       "regenerate_started": "Regeneracja uruchomiona",
       "delete_confirm": "Usunąć katalog „{{name}}”? Tej operacji nie można cofnąć.",
       "delete_success": "Katalog usunięty",
-      "action_error": "Nie udało się wykonać akcji. Spróbuj ponownie."
+      "action_error": "Nie udało się wykonać akcji. Spróbuj ponownie.",
+      "progress_generating": "Generowanie…",
+      "progress_percent": "{{pct}}%"
     },
     "wizard": {
       "title": "Nowy katalog PDF",
@@ -1073,7 +1075,8 @@
       "summary_filter_all": "Wszystkie produkty",
       "summary_filter_set": "Filtr aktywny",
       "summary_mappings": "Zmapowane pola",
-      "error_no_object_type": "Nie udało się ustalić typu obiektu „produkt”. Odśwież stronę i spróbuj ponownie."
+      "error_no_object_type": "Nie udało się ustalić typu obiektu „produkt”. Odśwież stronę i spróbuj ponownie.",
+      "preview_auto_refreshing": "Odświeżanie…"
     }
   },
   "topbar": {


### PR DESCRIPTION
Zamyka **CPDF-P5-04** (#2302). Blocked by P5-02/P5-03 (merged).

## Co
- **Live progres runów:** `useCatalogRunsStream` (plik SSE-only, separacja transportu ADR-0021) subskrybuje `tenant/{tid}/catalogs/{id}/runs`. Karta otwiera socket **tylko gdy jej regeneracja jest aktywna** (`catalogId=null` w spoczynku → zero socketów idle) i renderuje progress bar / „Generowanie…" z eventów; na terminal status invaliduje catalogs+KPI query.
- **Auto-refresh podglądu w kreatorze:** krok podglądu ~500ms po zmianie brandingu/mapowania/scope re-POST-uje `/api/catalogs/preview` do iframe z „Odświeżanie…"; manualny przycisk zostaje.
- **Graceful degradation:** brak EventSource / błąd huba → fallback na REST refresh.

## Walidacja (host + live)
- **tsc/biome/vitest 142/build/max-lines/i18n-parity** zielone; **jsonFetch/useEffect guard 59<61** (ADR-0021 utrzymane — SSE effect w osobnym pliku bez transportu).
- **Playwright** `cpdf-progress.spec.ts`: Regeneruj → generate call + afordancja „Generowanie…" (pending→live), graceful degradation bez SSE, axe 0 serious/critical. PASS.
- Podgląd (POST /api/catalogs/preview) potwierdzony na żywo w P5-02 (200, sample_count=3).

## Uwaga (smoke)
Realny end-to-end **SSE frame** nie jest ćwiczony w CI (wymaga runu przetworzonego przez workera emitującego Mercure) — publisher backendu pokryty w P3-01 (`GenerateCatalogHandlerTest`), a UI-afordancja + degradacja pokryte Playwrightem. Nie twierdzę „live SSE działa" bez ręcznego smoke z workerem.

Refs #2302