### PR TITLE
feat(export): add grid catalog archetype with cover and TOC

### DIFF
--- a/apps/api/src/Export/Catalog/Application/CatalogRenderService.php
+++ b/apps/api/src/Export/Catalog/Application/CatalogRenderService.php
@@ -53,7 +53,7 @@ final class CatalogRenderService
      */
     public function render(CatalogProfile $profile, string $targetPath, ?Closure $onChunk = null): CatalogRenderResult
     {
-        // grid raises TemplateNotAvailableException until CPDF-P6-02 — propagate.
+        // Future template kinds raise TemplateNotAvailableException — propagate.
         $template = $this->templates->get($profile->getTemplateKind());
         $mappings = CatalogFieldMapping::listFromArray($profile->getFieldMappings());
         $scope = $this->scope($profile, $mappings);
@@ -103,6 +103,8 @@ final class CatalogRenderService
         $html = $this->twig->render($template->twig, [
             'branding' => $profile->getBranding(),
             'products' => $products,
+            // Grid cover/TOC heading; sheet and pricelist ignore it.
+            'title' => $profile->getName(),
         ]);
 
         $pdf = $this->renderer->render($html, new PdfRenderOptions());

--- a/apps/api/src/Export/Catalog/Application/Preview/CatalogPreviewService.php
+++ b/apps/api/src/Export/Catalog/Application/Preview/CatalogPreviewService.php
@@ -62,7 +62,7 @@ final class CatalogPreviewService
     ): array {
         $limit = max(1, min($limit, self::MAX_LIMIT));
 
-        // grid raises TemplateNotAvailableException until CPDF-P6-02 — propagate
+        // Future template kinds raise TemplateNotAvailableException — propagate
         // (the controller maps it to a 422).
         $template = $this->templates->get($kind);
         $mappings = CatalogFieldMapping::listFromArray($fieldMappings);

--- a/apps/api/src/Export/Catalog/Domain/Template/CatalogTemplateCatalog.php
+++ b/apps/api/src/Export/Catalog/Domain/Template/CatalogTemplateCatalog.php
@@ -7,10 +7,11 @@ namespace App\Export\Catalog\Domain\Template;
 use App\Export\Catalog\Domain\Enum\CatalogTemplateKind;
 
 /**
- * The built-in catalog PDF templates (ADR-0027, CPDF-P2-01). Ships the `sheet`
- * archetype (one product per page) and the `pricelist` archetype (multi-page
- * price table, CPDF-P6-01); `grid` arrives in CPDF-P6-02 and raises
- * {@see TemplateNotAvailableException} until then. Mirrors
+ * The built-in catalog PDF templates (ADR-0027, CPDF-P2-01). Ships all three
+ * archetypes: `sheet` (one product per page), `pricelist` (multi-page price
+ * table, CPDF-P6-01) and `grid` (cover + TOC + card grid, CPDF-P6-02).
+ * Future kinds raise {@see TemplateNotAvailableException} until their
+ * archetype lands. Mirrors
  * {@see \App\Export\Feed\Domain\Template\FeedTemplateCatalog}.
  */
 final class CatalogTemplateCatalog
@@ -20,9 +21,7 @@ final class CatalogTemplateCatalog
         return match ($kind) {
             CatalogTemplateKind::Sheet => $this->sheet(),
             CatalogTemplateKind::Pricelist => $this->pricelist(),
-            CatalogTemplateKind::Grid => throw new TemplateNotAvailableException(
-                sprintf('Catalog template "%s" is not available yet; the grid archetype arrives in CPDF-P6-02.', $kind->value),
-            ),
+            CatalogTemplateKind::Grid => $this->grid(),
         };
     }
 
@@ -31,7 +30,7 @@ final class CatalogTemplateCatalog
      */
     public function all(): array
     {
-        return [$this->sheet(), $this->pricelist()];
+        return [$this->sheet(), $this->pricelist(), $this->grid()];
     }
 
     private function sheet(): CatalogTemplate
@@ -76,5 +75,24 @@ final class CatalogTemplateCatalog
         ];
 
         return new CatalogTemplate(CatalogTemplateKind::Pricelist, 'catalog/pricelist.html.twig', $slots, $defaultMappings);
+    }
+
+    private function grid(): CatalogTemplate
+    {
+        $slots = [
+            ['slot' => 'title', 'label' => 'Product name', 'format' => 'text'],
+            ['slot' => 'sku', 'label' => 'SKU', 'format' => 'text'],
+            ['slot' => 'image', 'label' => 'Main image', 'format' => 'url'],
+            ['slot' => 'price', 'label' => 'Price', 'format' => 'text'],
+        ];
+
+        $defaultMappings = [
+            ['slot' => 'title', 'source' => 'name'],
+            ['slot' => 'sku', 'source' => 'sku'],
+            ['slot' => 'image', 'source' => 'main_image'],
+            ['slot' => 'price', 'source' => 'price'],
+        ];
+
+        return new CatalogTemplate(CatalogTemplateKind::Grid, 'catalog/grid.html.twig', $slots, $defaultMappings);
     }
 }

--- a/apps/api/src/Export/Catalog/Domain/Template/TemplateNotAvailableException.php
+++ b/apps/api/src/Export/Catalog/Domain/Template/TemplateNotAvailableException.php
@@ -8,7 +8,8 @@ use RuntimeException;
 
 /**
  * Raised when a template kind is requested whose archetype is not yet shipped
- * (ADR-0027, CPDF-P2-01): the grid archetype arrives in CPDF-P6-02.
+ * (ADR-0027, CPDF-P2-01). All three built-in archetypes ship as of CPDF-P6-02;
+ * kept for future template kinds.
  */
 final class TemplateNotAvailableException extends RuntimeException
 {

--- a/apps/api/src/Export/Catalog/Presentation/Controller/CatalogPreviewController.php
+++ b/apps/api/src/Export/Catalog/Presentation/Controller/CatalogPreviewController.php
@@ -117,7 +117,7 @@ final class CatalogPreviewController
         try {
             $result = $this->preview->preview($kind, $branding, $fieldMappings, $scope, $limit);
         } catch (TemplateNotAvailableException $error) {
-            // the grid archetype is not renderable yet (CPDF-P6-02).
+            // a future template kind whose archetype has not shipped yet.
             throw new HttpException(Response::HTTP_UNPROCESSABLE_ENTITY, $error->getMessage(), $error);
         }
 

--- a/apps/api/templates/catalog/grid.html.twig
+++ b/apps/api/templates/catalog/grid.html.twig
@@ -1,0 +1,199 @@
+{#
+  Catalog PDF — "grid" archetype (ADR-0027, CPDF-P6-02): a full product
+  catalogue composed of three sections (the PrintContainer idea from Pimcore):
+  a branded cover page, a table of contents, and a paginated grid of product
+  cards (3 per row).
+
+  Dompdf-safe CSS only (CSS 2.1 subset, same rules as sheet/pricelist):
+  - the card grid is a <table> (Dompdf has no flex/grid); products are
+    chunked into rows with Twig's `batch(3)`;
+  - the page footer is `position: fixed` with a CSS 2.1 `counter(page)` page
+    number (Dompdf repeats it on every page, cover included);
+  - TOC page numbers need `target-counter()`, which Dompdf does not support —
+    they are gated behind the `premium` flag (false by default) and arrive
+    with the Gotenberg renderer (CPDF-P6-03/P6-05). On Dompdf the TOC
+    degrades gracefully to anchor links without page numbers.
+  - full @page margin boxes are likewise premium-gated; the plain fixed
+    footer below is the Dompdf-safe baseline.
+
+  The template receives:
+    - branding: map (company_name?, logo?, color?)
+    - products: list of maps keyed by slot name (title/sku/image/price)
+    - title:    catalog display name (cover + TOC heading)
+    - premium:  optional bool — full CSS Paged Media (Gotenberg-class
+                renderers only); defaults to false
+
+  strict_variables is ON in the test env, so every variable access is guarded
+  with `|default(...)` or `is defined`.
+#}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        @page {
+            margin: 48px 40px 64px 40px;
+        }
+        body {
+            font-family: DejaVu Sans, sans-serif;
+            color: #111827;
+            margin: 0;
+            font-size: 12px;
+        }
+        .page-footer {
+            position: fixed;
+            bottom: -48px;
+            left: 0;
+            right: 0;
+            border-top: 1px solid #e5e7eb;
+            padding-top: 6px;
+            font-size: 10px;
+            color: #9ca3af;
+        }
+        .page-footer .pagenum:before {
+            content: counter(page);
+        }
+        .cover {
+            page-break-after: always;
+            text-align: center;
+        }
+        .cover .band {
+            background-color: {{ branding.color|default('#1d4ed8') }};
+            height: 12px;
+            margin: 0 -8px 96px -8px;
+        }
+        .cover .logo {
+            max-height: 96px;
+            margin-bottom: 24px;
+        }
+        .cover .company {
+            font-size: 20px;
+            font-weight: bold;
+            color: {{ branding.color|default('#1d4ed8') }};
+            margin-bottom: 48px;
+        }
+        .cover .title {
+            font-size: 34px;
+            font-weight: bold;
+            margin-bottom: 12px;
+        }
+        .cover .count {
+            font-size: 13px;
+            color: #6b7280;
+        }
+        .toc {
+            page-break-after: always;
+        }
+        .toc h2 {
+            font-size: 20px;
+            border-bottom: 3px solid {{ branding.color|default('#1d4ed8') }};
+            padding-bottom: 8px;
+        }
+        .toc ul {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+        }
+        .toc li {
+            border-bottom: 1px dotted #e5e7eb;
+            padding: 4px 0;
+            font-size: 11px;
+        }
+        .toc a {
+            color: #111827;
+            text-decoration: none;
+        }
+        {% if premium|default(false) %}
+        /* Gotenberg-class renderers resolve the target page of each anchor. */
+        .toc a .toc-page:after {
+            content: target-counter(attr(href url), page);
+            float: right;
+            color: #6b7280;
+        }
+        {% endif %}
+        .grid {
+            width: 100%;
+            border-collapse: separate;
+            border-spacing: 8px;
+        }
+        .grid td {
+            width: 33%;
+            border: 1px solid #e5e7eb;
+            border-radius: 6px;
+            padding: 10px;
+            vertical-align: top;
+            page-break-inside: avoid;
+        }
+        .card-image {
+            text-align: center;
+            height: 110px;
+            margin-bottom: 8px;
+        }
+        .card-image img {
+            max-width: 100%;
+            max-height: 110px;
+        }
+        .card-title {
+            font-weight: bold;
+            font-size: 12.5px;
+            margin-bottom: 2px;
+        }
+        .card-sku {
+            font-size: 10px;
+            color: #6b7280;
+            margin-bottom: 6px;
+        }
+        .card-price {
+            font-weight: bold;
+            color: {{ branding.color|default('#1d4ed8') }};
+        }
+    </style>
+</head>
+<body>
+    <div class="page-footer">
+        {{ branding.company_name|default('') }} &mdash; <span class="pagenum"></span>
+    </div>
+
+    <div class="cover">
+        <div class="band"></div>
+        {% if branding.logo is defined and branding.logo %}
+            <img class="logo" src="{{ branding.logo }}" alt="">
+        {% endif %}
+        <div class="company">{{ branding.company_name|default('') }}</div>
+        <div class="title">{{ title|default('') }}</div>
+        <div class="count">{{ products|length }} products</div>
+    </div>
+
+    <div class="toc">
+        <h2>{{ title|default('') }}</h2>
+        <ul>
+            {% for product in products %}
+                <li>
+                    <a href="#product-{{ loop.index }}">{{ product.title|default('') }}<span class="toc-page"></span></a>
+                </li>
+            {% endfor %}
+        </ul>
+    </div>
+
+    <table class="grid">
+        {% for row in products|batch(3) %}
+            <tr>
+                {% for product in row %}
+                    <td id="product-{{ loop.parent.loop.index0 * 3 + loop.index }}">
+                        {% if product.image is defined and product.image %}
+                            <div class="card-image">
+                                <img src="{{ product.image }}" alt="">
+                            </div>
+                        {% endif %}
+                        <div class="card-title">{{ product.title|default('') }}</div>
+                        <div class="card-sku">{{ product.sku|default('') }}</div>
+                        {% if product.price is defined and product.price %}
+                            <div class="card-price">{{ product.price }}</div>
+                        {% endif %}
+                    </td>
+                {% endfor %}
+            </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>

--- a/apps/api/tests/Integration/Export/Catalog/CatalogRenderServiceTest.php
+++ b/apps/api/tests/Integration/Export/Catalog/CatalogRenderServiceTest.php
@@ -103,6 +103,40 @@ final class CatalogRenderServiceTest extends KernelTestCase
     }
 
     #[Test]
+    public function rendersGridCatalogWithCoverAndTocToPdf(): void
+    {
+        // Cover page + TOC page + the card grid — 30 products must span
+        // at least three pages (CPDF-P6-02).
+        [, $typeId] = $this->seedObjects(30, 'plain');
+
+        $service = $this->service();
+        $profile = new CatalogProfile(
+            'grid-cat',
+            'Grid catalog',
+            CatalogTemplateKind::Grid,
+            $typeId,
+            branding: ['color' => '#0ea5e9', 'company_name' => 'ACME'],
+            fieldMappings: [
+                ['slot' => 'title', 'source' => ['kind' => 'attribute', 'ref' => 'name']],
+                ['slot' => 'sku', 'source' => ['kind' => 'attribute', 'ref' => 'sku']],
+                ['slot' => 'price', 'source' => ['kind' => 'static', 'value' => '99,00 zł']],
+            ],
+        );
+
+        $target = tempnam(sys_get_temp_dir(), 'cpdf-');
+        self::assertNotFalse($target);
+        $result = $service->render($profile, $target);
+
+        self::assertSame(30, $result->itemCount, 'every seeded product becomes one grid card');
+        self::assertGreaterThanOrEqual(3, $result->pageCount, 'cover + TOC + grid pages');
+
+        $pdf = (string) file_get_contents($target);
+        self::assertStringStartsWith('%PDF-', $pdf, 'the render produced a valid PDF file');
+
+        @unlink($target);
+    }
+
+    #[Test]
     public function renderSurvivesMaliciousDescriptionValue(): void
     {
         [, $typeId] = $this->seedObjects(1, '<script>alert(1)</script>');

--- a/apps/api/tests/Integration/Export/Catalog/GridTemplateRenderTest.php
+++ b/apps/api/tests/Integration/Export/Catalog/GridTemplateRenderTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Export\Catalog;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Twig\Environment;
+
+/**
+ * CPDF-P6-02 — renders the grid archetype through the real Twig environment
+ * (strict_variables ON): the cover carries the brand tokens + catalog title,
+ * the TOC links every product to an anchored card, the cards are chunked into
+ * 3-per-row table rows, and the premium paged-media bits (target-counter TOC
+ * page numbers) only appear when the `premium` flag is set — the graceful
+ * Dompdf degradation demanded by the ticket.
+ */
+final class GridTemplateRenderTest extends KernelTestCase
+{
+    /**
+     * @param list<array<string, string>> $products
+     *
+     * @return array{branding: array<string, string|null>, products: list<array<string, string>>, title: string}
+     */
+    private static function context(array $products): array
+    {
+        return [
+            'branding' => [
+                'color' => '#0ea5e9',
+                'company_name' => 'ACME',
+                'logo' => null,
+            ],
+            'products' => $products,
+            'title' => 'Katalog wiosna',
+        ];
+    }
+
+    private function twig(): Environment
+    {
+        self::bootKernel();
+        $twig = self::getContainer()->get('twig');
+        self::assertInstanceOf(Environment::class, $twig);
+
+        return $twig;
+    }
+
+    #[Test]
+    public function rendersCoverTocAndChunkedCardRows(): void
+    {
+        $products = [];
+        for ($i = 1; $i <= 7; ++$i) {
+            $products[] = [
+                'title' => \sprintf('Produkt %d', $i),
+                'sku' => \sprintf('SKU-%03d', $i),
+                'image' => '',
+                'price' => '99,00 zł',
+            ];
+        }
+
+        $html = $this->twig()->render('catalog/grid.html.twig', self::context($products));
+
+        // Cover: brand colour in <style>, company + catalog title + count.
+        self::assertStringContainsString('#0ea5e9', $html);
+        self::assertStringContainsString('Katalog wiosna', $html);
+        self::assertStringContainsString('7 products', $html);
+        // TOC: one anchor per product, pointing at the card ids.
+        self::assertSame(7, substr_count($html, 'href="#product-'));
+        self::assertSame(7, substr_count($html, 'id="product-'));
+        self::assertStringContainsString('href="#product-7"', $html);
+        self::assertStringContainsString('id="product-7"', $html);
+        // Grid: 7 cards chunk into ceil(7/3) = 3 table rows.
+        self::assertSame(3, substr_count($html, '<tr>'));
+        // Page footer counter (CSS 2.1, Dompdf-supported).
+        self::assertStringContainsString('counter(page)', $html);
+    }
+
+    #[Test]
+    public function premiumPagedMediaIsGatedBehindTheFlag(): void
+    {
+        $twig = $this->twig();
+        $products = [['title' => 'P', 'sku' => 'S', 'image' => '', 'price' => '']];
+
+        // Default (Dompdf path): no target-counter — the TOC degrades to plain anchors.
+        $plain = $twig->render('catalog/grid.html.twig', self::context($products));
+        self::assertStringNotContainsString('target-counter', $plain);
+
+        // Premium (Gotenberg-class renderers, CPDF-P6-03/P6-05): TOC page numbers.
+        $premium = $twig->render('catalog/grid.html.twig', self::context($products) + ['premium' => true]);
+        self::assertStringContainsString('target-counter(attr(href url), page)', $premium);
+    }
+}

--- a/apps/api/tests/Unit/Export/Catalog/CatalogTemplateCatalogTest.php
+++ b/apps/api/tests/Unit/Export/Catalog/CatalogTemplateCatalogTest.php
@@ -6,14 +6,13 @@ namespace App\Tests\Unit\Export\Catalog;
 
 use App\Export\Catalog\Domain\Enum\CatalogTemplateKind;
 use App\Export\Catalog\Domain\Template\CatalogTemplateCatalog;
-use App\Export\Catalog\Domain\Template\TemplateNotAvailableException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
- * CPDF-P2-01 / CPDF-P6-01 — the built-in catalog template catalog exposes the
- * sheet and pricelist archetypes with their slots and default mappings, and
- * rejects kinds whose archetype is not yet shipped.
+ * CPDF-P2-01 / CPDF-P6-01 / CPDF-P6-02 — the built-in catalog template catalog
+ * exposes the sheet, pricelist and grid archetypes with their slots and
+ * default mappings.
  */
 final class CatalogTemplateCatalogTest extends TestCase
 {
@@ -48,19 +47,26 @@ final class CatalogTemplateCatalogTest extends TestCase
     }
 
     #[Test]
-    public function allReturnsSheetAndPricelist(): void
+    public function gridExposesFourSlotsWithDefaultMappings(): void
     {
-        $all = new CatalogTemplateCatalog()->all();
+        $template = new CatalogTemplateCatalog()->get(CatalogTemplateKind::Grid);
 
-        self::assertCount(2, $all);
-        self::assertSame(CatalogTemplateKind::Sheet, $all[0]->kind);
-        self::assertSame(CatalogTemplateKind::Pricelist, $all[1]->kind);
+        self::assertSame(CatalogTemplateKind::Grid, $template->kind);
+        self::assertSame('catalog/grid.html.twig', $template->twig);
+        self::assertSame(['title', 'sku', 'image', 'price'], $template->slotNames());
+        self::assertCount(4, $template->defaultMappings);
+        self::assertContains(['slot' => 'title', 'source' => 'name'], $template->defaultMappings);
+        self::assertContains(['slot' => 'image', 'source' => 'main_image'], $template->defaultMappings);
     }
 
     #[Test]
-    public function gridIsNotAvailableYet(): void
+    public function allReturnsEveryArchetype(): void
     {
-        $this->expectException(TemplateNotAvailableException::class);
-        new CatalogTemplateCatalog()->get(CatalogTemplateKind::Grid);
+        $all = new CatalogTemplateCatalog()->all();
+
+        self::assertCount(3, $all);
+        self::assertSame(CatalogTemplateKind::Sheet, $all[0]->kind);
+        self::assertSame(CatalogTemplateKind::Pricelist, $all[1]->kind);
+        self::assertSame(CatalogTemplateKind::Grid, $all[2]->kind);
     }
 }


### PR DESCRIPTION
## CPDF-P6-02 — archetyp `grid` (okładka + spis treści + siatka kart)

Zamyka #2305 (ręcznie, po live smoke). Trzeci i ostatni archetyp renderera katalogów PDF (ADR-0027) — kompozycja sekcji w jednym dokumencie Twig (idea Pimcore PrintContainer): **okładka → spis treści → siatka kart 3-na-wiersz**.

### Zakres
- **`templates/catalog/grid.html.twig`**:
  - okładka: brand band + logo + company + tytuł katalogu (nazwa profilu) + liczba produktów, `page-break-after: always`;
  - spis treści: `<a href="#product-N">` per produkt (kotwice na kartach), dotted separators;
  - siatka: `<table>` (Dompdf nie ma flex/grid), produkty chunkowane `batch(3)`, karty z obrazkiem/tytułem/SKU/ceną, `page-break-inside: avoid`;
  - stopka strony: `position:fixed` + `counter(page)` (CSS 2.1, Dompdf wspiera);
  - **feature-flag `premium`** (default `false`): numery stron w spisie przez `target-counter(attr(href url), page)` — Dompdf tego nie wspiera, więc blok CSS renderuje się TYLKO pod flagą (Gotenberg-class, CPDF-P6-03/P6-05). Na Dompdf spis degraduje się gracefully do samych kotwic. Pełne margin boxes analogicznie poza baseline.
- **`CatalogTemplateCatalog`** — wpis `grid` (sloty title/sku/image/price, defaults name/sku/main_image/price); `get()` nie rzuca już dla żadnego built-in kind; `TemplateNotAvailableException` + catch'e w preview zostają dla przyszłych kindów.
- **`CatalogRenderService`** — kontekst Twig dostaje `title` (nazwa profilu); sheet/pricelist ignorują (guardy `|default`).

### Testy (walidowane w kontenerze pim-api-1 przed pushem — 10/10)
- `CatalogTemplateCatalogTest` — sloty + defaults grid, `all()` = 3 archetypy.
- `GridTemplateRenderTest` — realny Twig (strict_variables ON): okładka (brand color, tytuł, count), spis 7 kotwic ↔ 7 id kart, chunking 7 produktów → 3 `<tr>`, `counter(page)`; **premium gating**: bez flagi zero `target-counter`, z flagą obecny.
- `CatalogRenderServiceTest::rendersGridCatalogWithCoverAndTocToPdf` — realny PDF end-to-end: 30 produktów → `%PDF-`, `pageCount >= 3` (okładka + spis + siatka).
- PHPStan max (full, świeży cache): 0 błędów · Deptrac: 0 errors · cs-fixer: clean.

### Poza zakresem (świadomie)
- Wizard FE dalej pokazuje grid jako „Wkrótce" (StepMapping sheet-only — jak w P6-01; archetyp w pełni dostępny przez API).
- Numery stron w spisie na Dompdf — z definicji ticketu gejtowane do Gotenberga.

Bez zmian tras → brak regeneracji `docs/api-spec/v0.json`.
