### PR TITLE
fix(ci): allow Tooling to reach Export Catalog layers in deptrac

### DIFF
--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -546,6 +546,13 @@ parameters:
             - Shared
             - Import
             - Export
+            # CPDF P6-04 (#2440) — CatalogPdfBenchmarkCommand drives the real
+            # render pipeline (CatalogRenderService, template catalog, Dompdf)
+            # to measure production-shaped memory/time; same legitimate
+            # tooling cross-cut as Catalog_Internals above.
+            - Export_Contracts
+            - Export_Catalog_Internals
+            - Export_Catalog_Contracts
             - Vendor
 
     # Inline baseline of pre-existing cross-BC violations that the cleanup


### PR DESCRIPTION
## Hotfix: czerwony main po merge CPDF #2440 (deptrac Tooling × Export_Catalog)

**Root cause:** PR #2440 (CPDF P6-04, `CatalogPdfBenchmarkCommand` w `src/Benchmark/Export/`) został zmergowany z czerwonymi checkami `PHPUnit (unit,architecture)` i `Agent removability` — benchmark sięga realnego pipeline'u renderu (`CatalogRenderService`, katalog szablonów, `DompdfRenderer`, `Export_Contracts`), a ruleset `Tooling` w `deptrac.yaml` pochodzi sprzed splitu warstw `Export_Catalog_*` (#2362) i dopuszczał tylko starą warstwę `Export`. Efekt: **12 violations deptrac, main czerwony od `b7dee569`**, zamaskowany przez kolejne docs-only merge'e (path-filter nie odpalał PHP suite). Wyszło na CI PR #2444 (AICG-P0-02), który dziedziczy stan main.

**Fix:** dopisanie `Export_Contracts` + `Export_Catalog_Internals` + `Export_Catalog_Contracts` do rulesetu `Tooling` — ten sam uprawniony tooling cross-cut, co istniejące `Catalog_Internals` (benchmark mierzy produkcyjny kształt pipeline'u, więc z definicji dotyka internals mierzonego podsystemu).

**Weryfikacja:** `deptrac analyse --no-cache` w kontenerze `pim-api-1` → **Violations 0** (przed fixem: 12). Uwaga procesowa: lokalny deptrac z cache pokazywał zieleń — przy weryfikacji regresji architektury zawsze `--no-cache` (idzie też do lessons).

Naprawa czerwonego main — do merge'a od razu po zielonym CI, przed re-runem #2444.
