### PR TITLE
feat(agent): add grounding completeness gate with structured verdict

### DIFF
--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -12,9 +12,10 @@
 - **✅ AICG-P1-02 #2328 (PR #2447):** encja `BrandVoiceProfile` + migracja (RLS FORCE + partial unique is_default per tenant); smoke: izolacja A=1/B=0, druga default → ERROR unique. Lekcja: testowa baza z mappingów ORM (nie migracji) — partial indexes re-wydawane w teście.
 - **✅ AICG-P1-03 #2329 (PR #2448):** CRUD API Platform obu bytów + moduł RBAC `settings.ai_content` (voter w Agent BC), built-in read-only + clone route, transakcyjny swap defaultu, OpenAPI snapshot; live smoke: 201/403 viewer/clone/swap.
 - **✅ AICG-P1-04 #2330 (PR #2449):** seeder built-in przepisów + default głosu, komenda `pim:agent:seed-content-defaults`, fix RLS GUC w konsoli. **M1 KOMPLET.**
-- **🔄 AICG-P2-01 #2331 (w toku):** `ObjectFactsPort` (nowy seam Catalog/Contracts, read-only fakty per locale/channel z overlay + sibling locales, provenance stripped) + `ContentGroundingService` w Agent BC (przecięcie recipe.sourceAttributes ∩ dostępne, zawężenie publication profile ADR-0018, missing codes dla bramki P2-02).
-- **Ostatnie 3 akcje:** (1) merge #2449 + close #2330 — M1 komplet, (2) P2-01 port faktów + grounding + testy (unit 4/4), (3) bramki zielone w pim-api-1.
-- **Następny krok:** PR P2-01 → CI → merge → P2-02 bramka [SEC] failing-first.
+- **✅ AICG-P2-01 #2331 (PR #2450):** `ObjectFactsPort` (seam Catalog/Contracts, read-only fakty + overlay locale/channel + sibling locales, provenance stripped) + `ContentGroundingService` (∩ recipe.sourceAttributes, zawężenie publication profile). Gotcha: port bez runtime-konsumenta inline'owany przez kontener → w kernel teście konstrukcja wprost.
+- **🔄 AICG-P2-02 #2332 (w toku, SEC):** `GroundingGate`+`GroundingVerdict` — failing-test-first w historii (commit 1 = czerwony spec, commit 2 = impl); verdict jako structured tool_result (nie wyjątek); progi z przepisu (`constraints.grounding.{min_facts,required}`, default min_facts=1).
+- **Ostatnie 3 akcje:** (1) merge #2450 + close #2331, (2) P2-02 failing-first commit + implementacja (6/6), (3) bramki zielone.
+- **Następny krok:** PR P2-02 → CI → merge → P2-03 prompt builder.
 - **Blokery:** brak.
 
 ## 2026-07-10: ✅ EPIK CPDF ZAMKNIĘTY — Katalogi PDF (27/27 ticketów, M0–M6, #2282–#2308)

--- a/apps/api/src/Agent/Application/Content/GroundingGate.php
+++ b/apps/api/src/Agent/Application/Content/GroundingGate.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Content;
+
+use App\Agent\Domain\Entity\ContentRecipe;
+
+/**
+ * AICG-P2-02 (#2332, SEC, ADR-0030) — "generate only when there is
+ * something to generate FROM" (plan §3a pkt 5, risk R2). Decides
+ * whether a grounding carries enough facts for generation:
+ *
+ *   - `constraints.grounding.required` — codes that must ALL resolve
+ *     (a spec sheet without dimensions is not a spec sheet),
+ *   - `constraints.grounding.min_facts` — minimum resolved fact count,
+ *     default 1: one hard fact beats an empty prompt, zero facts is
+ *     pure invention.
+ *
+ * Insufficient grounding is a structured verdict, never an exception —
+ * the tool returns it as tool_result and the model relays what is
+ * missing instead of hallucinating it.
+ */
+final readonly class GroundingGate
+{
+    private const int DEFAULT_MIN_FACTS = 1;
+
+    public function evaluate(ContentGrounding $grounding, ContentRecipe $recipe): GroundingVerdict
+    {
+        $rules = $this->groundingRules($recipe);
+        $presentFacts = \count($grounding->facts);
+
+        $minFacts = $rules['min_facts'] ?? self::DEFAULT_MIN_FACTS;
+        if (\is_int($minFacts) && $presentFacts < $minFacts) {
+            return GroundingVerdict::insufficient($grounding->missingCodes, $presentFacts);
+        }
+
+        $required = $rules['required'] ?? [];
+        if (\is_array($required)) {
+            foreach ($required as $code) {
+                if (\is_string($code) && !\array_key_exists($code, $grounding->facts)) {
+                    return GroundingVerdict::insufficient($grounding->missingCodes, $presentFacts);
+                }
+            }
+        }
+
+        return GroundingVerdict::sufficient($grounding->missingCodes, $presentFacts);
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function groundingRules(ContentRecipe $recipe): array
+    {
+        $slot = $recipe->getConstraints()['grounding'] ?? [];
+
+        return \is_array($slot) ? $slot : [];
+    }
+}

--- a/apps/api/src/Agent/Application/Content/GroundingVerdict.php
+++ b/apps/api/src/Agent/Application/Content/GroundingVerdict.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Content;
+
+/**
+ * AICG-P2-02 (#2332, ADR-0030) — the completeness gate's structured
+ * verdict. Deliberately NOT an exception: the executor treats refusals
+ * as tool_results the model can read and relay ("too little data to
+ * write this copy — fill material/size first"), same semantics as the
+ * forbidden-attribute results of GuardedToolExecutor.
+ */
+final readonly class GroundingVerdict
+{
+    public const string SUFFICIENT = 'sufficient';
+    public const string INSUFFICIENT = 'insufficient_grounding';
+
+    /**
+     * @param list<string> $missingCodes
+     */
+    private function __construct(
+        private string $status,
+        private array $missingCodes,
+        private int $presentFacts,
+    ) {
+    }
+
+    /**
+     * @param list<string> $missingCodes
+     */
+    public static function sufficient(array $missingCodes, int $presentFacts): self
+    {
+        return new self(self::SUFFICIENT, $missingCodes, $presentFacts);
+    }
+
+    /**
+     * @param list<string> $missingCodes
+     */
+    public static function insufficient(array $missingCodes, int $presentFacts): self
+    {
+        return new self(self::INSUFFICIENT, $missingCodes, $presentFacts);
+    }
+
+    public function isSufficient(): bool
+    {
+        return self::SUFFICIENT === $this->status;
+    }
+
+    public function status(): string
+    {
+        return $this->status;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function missingCodes(): array
+    {
+        return $this->missingCodes;
+    }
+
+    /**
+     * @return array{status: string, missing_source_attributes: list<string>, present_facts: int}
+     */
+    public function toToolResult(): array
+    {
+        return [
+            'status' => $this->status,
+            'missing_source_attributes' => $this->missingCodes,
+            'present_facts' => $this->presentFacts,
+        ];
+    }
+}

--- a/apps/api/tests/Unit/Agent/Application/GroundingGateTest.php
+++ b/apps/api/tests/Unit/Agent/Application/GroundingGateTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Agent\Application;
+
+use App\Agent\Application\Content\ContentGrounding;
+use App\Agent\Application\Content\GroundingGate;
+use App\Agent\Application\Content\GroundingVerdict;
+use App\Agent\Domain\Entity\ContentRecipe;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * AICG-P2-02 (#2332, SEC, ADR-0030) — the anti-hallucination fuse:
+ * "generate only when there is something to generate FROM" (plan §3a
+ * pkt 5, risk R2). Too few facts → a structured insufficient_grounding
+ * verdict the tool returns as tool_result — never an exception, never
+ * an attempt to generate.
+ *
+ * Written failing-first (SEC): these tests predate the gate
+ * implementation in the commit history.
+ */
+final class GroundingGateTest extends TestCase
+{
+    #[Test]
+    public function productWithNoFactsIsInsufficient(): void
+    {
+        $verdict = new GroundingGate()->evaluate(
+            $this->grounding(facts: [], missing: ['material', 'color']),
+            $this->recipe(['material', 'color']),
+        );
+
+        self::assertFalse($verdict->isSufficient());
+        self::assertSame(GroundingVerdict::INSUFFICIENT, $verdict->status());
+        self::assertSame(['material', 'color'], $verdict->missingCodes());
+    }
+
+    #[Test]
+    public function productWithAllFactsIsSufficient(): void
+    {
+        $verdict = new GroundingGate()->evaluate(
+            $this->grounding(facts: ['material' => ['value' => 'alu'], 'color' => ['option_code' => 'red']], missing: []),
+            $this->recipe(['material', 'color']),
+        );
+
+        self::assertTrue($verdict->isSufficient());
+        self::assertSame([], $verdict->missingCodes());
+    }
+
+    #[Test]
+    public function defaultThresholdIsAtLeastOneFact(): void
+    {
+        $verdict = new GroundingGate()->evaluate(
+            $this->grounding(facts: ['material' => ['value' => 'alu']], missing: ['color', 'size']),
+            $this->recipe(['material', 'color', 'size']),
+        );
+
+        self::assertTrue($verdict->isSufficient(), 'one hard fact beats an empty prompt — default min_facts = 1');
+        self::assertSame(['color', 'size'], $verdict->missingCodes());
+    }
+
+    #[Test]
+    public function recipeMayRaiseTheMinimumFactCount(): void
+    {
+        $recipe = $this->recipe(['material', 'color', 'size'], grounding: ['min_facts' => 2]);
+
+        $insufficient = new GroundingGate()->evaluate(
+            $this->grounding(facts: ['material' => ['value' => 'alu']], missing: ['color', 'size']),
+            $recipe,
+        );
+        $sufficient = new GroundingGate()->evaluate(
+            $this->grounding(
+                facts: ['material' => ['value' => 'alu'], 'color' => ['option_code' => 'red']],
+                missing: ['size'],
+            ),
+            $recipe,
+        );
+
+        self::assertFalse($insufficient->isSufficient());
+        self::assertTrue($sufficient->isSufficient());
+    }
+
+    #[Test]
+    public function recipeRequiredCodesMustAllBePresent(): void
+    {
+        $recipe = $this->recipe(['material', 'color', 'size'], grounding: ['required' => ['material', 'size']]);
+
+        $verdict = new GroundingGate()->evaluate(
+            $this->grounding(
+                facts: ['material' => ['value' => 'alu'], 'color' => ['option_code' => 'red']],
+                missing: ['size'],
+            ),
+            $recipe,
+        );
+
+        self::assertFalse($verdict->isSufficient(), 'a missing REQUIRED fact blocks generation even above min_facts');
+        self::assertContains('size', $verdict->missingCodes());
+    }
+
+    #[Test]
+    public function verdictIsAStructuredToolResultNotAnException(): void
+    {
+        $verdict = new GroundingGate()->evaluate(
+            $this->grounding(facts: [], missing: ['material']),
+            $this->recipe(['material']),
+        );
+
+        $payload = $verdict->toToolResult();
+        self::assertSame('insufficient_grounding', $payload['status']);
+        self::assertSame(['material'], $payload['missing_source_attributes']);
+        self::assertArrayHasKey('present_facts', $payload);
+        self::assertSame(0, $payload['present_facts']);
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $facts
+     * @param list<string>                        $missing
+     */
+    private function grounding(array $facts, array $missing): ContentGrounding
+    {
+        return new ContentGrounding(
+            facts: $facts,
+            usedCodes: array_keys($facts),
+            missingCodes: $missing,
+        );
+    }
+
+    /**
+     * @param list<string>         $sourceAttributes
+     * @param array<string, mixed> $grounding
+     */
+    private function recipe(array $sourceAttributes, array $grounding = []): ContentRecipe
+    {
+        $constraints = ['format' => ContentRecipe::FORMAT_PLAIN];
+        if ([] !== $grounding) {
+            $constraints['grounding'] = $grounding;
+        }
+
+        return new ContentRecipe(
+            code: 'gate_recipe',
+            name: 'Gate',
+            targetAttribute: 'description',
+            sourceAttributes: $sourceAttributes,
+            constraints: $constraints,
+        );
+    }
+}


### PR DESCRIPTION
## AICG-P2-02 — [SEC] bramka kompletności `insufficient_grounding`

Bezpiecznik anty-halucynacyjny (plan §3a pkt 5, ryzyko R2): „generuj tylko, gdy jest z czego". Za mało faktów → tool zwraca structured verdict, **nie zmyśla i nie rzuca wyjątkiem**.

### Failing-test-first (wymóg [SEC], widoczny w historii)
1. commit `80b72e9b test(agent): failing-first spec of the insufficient_grounding gate` — sam `GroundingGateTest` (6 case'ów), **czerwony** (klasy nie istnieją: Tests 6, Errors 6);
2. commit `f5f387ef feat(agent): add grounding completeness gate...` — `GroundingGate` + `GroundingVerdict`, testy zielone.

### Semantyka
- **`GroundingVerdict`** — `sufficient` | `insufficient_grounding` + `missingCodes` + `present_facts`; `toToolResult()` daje payload dla egzekutora (spójne z „forbidden jako tool_result" w `GuardedToolExecutor`, nie wyjątek).
- **Progi z przepisu, nie hardcode**: `constraints.grounding.required` (wszystkie muszą się rozwiązać — karta produktu bez wymiarów to nie karta) oraz `constraints.grounding.min_facts` (default **1** — jeden twardy fakt bije pusty prompt; zero faktów = czyste zmyślanie). Slot `grounding` przechodzi przez istniejący guard `constraints` bez zmian (free-form poza `format`/`max_len`/`seo`).
- Wejście = `ContentGrounding` z P2-01 (fakty już zawężone do publication profile — bramka ocenia realny odczyt, reuse sygnału kompletności z groundingu zamiast osobnej sondy `objects.completeness`; `CompletenessReportTool` pozostaje narzędziem raportowym).

### Case'y testowe
0 faktów → insufficient + komplet missing · komplet → sufficient · 1 fakt przy default → sufficient (missing raportowane dalej) · `min_facts=2` → 1 fakt insufficient / 2 sufficient · `required=[material,size]` → brak size blokuje mimo spełnionego min_facts · verdict jako structured tool_result (`status`/`missing_source_attributes`/`present_facts`).

### Bramki lokalnie (pim-api-1)
PHPUnit 6/6 · PHPStan max 0 · Deptrac --no-cache 0 · cs-fixer czysto.

Smoke live nie dotyczy (czysta logika bez endpointu/UI; pierwszy żywy przebieg z bramką = proof P3-02 #2335). Konsument: `GenerateProductDescriptionTool` (P3-02).

Closes #2332
