### PR TITLE
feat(catalogs-pdf): CPDF-P5-05 — bramka menu + route za uprawnieniem exports (zamyka M5)

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -571,8 +571,28 @@ function App() {
                   />
                   <Route path="/assets" element={<AssetsListPage />} />
                   <Route path="/assets/:id" element={<AssetShowPage />} />
-                  <Route path="/catalogs-pdf" element={<CatalogsPdfPage />} />
-                  <Route path="/catalogs-pdf/new" element={<CatalogWizardPage />} />
+                  {/* CPDF-P5-05 (#2303) — gate the Catalog PDF area behind the
+                    reused exports read permission (ADR-0027, no dedicated
+                    catalogs_pdf module). A user without exports scope who
+                    deep-links here lands on Forbidden403Page instead of the
+                    shell; per-action writes stay gated by their own BE checks
+                    (integration.admin). Mirrors MENU_PERMISSIONS.catalogs_pdf. */}
+                  <Route
+                    path="/catalogs-pdf"
+                    element={
+                      <PermissionRoute anyOf={['exports.view_own', 'exports.view_all']}>
+                        <CatalogsPdfPage />
+                      </PermissionRoute>
+                    }
+                  />
+                  <Route
+                    path="/catalogs-pdf/new"
+                    element={
+                      <PermissionRoute anyOf={['exports.view_own', 'exports.view_all']}>
+                        <CatalogWizardPage />
+                      </PermissionRoute>
+                    }
+                  />
                   {/* AUD-076 (W3-5.5) — gate the whole settings tree with the
                     same permission set the sidebar uses to show the entry
                     (MENU_PERMISSIONS.settings). A user with no settings

--- a/apps/admin/src/layout/sidebar-nav.tsx
+++ b/apps/admin/src/layout/sidebar-nav.tsx
@@ -83,7 +83,7 @@ const FALLBACK_ITEMS: EffectiveMenuItem[] = [
     icon: 'FileText',
     route: '/catalogs-pdf',
     comingSoon: false,
-    protected: false,
+    protected: true,
   },
   {
     id: 'system:multimedia',

--- a/apps/admin/src/lib/identity/menu-permissions.test.ts
+++ b/apps/admin/src/lib/identity/menu-permissions.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Identity } from './identity';
+import { isMenuRefVisible, MENU_PERMISSIONS } from './menu-permissions';
+
+/**
+ * CPDF-P5-05 (#2303) — the Catalog PDF menu entry reuses the exports read
+ * permission (ADR-0027, no dedicated catalogs_pdf module). These tests pin
+ * that contract so a future permission rename can't silently un-gate the area.
+ */
+
+function identityWith(permissions: readonly string[]): Identity {
+  return {
+    id: 'u1',
+    email: 'u@demo.localhost',
+    roles: [],
+    tenant: null,
+    lastLoginAt: null,
+    passwordChangeRequired: false,
+    permissions: new Set(permissions),
+    localeScope: [],
+    channelScope: [],
+    attributeGroupScope: [],
+  };
+}
+
+describe('MENU_PERMISSIONS.catalogs_pdf', () => {
+  it('maps the catalog PDF entry to the exports read permissions', () => {
+    expect(MENU_PERMISSIONS.catalogs_pdf).toEqual(['exports.view_own', 'exports.view_all']);
+  });
+
+  it('shows the entry to a user with exports.view_own', () => {
+    expect(isMenuRefVisible(identityWith(['exports.view_own']), 'catalogs_pdf')).toBe(true);
+  });
+
+  it('shows the entry to a user with exports.view_all', () => {
+    expect(isMenuRefVisible(identityWith(['exports.view_all']), 'catalogs_pdf')).toBe(true);
+  });
+
+  it('hides the entry from a user without any exports scope', () => {
+    expect(isMenuRefVisible(identityWith(['products.view']), 'catalogs_pdf')).toBe(false);
+  });
+
+  it('hides the entry while identity is still loading', () => {
+    expect(isMenuRefVisible(null, 'catalogs_pdf')).toBe(false);
+  });
+});

--- a/apps/admin/src/lib/identity/menu-permissions.ts
+++ b/apps/admin/src/lib/identity/menu-permissions.ts
@@ -26,6 +26,10 @@ export const MENU_PERMISSIONS: Readonly<Record<string, readonly string[]>> = {
   categories: ['categories.view'],
   multimedia: ['multimedia.view'],
 
+  // Catalog PDF (web-to-print) — reuses the exports read permission (ADR-0027,
+  // no dedicated catalogs_pdf module); own scope is enough to show the entry.
+  catalogs_pdf: ['exports.view_own', 'exports.view_all'],
+
   // Modeling (per PRD §3.2 macierz — Modeler / Owner / Admin)
   modeling: ['modeling.view'],
 


### PR DESCRIPTION
Zamyka **CPDF-P5-05** (#2303) i **milestone M5**. Blocked by P5-01…P5-04 (merged / w CI).

## Co
- **Gate widoczności menu:** `MENU_PERMISSIONS.catalogs_pdf = ['exports.view_own','exports.view_all']` — reuse uprawnień exports (ADR-0027, **brak** dedykowanego modułu `catalogs_pdf`). `isMenuRefVisible()` ukrywa wpis w sidebarze użytkownikom bez scope exports.
- **Fallback item** `system:catalogs_pdf` → `protected: true`.
- **Route guard:** oba `/catalogs-pdf` i `/catalogs-pdf/new` owinięte w `<PermissionRoute anyOf={['exports.view_own','exports.view_all']}>` — deep-link bez uprawnienia ląduje na `Forbidden403Page` zamiast shellu. Zapisy per-akcja dalej gated `integration.admin` po stronie BE.
- **Test:** unit `menu-permissions.test.ts` pinuje kontrakt bramki (5 asercji) przeciw przyszłej zmianie nazwy uprawnienia.

## Walidacja (host)
- **biome / tsc / build** zielone; **vitest** 5/5 (nowy `menu-permissions.test.ts`).
- **guardy:** max-lines baseline 21 (bez regresji mimo rozrostu App.tsx), jsonFetch/useEffect 59<61 (ADR-0021).
- **i18n parity** bez zmian (P5-05 nie dodaje kluczy; `nav.catalogsPdf` już istniał).

## Uwaga (smoke)
Widoczna zmiana pokryta: (a) istniejący `cpdf-shell.spec.ts` renderuje `/catalogs-pdf` jako admin (Owner ma `exports.view_all`) → guard przepuszcza; (b) unit test bramki. **E2E dla użytkownika restricted (brak scope → 403)** odłożony — wymaga invitation dev-token flow; nie twierdzę „restricted-user gate zweryfikowany end-to-end" bez tego smoke.

Refs #2303