### PR TITLE
feat(agent): add ContentRecipe entity with tenant RLS

### DIFF
--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -6,9 +6,11 @@
 ## 2026-07-10: Epik AICG W TOKU — Generowanie treści AI (opisy + SEO), marathon #2325–#2346
 - **Sub-faza / epik:** AICG (22 tickety, M0–M6, milestone'y #59–#65, label `epik-AICG`). Backlog SoT: `Project Plan/feature-aicg-tickets.md`; plan: `Project Plan/UI/feature-ai-content-generation.md` (decyzje A–E zatwierdzone 2026-07-08). Tryb: marathon przez cały epik, jeden ticket = jeden PR.
 - **✅ AICG-P0-01 #2325 (PR #2443):** ADR przyjęty jako **ADR-0030** (nie 0028 z backlogu — 0028 zarezerwował równolegle GRID, 0029 WFL; wolny numer = pliki ∪ rezerwacje backlogowe). `docs/adr/0030-ai-content-generation-tools.md`: toole treści `kind=Write` w istniejącym ToolRegistry, wyjątek „agent-native" (silnik=LLM), ContentRecipe+BrandVoiceProfile w `src/Agent/` (removability), grounding kontraktowany + `insufficient_grounding`, zero auto-zapisu, SEO w przepisie nie schemacie, defaultModel+BYOK. Backlog + issue przenumerowane.
-- **🔄 AICG-P0-02 #2326 (w toku):** `provenance_meta` + opcjonalne `source_attributes`/`recipe_id` — spec `docs/api/jsonb-schemas.md §5` + projekcja `AttributesIndexedRebuilder::globalSlot` (pass-through gdy well-typed, malformed dropped, gate na `agent_run_id`) + unit test 6 case'ów.
-- **Ostatnie 3 akcje:** (1) merge PR #2443 + close #2325 z proofem, (2) rozszerzenie globalSlot + docs §5, (3) unit suite 1516 zielone w pim-api-1.
-- **Następny krok:** PR dla P0-02 → CI → merge → M1 (P1-01 ContentRecipe).
+- **✅ AICG-P0-02 #2326 (PR #2444):** `provenance_meta` + opcjonalne `source_attributes`/`recipe_id` — spec `docs/api/jsonb-schemas.md §5` + projekcja `AttributesIndexedRebuilder::globalSlot` (pass-through gdy well-typed, malformed dropped, gate na `agent_run_id`) + unit test 6 case'ów. **M0 komplet.**
+- **⚠️ Hotfix czerwonego main (PR #2445):** PR #2440 (CPDF benchmark) wszedł z czerwonym deptrac (`Tooling` bez warstw `Export_Catalog_*` po splicie #2362) — 12 violations zamaskowanych przez docs-only merge'e; fix = ruleset Tooling + lessons (deptrac `--no-cache`, nie mergować z czerwonym checkiem).
+- **🔄 AICG-P1-01 #2327 (w toku):** encja `ContentRecipe` w `src/Agent/Domain/Entity/` + migracja `content_recipes` (RLS FORCE + super_admin bypass, UNIQUE(tenant_id,code)) + XML mapping + guard constraints (format∈{plain,html}) + testy (unit guard 8 case'ów zielone; kernel round-trip/izolacja/unique na CI). Smoke dev DB: migracja OK, RLS psql-proof (tenant A=1, tenant B=0).
+- **Ostatnie 3 akcje:** (1) merge #2444 + close #2326 z proofem, (2) hotfix deptrac #2445 merged, (3) P1-01 encja+migracja+smoke RLS na dev DB.
+- **Następny krok:** PR P1-01 → CI → merge → P1-02 BrandVoiceProfile (drafty gotowe).
 - **Blokery:** brak.
 
 ## 2026-07-10: ✅ EPIK CPDF ZAMKNIĘTY — Katalogi PDF (27/27 ticketów, M0–M6, #2282–#2308)

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -125,8 +125,10 @@ parameters:
               # Agent entities as an fnmatch PATTERN, not file paths — the
               # removability CI job (AGENT-P0-09) deletes src/Agent and
               # PHPStan hard-errors on non-existent ignore paths; a pattern
-              # matching nothing is legal.
-              - src/Agent/Domain/Entity/Agent*.php
+              # matching nothing is legal. Covers Agent* orchestration
+              # entities and the AICG configuration entities (ContentRecipe,
+              # BrandVoiceProfile — AICG-P1-01/02).
+              - src/Agent/Domain/Entity/*.php
               - src/Catalog/Domain/Entity/PendingChange.php
               - src/Channel/Domain/Entity/Channel.php
               - src/Channel/Domain/Entity/ChannelCategoryNode.php

--- a/apps/api/src/Agent/Domain/Entity/ContentRecipe.php
+++ b/apps/api/src/Agent/Domain/Entity/ContentRecipe.php
@@ -1,0 +1,277 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Domain\Entity;
+
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use InvalidArgumentException;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AICG-P1-01 (#2327, ADR-0030) — a reusable "how to write" configuration
+ * for the content-generation tools (the Akeneo *AI Configurations*
+ * counterpart): which attribute the generated text targets, which
+ * attribute codes feed the grounding as facts, and the constraints the
+ * output must satisfy (format, length, SEO rules).
+ *
+ * Lives in the removable Agent BC on purpose: a recipe is useless
+ * without the LLM engine, so it disappears with `rm -rf src/Agent`
+ * (ADR-0030 decision 3). Cross-BC references (`objectTypeId`,
+ * `brandVoiceId`) are bare UUIDs per ADR-0015 — never Doctrine
+ * associations into Catalog/Agent aggregates.
+ *
+ * `constraints` shape (plan §6.3):
+ *   {format: 'plain'|'html', max_len?: int, seo?: {keyword?, title_len?, meta_len?}}
+ * The guard only pins the slots the engine relies on (format enum,
+ * source attribute codes as strings); SEO rules stay free-form for the
+ * SeoRulesValidator (AICG-P4-01) — decision C: rules live in the
+ * recipe, not the schema.
+ */
+class ContentRecipe implements TenantScoped
+{
+    public const string FORMAT_PLAIN = 'plain';
+    public const string FORMAT_HTML = 'html';
+    private const array ALLOWED_FORMATS = [self::FORMAT_PLAIN, self::FORMAT_HTML];
+
+    private Uuid $id;
+    private ?Tenant $tenant = null;
+    private string $code;
+    private string $name;
+    private ?Uuid $objectTypeId;
+    /**
+     * Optional scope narrowing (category / channel), free-form envelope.
+     *
+     * @var array<string, mixed>
+     */
+    private array $appliesTo = [];
+    private string $targetAttribute;
+    /** @var list<string> attribute codes fed to the grounding as facts */
+    private array $sourceAttributes = [];
+    /** @var array<string, mixed> */
+    private array $constraints = [];
+    private ?string $toneHint = null;
+    private ?Uuid $brandVoiceId = null;
+    private bool $isBuiltIn = false;
+    private DateTimeImmutable $createdAt;
+    private DateTimeImmutable $updatedAt;
+
+    /**
+     * @param array<mixed>         $sourceAttributes attribute codes — validated to non-empty strings and reindexed
+     * @param array<string, mixed> $constraints
+     */
+    public function __construct(
+        string $code,
+        string $name,
+        string $targetAttribute,
+        array $sourceAttributes = [],
+        array $constraints = [],
+        ?Uuid $objectTypeId = null,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->code = $code;
+        $this->name = $name;
+        $this->targetAttribute = $targetAttribute;
+        $this->sourceAttributes = self::guardSourceAttributes($sourceAttributes);
+        $this->constraints = self::guardConstraints($constraints);
+        $this->objectTypeId = $objectTypeId;
+        $now = new DateTimeImmutable();
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant already assigned.');
+        }
+        $this->tenant = $tenant;
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function rename(string $name): void
+    {
+        $this->name = $name;
+        $this->touch();
+    }
+
+    public function getObjectTypeId(): ?Uuid
+    {
+        return $this->objectTypeId;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getAppliesTo(): array
+    {
+        return $this->appliesTo;
+    }
+
+    /**
+     * @param array<string, mixed> $appliesTo
+     */
+    public function updateAppliesTo(array $appliesTo): void
+    {
+        $this->appliesTo = $appliesTo;
+        $this->touch();
+    }
+
+    public function getTargetAttribute(): string
+    {
+        return $this->targetAttribute;
+    }
+
+    public function retarget(string $targetAttribute): void
+    {
+        $this->targetAttribute = $targetAttribute;
+        $this->touch();
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getSourceAttributes(): array
+    {
+        return $this->sourceAttributes;
+    }
+
+    /**
+     * @param array<mixed> $sourceAttributes attribute codes — validated to non-empty strings and reindexed
+     */
+    public function updateSourceAttributes(array $sourceAttributes): void
+    {
+        $this->sourceAttributes = self::guardSourceAttributes($sourceAttributes);
+        $this->touch();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getConstraints(): array
+    {
+        return $this->constraints;
+    }
+
+    /**
+     * @param array<string, mixed> $constraints
+     */
+    public function updateConstraints(array $constraints): void
+    {
+        $this->constraints = self::guardConstraints($constraints);
+        $this->touch();
+    }
+
+    public function getToneHint(): ?string
+    {
+        return $this->toneHint;
+    }
+
+    public function updateToneHint(?string $toneHint): void
+    {
+        $this->toneHint = $toneHint;
+        $this->touch();
+    }
+
+    public function getBrandVoiceId(): ?Uuid
+    {
+        return $this->brandVoiceId;
+    }
+
+    public function attachBrandVoice(?Uuid $brandVoiceId): void
+    {
+        $this->brandVoiceId = $brandVoiceId;
+        $this->touch();
+    }
+
+    public function isBuiltIn(): bool
+    {
+        return $this->isBuiltIn;
+    }
+
+    /**
+     * @internal seeders only (AICG-P1-04) — built-in recipes are cloned,
+     * never edited in place; there is deliberately no way back to false
+     */
+    public function markBuiltIn(): void
+    {
+        $this->isBuiltIn = true;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    /**
+     * @param array<mixed> $sourceAttributes
+     *
+     * @return list<string>
+     */
+    private static function guardSourceAttributes(array $sourceAttributes): array
+    {
+        foreach ($sourceAttributes as $code) {
+            if (!\is_string($code) || '' === $code) {
+                throw new InvalidArgumentException('source_attributes must be a list of non-empty attribute codes.');
+            }
+        }
+
+        return array_values($sourceAttributes);
+    }
+
+    /**
+     * @param array<string, mixed> $constraints
+     *
+     * @return array<string, mixed>
+     */
+    private static function guardConstraints(array $constraints): array
+    {
+        if (\array_key_exists('format', $constraints) && !\in_array($constraints['format'], self::ALLOWED_FORMATS, true)) {
+            throw new InvalidArgumentException(\sprintf(
+                'constraints.format must be one of [%s].',
+                implode(', ', self::ALLOWED_FORMATS),
+            ));
+        }
+        if (\array_key_exists('max_len', $constraints) && (!\is_int($constraints['max_len']) || $constraints['max_len'] < 1)) {
+            throw new InvalidArgumentException('constraints.max_len must be a positive integer.');
+        }
+        if (\array_key_exists('seo', $constraints) && !\is_array($constraints['seo'])) {
+            throw new InvalidArgumentException('constraints.seo must be an object.');
+        }
+
+        return $constraints;
+    }
+
+    private function touch(): void
+    {
+        $this->updatedAt = new DateTimeImmutable();
+    }
+}

--- a/apps/api/src/Agent/Infrastructure/Doctrine/Orm/Mapping/ContentRecipe.orm.xml
+++ b/apps/api/src/Agent/Infrastructure/Doctrine/Orm/Mapping/ContentRecipe.orm.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Agent\Domain\Entity\ContentRecipe" table="content_recipes">
+        <indexes>
+            <index name="idx_content_recipes_object_type" columns="tenant_id,object_type_id"/>
+        </indexes>
+        <unique-constraints>
+            <unique-constraint name="uniq_content_recipes_code" columns="tenant_id,code"/>
+        </unique-constraints>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <field name="code" type="string" length="128"/>
+        <field name="name" type="string" length="255"/>
+        <field name="objectTypeId" type="uuid" column="object_type_id" nullable="true"/>
+
+        <field name="appliesTo" type="json" column="applies_to">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+
+        <field name="targetAttribute" type="string" length="128" column="target_attribute"/>
+
+        <field name="sourceAttributes" type="json" column="source_attributes">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+
+        <field name="constraints" type="json" column="constraints_config">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+
+        <field name="toneHint" type="string" length="255" column="tone_hint" nullable="true"/>
+        <field name="brandVoiceId" type="uuid" column="brand_voice_id" nullable="true"/>
+
+        <field name="isBuiltIn" type="boolean" column="is_built_in">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
+
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+        <field name="updatedAt" type="datetime_immutable" column="updated_at"/>
+    </entity>
+</doctrine-mapping>

--- a/apps/api/src/Agent/Infrastructure/Migrations/Version20260710080000.php
+++ b/apps/api/src/Agent/Infrastructure/Migrations/Version20260710080000.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AgentMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * AICG-P1-01 (#2327, ADR-0030) — content_recipes: the reusable "how to
+ * write" configuration for the content-generation tools.
+ *
+ * Module-namespace migration (ADR-0024 a): ships inside src/Agent and
+ * disappears with it. TenantScoped with Postgres RLS (FORCE, NULLIF
+ * predicate + WITH CHECK, super-admin bypass) — same pattern as
+ * agent_runs (AGENT-P1-01). `object_type_id` / `brand_voice_id` are
+ * bare UUIDs (ADR-0015), deliberately without cross-BC FKs.
+ */
+final class Version20260710080000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'AICG-P1-01: content_recipes + tenant RLS policies';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE content_recipes (
+                id UUID NOT NULL,
+                tenant_id UUID NOT NULL,
+                code VARCHAR(128) NOT NULL,
+                name VARCHAR(255) NOT NULL,
+                object_type_id UUID DEFAULT NULL,
+                applies_to JSONB NOT NULL,
+                target_attribute VARCHAR(128) NOT NULL,
+                source_attributes JSONB NOT NULL,
+                constraints_config JSONB NOT NULL,
+                tone_hint VARCHAR(255) DEFAULT NULL,
+                brand_voice_id UUID DEFAULT NULL,
+                is_built_in BOOLEAN DEFAULT false NOT NULL,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY(id)
+            )
+            SQL);
+        $this->addSql('CREATE UNIQUE INDEX uniq_content_recipes_code ON content_recipes (tenant_id, code)');
+        $this->addSql('CREATE INDEX idx_content_recipes_object_type ON content_recipes (tenant_id, object_type_id)');
+        $this->addSql(
+            'ALTER TABLE content_recipes ADD CONSTRAINT fk_content_recipes_tenant '
+            .'FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE RESTRICT NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+
+        $predicate = "tenant_id = NULLIF(current_setting('app.current_tenant', true), '')::uuid";
+        $this->addSql('ALTER TABLE content_recipes ENABLE ROW LEVEL SECURITY');
+        $this->addSql('ALTER TABLE content_recipes FORCE ROW LEVEL SECURITY');
+        $this->addSql(\sprintf(
+            'CREATE POLICY tenant_isolation_content_recipes ON content_recipes USING (%s) WITH CHECK (%s)',
+            $predicate,
+            $predicate,
+        ));
+        $this->addSql(
+            'CREATE POLICY super_admin_bypass_content_recipes ON content_recipes '
+            ."USING (current_setting('app.is_super_admin', true) = 'true') "
+            ."WITH CHECK (current_setting('app.is_super_admin', true) = 'true')"
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP POLICY IF EXISTS super_admin_bypass_content_recipes ON content_recipes');
+        $this->addSql('DROP POLICY IF EXISTS tenant_isolation_content_recipes ON content_recipes');
+        $this->addSql('ALTER TABLE content_recipes NO FORCE ROW LEVEL SECURITY');
+        $this->addSql('ALTER TABLE content_recipes DISABLE ROW LEVEL SECURITY');
+        $this->addSql('DROP TABLE content_recipes');
+    }
+}

--- a/apps/api/tests/Integration/Agent/ContentRecipeEntityTest.php
+++ b/apps/api/tests/Integration/Agent/ContentRecipeEntityTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Agent;
+
+use App\Agent\Domain\Entity\ContentRecipe;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * AICG-P1-01 (#2327) — ContentRecipe against real Postgres: round-trip
+ * of the full column set, tenant isolation (cross-read = 0, DoD), and
+ * the UNIQUE(tenant_id, code) constraint (same code allowed for two
+ * tenants, rejected within one).
+ */
+final class ContentRecipeEntityTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function recipeRoundTripsWithFullColumnSet(): void
+    {
+        $tenant = $this->createTenant('alpha');
+        $this->activateTenantFilter($tenant);
+        $em = $this->em();
+
+        $objectTypeId = Uuid::v7();
+        $brandVoiceId = Uuid::v7();
+        $recipe = new ContentRecipe(
+            code: 'product_description',
+            name: 'Opis produktu',
+            targetAttribute: 'description',
+            sourceAttributes: ['material', 'color'],
+            constraints: ['format' => 'html', 'max_len' => 1200, 'seo' => ['keyword' => 'HDMI']],
+            objectTypeId: $objectTypeId,
+        );
+        $recipe->updateAppliesTo(['channel' => 'b2c']);
+        $recipe->updateToneHint('ekspercki, zwięzły');
+        $recipe->attachBrandVoice($brandVoiceId);
+
+        $em->persist($recipe);
+        $em->flush();
+        $em->clear();
+
+        $reloaded = $em->find(ContentRecipe::class, $recipe->getId());
+        self::assertNotNull($reloaded);
+        self::assertSame('product_description', $reloaded->getCode());
+        self::assertSame(['material', 'color'], $reloaded->getSourceAttributes());
+        self::assertSame('html', $reloaded->getConstraints()['format']);
+        self::assertSame(['channel' => 'b2c'], $reloaded->getAppliesTo());
+        self::assertSame('ekspercki, zwięzły', $reloaded->getToneHint());
+        self::assertTrue($objectTypeId->equals($reloaded->getObjectTypeId() ?? Uuid::v4()));
+        self::assertTrue($brandVoiceId->equals($reloaded->getBrandVoiceId() ?? Uuid::v4()));
+        self::assertFalse($reloaded->isBuiltIn());
+    }
+
+    #[Test]
+    public function recipesAreIsolatedByTenantFilter(): void
+    {
+        $alpha = $this->createTenant('alpha');
+        $beta = $this->createTenant('beta');
+        $em = $this->em();
+
+        $this->activateTenantFilter($alpha);
+        $recipe = new ContentRecipe('alpha_recipe', 'Alpha', 'description');
+        $em->persist($recipe);
+        $em->flush();
+        $em->clear();
+
+        $this->activateTenantFilter($beta);
+        self::assertNull(
+            $em->find(ContentRecipe::class, $recipe->getId()),
+            'TenantFilter must hide alpha recipes from beta context',
+        );
+        self::assertCount(0, $em->getRepository(ContentRecipe::class)->findAll());
+
+        $em->clear();
+        $this->activateTenantFilter($alpha);
+        self::assertNotNull($em->find(ContentRecipe::class, $recipe->getId()));
+    }
+
+    #[Test]
+    public function sameCodeIsAllowedAcrossTenantsButUniqueWithinOne(): void
+    {
+        $alpha = $this->createTenant('alpha');
+        $beta = $this->createTenant('beta');
+        $em = $this->em();
+
+        $this->activateTenantFilter($alpha);
+        $em->persist(new ContentRecipe('meta_seo', 'Meta SEO', 'meta_description'));
+        $em->flush();
+        $em->clear();
+
+        $this->activateTenantFilter($beta);
+        $em->persist(new ContentRecipe('meta_seo', 'Meta SEO', 'meta_description'));
+        $em->flush();
+        $em->clear();
+
+        $this->activateTenantFilter($alpha);
+        $em->persist(new ContentRecipe('meta_seo', 'Duplicate', 'meta_description'));
+
+        $this->expectException(UniqueConstraintViolationException::class);
+        $em->flush();
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function createTenant(string $code): Tenant
+    {
+        $em = $this->em();
+        $tenant = new Tenant($code, ucfirst($code).' Tenant');
+        $em->persist($tenant);
+        $em->flush();
+
+        return $tenant;
+    }
+
+    private function activateTenantFilter(Tenant $tenant): void
+    {
+        $managed = $this->em()->find(Tenant::class, $tenant->getId()->toRfc4122());
+        \assert($managed instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($managed);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+    }
+}

--- a/apps/api/tests/Unit/Agent/Domain/ContentRecipeGuardTest.php
+++ b/apps/api/tests/Unit/Agent/Domain/ContentRecipeGuardTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Agent\Domain;
+
+use App\Agent\Domain\Entity\ContentRecipe;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * AICG-P1-01 (#2327) — shape guards of the ContentRecipe aggregate:
+ * `constraints.format` is pinned to plain|html and `source_attributes`
+ * to non-empty string codes; everything else in `constraints` stays
+ * free-form for the SEO validator (decision C, ADR-0030).
+ */
+final class ContentRecipeGuardTest extends TestCase
+{
+    #[Test]
+    public function acceptsPlainAndHtmlFormatsWithSeoSlots(): void
+    {
+        $recipe = new ContentRecipe(
+            code: 'product_description',
+            name: 'Opis produktu',
+            targetAttribute: 'description',
+            sourceAttributes: ['material', 'color', 'brand'],
+            constraints: ['format' => ContentRecipe::FORMAT_HTML, 'max_len' => 1200, 'seo' => ['keyword' => 'HDMI', 'title_len' => 60, 'meta_len' => 155]],
+        );
+
+        self::assertSame(['material', 'color', 'brand'], $recipe->getSourceAttributes());
+        self::assertSame('html', $recipe->getConstraints()['format']);
+        self::assertFalse($recipe->isBuiltIn());
+    }
+
+    #[Test]
+    public function rejectsUnknownFormat(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('constraints.format');
+
+        new ContentRecipe('r', 'R', 'description', [], ['format' => 'markdown']);
+    }
+
+    #[Test]
+    public function rejectsUnknownFormatOnUpdate(): void
+    {
+        $recipe = new ContentRecipe('r', 'R', 'description');
+
+        $this->expectException(InvalidArgumentException::class);
+        $recipe->updateConstraints(['format' => 'pdf']);
+    }
+
+    #[Test]
+    public function rejectsNonPositiveMaxLen(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('max_len');
+
+        new ContentRecipe('r', 'R', 'description', [], ['format' => 'plain', 'max_len' => 0]);
+    }
+
+    #[Test]
+    public function rejectsNonObjectSeoSlot(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('constraints.seo');
+
+        new ContentRecipe('r', 'R', 'description', [], ['seo' => 'keyword=HDMI']);
+    }
+
+    #[Test]
+    public function rejectsEmptyOrNonStringSourceAttributeCodes(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('source_attributes');
+
+        new ContentRecipe('r', 'R', 'description', ['material', '']);
+    }
+
+    #[Test]
+    public function reindexesSourceAttributesToAList(): void
+    {
+        $recipe = new ContentRecipe('r', 'R', 'description');
+        $recipe->updateSourceAttributes([2 => 'material', 5 => 'color']);
+
+        self::assertSame(['material', 'color'], $recipe->getSourceAttributes());
+    }
+
+    #[Test]
+    public function builtInFlagIsOneWay(): void
+    {
+        $recipe = new ContentRecipe('r', 'R', 'description');
+        $recipe->markBuiltIn();
+
+        self::assertTrue($recipe->isBuiltIn());
+    }
+}


### PR DESCRIPTION
## AICG-P1-01 — encja `ContentRecipe` z tenant RLS

Pierwszy byt domenowy epiku AICG (ADR-0030): reużywalny „przepis" — jak pisać treść (target-pole, atrybuty-źródła jako fakty groundingu, ograniczenia formatu/długości/SEO). Na nim opierają się grounding (P2-01), toole (P3/P4) i CRUD (P1-03).

### Zmiany
- **`src/Agent/Domain/Entity/ContentRecipe.php`** — aggregate root wg planu §6.3: `code`, `name`, `objectTypeId` (bare UUID, ADR-0015), `appliesTo` JSONB, `targetAttribute`, `sourceAttributes` JSONB, `constraints` JSONB (kolumna `constraints_config`), `toneHint`, `brandVoiceId` (bare UUID), `isBuiltIn` (one-way, seedery), timestamps. W Agent BC — znika z `rm -rf src/Agent` (removability, ADR-0030 decyzja 3).
- **Guardy kształtu**: `constraints.format` ∈ {plain, html}; `max_len` > 0; `seo` = obiekt; `source_attributes` = niepuste stringi (reindeks do listy). Reszta `constraints` celowo free-form — reguły SEO żyją w przepisie, waliduje je `SeoRulesValidator` (P4-01, decyzja C).
- **Migracja `AgentMigrations\Version20260710080000`** — `content_recipes` z `tenant_id NOT NULL` + FK do tenants, `UNIQUE(tenant_id, code)`, indeks `(tenant_id, object_type_id)`, RLS: ENABLE+FORCE, `tenant_isolation_*` (NULLIF predicate, USING+WITH CHECK) + `super_admin_bypass_*` — wzorzec 1:1 z `agent_runs`.
- **XML mapping** w `Infrastructure/Doctrine/Orm/Mapping` (ADR-0011); `doctrine:schema:validate` → „The mapping files are correct", `content_recipes` nieobecne w schema-diff po migracji.
- **`phpstan.dist.neon`**: pattern ignore `?Tenant` write-window rozszerzony `Agent*.php` → `*.php` (nadal fnmatch — legalny przy removability delete).

### Testy
- **Unit (`ContentRecipeGuardTest`, 8 case'ów, zielone lokalnie)**: format plain/html + sloty SEO, odrzucenie nieznanego formatu (create+update), max_len ≤ 0, seo nie-obiekt, pusty kod atrybutu, reindeks listy, one-way built-in.
- **Kernel (`ContentRecipeEntityTest`, CI)**: round-trip pełnego zestawu kolumn, **izolacja TenantFilter (cross-read = 0, DoD)**, UNIQUE(tenant_id, code) — ten sam kod w 2 tenantach OK / duplikat w jednym → `UniqueConstraintViolationException`.

### Smoke (dev DB, wykonany)
- `doctrine:migrations:migrate` → OK (1 migracja, 8 SQL).
- psql: `pg_policy` pokazuje obie polityki; `relforcerowsecurity = t`.
- **Izolacja RLS jako `pim_app`**: INSERT z GUC tenanta A → `count=1` w kontekście A, **`count=0` w kontekście B**, cleanup czysty.

### Bramki lokalnie (pim-api-1)
PHPStan max 0 errors · Deptrac `--no-cache` 0 violations · cs-fixer czysto · unit test 8/8. Kernel-suity → CI (lokalny harness ich nie odpala).

Poza zakresem (kolejne tickety): BrandVoiceProfile (P1-02), CRUD+RBAC (P1-03), seedy (P1-04), grounding (M2).

Closes #2327
