### PR TITLE
feat(catalog): extend provenance_meta with source_attributes and recipe_id

### DIFF
--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -3,6 +3,14 @@
 > Zwięzły status bieżący (CLAUDE.md §Workflow pkt 2). Pełna historia: `git log`, GitHub Issues/milestones, `agent/lessons.md`, `Project Plan/*`.
 > Przepisany 2026-06-13 (poprzednie 2066 linii append-only logu, m.in. epiki NUI/UI/RBAC — w historii gita).
 
+## 2026-07-10: Epik AICG W TOKU — Generowanie treści AI (opisy + SEO), marathon #2325–#2346
+- **Sub-faza / epik:** AICG (22 tickety, M0–M6, milestone'y #59–#65, label `epik-AICG`). Backlog SoT: `Project Plan/feature-aicg-tickets.md`; plan: `Project Plan/UI/feature-ai-content-generation.md` (decyzje A–E zatwierdzone 2026-07-08). Tryb: marathon przez cały epik, jeden ticket = jeden PR.
+- **✅ AICG-P0-01 #2325 (PR #2443):** ADR przyjęty jako **ADR-0030** (nie 0028 z backlogu — 0028 zarezerwował równolegle GRID, 0029 WFL; wolny numer = pliki ∪ rezerwacje backlogowe). `docs/adr/0030-ai-content-generation-tools.md`: toole treści `kind=Write` w istniejącym ToolRegistry, wyjątek „agent-native" (silnik=LLM), ContentRecipe+BrandVoiceProfile w `src/Agent/` (removability), grounding kontraktowany + `insufficient_grounding`, zero auto-zapisu, SEO w przepisie nie schemacie, defaultModel+BYOK. Backlog + issue przenumerowane.
+- **🔄 AICG-P0-02 #2326 (w toku):** `provenance_meta` + opcjonalne `source_attributes`/`recipe_id` — spec `docs/api/jsonb-schemas.md §5` + projekcja `AttributesIndexedRebuilder::globalSlot` (pass-through gdy well-typed, malformed dropped, gate na `agent_run_id`) + unit test 6 case'ów.
+- **Ostatnie 3 akcje:** (1) merge PR #2443 + close #2325 z proofem, (2) rozszerzenie globalSlot + docs §5, (3) unit suite 1516 zielone w pim-api-1.
+- **Następny krok:** PR dla P0-02 → CI → merge → M1 (P1-01 ContentRecipe).
+- **Blokery:** brak.
+
 ## 2026-07-10: ✅ EPIK CPDF ZAMKNIĘTY — Katalogi PDF (27/27 ticketów, M0–M6, #2282–#2308)
 - **Co:** pełny web-to-print dla PIM: `CatalogProfile`/`CatalogRun` + silnik szablonów Twig (3 archetypy: sheet / pricelist / grid z okładką+spisem) + port `PdfRenderer` (Dompdf in-process default, Gotenberg sidecar opt-in) + async z progresem Mercure + delivery cache-and-serve z tokenem URL + pełne UI (hub KPI/karty/akcje, kreator 6-krok, live preview, menu gate RBAC). Marathon 2026-07-09/10, każdy ticket: branch → PR → CI → squash-merge → **live smoke proof w komencie zamknięcia** (CLOSED MEANS CLOSED).
 - **Finał M5 (UI):** #2382 Mercure live progress (proof: Playwright na żywym stacku łapie subskrypcję EventSource `catalogs/{id}/runs`, progress → terminal → refresh karty), #2383 menu gate (`exports.view_own|view_all` anyOf; persona negatywna = modeler bez `exports.*` → brak wpisu + Forbidden403 na deep-linkach).

--- a/agent/lessons.md
+++ b/agent/lessons.md
@@ -2,6 +2,12 @@
 
 > Plik startowy zasiany twardymi wytycznymi z `Project Plan/01-architektura-pim.md`. Po każdej korekcie operatora lub odkrytym wzorcu (sukces ALBO porażka) — dopisz wpis. Czytaj przed każdą sesją.
 
+## Lessons z AICG-P0-02 (2026-07-10, czerwony main po CPDF + deptrac cache)
+
+### Patterns to Avoid
+- **Lokalny `deptrac analyse` z cache pokazuje zieleń mimo realnych violations na CI.** `.deptrac.cache` w kontenerze przeżywa zmiany kodu z innych branchy (bind-mount + przełączanie); PR #2444 dostał 12 violations na CI, podczas gdy lokalny run mówił „Errors 0". Przy weryfikacji bramki architektury zawsze `deptrac analyse --no-cache`.
+- **Path-filtrowane workflow maskują czerwony main.** PR #2440 (CPDF P6-04) wszedł z FAILED `PHPUnit (unit,architecture)` + `Agent removability` (benchmark sięga `Export_Catalog_Internals`, ruleset `Tooling` sprzed splitu #2362); kolejne merge'e były docs-only, więc PHP suite się nie odpalał i main wyglądał na zdrowy. Wykryte dopiero przez CI pierwszego PR-a BE (AICG-P0-02). Reguła bez zmian od incydentu #2208: **nie mergować z jakimkolwiek czerwonym checkiem**; a przy dziedzicznie czerwonym CI własnego PR-a najpierw sprawdź, czy fail nie reprodukuje się na czystym main (`git log` ostatnich merged PR-ów po nazwie failującego checku). Fix: PR #2445 (Tooling + Export_Catalog_* w deptrac).
+
 ## Lessons z epiku DASH (2026-07-05…08, uinteraktywnienie dashboardu, #2249–#2275)
 
 ### Patterns to Follow

--- a/apps/api/src/Catalog/Application/AttributesIndexedRebuilder.php
+++ b/apps/api/src/Catalog/Application/AttributesIndexedRebuilder.php
@@ -97,7 +97,20 @@ final readonly class AttributesIndexedRebuilder
         $slot['provenance'] = $value->getProvenance()->value;
         $meta = $value->getProvenanceMeta();
         if (isset($meta['agent_run_id']) && \is_string($meta['agent_run_id'])) {
-            $slot['provenance_meta'] = ['agent_run_id' => $meta['agent_run_id']];
+            // AICG-P0-02 (#2326) — content-generation audit fields ride along
+            // when present; both optional, absent for pre-AICG rows. Malformed
+            // shapes are dropped, never propagated (jsonb-schemas rule #1).
+            $projected = ['agent_run_id' => $meta['agent_run_id']];
+            if (isset($meta['recipe_id']) && \is_string($meta['recipe_id'])) {
+                $projected['recipe_id'] = $meta['recipe_id'];
+            }
+            if (isset($meta['source_attributes']) && \is_array($meta['source_attributes'])) {
+                $codes = array_values(array_filter($meta['source_attributes'], \is_string(...)));
+                if ([] !== $codes) {
+                    $projected['source_attributes'] = $codes;
+                }
+            }
+            $slot['provenance_meta'] = $projected;
         }
 
         return $slot;

--- a/apps/api/tests/Unit/Catalog/Application/AttributesIndexedProvenanceSlotTest.php
+++ b/apps/api/tests/Unit/Catalog/Application/AttributesIndexedProvenanceSlotTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Application;
+
+use App\Catalog\Application\AttributesIndexedRebuilder;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Provenance;
+use App\Catalog\Domain\Service\EffectiveAttributeGroupResolver;
+use App\Channel\Contracts\LocaleFallbackResolverInterface;
+use App\Channel\Contracts\ScopeEnumeratorInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AICG-P0-02 (#2326, ADR-0030) — `provenance_meta` extended with the
+ * optional content-generation audit fields `source_attributes` +
+ * `recipe_id`. This pins the projection contract of
+ * {@see AttributesIndexedRebuilder::globalSlot}:
+ *
+ *   - new fields ride into the `attributes_indexed` slot when present
+ *     and well-typed (the badge tooltip reads them, AICG-P5-02),
+ *   - legacy rows without them keep their exact pre-AICG shape,
+ *   - malformed shapes are dropped, never propagated into the cache
+ *     (jsonb-schemas cross-cutting rule #1).
+ */
+final class AttributesIndexedProvenanceSlotTest extends TestCase
+{
+    #[Test]
+    public function contentGenerationAuditFieldsAreProjectedIntoTheSlot(): void
+    {
+        $recipeId = Uuid::v7()->toRfc4122();
+        $runId = Uuid::v7()->toRfc4122();
+        $value = $this->agentValue([
+            'agent_run_id' => $runId,
+            'model' => 'claude-sonnet-4-6',
+            'intent' => 'generate_product_description',
+            'source_attributes' => ['material', 'color'],
+            'recipe_id' => $recipeId,
+        ]);
+
+        $slot = $this->newRebuilder()->globalSlot($value);
+
+        self::assertSame('agent', $slot['provenance']);
+        self::assertSame(
+            [
+                'agent_run_id' => $runId,
+                'recipe_id' => $recipeId,
+                'source_attributes' => ['material', 'color'],
+            ],
+            $slot['provenance_meta'],
+        );
+    }
+
+    #[Test]
+    public function legacyAgentMetaWithoutNewFieldsKeepsItsPreAicgShape(): void
+    {
+        $runId = Uuid::v7()->toRfc4122();
+        $value = $this->agentValue([
+            'agent_run_id' => $runId,
+            'model' => 'claude-sonnet-4-6',
+            'intent' => 'set missing prices to 100',
+        ]);
+
+        $slot = $this->newRebuilder()->globalSlot($value);
+
+        self::assertSame(['agent_run_id' => $runId], $slot['provenance_meta']);
+    }
+
+    #[Test]
+    public function malformedNewFieldsAreDroppedNotPropagated(): void
+    {
+        $runId = Uuid::v7()->toRfc4122();
+        $value = $this->agentValue([
+            'agent_run_id' => $runId,
+            // recipe_id must be a string, source_attributes a list of
+            // strings — anything else never reaches the cache.
+            'recipe_id' => 123,
+            'source_attributes' => 'material,color',
+        ]);
+
+        $slot = $this->newRebuilder()->globalSlot($value);
+
+        self::assertSame(['agent_run_id' => $runId], $slot['provenance_meta']);
+    }
+
+    #[Test]
+    public function nonStringEntriesInSourceAttributesAreFilteredOut(): void
+    {
+        $runId = Uuid::v7()->toRfc4122();
+        $value = $this->agentValue([
+            'agent_run_id' => $runId,
+            'source_attributes' => ['material', 42, null, 'color'],
+        ]);
+
+        $slot = $this->newRebuilder()->globalSlot($value);
+
+        self::assertSame(
+            ['agent_run_id' => $runId, 'source_attributes' => ['material', 'color']],
+            $slot['provenance_meta'],
+        );
+    }
+
+    #[Test]
+    public function emptySourceAttributesListIsOmittedFromTheSlot(): void
+    {
+        $runId = Uuid::v7()->toRfc4122();
+        $value = $this->agentValue([
+            'agent_run_id' => $runId,
+            'source_attributes' => [],
+        ]);
+
+        $slot = $this->newRebuilder()->globalSlot($value);
+
+        self::assertSame(['agent_run_id' => $runId], $slot['provenance_meta']);
+    }
+
+    #[Test]
+    public function newFieldsWithoutAgentRunIdDoNotCreateAProvenanceMetaSlot(): void
+    {
+        // The cache-level provenance_meta is gated on agent_run_id (the
+        // badge signal); recipe_id/source_attributes alone must not
+        // start projecting for non-agent writes.
+        $value = $this->agentValue([
+            'source_attributes' => ['material'],
+            'recipe_id' => Uuid::v7()->toRfc4122(),
+        ]);
+
+        $slot = $this->newRebuilder()->globalSlot($value);
+
+        self::assertArrayNotHasKey('provenance_meta', $slot);
+    }
+
+    /**
+     * @param array<string, mixed> $meta
+     */
+    private function agentValue(array $meta): ObjectValue
+    {
+        $tenant = new Tenant('demo-test-'.bin2hex(random_bytes(2)), 'Demo');
+        $objectType = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $objectType->assignTenant($tenant);
+        $object = new CatalogObject($objectType, 'SKU-PROV-1');
+
+        $attribute = new Attribute('description', ['en' => 'Description'], AttributeType::Textarea);
+        $attribute->assignTenant($tenant);
+
+        $value = new ObjectValue($object, $attribute, ['value' => 'generated copy'], Provenance::Agent);
+        $value->updateProvenanceMeta($meta);
+
+        return $value;
+    }
+
+    private function newRebuilder(): AttributesIndexedRebuilder
+    {
+        $resolver = $this->createStub(EffectiveAttributeGroupResolver::class);
+        $resolver->method('resolve')->willReturn([]);
+        $resolver->method('loadGroupAttributes')->willReturn([]);
+
+        $scopes = $this->createStub(ScopeEnumeratorInterface::class);
+        $scopes->method('localeShortCodes')->willReturn([]);
+        $scopes->method('channelIdsByCode')->willReturn([]);
+
+        return new AttributesIndexedRebuilder(
+            $this->createStub(EntityManagerInterface::class),
+            $resolver,
+            $scopes,
+            $this->createStub(LocaleFallbackResolverInterface::class),
+        );
+    }
+}

--- a/docs/api/jsonb-schemas.md
+++ b/docs/api/jsonb-schemas.md
@@ -273,13 +273,15 @@ Lista reguł dwóch rodzajów:
     "agent_run_id": { "type": "string", "format": "uuid", "description": "provenance=agent — id AgentRun (epik 0.7, tabela agent_runs)" },
     "model": { "type": "string", "description": "provenance=agent — id modelu Anthropic użytego w runie (np. claude-sonnet-*)" },
     "intent": { "type": "string", "description": "provenance=agent — intencja usera, z której powstała zmiana (skrót)" },
-    "channel": { "type": "string", "description": "Integration channel id jeśli provenance=integration" }
+    "channel": { "type": "string", "description": "Integration channel id jeśli provenance=integration" },
+    "source_attributes": { "type": "array", "items": { "type": "string" }, "description": "provenance=agent, opcjonalne (AICG) — kody atrybutów-źródeł użytych jako fakty przy generowaniu treści (audyt „skąd ten fakt")" },
+    "recipe_id": { "type": ["string", "null"], "format": "uuid", "description": "provenance=agent, opcjonalne (AICG) — id ContentRecipe, z którego wygenerowano wartość" }
   },
   "additionalProperties": true
 }
 ```
 
-### Shape per provenance=agent (AGENT-P0-04 #1947, ADR-0024)
+### Shape per provenance=agent (AGENT-P0-04 #1947, ADR-0024; rozszerzenie AICG-P0-02 #2326, ADR-0030)
 
 Wartości zapisane przez agenta (po akcepcie batcha `pending_changes`) niosą:
 
@@ -288,6 +290,22 @@ Wartości zapisane przez agenta (po akcepcie batcha `pending_changes`) niosą:
 ```
 
 `agent_run_id` linkuje wartość do runu (audyt + tooltip badge'a „agent" w UI, P6-05).
+
+Wartości wygenerowane przez **toole treści** (epik AICG, ADR-0030) niosą dodatkowo dwa opcjonalne pola:
+
+```json
+{
+  "agent_run_id": "<uuid AgentRun>",
+  "model": "claude-sonnet-…",
+  "intent": "generate_product_description",
+  "source_attributes": ["material", "color", "brand"],
+  "recipe_id": "<uuid ContentRecipe|null>"
+}
+```
+
+- `source_attributes` — dokładnie te kody atrybutów, których wartości weszły do promptu jako fakty (kontrakt anty-halucynacyjny: audyt „skąd ten fakt"). Brak pola = zapis sprzed AICG lub nie-treściowy; readery traktują jak `[]`.
+- `recipe_id` — `ContentRecipe`, według którego pisano. Brak pola / `null` = generacja bez przepisu; readery traktują jak `null`.
+- **Backward compatibility:** oba pola są czysto addytywne (reguła cross-cutting #2) — zapisy `provenance_meta` sprzed rozszerzenia parsują bez zmian, a projekcja do `attributes_indexed` (`AttributesIndexedRebuilder::globalSlot`) przepuszcza je tylko, gdy są obecne i poprawnie typowane (malformed → dropped, nigdy nie propagowane).
 
 ### Reguły
 


### PR DESCRIPTION
## AICG-P0-02 — rozszerzenie `provenance_meta` o `source_attributes` + `recipe_id`

Kontrakt anty-halucynacyjny (ADR-0030) wymaga audytu „skąd ten fakt": po generacji treści zapisujemy, **których atrybutów** model użył i **z jakiego przepisu**. Ten PR przygotowuje reader/writer envelope, zanim powstaną toole (M3+).

### Zmiany
- **`docs/api/jsonb-schemas.md §5`** — schema envelope + `source_attributes: string[]` i `recipe_id: uuid|null` (oba opcjonalne, addytywne — reguła cross-cutting #2); nowy przykład shape dla tooli treści + semantyka braku pól (readery → `[]`/`null`).
- **`AttributesIndexedRebuilder::globalSlot`** — projekcja do cache przepuszcza nowe pola, gdy obecne i poprawnie typowane; malformed shapes dropped (reguła #1); gate na `agent_run_id` bez zmian (provenance_meta w cache ⇒ zapis agentowy); legacy rows zachowują dokładnie kształt sprzed AICG.
- **`AttributesIndexedProvenanceSlotTest`** (unit, 6 case'ów): komplet pól → projekcja; legacy bez pól → shape niezmieniony (test regresji wstecznej zgodności); malformed `recipe_id`/`source_attributes` → dropped; nie-stringi w liście → odfiltrowane; pusta lista → pominięta; nowe pola bez `agent_run_id` → brak slotu provenance_meta.

Writer commit-path (`PendingBatchCommitter::stampProvenanceMeta`) jest generycznym pass-through (`json_encode` dowolnej mapy) — nie wymagał zmian; kompozycja meta z realnymi wartościami to AICG-P3-01/P3-02.

### Bramki
- PHPUnit unit suite w kontenerze `pim-api-1`: **1516 testów zielone** (w tym 6 nowych).
- PHPStan max: 0 errors · Deptrac: 0 violations · php-cs-fixer: czysto.
- Bez zmian API/tras — OpenAPI snapshot nietknięty. Bez migracji (JSONB additive).

### Zakres świadomie poza PR
- Materializer treści zapisujący te pola — AICG-P3-01 (#2334).
- Badge/tooltip w UI czytający `source_attributes` — AICG-P5-02 (#2340).

Zmiana czysto backendowo-dokumentacyjna (nowe pola nigdzie jeszcze nie są komponowane), więc „Content smoke" z DoD nie ma tu żywego flow do kliknięcia — weryfikacja = testy jednostkowe projekcji + regresja wstecznej zgodności; live-smoke end-to-end nastąpi przy P3-02 (pierwszy tool treści).

Closes #2326
