### PR TITLE
perf(export): benchmark Dompdf memory and enforce catalog product cap

### DIFF
--- a/apps/api/.env
+++ b/apps/api/.env
@@ -100,6 +100,14 @@ CATALOG_ENABLE_CUSTOM_OBJECT_TYPES=true
 # gotenberg selection without GOTENBERG_URL falls back to dompdf.
 CATALOG_PDF_RENDERER=dompdf
 GOTENBERG_URL=
+# CPDF-P6-04 (decision A) — max products per catalog for in-process renderers
+# (Dompdf). Benchmarked 2026-07-10 (agent/cpdf-p6-04-dompdf-benchmark.md):
+# at 500 products the worst archetype (grid, 48 pages) peaks at ~150 MB PHP
+# memory in ~1.8 s — comfortably under the 256 MB worker alert (§3.10); the
+# linear trend (~13 MB/100 products over the ~80 MB baseline) would only cross
+# the alert around ~1200+ products, so 500 guards the pathological tail, not
+# normal use. Renderers with supportsLargeDocuments() (Gotenberg) are uncapped.
+CATALOG_PDF_MAX_ITEMS=500
 # AGENT-P0-08 (#1951) — global agent kill-switch (open-core: a deploy
 # without the agent sets 0 and every /api/agent/* endpoint refuses with
 # a 403 problem document). Per-tenant availability additionally

--- a/apps/api/agent/cpdf-p6-04-dompdf-benchmark.md
+++ b/apps/api/agent/cpdf-p6-04-dompdf-benchmark.md
@@ -1,0 +1,30 @@
+# CPDF-P6-04 — Dompdf catalog render benchmark log
+
+> **Ticket:** [#2307](https://github.com/malipie/PIM/issues/2307)
+>
+> Append-only run log produced by `bin/console pim:catalog:benchmark`.
+> Each row renders the archetype at the given product count through the
+> real pipeline (values → mapper → Twig → Dompdf) inside one process,
+> sizes ascending. `peak_mb` is `memory_get_peak_usage(true)` — the
+> worker guardrail number (CLAUDE.md §3.10 alert fires at 256 MB).
+> Decision A: the numbers picked the `CATALOG_PDF_MAX_ITEMS` default
+> (see `apps/api/.env`); exceeding it on Dompdf raises
+> `CatalogTooLargeException` ("enable Gotenberg") instead of an OOM.
+
+| timestamp | tenant | template | products | pages | elapsed_ms | peak_mb | pdf_kb |
+|---|---|---|---|---|---|---|---|
+| 2026-07-10T02:17:18+00:00 | demo | grid | 50 | 8 | 272.9 | 86.5 | 88.0 |
+| 2026-07-10T02:17:18+00:00 | demo | grid | 100 | 13 | 306.8 | 96.5 | 156.2 |
+| 2026-07-10T02:17:18+00:00 | demo | grid | 150 | 18 | 484.7 | 104.5 | 236.2 |
+| 2026-07-10T02:17:18+00:00 | demo | grid | 300 | 27 | 910.6 | 126.5 | 430.3 |
+| 2026-07-10T02:17:18+00:00 | demo | grid | 500 | 48 | 1824.8 | 150.5 | 709.5 |
+| 2026-07-10T02:17:31+00:00 | demo | pricelist | 50 | 2 | 211.5 | 84.5 | 22.7 |
+| 2026-07-10T02:17:31+00:00 | demo | pricelist | 100 | 4 | 153.2 | 90.5 | 27.1 |
+| 2026-07-10T02:17:31+00:00 | demo | pricelist | 150 | 6 | 214.9 | 94.5 | 37.7 |
+| 2026-07-10T02:17:31+00:00 | demo | pricelist | 300 | 12 | 475.5 | 112.5 | 49.4 |
+| 2026-07-10T02:17:31+00:00 | demo | pricelist | 500 | 20 | 971.6 | 140.5 | 69.0 |
+| 2026-07-10T02:17:39+00:00 | demo | sheet | 50 | 50 | 397.2 | 82.5 | 58.3 |
+| 2026-07-10T02:17:39+00:00 | demo | sheet | 100 | 100 | 480.0 | 92.5 | 96.8 |
+| 2026-07-10T02:17:39+00:00 | demo | sheet | 150 | 150 | 687.1 | 98.5 | 139.6 |
+| 2026-07-10T02:17:39+00:00 | demo | sheet | 300 | 300 | 1742.7 | 112.5 | 229.0 |
+| 2026-07-10T02:17:39+00:00 | demo | sheet | 500 | 500 | 4490.2 | 126.5 | 377.5 |

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -95,6 +95,15 @@ services:
     App\Export\Contracts\PdfRenderer:
         factory: ['@App\Export\Catalog\Infrastructure\Renderer\CatalogPdfRendererFactory', 'create']
 
+    # CPDF-P6-04 (decision A) — product cap for in-process renderers (Dompdf
+    # builds the whole document in PHP memory; exceeding the cap raises a clear
+    # "enable Gotenberg" error instead of OOM-killing the worker). Benchmarked
+    # default in apps/api/.env; renderers with supportsLargeDocuments() render
+    # uncapped.
+    App\Export\Catalog\Application\CatalogRenderService:
+        arguments:
+            $maxInMemoryItems: '%env(int:CATALOG_PDF_MAX_ITEMS)%'
+
     # W2-7 / AUD-042 — single RFC 7807 contract for custom controllers.
     # `$debug` is bound to the kernel flag so the listener can keep the
     # real exception message in `detail` for 5xx locally while collapsing

--- a/apps/api/src/Benchmark/Export/CatalogPdfBenchmarkCommand.php
+++ b/apps/api/src/Benchmark/Export/CatalogPdfBenchmarkCommand.php
@@ -1,0 +1,306 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Benchmark\Export;
+
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Export\Catalog\Application\CatalogRenderService;
+use App\Export\Catalog\Application\HtmlValueSanitizer;
+use App\Export\Catalog\Domain\Entity\CatalogProfile;
+use App\Export\Catalog\Domain\Enum\CatalogTemplateKind;
+use App\Export\Catalog\Domain\Mapping\CatalogItemMapper;
+use App\Export\Catalog\Domain\Template\CatalogTemplateCatalog;
+use App\Export\Catalog\Infrastructure\Renderer\DompdfRenderer;
+use App\Export\Contracts\CatalogProductScope;
+use App\Export\Contracts\CatalogProductValues;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use App\Shared\Infrastructure\Doctrine\RlsTenantGuard;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Twig\Environment;
+
+use const PHP_INT_MAX;
+
+/**
+ * CPDF-P6-04 (#2307) — Dompdf catalog render benchmark, the CPDF sibling of
+ * {@see ExportBenchmarkCommand} (EXP-04).
+ *
+ * Resolves open decision A: Dompdf builds the whole PDF document in PHP
+ * memory, so this command renders the chosen archetype at increasing product
+ * counts (default 50/100/150/300/500) through the REAL pipeline
+ * (CatalogProductValues → CatalogItemMapper → Twig → DompdfRenderer) and
+ * reports elapsed time + PHP peak memory per size. The numbers pick the
+ * CATALOG_PDF_MAX_ITEMS default enforced by {@see CatalogRenderService}.
+ *
+ * The value source wraps the real adapter and CYCLES the tenant's products
+ * until the requested count — the dev dataset (~300 demo products) can then
+ * exercise the 500-product point; render cost depends on document size, not
+ * on row distinctness. Sizes run ascending so `memory_get_peak_usage()`
+ * (monotonic per process) stays attributable to the size that moved it.
+ *
+ * Output: stdout table + an append-only snapshot in
+ * `agent/cpdf-p6-04-dompdf-benchmark.md` (historical trend over runs).
+ */
+#[AsCommand(
+    name: 'pim:catalog:benchmark',
+    description: 'Render a catalog archetype at increasing product counts on Dompdf and report time + peak memory (CPDF-P6-04).'
+)]
+final class CatalogPdfBenchmarkCommand extends Command
+{
+    private const string REPORT_PATH = 'agent/cpdf-p6-04-dompdf-benchmark.md';
+
+    public function __construct(
+        private readonly CatalogProductValues $values,
+        private readonly CatalogTemplateCatalog $templates,
+        private readonly ObjectTypeRepositoryInterface $objectTypes,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly TenantContext $tenantContext,
+        private readonly TenantFilterConfigurator $tenantFilter,
+        private readonly RlsTenantGuard $rlsGuard,
+        private readonly Environment $twig,
+        #[Autowire(param: 'kernel.project_dir')]
+        private readonly string $projectDir,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('tenant', null, InputOption::VALUE_REQUIRED, 'Tenant code to scope the benchmark', 'demo')
+            ->addOption('template', null, InputOption::VALUE_REQUIRED, 'Archetype to render (sheet|pricelist|grid)', 'grid')
+            ->addOption('sizes', null, InputOption::VALUE_REQUIRED, 'Comma-separated ascending product counts', '50,100,150,300,500')
+            ->addOption('no-report', null, InputOption::VALUE_NONE, 'Skip appending to '.self::REPORT_PATH);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $tenantCode = $this->stringOption($input, 'tenant');
+        $kind = CatalogTemplateKind::tryFrom($this->stringOption($input, 'template'));
+        if (null === $kind) {
+            $io->error('template must be one of: sheet, pricelist, grid.');
+
+            return Command::FAILURE;
+        }
+        $sizes = array_values(array_filter(array_map(
+            static fn (string $s): int => (int) trim($s),
+            explode(',', $this->stringOption($input, 'sizes')),
+        ), static fn (int $n): bool => $n > 0));
+        sort($sizes);
+        if ([] === $sizes) {
+            $io->error('sizes must contain at least one positive count.');
+
+            return Command::FAILURE;
+        }
+
+        $tenant = $this->entityManager->getRepository(Tenant::class)->findOneBy(['code' => $tenantCode]);
+        if (!$tenant instanceof Tenant) {
+            $io->error(sprintf('Tenant "%s" not found.', $tenantCode));
+
+            return Command::FAILURE;
+        }
+        $this->tenantContext->set($tenant);
+        $this->tenantFilter->apply();
+        // CLI has no request listener — establish the RLS GUC explicitly, or
+        // pim_app's row-level policies return zero rows on every domain table.
+        $this->rlsGuard->reassert($tenant);
+
+        $productType = $this->objectTypes->findBuiltInByKind(ObjectKind::Product, $tenant);
+        if (null === $productType) {
+            $io->error('No built-in product ObjectType for this tenant — seed the demo dataset first.');
+
+            return Command::FAILURE;
+        }
+
+        $template = $this->templates->get($kind);
+        $profile = new CatalogProfile(
+            'benchmark',
+            'Benchmark catalog',
+            $kind,
+            $productType->getId(),
+            branding: ['color' => '#1d4ed8', 'company_name' => 'Benchmark'],
+            fieldMappings: array_map(
+                static fn (array $mapping): array => [
+                    'slot' => $mapping['slot'],
+                    'source' => ['kind' => 'attribute', 'ref' => $mapping['source']],
+                ],
+                $template->defaultMappings,
+            ),
+        );
+
+        $io->section(sprintf(
+            'Dompdf catalog benchmark: tenant=%s, template=%s, sizes=%s',
+            $tenantCode,
+            $kind->value,
+            implode(',', $sizes),
+        ));
+
+        $rows = [];
+        foreach ($sizes as $count) {
+            $service = new CatalogRenderService(
+                $this->cyclingValues($count),
+                new CatalogItemMapper(),
+                $this->templates,
+                new HtmlValueSanitizer(),
+                $this->twig,
+                new DompdfRenderer(),
+                maxInMemoryItems: PHP_INT_MAX, // the benchmark measures past the cap on purpose
+            );
+
+            $target = tempnam(sys_get_temp_dir(), 'cpdf-bench-');
+            if (false === $target) {
+                $io->error('Unable to allocate a temp file.');
+
+                return Command::FAILURE;
+            }
+
+            gc_collect_cycles();
+            $startedAt = microtime(true);
+            $result = $service->render($profile, $target);
+            $elapsedMs = (microtime(true) - $startedAt) * 1000.0;
+            $peakMb = memory_get_peak_usage(true) / 1024 / 1024;
+            @unlink($target);
+
+            $rows[] = [
+                'products' => $result->itemCount,
+                'pages' => $result->pageCount,
+                'elapsed_ms' => $elapsedMs,
+                'peak_mb' => $peakMb,
+                'pdf_kb' => $result->byteSize / 1024,
+            ];
+            $io->writeln(sprintf(
+                '  %5d products → %3d pages, %8.1f ms, peak %7.1f MB, %7.1f KB pdf',
+                $result->itemCount,
+                $result->pageCount,
+                $elapsedMs,
+                $peakMb,
+                $result->byteSize / 1024,
+            ));
+        }
+
+        if (!$input->getOption('no-report')) {
+            $this->appendReport($tenantCode, $kind->value, $rows);
+            $io->success(sprintf('Snapshot appended to %s', self::REPORT_PATH));
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Wrap the real value source: cycle its rows until $target products so the
+     * benchmark can exceed the dev dataset size.
+     */
+    private function cyclingValues(int $target): CatalogProductValues
+    {
+        $inner = $this->values;
+
+        return new class($inner, $target) implements CatalogProductValues {
+            public function __construct(
+                private readonly CatalogProductValues $inner,
+                private readonly int $target,
+            ) {
+            }
+
+            public function forScope(CatalogProductScope $scope): iterable
+            {
+                $emitted = 0;
+                while ($emitted < $this->target) {
+                    $before = $emitted;
+                    foreach ($this->inner->forScope($scope) as $row) {
+                        yield $row;
+                        if (++$emitted >= $this->target) {
+                            return;
+                        }
+                    }
+                    if ($emitted === $before) {
+                        return; // empty source — avoid an infinite loop
+                    }
+                }
+            }
+        };
+    }
+
+    private function stringOption(InputInterface $input, string $name): string
+    {
+        $value = $input->getOption($name);
+
+        return \is_string($value) ? $value : '';
+    }
+
+    /**
+     * @param list<array{products: int, pages: int, elapsed_ms: float, peak_mb: float, pdf_kb: float}> $rows
+     */
+    private function appendReport(string $tenantCode, string $template, array $rows): void
+    {
+        $path = $this->projectDir.'/'.self::REPORT_PATH;
+        if (!is_dir(\dirname($path))) {
+            @mkdir(\dirname($path), 0o755, true);
+        }
+
+        $timestamp = new DateTimeImmutable()->format(DateTimeInterface::ATOM);
+        $lines = '';
+        foreach ($rows as $row) {
+            $lines .= sprintf(
+                "| %s | %s | %s | %d | %d | %.1f | %.1f | %.1f |\n",
+                $timestamp,
+                $tenantCode,
+                $template,
+                $row['products'],
+                $row['pages'],
+                $row['elapsed_ms'],
+                $row['peak_mb'],
+                $row['pdf_kb'],
+            );
+        }
+
+        $needsHeader = !file_exists($path);
+        $fh = fopen($path, 'a');
+        if (false === $fh) {
+            return;
+        }
+        try {
+            if ($needsHeader) {
+                fwrite($fh, $this->reportHeader());
+            }
+            fwrite($fh, $lines);
+        } finally {
+            fclose($fh);
+        }
+    }
+
+    private function reportHeader(): string
+    {
+        return <<<MD
+            # CPDF-P6-04 — Dompdf catalog render benchmark log
+
+            > **Ticket:** [#2307](https://github.com/malipie/PIM/issues/2307)
+            >
+            > Append-only run log produced by `bin/console pim:catalog:benchmark`.
+            > Each row renders the archetype at the given product count through the
+            > real pipeline (values → mapper → Twig → Dompdf) inside one process,
+            > sizes ascending. `peak_mb` is `memory_get_peak_usage(true)` — the
+            > worker guardrail number (CLAUDE.md §3.10 alert fires at 256 MB).
+            > Decision A: the numbers picked the `CATALOG_PDF_MAX_ITEMS` default
+            > (see `apps/api/.env`); exceeding it on Dompdf raises
+            > `CatalogTooLargeException` ("enable Gotenberg") instead of an OOM.
+
+            | timestamp | tenant | template | products | pages | elapsed_ms | peak_mb | pdf_kb |
+            |---|---|---|---|---|---|---|---|
+
+            MD;
+    }
+}

--- a/apps/api/src/Export/Catalog/Application/CatalogRenderService.php
+++ b/apps/api/src/Export/Catalog/Application/CatalogRenderService.php
@@ -28,9 +28,12 @@ use Twig\Environment;
  *
  * Memory: the value source is memory-bounded (chunked ExportBuilder +
  * EntityManager::clear()), but Dompdf accumulates the whole document in memory,
- * so large catalogs are capped/chunked in CPDF-P6-04 (decision A). Image
- * embedding as a data-URI is refined in CPDF-P6-03 (decision B) — for now the
- * resolved image value is passed straight through.
+ * so renderers that answer false to {@see PdfRenderer::supportsLargeDocuments()}
+ * get a product cap ($maxInMemoryItems, env CATALOG_PDF_MAX_ITEMS — decision A,
+ * CPDF-P6-04): exceeding it raises {@see CatalogTooLargeException} with an
+ * actionable "enable Gotenberg" message instead of an OOM'd worker. Image
+ * embedding stays URL-based (decision B, CPDF-P6-03) — the resolved image
+ * value is passed straight through and the sidecar fetches it itself.
  */
 final class CatalogRenderService
 {
@@ -44,6 +47,7 @@ final class CatalogRenderService
         private readonly HtmlValueSanitizer $sanitizer,
         private readonly Environment $twig,
         private readonly PdfRenderer $renderer,
+        private readonly int $maxInMemoryItems = 500,
     ) {
     }
 
@@ -72,8 +76,16 @@ final class CatalogRenderService
         /** @var list<array<string, mixed>> $products */
         $products = [];
         $processed = 0;
+        $capped = !$this->renderer->supportsLargeDocuments();
 
         foreach ($this->values->forScope($scope) as $row) {
+            if ($capped && $processed >= $this->maxInMemoryItems) {
+                // Stop before the in-process renderer OOMs the worker
+                // (decision A, CPDF-P6-04) — the async handler records the
+                // message on the run.
+                throw CatalogTooLargeException::forCap($this->maxInMemoryItems);
+            }
+
             $slots = $this->mapper->map($mappings, $row);
 
             $product = [];

--- a/apps/api/src/Export/Catalog/Application/CatalogTooLargeException.php
+++ b/apps/api/src/Export/Catalog/Application/CatalogTooLargeException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Catalog\Application;
+
+use RuntimeException;
+
+/**
+ * Raised when a catalog exceeds the product cap of an in-process renderer
+ * (CPDF-P6-04, decision A): Dompdf builds the whole document in PHP memory,
+ * so instead of letting a FrankenPHP worker die on OOM mid-render, the render
+ * pipeline stops early with an actionable message. The async handler records
+ * it on the CatalogRun (markError), so the operator sees it in the monitor.
+ */
+final class CatalogTooLargeException extends RuntimeException
+{
+    public static function forCap(int $cap): self
+    {
+        return new self(sprintf(
+            'Catalog exceeds the %d-product limit of the in-process Dompdf renderer. '
+            .'Narrow the catalog filter, or enable the Gotenberg sidecar for large catalogs '
+            .'(CATALOG_PDF_RENDERER=gotenberg + GOTENBERG_URL, see docker compose profile "gotenberg").',
+            $cap,
+        ));
+    }
+}

--- a/apps/api/src/Export/Catalog/Application/Generator/CatalogRegenerator.php
+++ b/apps/api/src/Export/Catalog/Application/Generator/CatalogRegenerator.php
@@ -14,6 +14,8 @@ use App\Export\Catalog\Domain\Repository\CatalogRunRepositoryInterface;
 use App\Shared\Application\TenantContext;
 use Closure;
 use DateTimeImmutable;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use RuntimeException;
 use Throwable;
 
@@ -49,13 +51,17 @@ use Throwable;
  */
 final class CatalogRegenerator
 {
+    private readonly LoggerInterface $logger;
+
     public function __construct(
         private readonly CatalogRenderService $renderer,
         private readonly CatalogCacheStorage $cache,
         private readonly CatalogProfileRepositoryInterface $profiles,
         private readonly CatalogRunRepositoryInterface $runs,
         private readonly TenantContext $tenantContext,
+        ?LoggerInterface $logger = null,
     ) {
+        $this->logger = $logger ?? new NullLogger();
     }
 
     /**
@@ -98,6 +104,16 @@ final class CatalogRegenerator
             $managedRun = $this->runs->findById($run->getId()) ?? $run;
             $managedRun->markDone($result->pageCount, $result->byteSize, $result->itemCount, $durationMs);
             $this->runs->save($managedRun);
+
+            // Peak-memory telemetry (CPDF-P6-04, decision A): feeds the worker
+            // memory guardrail (§3.10 Prometheus alert) with a per-run number.
+            $this->logger->info('Catalog render completed', [
+                'run_id' => $managedRun->getId()->toRfc4122(),
+                'items' => $result->itemCount,
+                'pages' => $result->pageCount,
+                'duration_ms' => $durationMs,
+                'peak_memory_mb' => round(memory_get_peak_usage(true) / 1024 / 1024, 1),
+            ]);
 
             return $managedRun;
         } catch (CatalogCancelledException) {

--- a/apps/api/src/Export/Catalog/Infrastructure/Renderer/DompdfRenderer.php
+++ b/apps/api/src/Export/Catalog/Infrastructure/Renderer/DompdfRenderer.php
@@ -23,6 +23,13 @@ use Throwable;
  */
 final class DompdfRenderer implements PdfRenderer
 {
+    public function supportsLargeDocuments(): bool
+    {
+        // Dompdf accumulates the whole document in PHP memory — the render
+        // pipeline caps the product count (CPDF-P6-04, decision A).
+        return false;
+    }
+
     public function render(string $html, PdfRenderOptions $options): string
     {
         $dompdfOptions = new Options();

--- a/apps/api/src/Export/Catalog/Infrastructure/Renderer/GotenbergRenderer.php
+++ b/apps/api/src/Export/Catalog/Infrastructure/Renderer/GotenbergRenderer.php
@@ -60,6 +60,13 @@ final class GotenbergRenderer implements PdfRenderer
         };
     }
 
+    public function supportsLargeDocuments(): bool
+    {
+        // The sidecar renders in its own Chromium process space — no PHP
+        // worker-memory ceiling applies (CPDF-P6-04, decision A).
+        return true;
+    }
+
     public function render(string $html, PdfRenderOptions $options): string
     {
         [$paperWidth, $paperHeight] = self::PAPER_SIZES[$options->paperSize] ?? self::PAPER_SIZES['A4'];
@@ -123,6 +130,6 @@ final class GotenbergRenderer implements PdfRenderer
 
     private function backOff(int $attempt): void
     {
-        ($this->sleep)(min(2 ** $attempt, self::BACKOFF_CAP_SECONDS));
+        ($this->sleep)((int) min(2 ** $attempt, self::BACKOFF_CAP_SECONDS));
     }
 }

--- a/apps/api/src/Export/Contracts/PdfRenderer.php
+++ b/apps/api/src/Export/Contracts/PdfRenderer.php
@@ -25,4 +25,13 @@ interface PdfRenderer
      * @throws PdfRenderException when the document cannot be rendered
      */
     public function render(string $html, PdfRenderOptions $options): string;
+
+    /**
+     * Whether the renderer can take arbitrarily large documents (CPDF-P6-04,
+     * decision A). In-process engines that build the whole document in PHP
+     * memory (Dompdf) answer false and the catalog render pipeline enforces a
+     * product cap on them; sidecar engines with their own process space
+     * (Gotenberg) answer true and render uncapped.
+     */
+    public function supportsLargeDocuments(): bool;
 }

--- a/apps/api/tests/Integration/Export/Catalog/CatalogRenderServiceTest.php
+++ b/apps/api/tests/Integration/Export/Catalog/CatalogRenderServiceTest.php
@@ -16,12 +16,15 @@ use App\Export\Application\Builder\ExportBuilder;
 use App\Export\Application\Catalog\ExportBuilderCatalogValues;
 use App\Export\Catalog\Application\CatalogRenderResult;
 use App\Export\Catalog\Application\CatalogRenderService;
+use App\Export\Catalog\Application\CatalogTooLargeException;
 use App\Export\Catalog\Application\HtmlValueSanitizer;
 use App\Export\Catalog\Domain\Entity\CatalogProfile;
 use App\Export\Catalog\Domain\Enum\CatalogTemplateKind;
 use App\Export\Catalog\Domain\Mapping\CatalogItemMapper;
 use App\Export\Catalog\Domain\Template\CatalogTemplateCatalog;
 use App\Export\Catalog\Infrastructure\Renderer\DompdfRenderer;
+use App\Export\Contracts\PdfRenderer;
+use App\Export\Contracts\PdfRenderOptions;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
 use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
@@ -137,6 +140,62 @@ final class CatalogRenderServiceTest extends KernelTestCase
     }
 
     #[Test]
+    public function capRaisesActionableErrorOnInMemoryRenderer(): void
+    {
+        // Decision A (CPDF-P6-04): Dompdf answers false to
+        // supportsLargeDocuments(), so exceeding the cap stops the render with
+        // an actionable message instead of OOM-killing the worker.
+        [, $typeId] = $this->seedObjects(12, 'plain');
+
+        $service = $this->service(maxInMemoryItems: 10);
+        $profile = $this->profile($typeId);
+
+        $target = tempnam(sys_get_temp_dir(), 'cpdf-');
+        self::assertNotFalse($target);
+
+        try {
+            $service->render($profile, $target);
+            self::fail('expected CatalogTooLargeException');
+        } catch (CatalogTooLargeException $error) {
+            self::assertStringContainsString('10-product limit', $error->getMessage());
+            self::assertStringContainsString('Gotenberg', $error->getMessage());
+        } finally {
+            @unlink($target);
+        }
+    }
+
+    #[Test]
+    public function capDoesNotApplyToLargeDocumentRenderers(): void
+    {
+        [, $typeId] = $this->seedObjects(12, 'plain');
+
+        // A Gotenberg-class renderer (supportsLargeDocuments() === true)
+        // renders uncapped — the same 12 products pass a cap of 10.
+        $sidecarLike = new class implements PdfRenderer {
+            public function supportsLargeDocuments(): bool
+            {
+                return true;
+            }
+
+            public function render(string $html, PdfRenderOptions $options): string
+            {
+                return '%PDF-fake';
+            }
+        };
+
+        $service = $this->service($sidecarLike, maxInMemoryItems: 10);
+        $profile = $this->profile($typeId);
+
+        $target = tempnam(sys_get_temp_dir(), 'cpdf-');
+        self::assertNotFalse($target);
+        $result = $service->render($profile, $target);
+
+        self::assertSame(12, $result->itemCount, 'the cap only guards in-memory renderers');
+
+        @unlink($target);
+    }
+
+    #[Test]
     public function renderSurvivesMaliciousDescriptionValue(): void
     {
         [, $typeId] = $this->seedObjects(1, '<script>alert(1)</script>');
@@ -155,7 +214,7 @@ final class CatalogRenderServiceTest extends KernelTestCase
         @unlink($target);
     }
 
-    private function service(): CatalogRenderService
+    private function service(?PdfRenderer $renderer = null, int $maxInMemoryItems = 500): CatalogRenderService
     {
         // No consumer wires CatalogRenderService yet, so the DI compiler may
         // inline/remove it — build it directly from its (retained) deps, the
@@ -184,7 +243,8 @@ final class CatalogRenderServiceTest extends KernelTestCase
             $twig,
             // PdfRenderer alias has no consumer yet (DI removes it) — the default
             // in-process Dompdf adapter is constructor-less, use it directly.
-            new DompdfRenderer(),
+            $renderer ?? new DompdfRenderer(),
+            $maxInMemoryItems,
         );
     }
 

--- a/apps/api/tests/Unit/Export/Catalog/DompdfRendererTest.php
+++ b/apps/api/tests/Unit/Export/Catalog/DompdfRendererTest.php
@@ -37,4 +37,11 @@ final class DompdfRendererTest extends TestCase
 
         self::assertStringStartsWith('%PDF-', $pdf);
     }
+
+    public function testDoesNotSupportLargeDocuments(): void
+    {
+        // Dompdf builds the whole document in PHP memory — the render pipeline
+        // caps the product count (CPDF-P6-04, decision A).
+        self::assertFalse(new DompdfRenderer()->supportsLargeDocuments());
+    }
 }

--- a/apps/api/tests/Unit/Export/Catalog/GotenbergRendererTest.php
+++ b/apps/api/tests/Unit/Export/Catalog/GotenbergRendererTest.php
@@ -112,6 +112,14 @@ final class GotenbergRendererTest extends TestCase
     }
 
     #[Test]
+    public function supportsLargeDocuments(): void
+    {
+        // The sidecar renders in its own Chromium process space — the catalog
+        // product cap does not apply (CPDF-P6-04, decision A).
+        self::assertTrue($this->renderer(new MockHttpClient())->supportsLargeDocuments());
+    }
+
+    #[Test]
     public function nonPdfResponseBodyIsRejected(): void
     {
         $client = new MockHttpClient([new MockResponse('<html>not a pdf</html>')]);


### PR DESCRIPTION
## CPDF-P6-04 — benchmark pamięci Dompdf + cap produktów (decyzja A rozstrzygnięta)

Zamyka #2307 (ręcznie, po CI — live proof wykonany, niżej). Rozstrzyga otwartą decyzję A z ADR-0027 danymi, nie zgadywaniem.

### Benchmark (`pim:catalog:benchmark`, kalka `pim:export:benchmark`)
Renderuje wybrany archetyp przy 50/100/150/300/500 produktach przez REALNY pipeline (CatalogProductValues → mapper → Twig → Dompdf); dekorator cykluje realne produkty tenanta do zadanego N (demo=294 → punkt 500 osiągalny). Wyniki na żywych danych demo (log: `apps/api/agent/cpdf-p6-04-dompdf-benchmark.md`, append-only jak EXP-04):

| archetyp | 500 produktów | peak PHP | czas |
|---|---|---|---|
| grid (najcięższy) | 48 stron | **150.5 MB** | 1.82 s |
| pricelist | 20 stron | 140.5 MB | 0.97 s |
| sheet | 500 stron | 126.5 MB | 4.49 s |

Trend liniowy ~13 MB/100 produktów nad baseline ~80 MB → alert workera 256 MB (§3.10) przecięty dopiero przy ~1200+ produktach.

### Decyzja A: **cap (nie chunk→merge)**, default **CATALOG_PDF_MAX_ITEMS=500**
- `PdfRenderer` dostaje `supportsLargeDocuments(): bool` — Dompdf `false` (cały dokument w pamięci PHP), Gotenberg `true` (własny process space) → **Gotenberg renderuje bez capa**.
- `CatalogRenderService` egzekwuje cap tylko dla rendererów in-memory: przekroczenie → `CatalogTooLargeException` z akcjonowalnym komunikatem („zawęź filtr albo włącz Gotenberg: CATALOG_PDF_RENDERER=gotenberg + GOTENBERG_URL"), rejestrowanym przez async handler na runie (`markError`) — zamiast OOM-killed workera.
- Chunk→merge odrzucony świadomie: wymaga zależności do sklejania PDF-ów, a dane pokazują że cap wystarcza (500 = 59% alertu).
- Telemetria: `CatalogRegenerator` loguje per-run `peak_memory_mb` + items/pages/duration (zasila guardrail §3.10).
- RLS w CLI: komenda używa `RlsTenantGuard::reassert()` (bez tego pim_app widzi zero wierszy — pułapka znaleziona przy pierwszym runie).

### Testy (kontener pim-api-1: 52 pass / 1 skip warunkowego live-Gotenberga)
- `CatalogRenderServiceTest`: **cap 10 na 12 produktach → wyjątek z „10-product limit" + „Gotenberg"** (integration, realny Postgres) · ten sam cap z rendererem `supportsLargeDocuments()=true` → renderuje 12/12 bez capa.
- `DompdfRendererTest`/`GotenbergRendererTest`: capability na obu adapterach.
- PHPStan max (full, świeży cache): 0 — w tym fix realnego błędu z P6-03, który przemknął przez OOM-killed run (`(int) min(2**n, cap)` w backoffie) · Deptrac 0 · `lint:container` OK · cs-fixer clean.

### Live proof na `https://pim.localhost` (2026-07-10)
1. **Cap egzekwowany end-to-end**: tymczasowo `CATALOG_PDF_MAX_ITEMS=50` + restart → `POST /generate` katalogu 294-produktowego → **202 → run `error`** z pełnym komunikatem enable-Gotenberg w `error_message` (widoczny w monitorze runów).
2. **Happy path po przywróceniu 500**: ten sam katalog → run `done`, 16 stron, 294 items.
3. Benchmark odpalony 3× (grid/pricelist/sheet) na realnych danych demo — tabele wyżej.

Bez zmian tras → brak regeneracji `docs/api-spec/v0.json`.
