### PR TITLE
feat(agent): seed built-in content recipes and default brand voice

### DIFF
--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -10,9 +10,10 @@
 - **⚠️ Hotfix czerwonego main (PR #2445):** PR #2440 (CPDF benchmark) wszedł z czerwonym deptrac (`Tooling` bez warstw `Export_Catalog_*` po splicie #2362) — 12 violations zamaskowanych przez docs-only merge'e; fix = ruleset Tooling + lessons (deptrac `--no-cache`, nie mergować z czerwonym checkiem).
 - **✅ AICG-P1-01 #2327 (PR #2446):** encja `ContentRecipe` + migracja `content_recipes` (RLS FORCE, UNIQUE(tenant_id,code)) + guardy (format∈{plain,html}); smoke RLS psql-proof (A=1, B=0).
 - **✅ AICG-P1-02 #2328 (PR #2447):** encja `BrandVoiceProfile` + migracja (RLS FORCE + partial unique is_default per tenant); smoke: izolacja A=1/B=0, druga default → ERROR unique. Lekcja: testowa baza z mappingów ORM (nie migracji) — partial indexes re-wydawane w teście.
-- **🔄 AICG-P1-03 #2329 (w toku):** CRUD API Platform dla obu bytów (`/api/content-recipes`, `/api/brand-voice-profiles`) + moduł RBAC `settings.ai_content` (read/create/admin; voter w Agent BC — core nie importuje Agent) + built-in read-only + custom route clone + transakcyjny swap defaultu + OpenAPI snapshot. **Live smoke wykonany:** POST 201 / GET / clone 201 / PATCH 200 / default-swap / viewer 403 (GET+POST); artefakty posprzątane.
-- **Ostatnie 3 akcje:** (1) merge #2447 + close #2328, (2) P1-03 pełna powierzchnia CRUD+RBAC+testy API (10 case'ów), (3) live smoke na pim.localhost z provisioningiem permissions na dev DB.
-- **Następny krok:** PR P1-03 → CI → merge → P1-04 seedy.
+- **✅ AICG-P1-03 #2329 (PR #2448):** CRUD API Platform obu bytów + moduł RBAC `settings.ai_content` (voter w Agent BC), built-in read-only + clone route, transakcyjny swap defaultu, OpenAPI snapshot; live smoke: 201/403 viewer/clone/swap.
+- **🔄 AICG-P1-04 #2330 (w toku):** `AiContentDefaultsSeeder` + komenda `pim:agent:seed-content-defaults` (Agent BC — core fixtures nie importują Agent); live: 2 tenanty × (2 built-in przepisy + 1 default głos), re-run idempotentny 0; fix RLS GUC w konsoli przez `RlsTenantGuard::reassert`.
+- **Ostatnie 3 akcje:** (1) merge #2448 + close #2329 z proofem live-smoke, (2) P1-04 seeder+komenda+testy, (3) live seed na dev DB (3+3, re-run 0) + weryfikacja przez API.
+- **Następny krok:** PR P1-04 → CI → merge → **M2** (P2-01 grounding).
 - **Blokery:** brak.
 
 ## 2026-07-10: ✅ EPIK CPDF ZAMKNIĘTY — Katalogi PDF (27/27 ticketów, M0–M6, #2282–#2308)

--- a/apps/api/src/Agent/Application/Content/AiContentDefaultsSeeder.php
+++ b/apps/api/src/Agent/Application/Content/AiContentDefaultsSeeder.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Content;
+
+use App\Agent\Domain\Entity\BrandVoiceProfile;
+use App\Agent\Domain\Entity\ContentRecipe;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\RlsTenantGuard;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * AICG-P1-04 (#2330, ADR-0030) — idempotent per-tenant seeder of the
+ * built-in content-generation defaults (the Akeneo built-in AI
+ * Configurations counterpart): an editor starts from working templates,
+ * not an empty form.
+ *
+ *   - "Opis produktu" — HTML product description grounded in the
+ *     standard fact attributes,
+ *   - "Meta SEO" — plain-text meta description with the default SEO
+ *     length budget (title ~60 / meta ~155),
+ *   - one default BrandVoiceProfile ("ekspercki, zwięzły").
+ *
+ * Built-in recipes are read-only in the CRUD (AICG-P1-03) — editors
+ * clone them. The voice profile is seeded as default only when the
+ * tenant has no default yet (never steals an operator's choice).
+ * Lives in the removable Agent BC and is invoked from the module's own
+ * console command — core fixtures must not import App\Agent\*
+ * (ADR-0024 a); dev/demo tenants get the defaults via that command.
+ *
+ * Idempotent: matching by recipe code / built-in flag, re-runs are
+ * no-ops.
+ */
+final readonly class AiContentDefaultsSeeder
+{
+    public const string RECIPE_PRODUCT_DESCRIPTION = 'product_description';
+    public const string RECIPE_META_SEO = 'meta_seo';
+
+    public function __construct(
+        private EntityManagerInterface $em,
+        private TenantContext $tenantContext,
+        private RlsTenantGuard $rls,
+    ) {
+    }
+
+    /**
+     * @return int number of rows actually created (0 = idempotent no-op)
+     */
+    public function seed(Tenant $tenant): int
+    {
+        $previous = $this->tenantContext->get();
+        $this->tenantContext->set($tenant);
+        // Console invocations have no HTTP listener / worker middleware to
+        // bind the RLS GUC - without it FORCE RLS rejects the INSERTs.
+        $this->rls->reassert($tenant);
+
+        try {
+            $created = 0;
+            $created += $this->seedRecipes($tenant);
+            $created += $this->seedDefaultVoice($tenant);
+
+            if ($created > 0) {
+                $this->em->flush();
+            }
+
+            return $created;
+        } finally {
+            if (null === $previous) {
+                $this->tenantContext->clear();
+            } else {
+                $this->tenantContext->set($previous);
+            }
+        }
+    }
+
+    private function seedRecipes(Tenant $tenant): int
+    {
+        $recipes = $this->em->getRepository(ContentRecipe::class);
+        $created = 0;
+
+        if (null === $recipes->findOneBy(['code' => self::RECIPE_PRODUCT_DESCRIPTION, 'tenant' => $tenant])) {
+            $description = new ContentRecipe(
+                code: self::RECIPE_PRODUCT_DESCRIPTION,
+                name: 'Opis produktu',
+                targetAttribute: 'description',
+                sourceAttributes: ['material', 'dimensions', 'features', 'color', 'category', 'brand'],
+                constraints: ['format' => ContentRecipe::FORMAT_HTML, 'max_len' => 1500],
+            );
+            $description->updateToneHint('neutralny, rzeczowy');
+            $description->markBuiltIn();
+            $this->em->persist($description);
+            ++$created;
+        }
+
+        if (null === $recipes->findOneBy(['code' => self::RECIPE_META_SEO, 'tenant' => $tenant])) {
+            $seo = new ContentRecipe(
+                code: self::RECIPE_META_SEO,
+                name: 'Meta SEO',
+                targetAttribute: 'meta_description',
+                sourceAttributes: ['name', 'category', 'brand', 'features'],
+                constraints: [
+                    'format' => ContentRecipe::FORMAT_PLAIN,
+                    'seo' => ['title_len' => 60, 'meta_len' => 155],
+                ],
+            );
+            $seo->markBuiltIn();
+            $this->em->persist($seo);
+            ++$created;
+        }
+
+        return $created;
+    }
+
+    private function seedDefaultVoice(Tenant $tenant): int
+    {
+        $voices = $this->em->getRepository(BrandVoiceProfile::class);
+        if (null !== $voices->findOneBy(['isDefault' => true, 'tenant' => $tenant])) {
+            return 0;
+        }
+
+        $voice = new BrandVoiceProfile(
+            name: 'Domyślny głos marki',
+            tone: 'ekspercki, zwięzły',
+            examples: [[
+                'good' => 'Rama z anodowanego aluminium utrzymuje 120 kg przy wadze własnej 1,8 kg.',
+                'bad' => 'Mega lekka i super wytrzymała rama w okazyjnej cenie!!!',
+            ]],
+        );
+        $voice->markDefault(true);
+        $this->em->persist($voice);
+
+        return 1;
+    }
+}

--- a/apps/api/src/Agent/Presentation/Command/SeedAiContentDefaultsCommand.php
+++ b/apps/api/src/Agent/Presentation/Command/SeedAiContentDefaultsCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Presentation\Command;
+
+use App\Agent\Application\Content\AiContentDefaultsSeeder;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * AICG-P1-04 (#2330) — seeds the built-in content recipes + default
+ * brand voice for every tenant (or one, via --tenant). Idempotent;
+ * ships with the removable Agent BC — core fixtures must not import
+ * App\Agent\*, so dev/demo provisioning goes through this command.
+ */
+#[AsCommand(
+    name: 'pim:agent:seed-content-defaults',
+    description: 'Seed built-in content recipes and the default brand voice per tenant (idempotent).',
+)]
+final class SeedAiContentDefaultsCommand extends Command
+{
+    public function __construct(
+        private readonly AiContentDefaultsSeeder $seeder,
+        private readonly EntityManagerInterface $em,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('tenant', null, InputOption::VALUE_REQUIRED, 'Seed a single tenant by code instead of all tenants.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $tenantCode = $input->getOption('tenant');
+
+        $criteria = \is_string($tenantCode) && '' !== $tenantCode ? ['code' => $tenantCode] : [];
+        /** @var list<Tenant> $tenants */
+        $tenants = $this->em->getRepository(Tenant::class)->findBy($criteria);
+        if ([] === $tenants) {
+            $io->error(\is_string($tenantCode) ? \sprintf('Tenant "%s" not found.', $tenantCode) : 'No tenants found.');
+
+            return Command::FAILURE;
+        }
+
+        $total = 0;
+        foreach ($tenants as $tenant) {
+            $created = $this->seeder->seed($tenant);
+            $total += $created;
+            $io->writeln(\sprintf('%s: %d row(s) created', $tenant->getCode(), $created));
+        }
+
+        $io->success(\sprintf('Done — %d row(s) created across %d tenant(s).', $total, \count($tenants)));
+
+        return Command::SUCCESS;
+    }
+}

--- a/apps/api/tests/Integration/Agent/AiContentDefaultsSeederTest.php
+++ b/apps/api/tests/Integration/Agent/AiContentDefaultsSeederTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Agent;
+
+use App\Agent\Application\Content\AiContentDefaultsSeeder;
+use App\Agent\Domain\Entity\BrandVoiceProfile;
+use App\Agent\Domain\Entity\ContentRecipe;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * AICG-P1-04 (#2330) — the built-in defaults seeder: two built-in
+ * recipes + one default voice per tenant, idempotent re-runs, never
+ * steals an operator-chosen default, per-tenant scoping.
+ */
+final class AiContentDefaultsSeederTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function seedsTwoBuiltInRecipesAndADefaultVoice(): void
+    {
+        $tenant = $this->createTenant('alpha');
+
+        $created = $this->seeder()->seed($tenant);
+
+        self::assertSame(3, $created);
+        $this->activateTenantFilter($tenant);
+        $recipes = $this->em()->getRepository(ContentRecipe::class)->findBy(['isBuiltIn' => true]);
+        self::assertCount(2, $recipes);
+        $codes = array_map(static fn (ContentRecipe $r): string => $r->getCode(), $recipes);
+        sort($codes);
+        self::assertSame(['meta_seo', 'product_description'], $codes);
+
+        $default = $this->em()->getRepository(BrandVoiceProfile::class)->findOneBy(['isDefault' => true]);
+        self::assertNotNull($default);
+        self::assertSame('ekspercki, zwięzły', $default->getTone());
+    }
+
+    #[Test]
+    public function reRunIsAnIdempotentNoOp(): void
+    {
+        $tenant = $this->createTenant('alpha');
+        $seeder = $this->seeder();
+
+        self::assertSame(3, $seeder->seed($tenant));
+        self::assertSame(0, $seeder->seed($tenant));
+
+        $this->activateTenantFilter($tenant);
+        self::assertCount(2, $this->em()->getRepository(ContentRecipe::class)->findAll());
+        self::assertCount(1, $this->em()->getRepository(BrandVoiceProfile::class)->findAll());
+    }
+
+    #[Test]
+    public function neverStealsAnExistingOperatorDefaultVoice(): void
+    {
+        $tenant = $this->createTenant('alpha');
+        $this->activateTenantFilter($tenant);
+        $em = $this->em();
+
+        $operatorVoice = new BrandVoiceProfile('Głos operatora', 'swobodny');
+        $operatorVoice->markDefault(true);
+        $em->persist($operatorVoice);
+        $em->flush();
+
+        // Recipes still seed (2), the voice does not (operator default wins).
+        self::assertSame(2, $this->seeder()->seed($tenant));
+
+        $default = $em->getRepository(BrandVoiceProfile::class)->findOneBy(['isDefault' => true]);
+        self::assertNotNull($default);
+        self::assertSame('Głos operatora', $default->getName());
+        self::assertCount(1, $em->getRepository(BrandVoiceProfile::class)->findAll());
+    }
+
+    #[Test]
+    public function eachTenantGetsItsOwnDefaults(): void
+    {
+        $alpha = $this->createTenant('alpha');
+        $beta = $this->createTenant('beta');
+        $seeder = $this->seeder();
+
+        self::assertSame(3, $seeder->seed($alpha));
+        self::assertSame(3, $seeder->seed($beta));
+
+        $this->activateTenantFilter($beta);
+        self::assertCount(2, $this->em()->getRepository(ContentRecipe::class)->findAll());
+        self::assertCount(1, $this->em()->getRepository(BrandVoiceProfile::class)->findAll());
+    }
+
+    private function seeder(): AiContentDefaultsSeeder
+    {
+        return self::getContainer()->get(AiContentDefaultsSeeder::class);
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function createTenant(string $code): Tenant
+    {
+        $em = $this->em();
+        $tenant = new Tenant($code, ucfirst($code).' Tenant');
+        $em->persist($tenant);
+        $em->flush();
+
+        return $tenant;
+    }
+
+    private function activateTenantFilter(Tenant $tenant): void
+    {
+        $managed = $this->em()->find(Tenant::class, $tenant->getId()->toRfc4122());
+        \assert($managed instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($managed);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+    }
+}


### PR DESCRIPTION
## AICG-P1-04 — seedy built-in przepisów + domyślny głos marki

Redaktor zaczyna od gotowca (odpowiednik built-in AI Configurations Akeneo), nie od pustego formularza. Domyka **M1**.

### Zmiany
- **`AiContentDefaultsSeeder`** (`src/Agent/Application/Content/`) — idempotentny seeder per tenant:
  - built-in „Opis produktu" (`product_description`): target `description`, source = material/dimensions/features/color/category/brand, `format=html`, `max_len=1500`, ton neutralny;
  - built-in „Meta SEO" (`meta_seo`): target `meta_description`, `format=plain`, `constraints.seo={title_len:60, meta_len:155}`;
  - 1 domyślny `BrandVoiceProfile` („ekspercki, zwięzły" + przykład tak/nie) — seedowany **tylko gdy tenant nie ma defaultu** (nigdy nie zabiera wyboru operatora).
- **Komenda `pim:agent:seed-content-defaults [--tenant CODE]`** — jedyny punkt wywołania: core fixtures (`AppFixtures`) nie mogą importować `App\Agent\*` (removability ADR-0024a), więc provisioning dev/demo idzie przez komendę modułu (znika razem z nim).
- **Fix RLS w konsoli:** komendy nie mają listenera HTTP ani middleware workera bindującego GUC `app.current_tenant` — pierwsza próba padła na `42501 new row violates row-level security policy`. Seeder re-asertuje GUC przez istniejący `RlsTenantGuard::reassert()` (dokładnie jego przeznaczenie, #2156).
- Zapytania idempotencji z jawnym `tenant` w kryteriach (nie polegają na aktywności TenantFilter w konsoli — wzorzec `BuiltInObjectTypeSeeder`).

### Testy (kernel, CI)
`AiContentDefaultsSeederTest` — 4 case'y: (1) po seedzie 2 built-in przepisy (`meta_seo` + `product_description`) + 1 default głos; (2) **re-run = 0 wierszy** (idempotencja); (3) istniejący default operatora NIE jest kradziony (seeduje tylko 2 przepisy); (4) każdy tenant dostaje własny komplet (izolacja).
Klonowalność built-in pokryta w P1-03 (`builtInRecipesAreReadOnlyAndCloneable`).

### Live smoke (dev DB, wykonany)
- `pim:agent:seed-content-defaults` → **demo: 3, acme: 3**; re-run → **0 + 0** (nie 4 przepisy — AC idempotencji).
- Weryfikacja przez API P1-03 (`GET /api/content-recipes` jako admin@demo): `[('product_description', builtIn=True), ('meta_seo', builtIn=True)]`; `GET /api/brand-voice-profiles`: `[('Domyślny głos marki', default=True)]`.

### Bramki lokalnie (pim-api-1)
PHPStan max 0 · Deptrac --no-cache 0 · cs-fixer czysto. Kernel-suita → CI.

Closes #2330
