### PR TITLE
feat(export): add pricelist archetype template

### DIFF
--- a/apps/api/src/Export/Catalog/Application/CatalogRenderService.php
+++ b/apps/api/src/Export/Catalog/Application/CatalogRenderService.php
@@ -17,7 +17,7 @@ use Closure;
 use Twig\Environment;
 
 /**
- * Orchestrates one catalog regeneration for the `sheet` archetype (ADR-0027,
+ * Orchestrates one catalog regeneration for the shipped archetypes (ADR-0027,
  * CPDF-P2-03): resolves the profile's template, streams the memory-bounded
  * product value maps ({@see CatalogProductValues}), applies the field mappings
  * ({@see CatalogItemMapper}), sanitises rich-text slots ({@see HtmlValueSanitizer}),
@@ -53,7 +53,7 @@ final class CatalogRenderService
      */
     public function render(CatalogProfile $profile, string $targetPath, ?Closure $onChunk = null): CatalogRenderResult
     {
-        // grid / pricelist raise TemplateNotAvailableException until M6 — propagate.
+        // grid raises TemplateNotAvailableException until CPDF-P6-02 — propagate.
         $template = $this->templates->get($profile->getTemplateKind());
         $mappings = CatalogFieldMapping::listFromArray($profile->getFieldMappings());
         $scope = $this->scope($profile, $mappings);

--- a/apps/api/src/Export/Catalog/Application/Preview/CatalogPreviewService.php
+++ b/apps/api/src/Export/Catalog/Application/Preview/CatalogPreviewService.php
@@ -62,7 +62,7 @@ final class CatalogPreviewService
     ): array {
         $limit = max(1, min($limit, self::MAX_LIMIT));
 
-        // grid / pricelist raise TemplateNotAvailableException until M6 — propagate
+        // grid raises TemplateNotAvailableException until CPDF-P6-02 — propagate
         // (the controller maps it to a 422).
         $template = $this->templates->get($kind);
         $mappings = CatalogFieldMapping::listFromArray($fieldMappings);

--- a/apps/api/src/Export/Catalog/Domain/Template/CatalogTemplateCatalog.php
+++ b/apps/api/src/Export/Catalog/Domain/Template/CatalogTemplateCatalog.php
@@ -7,9 +7,10 @@ namespace App\Export\Catalog\Domain\Template;
 use App\Export\Catalog\Domain\Enum\CatalogTemplateKind;
 
 /**
- * The built-in catalog PDF templates (ADR-0027, CPDF-P2-01). MVP ships the
- * `sheet` archetype (one product per page); `grid` and `pricelist` arrive in
- * M6 and raise {@see TemplateNotAvailableException} until then. Mirrors
+ * The built-in catalog PDF templates (ADR-0027, CPDF-P2-01). Ships the `sheet`
+ * archetype (one product per page) and the `pricelist` archetype (multi-page
+ * price table, CPDF-P6-01); `grid` arrives in CPDF-P6-02 and raises
+ * {@see TemplateNotAvailableException} until then. Mirrors
  * {@see \App\Export\Feed\Domain\Template\FeedTemplateCatalog}.
  */
 final class CatalogTemplateCatalog
@@ -18,8 +19,9 @@ final class CatalogTemplateCatalog
     {
         return match ($kind) {
             CatalogTemplateKind::Sheet => $this->sheet(),
-            CatalogTemplateKind::Grid, CatalogTemplateKind::Pricelist => throw new TemplateNotAvailableException(
-                sprintf('Catalog template "%s" is not available yet; grid and pricelist archetypes arrive in M6.', $kind->value),
+            CatalogTemplateKind::Pricelist => $this->pricelist(),
+            CatalogTemplateKind::Grid => throw new TemplateNotAvailableException(
+                sprintf('Catalog template "%s" is not available yet; the grid archetype arrives in CPDF-P6-02.', $kind->value),
             ),
         };
     }
@@ -29,7 +31,7 @@ final class CatalogTemplateCatalog
      */
     public function all(): array
     {
-        return [$this->sheet()];
+        return [$this->sheet(), $this->pricelist()];
     }
 
     private function sheet(): CatalogTemplate
@@ -53,5 +55,26 @@ final class CatalogTemplateCatalog
         ];
 
         return new CatalogTemplate(CatalogTemplateKind::Sheet, 'catalog/sheet.html.twig', $slots, $defaultMappings);
+    }
+
+    private function pricelist(): CatalogTemplate
+    {
+        $slots = [
+            ['slot' => 'sku', 'label' => 'SKU', 'format' => 'text'],
+            ['slot' => 'name', 'label' => 'Product name', 'format' => 'text'],
+            ['slot' => 'price', 'label' => 'Price', 'format' => 'text'],
+            ['slot' => 'availability', 'label' => 'Availability', 'format' => 'text'],
+        ];
+
+        $defaultMappings = [
+            ['slot' => 'sku', 'source' => 'sku'],
+            ['slot' => 'name', 'source' => 'name'],
+            ['slot' => 'price', 'source' => 'price'],
+            // The demo/default schema signals availability with the boolean
+            // `in_stock` attribute; remappable per profile like every slot.
+            ['slot' => 'availability', 'source' => 'in_stock'],
+        ];
+
+        return new CatalogTemplate(CatalogTemplateKind::Pricelist, 'catalog/pricelist.html.twig', $slots, $defaultMappings);
     }
 }

--- a/apps/api/src/Export/Catalog/Domain/Template/TemplateNotAvailableException.php
+++ b/apps/api/src/Export/Catalog/Domain/Template/TemplateNotAvailableException.php
@@ -8,7 +8,7 @@ use RuntimeException;
 
 /**
  * Raised when a template kind is requested whose archetype is not yet shipped
- * (ADR-0027, CPDF-P2-01): grid and pricelist archetypes arrive in M6.
+ * (ADR-0027, CPDF-P2-01): the grid archetype arrives in CPDF-P6-02.
  */
 final class TemplateNotAvailableException extends RuntimeException
 {

--- a/apps/api/src/Export/Catalog/Presentation/Controller/CatalogPreviewController.php
+++ b/apps/api/src/Export/Catalog/Presentation/Controller/CatalogPreviewController.php
@@ -117,7 +117,7 @@ final class CatalogPreviewController
         try {
             $result = $this->preview->preview($kind, $branding, $fieldMappings, $scope, $limit);
         } catch (TemplateNotAvailableException $error) {
-            // grid / pricelist archetypes are not renderable yet (M6).
+            // the grid archetype is not renderable yet (CPDF-P6-02).
             throw new HttpException(Response::HTTP_UNPROCESSABLE_ENTITY, $error->getMessage(), $error);
         }
 

--- a/apps/api/templates/catalog/pricelist.html.twig
+++ b/apps/api/templates/catalog/pricelist.html.twig
@@ -1,0 +1,133 @@
+{#
+  Catalog PDF — "pricelist" archetype (ADR-0027, CPDF-P6-01): one compact,
+  multi-page price table (SKU / name / price / availability). Rendered to HTML
+  here, then to PDF by the Dompdf-backed PdfRenderer.
+
+  Dompdf-safe CSS only (CSS 2.1 subset, same rules as sheet.html.twig):
+  - the repeating column header uses `<thead>` + `display: table-header-group`,
+    which Dompdf re-emits at the top of every page a table spans;
+  - the branded page header and the page footer use `position: fixed`, which
+    Dompdf repeats on every page; the page number comes from the CSS 2.1
+    `counter(page)` in generated content (supported by Dompdf);
+  - brand colours are interpolated straight into the <style> block, NOT via
+    CSS custom properties (Dompdf does not resolve `var(--x)` reliably).
+
+  The template receives exactly two variables:
+    - branding: map (company_name?, logo?, color?)
+    - products: list of maps keyed by slot name (sku/name/price/availability)
+
+  strict_variables is ON in the test env, so every variable access is guarded
+  with `|default(...)` or `is defined`.
+#}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        @page {
+            margin: 96px 40px 64px 40px;
+        }
+        body {
+            font-family: DejaVu Sans, sans-serif;
+            color: #111827;
+            margin: 0;
+            font-size: 12px;
+        }
+        .page-header {
+            position: fixed;
+            top: -72px;
+            left: 0;
+            right: 0;
+            height: 48px;
+            border-bottom: 3px solid {{ branding.color|default('#1d4ed8') }};
+            padding-bottom: 8px;
+        }
+        .page-header .company {
+            font-size: 18px;
+            font-weight: bold;
+            color: {{ branding.color|default('#1d4ed8') }};
+        }
+        .page-header .logo {
+            max-height: 40px;
+            margin-right: 12px;
+        }
+        .page-footer {
+            position: fixed;
+            bottom: -48px;
+            left: 0;
+            right: 0;
+            border-top: 1px solid #e5e7eb;
+            padding-top: 6px;
+            font-size: 10px;
+            color: #9ca3af;
+        }
+        .page-footer .pagenum:before {
+            content: counter(page);
+        }
+        .pricelist {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        .pricelist thead {
+            display: table-header-group;
+        }
+        .pricelist th {
+            text-align: left;
+            font-size: 11px;
+            text-transform: uppercase;
+            color: #ffffff;
+            background-color: {{ branding.color|default('#1d4ed8') }};
+            padding: 6px 8px;
+        }
+        .pricelist td {
+            border-bottom: 1px solid #e5e7eb;
+            padding: 5px 8px;
+        }
+        .pricelist tr {
+            page-break-inside: avoid;
+        }
+        .pricelist td.price {
+            font-weight: bold;
+            color: {{ branding.color|default('#1d4ed8') }};
+            white-space: nowrap;
+        }
+        .pricelist td.sku {
+            color: #6b7280;
+            white-space: nowrap;
+        }
+    </style>
+</head>
+<body>
+    <div class="page-header">
+        {% if branding.logo is defined and branding.logo %}
+            <img class="logo" src="{{ branding.logo }}" alt="">
+        {% endif %}
+        <span class="company">{{ branding.company_name|default('') }}</span>
+    </div>
+
+    <div class="page-footer">
+        {{ branding.company_name|default('') }} &mdash; <span class="pagenum"></span>
+    </div>
+
+    <table class="pricelist">
+        <thead>
+            <tr>
+                <th>SKU</th>
+                <th>Name</th>
+                <th>Price</th>
+                <th>Availability</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for product in products %}
+                <tr>
+                    <td class="sku">{{ product.sku|default('') }}</td>
+                    <td>{{ product.name|default('') }}</td>
+                    <td class="price">{{ product.price|default('') }}</td>
+                    <td>{{ product.availability|default('') }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>

--- a/apps/api/tests/Integration/Export/Catalog/CatalogRenderServiceTest.php
+++ b/apps/api/tests/Integration/Export/Catalog/CatalogRenderServiceTest.php
@@ -67,6 +67,42 @@ final class CatalogRenderServiceTest extends KernelTestCase
     }
 
     #[Test]
+    public function rendersPricelistCatalogToMultipagePdf(): void
+    {
+        // ~60 rows do not fit one A4 page — the table must paginate (CPDF-P6-01).
+        [, $typeId] = $this->seedObjects(60, 'plain');
+
+        $service = $this->service();
+        $profile = new CatalogProfile(
+            'pricelist-cat',
+            'Pricelist',
+            CatalogTemplateKind::Pricelist,
+            $typeId,
+            branding: ['color' => '#0ea5e9', 'company_name' => 'ACME'],
+            fieldMappings: [
+                ['slot' => 'sku', 'source' => ['kind' => 'attribute', 'ref' => 'sku']],
+                ['slot' => 'name', 'source' => ['kind' => 'attribute', 'ref' => 'name']],
+                // The seed schema has no price/availability attributes — static
+                // sources exercise the same mapper path.
+                ['slot' => 'price', 'source' => ['kind' => 'static', 'value' => '199,00 zł']],
+                ['slot' => 'availability', 'source' => ['kind' => 'static', 'value' => 'in stock']],
+            ],
+        );
+
+        $target = tempnam(sys_get_temp_dir(), 'cpdf-');
+        self::assertNotFalse($target);
+        $result = $service->render($profile, $target);
+
+        self::assertSame(60, $result->itemCount, 'every seeded product becomes one table row');
+        self::assertGreaterThan(1, $result->pageCount, 'a 60-row price table spans multiple pages');
+
+        $pdf = (string) file_get_contents($target);
+        self::assertStringStartsWith('%PDF-', $pdf, 'the render produced a valid PDF file');
+
+        @unlink($target);
+    }
+
+    #[Test]
     public function renderSurvivesMaliciousDescriptionValue(): void
     {
         [, $typeId] = $this->seedObjects(1, '<script>alert(1)</script>');

--- a/apps/api/tests/Integration/Export/Catalog/PricelistTemplateRenderTest.php
+++ b/apps/api/tests/Integration/Export/Catalog/PricelistTemplateRenderTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Export\Catalog;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Twig\Environment;
+
+/**
+ * CPDF-P6-01 — renders the pricelist archetype through the real Twig
+ * environment (strict_variables ON) to prove the template is valid, brand
+ * tokens land in the <style> block, and the Dompdf paged-media hooks are in
+ * place: a `<thead>` repeated via table-header-group and a fixed page footer
+ * numbered with counter(page). Mirrors {@see SheetTemplateRenderTest}.
+ */
+final class PricelistTemplateRenderTest extends KernelTestCase
+{
+    #[Test]
+    public function rendersPricelistWithBrandColourAndPagedMediaHooks(): void
+    {
+        self::bootKernel();
+        $twig = self::getContainer()->get('twig');
+        self::assertInstanceOf(Environment::class, $twig);
+
+        $html = $twig->render('catalog/pricelist.html.twig', [
+            'branding' => [
+                'color' => '#0ea5e9',
+                'company_name' => 'ACME',
+                'logo' => null,
+            ],
+            'products' => [
+                [
+                    'sku' => 'SKU-001',
+                    'name' => 'Wiertarka X1',
+                    'price' => '199,00 zł',
+                    'availability' => 'in stock',
+                ],
+                [
+                    'sku' => 'SKU-002',
+                    'name' => 'Szlifierka Z4',
+                    'price' => '349,00 zł',
+                    'availability' => 'out of stock',
+                ],
+            ],
+        ]);
+
+        // Brand colour injected verbatim into the <style> block (not via CSS var).
+        self::assertStringContainsString('#0ea5e9', $html);
+        self::assertStringContainsString('Wiertarka X1', $html);
+        self::assertStringContainsString('349,00 zł', $html);
+        // The paged-media hooks Dompdf repeats on every page.
+        self::assertStringContainsString('table-header-group', $html);
+        self::assertStringContainsString('counter(page)', $html);
+        self::assertStringContainsString('<thead>', $html);
+    }
+}

--- a/apps/api/tests/Unit/Export/Catalog/CatalogTemplateCatalogTest.php
+++ b/apps/api/tests/Unit/Export/Catalog/CatalogTemplateCatalogTest.php
@@ -11,9 +11,9 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
- * CPDF-P2-01 — the built-in catalog template catalog exposes the sheet
- * archetype with its slots and default mappings, and rejects kinds whose
- * archetype is not yet shipped.
+ * CPDF-P2-01 / CPDF-P6-01 — the built-in catalog template catalog exposes the
+ * sheet and pricelist archetypes with their slots and default mappings, and
+ * rejects kinds whose archetype is not yet shipped.
  */
 final class CatalogTemplateCatalogTest extends TestCase
 {
@@ -35,12 +35,26 @@ final class CatalogTemplateCatalogTest extends TestCase
     }
 
     #[Test]
-    public function allReturnsOnlyTheSheet(): void
+    public function pricelistExposesFourSlotsWithDefaultMappings(): void
+    {
+        $template = new CatalogTemplateCatalog()->get(CatalogTemplateKind::Pricelist);
+
+        self::assertSame(CatalogTemplateKind::Pricelist, $template->kind);
+        self::assertSame('catalog/pricelist.html.twig', $template->twig);
+        self::assertSame(['sku', 'name', 'price', 'availability'], $template->slotNames());
+        self::assertCount(4, $template->defaultMappings);
+        self::assertContains(['slot' => 'price', 'source' => 'price'], $template->defaultMappings);
+        self::assertContains(['slot' => 'availability', 'source' => 'in_stock'], $template->defaultMappings);
+    }
+
+    #[Test]
+    public function allReturnsSheetAndPricelist(): void
     {
         $all = new CatalogTemplateCatalog()->all();
 
-        self::assertCount(1, $all);
+        self::assertCount(2, $all);
         self::assertSame(CatalogTemplateKind::Sheet, $all[0]->kind);
+        self::assertSame(CatalogTemplateKind::Pricelist, $all[1]->kind);
     }
 
     #[Test]
@@ -48,12 +62,5 @@ final class CatalogTemplateCatalogTest extends TestCase
     {
         $this->expectException(TemplateNotAvailableException::class);
         new CatalogTemplateCatalog()->get(CatalogTemplateKind::Grid);
-    }
-
-    #[Test]
-    public function pricelistIsNotAvailableYet(): void
-    {
-        $this->expectException(TemplateNotAvailableException::class);
-        new CatalogTemplateCatalog()->get(CatalogTemplateKind::Pricelist);
     }
 }


### PR DESCRIPTION
## CPDF-P6-01 — archetyp `pricelist` (Closes #2304)

Drugi archetyp renderera katalogów PDF (ADR-0027): wielostronicowy cennik-tabela (SKU / nazwa / cena / dostępność).

### Zakres
- **`templates/catalog/pricelist.html.twig`** — tabela z powtarzalnym nagłówkiem kolumn (`<thead>` + `display: table-header-group` — Dompdf re-emituje na każdej stronie), brandowany nagłówek strony i stopka przez `position: fixed` (Dompdf powtarza per strona), numer strony z CSS `counter(page)`. Wyłącznie Dompdf-safe CSS 2.1 (bez flex/grid/custom properties), brand color interpolowany wprost do `<style>` — te same reguły co `sheet.html.twig`.
- **`CatalogTemplateCatalog`** — wpis `pricelist` (4 sloty: sku/name/price/availability, wszystkie `text`); domyślne mapowanie `sku→sku`, `name→name`, `price→price`, `availability→in_stock` (boolean z demo schema; remapowalne per profil). `grid` dalej rzuca `TemplateNotAvailableException` (CPDF-P6-02).
- Zaktualizowane komentarze „pricelist arrives in M6" w render/preview servisach.

### Testy (walidowane w kontenerze pim-api-1 przed pushem)
- `CatalogTemplateCatalogTest` — sloty + default mappings pricelist, `all()` = sheet+pricelist, grid dalej niedostępny (5/5 z Twig testem).
- `PricelistTemplateRenderTest` — render przez realny Twig (strict_variables ON): brand color w `<style>`, hooki paged-media (`table-header-group`, `counter(page)`).
- `CatalogRenderServiceTest::rendersPricelistCatalogToMultipagePdf` — **realny PDF end-to-end**: 60 zaseedowanych produktów → ExportBuilder → mapper (attribute + static sources) → Twig → Dompdf → `%PDF-`, `pageCount > 1` (paginacja działa), 3/3.
- PHPStan max (full, świeży cache): 0 błędów · Deptrac: 0 errors · cs-fixer: clean.

### Poza zakresem (świadomie, zgodnie z ticketem — Cls: BE)
- Wizard FE dalej pokazuje pricelist jako „Wkrótce" (StepMapping jest sheet-only — odblokowanie FE wymaga slot-aware mapping stepu; archetyp jest w pełni dostępny przez API: `POST /api/catalogs` z `template_kind=pricelist` + generate/preview).
- Zaawansowane formatowanie walut — hook per backlog.

Bez zmian tras → brak regeneracji `docs/api-spec/v0.json`.
