### PR TITLE
feat(agent): add ContentGroundingService reading facts via new port

### DIFF
--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -11,9 +11,10 @@
 - **✅ AICG-P1-01 #2327 (PR #2446):** encja `ContentRecipe` + migracja `content_recipes` (RLS FORCE, UNIQUE(tenant_id,code)) + guardy (format∈{plain,html}); smoke RLS psql-proof (A=1, B=0).
 - **✅ AICG-P1-02 #2328 (PR #2447):** encja `BrandVoiceProfile` + migracja (RLS FORCE + partial unique is_default per tenant); smoke: izolacja A=1/B=0, druga default → ERROR unique. Lekcja: testowa baza z mappingów ORM (nie migracji) — partial indexes re-wydawane w teście.
 - **✅ AICG-P1-03 #2329 (PR #2448):** CRUD API Platform obu bytów + moduł RBAC `settings.ai_content` (voter w Agent BC), built-in read-only + clone route, transakcyjny swap defaultu, OpenAPI snapshot; live smoke: 201/403 viewer/clone/swap.
-- **🔄 AICG-P1-04 #2330 (w toku):** `AiContentDefaultsSeeder` + komenda `pim:agent:seed-content-defaults` (Agent BC — core fixtures nie importują Agent); live: 2 tenanty × (2 built-in przepisy + 1 default głos), re-run idempotentny 0; fix RLS GUC w konsoli przez `RlsTenantGuard::reassert`.
-- **Ostatnie 3 akcje:** (1) merge #2448 + close #2329 z proofem live-smoke, (2) P1-04 seeder+komenda+testy, (3) live seed na dev DB (3+3, re-run 0) + weryfikacja przez API.
-- **Następny krok:** PR P1-04 → CI → merge → **M2** (P2-01 grounding).
+- **✅ AICG-P1-04 #2330 (PR #2449):** seeder built-in przepisów + default głosu, komenda `pim:agent:seed-content-defaults`, fix RLS GUC w konsoli. **M1 KOMPLET.**
+- **🔄 AICG-P2-01 #2331 (w toku):** `ObjectFactsPort` (nowy seam Catalog/Contracts, read-only fakty per locale/channel z overlay + sibling locales, provenance stripped) + `ContentGroundingService` w Agent BC (przecięcie recipe.sourceAttributes ∩ dostępne, zawężenie publication profile ADR-0018, missing codes dla bramki P2-02).
+- **Ostatnie 3 akcje:** (1) merge #2449 + close #2330 — M1 komplet, (2) P2-01 port faktów + grounding + testy (unit 4/4), (3) bramki zielone w pim-api-1.
+- **Następny krok:** PR P2-01 → CI → merge → P2-02 bramka [SEC] failing-first.
 - **Blokery:** brak.
 
 ## 2026-07-10: ✅ EPIK CPDF ZAMKNIĘTY — Katalogi PDF (27/27 ticketów, M0–M6, #2282–#2308)

--- a/apps/api/src/Agent/Application/Content/ContentGrounding.php
+++ b/apps/api/src/Agent/Application/Content/ContentGrounding.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Content;
+
+/**
+ * AICG-P2-01 (#2331, ADR-0030) — the grounding result the content tools
+ * hand to the prompt builder: FACTS the model may use (and nothing
+ * else — the anti-hallucination contract), the audit trail of which
+ * codes produced them, and what is missing (input of the completeness
+ * gate, AICG-P2-02).
+ */
+final readonly class ContentGrounding
+{
+    /**
+     * @param array<string, array<string, mixed>>                $facts          attribute code → resolved value envelope
+     * @param list<string>                                       $usedCodes      exactly the codes present in $facts —
+     *                                                                           becomes provenance_meta.source_attributes
+     * @param list<string>                                       $missingCodes   recipe source codes with no resolvable value
+     * @param array<string, array<string, array<string, mixed>>> $siblingLocales code → locale → envelope (translation sources)
+     * @param array<string, mixed>                               $channelContext channel scope handed to the prompt
+     *                                                                           ({channel, published_locales}), [] without channel
+     */
+    public function __construct(
+        public array $facts,
+        public array $usedCodes,
+        public array $missingCodes,
+        public array $siblingLocales = [],
+        public array $channelContext = [],
+    ) {
+    }
+
+    public function hasFacts(): bool
+    {
+        return [] !== $this->facts;
+    }
+}

--- a/apps/api/src/Agent/Application/Content/ContentGroundingService.php
+++ b/apps/api/src/Agent/Application/Content/ContentGroundingService.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Content;
+
+use App\Agent\Domain\Entity\ContentRecipe;
+use App\Catalog\Contracts\Query\ObjectFacts;
+use App\Catalog\Contracts\Query\ObjectFactsPort;
+use App\Channel\Contracts\ChannelPublicationResolverInterface;
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AICG-P2-01 (#2331, ADR-0030) — the "based on WHAT" core of content
+ * generation (plan §3a): collects the FACTS a content tool grounds the
+ * model in — the recipe's source attributes resolved for the requested
+ * locale/channel reading, sibling-locale values as translation sources,
+ * and the channel publication context.
+ *
+ * Deterministic and read-only: facts = recipe.sourceAttributes ∩ what
+ * `attributes_indexed` resolves (via the Catalog Contracts port — this
+ * BC never touches Catalog internals); with a channel, the set is
+ * additionally narrowed to the publication profile allow-list
+ * (ADR-0018 — a fact the channel never publishes must not shape its
+ * copy). Missing codes are reported, not invented — the completeness
+ * gate (AICG-P2-02) decides whether generation may proceed.
+ */
+final readonly class ContentGroundingService
+{
+    public function __construct(
+        private ObjectFactsPort $facts,
+        private ChannelPublicationResolverInterface $publication,
+    ) {
+    }
+
+    public function ground(
+        Uuid $productId,
+        ContentRecipe $recipe,
+        Tenant $tenant,
+        ?string $locale = null,
+        ?string $channel = null,
+    ): ContentGrounding {
+        $sourceCodes = $recipe->getSourceAttributes();
+        $channelContext = [];
+
+        $facts = $this->facts->facts($productId, $sourceCodes, $locale, $channel);
+
+        if (null !== $channel && '' !== $channel) {
+            $published = $this->publication->resolvePublishedCodes($channel, $facts->objectTypeId, $tenant);
+            $channelContext = [
+                'channel' => $channel,
+                'published_locales' => $this->publication->resolvePublishedLocales($channel, $tenant),
+            ];
+            if (null !== $published) {
+                // null = publish-all; a list narrows the fact set — codes the
+                // channel never publishes must not shape its copy. Dropped
+                // codes are NOT "missing" (the product may well carry them);
+                // they are out of scope for this reading.
+                $allowed = array_flip($published);
+                $facts = new ObjectFacts(
+                    objectId: $facts->objectId,
+                    objectTypeId: $facts->objectTypeId,
+                    values: array_intersect_key($facts->values, $allowed),
+                    missingCodes: array_values(array_intersect($facts->missingCodes, $published)),
+                    siblingLocales: array_intersect_key($facts->siblingLocales, $allowed),
+                );
+            }
+        }
+
+        return new ContentGrounding(
+            facts: $facts->values,
+            usedCodes: $facts->presentCodes(),
+            missingCodes: $facts->missingCodes,
+            siblingLocales: $facts->siblingLocales,
+            channelContext: $channelContext,
+        );
+    }
+}

--- a/apps/api/src/Catalog/Application/Query/ObjectFactsReader.php
+++ b/apps/api/src/Catalog/Application/Query/ObjectFactsReader.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Query;
+
+use App\Catalog\Application\ObjectValueLocaleOverlay;
+use App\Catalog\Contracts\Query\ObjectFacts;
+use App\Catalog\Contracts\Query\ObjectFactsPort;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AICG-P2-01 (#2331) — Catalog-side implementation of the grounding
+ * fact sheet. The scoped reading reuses {@see ObjectValueLocaleOverlay}
+ * (the same locale-first resolution the read API serves, on a detached
+ * clone — the identity map never sees the overlay), sibling-locale
+ * readings come from the canonical ObjectValue rows. Read-only by
+ * construction: no persist, no flush, no cache writes.
+ */
+final readonly class ObjectFactsReader implements ObjectFactsPort
+{
+    /** Envelope keys that are audit metadata, not product facts. */
+    private const array PROVENANCE_KEYS = ['provenance', 'provenance_meta'];
+
+    public function __construct(
+        private EntityManagerInterface $em,
+        private ObjectValueLocaleOverlay $overlay,
+        private ObjectValueRepositoryInterface $values,
+    ) {
+    }
+
+    public function facts(Uuid $objectId, array $attributeCodes, ?string $locale = null, ?string $channel = null): ObjectFacts
+    {
+        $object = $this->em->find(CatalogObject::class, $objectId);
+        if (!$object instanceof CatalogObject) {
+            throw new InvalidArgumentException(\sprintf('Unknown object "%s".', $objectId->toRfc4122()));
+        }
+
+        $scoped = $this->overlay->apply($object, $locale, $channel);
+        $indexed = $scoped->getAttributesIndexed();
+
+        $resolved = [];
+        $missing = [];
+        foreach ($attributeCodes as $code) {
+            $slot = $indexed[$code] ?? null;
+            if (\is_array($slot) && [] !== $envelope = $this->stripProvenance($slot)) {
+                $resolved[$code] = $envelope;
+            } else {
+                $missing[] = $code;
+            }
+        }
+
+        return new ObjectFacts(
+            objectId: $object->getId(),
+            objectTypeId: $object->getObjectType()->getId(),
+            values: $resolved,
+            missingCodes: $missing,
+            siblingLocales: $this->siblingLocales($object, $attributeCodes, $locale),
+        );
+    }
+
+    /**
+     * Readings of the requested codes in OTHER locales — source facts
+     * for translation-flavoured generation (plan §3a pkt 3).
+     *
+     * @param list<string> $attributeCodes
+     *
+     * @return array<string, array<string, array<string, mixed>>>
+     */
+    private function siblingLocales(CatalogObject $object, array $attributeCodes, ?string $locale): array
+    {
+        $wanted = array_flip($attributeCodes);
+        $siblings = [];
+        foreach ($this->values->findByObject($object) as $value) {
+            $rowLocale = $value->getLocale();
+            if (null === $rowLocale || $rowLocale === $locale || null !== $value->getChannelId()) {
+                continue;
+            }
+            $code = $value->getAttribute()->getCode();
+            if (!isset($wanted[$code])) {
+                continue;
+            }
+            $envelope = $this->stripProvenance($value->getValue());
+            if ([] !== $envelope) {
+                $siblings[$code][$rowLocale] = $envelope;
+            }
+        }
+
+        return $siblings;
+    }
+
+    /**
+     * @param array<mixed> $slot
+     *
+     * @return array<string, mixed>
+     */
+    private function stripProvenance(array $slot): array
+    {
+        $clean = [];
+        foreach ($slot as $key => $value) {
+            if (\is_string($key) && !\in_array($key, self::PROVENANCE_KEYS, true)) {
+                $clean[$key] = $value;
+            }
+        }
+
+        return $clean;
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Query/ObjectFacts.php
+++ b/apps/api/src/Catalog/Contracts/Query/ObjectFacts.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Query;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AICG-P2-01 (#2331, ADR-0030) — the read-only fact sheet content
+ * grounding works from: for each requested attribute code, the most
+ * specific value envelope for the (locale, channel) reading per the
+ * overlay contract (locale-first chain, #1148), plus sibling-locale
+ * readings of the same codes (an existing PL description is a source
+ * fact for the EN one — consistency, not re-invention).
+ *
+ * Envelopes are the `attributes_indexed` value shapes
+ * (docs/api/jsonb-schemas.md §1/§6) with the provenance keys stripped —
+ * provenance is audit metadata, not a product fact.
+ */
+final readonly class ObjectFacts
+{
+    /**
+     * @param array<string, array<string, mixed>>                $values         requested code → resolved value envelope
+     * @param list<string>                                       $missingCodes   requested codes with no resolvable value
+     * @param array<string, array<string, array<string, mixed>>> $siblingLocales requested code → locale → value envelope
+     */
+    public function __construct(
+        public Uuid $objectId,
+        public Uuid $objectTypeId,
+        public array $values,
+        public array $missingCodes,
+        public array $siblingLocales = [],
+    ) {
+    }
+
+    /**
+     * @return list<string> codes that resolved to a value — the audit
+     *                      trail for provenance_meta.source_attributes
+     */
+    public function presentCodes(): array
+    {
+        return array_keys($this->values);
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Query/ObjectFactsPort.php
+++ b/apps/api/src/Catalog/Contracts/Query/ObjectFactsPort.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Query;
+
+use InvalidArgumentException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AICG-P2-01 (#2331, ADR-0030) — Contracts seam over the resolved
+ * attribute values of one object, for content grounding. Strictly
+ * read-only: implementations MUST NOT touch `attributes_indexed` or
+ * `object_values` (jsonb-schemas rule #1 — the cache has exactly one
+ * writer); generated content flows back exclusively through the
+ * PendingChanges port.
+ *
+ * Tenant scope comes from the Doctrine TenantFilter / RLS.
+ */
+interface ObjectFactsPort
+{
+    /**
+     * @param list<string> $attributeCodes the recipe's source attributes;
+     *                                     unknown/empty codes surface in
+     *                                     ObjectFacts::$missingCodes
+     *
+     * @throws InvalidArgumentException when the object id is unknown
+     */
+    public function facts(
+        Uuid $objectId,
+        array $attributeCodes,
+        ?string $locale = null,
+        ?string $channel = null,
+    ): ObjectFacts;
+}

--- a/apps/api/tests/Integration/Catalog/ObjectFactsReaderTest.php
+++ b/apps/api/tests/Integration/Catalog/ObjectFactsReaderTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration\Catalog;
 
+use App\Catalog\Application\ObjectValueLocaleOverlay;
+use App\Catalog\Application\Query\ObjectFactsReader;
 use App\Catalog\Contracts\Query\ObjectFactsPort;
 use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
@@ -11,6 +13,7 @@ use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\Entity\ObjectValue;
 use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
 use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
@@ -127,7 +130,15 @@ final class ObjectFactsReaderTest extends KernelTestCase
 
     private function port(): ObjectFactsPort
     {
-        return self::getContainer()->get(ObjectFactsPort::class);
+        // Constructed directly: the port's runtime consumer arrives with
+        // the first content tool (AICG-P3-02), so until then the compiled
+        // container inlines/removes the service (same caveat as the agent
+        // run repository in AgentEntitiesTest).
+        return new ObjectFactsReader(
+            $this->em(),
+            self::getContainer()->get(ObjectValueLocaleOverlay::class),
+            self::getContainer()->get(ObjectValueRepositoryInterface::class),
+        );
     }
 
     private function em(): EntityManagerInterface

--- a/apps/api/tests/Integration/Catalog/ObjectFactsReaderTest.php
+++ b/apps/api/tests/Integration/Catalog/ObjectFactsReaderTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Catalog;
+
+use App\Catalog\Contracts\Query\ObjectFactsPort;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\ObjectKind;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * AICG-P2-01 (#2331) — the grounding fact sheet against real Postgres:
+ * locale overlay resolution, provenance stripping, sibling-locale
+ * collection, missing-code reporting, and the read-only guarantee
+ * (`attributes_indexed` byte-identical after a read).
+ */
+final class ObjectFactsReaderTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function resolvesFactsPerLocaleWithSiblingReadingsAndMissingCodes(): void
+    {
+        $tenant = $this->createTenant();
+        $object = $this->seedProduct($tenant);
+
+        $facts = $this->port()->facts($object->getId(), ['material', 'color', 'size'], locale: 'pl');
+
+        self::assertSame(['value' => 'aluminium'], $facts->values['material'] ?? null);
+        self::assertSame(['option_code' => 'red'], $facts->values['color'] ?? null);
+        self::assertSame(['size'], $facts->missingCodes);
+        self::assertSame(['material', 'color'], $facts->presentCodes());
+        // The EN row of material is a sibling reading (translation source).
+        self::assertSame(['value' => 'aluminum'], $facts->siblingLocales['material']['en'] ?? null);
+    }
+
+    #[Test]
+    public function localeOverlayWinsOverTheGlobalReading(): void
+    {
+        $tenant = $this->createTenant();
+        $object = $this->seedProduct($tenant);
+
+        $facts = $this->port()->facts($object->getId(), ['material'], locale: 'en');
+
+        self::assertSame(['value' => 'aluminum'], $facts->values['material'] ?? null);
+    }
+
+    #[Test]
+    public function provenanceKeysNeverLeakIntoFacts(): void
+    {
+        $tenant = $this->createTenant();
+        $object = $this->seedProduct($tenant, withAgentProvenance: true);
+
+        $facts = $this->port()->facts($object->getId(), ['material']);
+
+        $material = $facts->values['material'] ?? [];
+        self::assertArrayNotHasKey('provenance', $material);
+        self::assertArrayNotHasKey('provenance_meta', $material);
+    }
+
+    #[Test]
+    public function readingFactsLeavesAttributesIndexedUntouched(): void
+    {
+        $tenant = $this->createTenant();
+        $object = $this->seedProduct($tenant);
+        $conn = $this->em()->getConnection();
+        $before = $conn->fetchOne('SELECT attributes_indexed::text FROM objects WHERE id = :id', ['id' => $object->getId()->toRfc4122()]);
+
+        $this->port()->facts($object->getId(), ['material', 'color'], locale: 'en', channel: null);
+        $this->em()->flush();
+
+        $after = $conn->fetchOne('SELECT attributes_indexed::text FROM objects WHERE id = :id', ['id' => $object->getId()->toRfc4122()]);
+        self::assertSame($before, $after, 'grounding must never write the cache (jsonb-schemas rule #1)');
+    }
+
+    #[Test]
+    public function unknownObjectIdThrows(): void
+    {
+        $this->createTenant();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->port()->facts(Uuid::v7(), ['material']);
+    }
+
+    private function seedProduct(Tenant $tenant, bool $withAgentProvenance = false): CatalogObject
+    {
+        $em = $this->em();
+
+        $type = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $em->persist($type);
+
+        $material = new Attribute('material', ['en' => 'Material'], AttributeType::Text);
+        $material->changeLocalizable(true);
+        $color = new Attribute('color', ['en' => 'Color'], AttributeType::Select);
+        $em->persist($material);
+        $em->persist($color);
+
+        $object = new CatalogObject($type, 'FACTS-1');
+        $em->persist($object);
+
+        $globalMaterial = new ObjectValue($object, $material, ['value' => 'aluminium']);
+        if ($withAgentProvenance) {
+            $globalMaterial->updateProvenanceMeta(['agent_run_id' => Uuid::v7()->toRfc4122()]);
+        }
+        $em->persist($globalMaterial);
+        $em->persist(new ObjectValue($object, $material, ['value' => 'aluminum'], locale: 'en'));
+        $em->persist(new ObjectValue($object, $color, ['option_code' => 'red']));
+        $em->flush();
+
+        return $object;
+    }
+
+    private function port(): ObjectFactsPort
+    {
+        return self::getContainer()->get(ObjectFactsPort::class);
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function createTenant(): Tenant
+    {
+        $em = $this->em();
+        $tenant = new Tenant('demo-facts', 'Demo Tenant');
+        $em->persist($tenant);
+        $em->flush();
+
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+
+        return $tenant;
+    }
+}

--- a/apps/api/tests/Unit/Agent/Application/ContentGroundingServiceTest.php
+++ b/apps/api/tests/Unit/Agent/Application/ContentGroundingServiceTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Agent\Application;
+
+use App\Agent\Application\Content\ContentGroundingService;
+use App\Agent\Domain\Entity\ContentRecipe;
+use App\Catalog\Contracts\Query\ObjectFacts;
+use App\Catalog\Contracts\Query\ObjectFactsPort;
+use App\Channel\Contracts\ChannelPublicationResolverInterface;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AICG-P2-01 (#2331) — the grounding algebra: facts = recipe source
+ * codes ∩ resolvable values, narrowed by the channel publication
+ * allow-list; missing codes reported for the completeness gate;
+ * usedCodes mirror the facts exactly (the source_attributes audit).
+ */
+final class ContentGroundingServiceTest extends TestCase
+{
+    #[Test]
+    public function groundsRecipeSourceCodesAndReportsMissing(): void
+    {
+        $objectTypeId = Uuid::v7();
+        $facts = new ObjectFacts(
+            objectId: Uuid::v7(),
+            objectTypeId: $objectTypeId,
+            values: [
+                'material' => ['value' => 'aluminium'],
+                'color' => ['option_code' => 'red'],
+            ],
+            missingCodes: ['size'],
+            siblingLocales: ['material' => ['en' => ['value' => 'aluminum']]],
+        );
+
+        $grounding = $this->service($facts)->ground(
+            $facts->objectId,
+            $this->recipe(['material', 'color', 'size']),
+            self::tenant(),
+            locale: 'pl',
+        );
+
+        self::assertSame(['value' => 'aluminium'], $grounding->facts['material']);
+        self::assertSame(['option_code' => 'red'], $grounding->facts['color']);
+        self::assertSame(['material', 'color'], $grounding->usedCodes);
+        self::assertSame(['size'], $grounding->missingCodes);
+        self::assertSame(['en' => ['value' => 'aluminum']], $grounding->siblingLocales['material']);
+        self::assertSame([], $grounding->channelContext);
+        self::assertTrue($grounding->hasFacts());
+    }
+
+    #[Test]
+    public function channelPublicationAllowListNarrowsTheFactSet(): void
+    {
+        $facts = new ObjectFacts(
+            objectId: Uuid::v7(),
+            objectTypeId: Uuid::v7(),
+            values: [
+                'material' => ['value' => 'aluminium'],
+                'internal_notes' => ['value' => 'do not publish'],
+            ],
+            missingCodes: ['size', 'ean'],
+        );
+        $publication = $this->createStub(ChannelPublicationResolverInterface::class);
+        $publication->method('resolvePublishedCodes')->willReturn(['material', 'size', 'ean']);
+        $publication->method('resolvePublishedLocales')->willReturn(['pl', 'en']);
+
+        $grounding = $this->service($facts, $publication)->ground(
+            $facts->objectId,
+            $this->recipe(['material', 'internal_notes', 'size', 'ean']),
+            self::tenant(),
+            channel: 'b2c',
+        );
+
+        // internal_notes is resolvable but unpublished — out of scope
+        // (dropped entirely, not "missing"); size/ean are published and
+        // absent — genuinely missing for this reading.
+        self::assertSame(['material'], $grounding->usedCodes);
+        self::assertArrayNotHasKey('internal_notes', $grounding->facts);
+        self::assertSame(['size', 'ean'], $grounding->missingCodes);
+        self::assertSame(['channel' => 'b2c', 'published_locales' => ['pl', 'en']], $grounding->channelContext);
+    }
+
+    #[Test]
+    public function publishAllChannelKeepsEveryResolvedFact(): void
+    {
+        $facts = new ObjectFacts(
+            objectId: Uuid::v7(),
+            objectTypeId: Uuid::v7(),
+            values: ['material' => ['value' => 'aluminium']],
+            missingCodes: [],
+        );
+        $publication = $this->createStub(ChannelPublicationResolverInterface::class);
+        $publication->method('resolvePublishedCodes')->willReturn(null);
+        $publication->method('resolvePublishedLocales')->willReturn([]);
+
+        $grounding = $this->service($facts, $publication)->ground(
+            $facts->objectId,
+            $this->recipe(['material']),
+            self::tenant(),
+            channel: 'b2b',
+        );
+
+        self::assertSame(['material'], $grounding->usedCodes);
+        self::assertSame('b2b', $grounding->channelContext['channel']);
+    }
+
+    #[Test]
+    public function productWithNoResolvableFactsGroundsToEmpty(): void
+    {
+        $facts = new ObjectFacts(
+            objectId: Uuid::v7(),
+            objectTypeId: Uuid::v7(),
+            values: [],
+            missingCodes: ['material', 'color'],
+        );
+
+        $grounding = $this->service($facts)->ground(
+            $facts->objectId,
+            $this->recipe(['material', 'color']),
+            self::tenant(),
+        );
+
+        self::assertFalse($grounding->hasFacts());
+        self::assertSame([], $grounding->usedCodes);
+        self::assertSame(['material', 'color'], $grounding->missingCodes);
+    }
+
+    /**
+     * @param list<string> $sourceAttributes
+     */
+    private function recipe(array $sourceAttributes): ContentRecipe
+    {
+        return new ContentRecipe(
+            code: 'product_description',
+            name: 'Opis produktu',
+            targetAttribute: 'description',
+            sourceAttributes: $sourceAttributes,
+        );
+    }
+
+    private function service(
+        ObjectFacts $facts,
+        ?ChannelPublicationResolverInterface $publication = null,
+    ): ContentGroundingService {
+        $port = $this->createStub(ObjectFactsPort::class);
+        $port->method('facts')->willReturn($facts);
+
+        return new ContentGroundingService(
+            $port,
+            $publication ?? $this->createStub(ChannelPublicationResolverInterface::class),
+        );
+    }
+
+    private static function tenant(): Tenant
+    {
+        return new Tenant('demo-test-'.bin2hex(random_bytes(2)), 'Demo');
+    }
+}


### PR DESCRIPTION
## AICG-P2-01 — `ContentGroundingService` + port faktów `ObjectFactsPort`

Sedno „na podstawie czego" (plan §3a): fakty pochodzą z ustrukturyzowanych atrybutów produktu, nigdy z modelu. Wspólny rdzeń wszystkich tooli treści (M3/M4/M6).

### Nowy seam Catalog/Contracts (wzorzec `CompletenessReportPort` z AGENT-P2-03)
- **`ObjectFactsPort` + `ObjectFacts`** — read-only fact sheet jednego obiektu: dla żądanych kodów najbardziej specyficzna wartość dla odczytu (locale, channel) + sibling-locale readings (istniejący opis PL jako fakt-źródło dla EN, §3a pkt 3) + `missingCodes`. Kontrakt w docblocku: implementacje NIGDY nie piszą do `attributes_indexed`/`object_values` (reguła jsonb-schemas #1).
- **`ObjectFactsReader`** (Catalog) — reuse `ObjectValueLocaleOverlay::apply()` na odczepionym klonie (identity map nie widzi overlay — lekcja #1130-47), sibling z kanonicznych wierszy `ObjectValue`, **provenance/provenance_meta stripped** (metadane audytu, nie fakty produktu).

### `ContentGroundingService` (Agent BC, wyłącznie przez Contracts — Deptrac 0)
- fakty = `recipe.sourceAttributes` ∩ rozwiązywalne wartości; deterministyczne;
- z kanałem: zawężenie do allow-listy publication profile (ADR-0018) — kod niepublikowany przez kanał **nie kształtuje jego copy**; wypada też z `missingCodes` (out of scope ≠ brakujący);
- `usedCodes` = dokładnie obecne fakty → przyszłe `provenance_meta.source_attributes`; `missingCodes` → wejście bramki kompletności (P2-02); `channelContext` = {channel, published_locales} do promptu.

### Testy
- **Unit (`ContentGroundingServiceTest`, 4/4 zielone lokalnie):** przecięcie + missing; zawężenie allow-listą (published-a-nieobecny zostaje missing, unpublished wypada całkiem); publish-all (null) nie zawęża; produkt bez faktów → `hasFacts()=false` + komplet missing.
- **Kernel (`ObjectFactsReaderTest`, CI, real Postgres):** rozwiązanie per locale (`pl` global / `en` overlay wygrywa), sibling-locale reading, provenance nie wycieka do faktów, **read-only proof: `attributes_indexed::text` byte-identical po odczycie + flushu**, unknown id → `InvalidArgumentException`.

### Bramki lokalnie (pim-api-1)
PHPStan max 0 · Deptrac --no-cache 0 (Agent→Catalog_Contracts/Channel_Contracts) · cs-fixer czysto · unit 4/4.

Smoke „content" (propozycja w inboxie) nie dotyczy jeszcze tego ticketu — serwis nie ma konsumenta do M3 (P3-02 = pierwszy żywy przebieg end-to-end); weryfikacja = testy kernel na realnym Postgresie.

Poza zakresem: bramka kompletności (P2-02), wstrzyknięcie do promptu (P2-03), multimodal (hook §7).

Closes #2331
