### PR TITLE
feat(agent): inject brand voice and recipe into the system prompt

### DIFF
--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -13,9 +13,11 @@
 - **✅ AICG-P1-03 #2329 (PR #2448):** CRUD API Platform obu bytów + moduł RBAC `settings.ai_content` (voter w Agent BC), built-in read-only + clone route, transakcyjny swap defaultu, OpenAPI snapshot; live smoke: 201/403 viewer/clone/swap.
 - **✅ AICG-P1-04 #2330 (PR #2449):** seeder built-in przepisów + default głosu, komenda `pim:agent:seed-content-defaults`, fix RLS GUC w konsoli. **M1 KOMPLET.**
 - **✅ AICG-P2-01 #2331 (PR #2450):** `ObjectFactsPort` (seam Catalog/Contracts, read-only fakty + overlay locale/channel + sibling locales, provenance stripped) + `ContentGroundingService` (∩ recipe.sourceAttributes, zawężenie publication profile). Gotcha: port bez runtime-konsumenta inline'owany przez kontener → w kernel teście konstrukcja wprost.
-- **🔄 AICG-P2-02 #2332 (w toku, SEC):** `GroundingGate`+`GroundingVerdict` — failing-test-first w historii (commit 1 = czerwony spec, commit 2 = impl); verdict jako structured tool_result (nie wyjątek); progi z przepisu (`constraints.grounding.{min_facts,required}`, default min_facts=1).
-- **Ostatnie 3 akcje:** (1) merge #2450 + close #2331, (2) P2-02 failing-first commit + implementacja (6/6), (3) bramki zielone.
-- **Następny krok:** PR P2-02 → CI → merge → P2-03 prompt builder.
+- **✅ AICG-P2-02 #2332 (PR #2451, SEC):** `GroundingGate`+`GroundingVerdict` — failing-first w historii; verdict jako structured tool_result; progi z przepisu (`constraints.grounding.{min_facts,required}`, default min_facts=1).
+- **🔄 AICG-P2-03 #2333 (w toku):** `AgentSystemPromptBuilder` + sekcje content (recipe: target/format/max_len/SEO/tone; brand voice: ton/glosariusz/banned/przykłady; kontrakt anty-halucynacyjny) gdy run niesie `recipe_id`/`brand_voice_id`; backward compat (prompt niezmieniony bez kluczy); głos przypięty do przepisu resolwowany gdy kontekst go nie nazywa.
+- **Decyzja operatora (2026-07-10, czat):** selektywne bundle PR-ów dla par producer–consumer: P4-01+P4-02, P5-01+P5-02, P5-04+P5-05 (~3 rundy CI mniej); [SEC] i granice BC bez zmian — osobno.
+- **Ostatnie 3 akcje:** (1) merge #2451 + close #2332, (2) P2-03 builder + 8 testów (28 asercji), (3) unit suite 1546 zielone.
+- **Następny krok:** PR P2-03 → CI → merge → **M3** (P3-01 materializer).
 - **Blokery:** brak.
 
 ## 2026-07-10: ✅ EPIK CPDF ZAMKNIĘTY — Katalogi PDF (27/27 ticketów, M0–M6, #2282–#2308)

--- a/apps/api/src/Agent/Application/Run/AgentSystemPromptBuilder.php
+++ b/apps/api/src/Agent/Application/Run/AgentSystemPromptBuilder.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace App\Agent\Application\Run;
 
 use App\Agent\Domain\Entity\AgentRun;
+use App\Agent\Domain\Entity\BrandVoiceProfile;
+use App\Agent\Domain\Entity\ContentRecipe;
+use Doctrine\ORM\EntityManagerInterface;
 
 use const JSON_UNESCAPED_SLASHES;
 use const JSON_UNESCAPED_UNICODE;
@@ -13,9 +16,19 @@ use const JSON_UNESCAPED_UNICODE;
  * AGENT-P1-03 (#1955) — deterministic system prompt of the loop
  * (PRD 5.2): ground plans in read tools, ask when ambiguous, write
  * only through approval-gated tools, never fabricate numbers.
+ *
+ * AICG-P2-03 (#2333, ADR-0030) — content-generation runs (recipe_id /
+ * brand_voice_id in the view context) additionally get the "how to
+ * write" sections: the recipe's output contract, the tenant's brand
+ * voice, and the hard anti-hallucination contract. Runs without those
+ * keys produce a byte-identical prompt.
  */
 final readonly class AgentSystemPromptBuilder
 {
+    public function __construct(private EntityManagerInterface $em)
+    {
+    }
+
     public function build(AgentRun $run): string
     {
         $context = $run->getContext();
@@ -24,6 +37,7 @@ final readonly class AgentSystemPromptBuilder
             : json_encode($context, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
         $scopeRule = $this->scopeRule($context);
+        $contentSections = $this->contentSections($context);
 
         return <<<PROMPT
             You are the catalog agent of a PIM system, acting strictly within the permissions of the initiating user.
@@ -37,7 +51,7 @@ final readonly class AgentSystemPromptBuilder
             - When you are done (proposal materialized or question asked), reply with a short plain-text summary in the user's language: for multi-step plans list each step with its numbers.{$scopeRule}
 
             View context of the initiating user (carry it into tool calls instead of asking for it):
-            {$contextJson}
+            {$contextJson}{$contentSections}
             PROMPT;
     }
 
@@ -66,5 +80,120 @@ final readonly class AgentSystemPromptBuilder
             : 'the whole list';
 
         return "\n            - SELECTION SCOPE: the operator has {$count} object(s) SELECTED in the list. The write tools default to this selection when you omit object_ids and filter_dsl - use that default. Only target {$totalPhrase} if the intent CLEARLY says so (e.g. \"all\", \"every\", \"the whole list\"). If it is not clear whether they mean the {$count} selected or {$totalPhrase}, ask ONE clarifying question first and stop.";
+    }
+
+    /**
+     * AICG-P2-03 (#2333) — the "how to write" block of content runs.
+     * Both ids resolve tenant-scoped (TenantFilter); an unknown id keeps
+     * the prompt baseline — the tool rejects the unknown recipe earlier
+     * with its own error. A recipe-attached voice is used when the
+     * context does not name one explicitly.
+     *
+     * @param array<string, mixed> $context
+     */
+    private function contentSections(array $context): string
+    {
+        $recipe = $this->loadRecipe($context['recipe_id'] ?? null);
+        $voice = $this->loadVoice($context['brand_voice_id'] ?? null);
+        if (null === $voice && null !== $recipe && null !== $recipe->getBrandVoiceId()) {
+            $voice = $this->loadVoice($recipe->getBrandVoiceId()->toRfc4122());
+        }
+
+        if (null === $recipe && null === $voice) {
+            return '';
+        }
+
+        $sections = '';
+        if (null !== $recipe) {
+            $sections .= $this->recipeSection($recipe);
+        }
+        if (null !== $voice) {
+            $sections .= $this->voiceSection($voice);
+        }
+
+        return $sections."\n\n            ANTI-HALLUCINATION CONTRACT for content generation:"
+            ."\n            - Use ONLY the facts provided in the grounding/tool results of this run."
+            ."\n            - NEVER state a parameter, number, feature or property that is absent from the provided facts."
+            ."\n            - When the facts are insufficient, say exactly what is missing instead of inventing it.";
+    }
+
+    private function loadRecipe(mixed $id): ?ContentRecipe
+    {
+        if (!\is_string($id) || '' === $id) {
+            return null;
+        }
+
+        return $this->em->find(ContentRecipe::class, $id);
+    }
+
+    private function loadVoice(mixed $id): ?BrandVoiceProfile
+    {
+        if (!\is_string($id) || '' === $id) {
+            return null;
+        }
+
+        return $this->em->find(BrandVoiceProfile::class, $id);
+    }
+
+    private function recipeSection(ContentRecipe $recipe): string
+    {
+        $constraints = $recipe->getConstraints();
+        $format = \is_string($constraints['format'] ?? null) ? $constraints['format'] : 'plain';
+        $maxLen = $constraints['max_len'] ?? null;
+        $lines = [
+            \sprintf('Content recipe "%s":', $recipe->getName()),
+            \sprintf('- Target attribute: %s', $recipe->getTargetAttribute()),
+            \sprintf('- Output format: %s%s', $format, \is_int($maxLen) ? \sprintf('; max length %d characters', $maxLen) : ''),
+        ];
+
+        $seo = $constraints['seo'] ?? null;
+        if (\is_array($seo) && [] !== $seo) {
+            $rules = [];
+            if (\is_string($seo['keyword'] ?? null) && '' !== $seo['keyword']) {
+                $rules[] = \sprintf('focus keyword "%s" must appear naturally', $seo['keyword']);
+            }
+            if (\is_int($seo['title_len'] ?? null)) {
+                $rules[] = \sprintf('title at most %d characters', $seo['title_len']);
+            }
+            if (\is_int($seo['meta_len'] ?? null)) {
+                $rules[] = \sprintf('meta description at most %d characters', $seo['meta_len']);
+            }
+            if ([] !== $rules) {
+                $lines[] = '- SEO rules: '.implode('; ', $rules).'. No keyword stuffing.';
+            }
+        }
+
+        $toneHint = $recipe->getToneHint();
+        if (null !== $toneHint && '' !== $toneHint) {
+            $lines[] = \sprintf('- Tone hint: %s', $toneHint);
+        }
+
+        return "\n\n            ".implode("\n            ", $lines);
+    }
+
+    private function voiceSection(BrandVoiceProfile $voice): string
+    {
+        $lines = [
+            \sprintf('Brand voice "%s":', $voice->getName()),
+            \sprintf('- Tone: %s', $voice->getTone()),
+        ];
+
+        if ([] !== $voice->getGlossary()) {
+            $terms = array_map(
+                static fn (array $entry): string => \sprintf('"%s" -> "%s"', $entry['term'], $entry['use']),
+                $voice->getGlossary(),
+            );
+            $lines[] = '- Imposed glossary (always use the right-hand phrasing): '.implode('; ', $terms);
+        }
+        if ([] !== $voice->getBannedWords()) {
+            $lines[] = '- Banned words (never use): '.implode(', ', $voice->getBannedWords());
+        }
+        $example = $voice->getExamples()[0] ?? null;
+        if (null !== $example) {
+            $lines[] = \sprintf('- GOOD copy example: "%s"', $example['good']);
+            $lines[] = \sprintf('- BAD copy example (never write like this): "%s"', $example['bad']);
+        }
+
+        return "\n\n            ".implode("\n            ", $lines);
     }
 }

--- a/apps/api/tests/Integration/Agent/AgentLoopRunnerTest.php
+++ b/apps/api/tests/Integration/Agent/AgentLoopRunnerTest.php
@@ -244,7 +244,7 @@ final class AgentLoopRunnerTest extends KernelTestCase
             registry: $registry,
             executor: new GuardedToolExecutor($registry, $em),
             models: $selector,
-            prompts: new AgentSystemPromptBuilder(),
+            prompts: new AgentSystemPromptBuilder($em),
             costs: new UsageCostCalculator($selector, 3.0, 15.0, 5.0, 25.0),
             tenantConfig: new class implements \App\Identity\Contracts\Byok\ByokConfigReaderInterface {
                 public function isProactiveScanEnabled(Tenant $tenant): bool

--- a/apps/api/tests/Integration/Agent/ModelSelectionTest.php
+++ b/apps/api/tests/Integration/Agent/ModelSelectionTest.php
@@ -146,7 +146,7 @@ final class ModelSelectionTest extends KernelTestCase
             registry: $registry,
             executor: new GuardedToolExecutor($registry, $em),
             models: $selector,
-            prompts: new AgentSystemPromptBuilder(),
+            prompts: new AgentSystemPromptBuilder($em),
             costs: new UsageCostCalculator($selector, 3.0, 15.0, 5.0, 25.0),
             tenantConfig: $tenantConfig,
             entityManager: $em,

--- a/apps/api/tests/Integration/Agent/PromptInjectionRedTeamTest.php
+++ b/apps/api/tests/Integration/Agent/PromptInjectionRedTeamTest.php
@@ -329,7 +329,7 @@ final class PromptInjectionRedTeamTest extends KernelTestCase
             registry: $registry,
             executor: new GuardedToolExecutor($registry, $em),
             models: $selector,
-            prompts: new AgentSystemPromptBuilder(),
+            prompts: new AgentSystemPromptBuilder($em),
             costs: new UsageCostCalculator($selector, 3.0, 15.0, 5.0, 25.0),
             tenantConfig: new class implements \App\Identity\Contracts\Byok\ByokConfigReaderInterface {
                 public function isProactiveScanEnabled(Tenant $tenant): bool

--- a/apps/api/tests/Unit/Agent/AgentSystemPromptBuilderTest.php
+++ b/apps/api/tests/Unit/Agent/AgentSystemPromptBuilderTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Agent;
 use App\Agent\Application\Run\AgentSystemPromptBuilder;
 use App\Agent\Domain\AgentRunSurface;
 use App\Agent\Domain\Entity\AgentRun;
+use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Uid\Uuid;
@@ -26,7 +27,7 @@ final class AgentSystemPromptBuilderTest extends TestCase
             'total_matching' => 95,
         ]);
 
-        $prompt = new AgentSystemPromptBuilder()->build($run);
+        $prompt = new AgentSystemPromptBuilder($this->createStub(EntityManagerInterface::class))->build($run);
 
         self::assertStringContainsString('SELECTION SCOPE', $prompt);
         self::assertStringContainsString('1 object(s) SELECTED', $prompt);
@@ -41,7 +42,7 @@ final class AgentSystemPromptBuilderTest extends TestCase
             'filter_dsl' => ['field' => 'brand', 'op' => 'eq', 'value' => 'Acme'],
         ]);
 
-        $prompt = new AgentSystemPromptBuilder()->build($run);
+        $prompt = new AgentSystemPromptBuilder($this->createStub(EntityManagerInterface::class))->build($run);
 
         self::assertStringNotContainsString('SELECTION SCOPE', $prompt);
     }
@@ -53,7 +54,7 @@ final class AgentSystemPromptBuilderTest extends TestCase
             'selected_ids' => [],
         ]);
 
-        $prompt = new AgentSystemPromptBuilder()->build($run);
+        $prompt = new AgentSystemPromptBuilder($this->createStub(EntityManagerInterface::class))->build($run);
 
         self::assertStringNotContainsString('SELECTION SCOPE', $prompt);
     }

--- a/apps/api/tests/Unit/Agent/Application/AgentSystemPromptContentTest.php
+++ b/apps/api/tests/Unit/Agent/Application/AgentSystemPromptContentTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Agent\Application;
+
+use App\Agent\Application\Run\AgentSystemPromptBuilder;
+use App\Agent\Domain\AgentRunSurface;
+use App\Agent\Domain\Entity\AgentRun;
+use App\Agent\Domain\Entity\BrandVoiceProfile;
+use App\Agent\Domain\Entity\ContentRecipe;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AICG-P2-03 (#2333, ADR-0030) — brand voice + recipe + the
+ * anti-hallucination contract are injected into the system prompt only
+ * when the run carries recipe_id / brand_voice_id; every other run
+ * produces a byte-identical prompt (backward compat).
+ */
+final class AgentSystemPromptContentTest extends TestCase
+{
+    #[Test]
+    public function runWithoutContentKeysProducesTheBaselinePrompt(): void
+    {
+        $em = $this->createStub(EntityManagerInterface::class);
+        $builder = new AgentSystemPromptBuilder($em);
+
+        $prompt = $builder->build($this->contentRun(['object_type' => 'product']));
+
+        self::assertStringNotContainsString('Brand voice', $prompt);
+        self::assertStringNotContainsString('Content recipe', $prompt);
+        self::assertStringNotContainsString('ANTI-HALLUCINATION', $prompt);
+    }
+
+    #[Test]
+    public function unknownRecipeIdKeepsThePromptBaseline(): void
+    {
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('find')->willReturn(null);
+        $builder = new AgentSystemPromptBuilder($em);
+
+        $prompt = $builder->build($this->contentRun(['recipe_id' => Uuid::v7()->toRfc4122()]));
+
+        self::assertStringNotContainsString('Content recipe', $prompt);
+        self::assertStringNotContainsString('ANTI-HALLUCINATION', $prompt);
+    }
+
+    #[Test]
+    public function brandVoiceInjectsToneBannedWordsAndTheContract(): void
+    {
+        $voice = new BrandVoiceProfile(
+            name: 'Ekspercki',
+            tone: 'ekspercki, zwięzły',
+            glossary: [['term' => 'smart TV', 'use' => 'telewizor smart']],
+            bannedWords: ['tani', 'promocja'],
+            examples: [['good' => 'Rzeczowy opis.', 'bad' => 'Super okazja!!!']],
+        );
+        $builder = new AgentSystemPromptBuilder($this->emReturning($voice));
+
+        $prompt = $builder->build($this->contentRun(['brand_voice_id' => Uuid::v7()->toRfc4122()]));
+
+        self::assertStringContainsString('Brand voice "Ekspercki"', $prompt);
+        self::assertStringContainsString('ekspercki, zwięzły', $prompt);
+        self::assertStringContainsString('Banned words (never use): tani, promocja', $prompt);
+        self::assertStringContainsString('"smart TV" -> "telewizor smart"', $prompt);
+        self::assertStringContainsString('BAD copy example', $prompt);
+        self::assertStringContainsString('ANTI-HALLUCINATION CONTRACT', $prompt);
+        self::assertStringContainsString('NEVER state a parameter', $prompt);
+    }
+
+    #[Test]
+    public function recipeInjectsTargetFormatSeoRulesAndToneHint(): void
+    {
+        $recipe = new ContentRecipe(
+            code: 'meta_seo',
+            name: 'Meta SEO',
+            targetAttribute: 'meta_description',
+            sourceAttributes: ['name', 'brand'],
+            constraints: ['format' => 'plain', 'max_len' => 300, 'seo' => ['keyword' => 'HDMI', 'title_len' => 60, 'meta_len' => 155]],
+        );
+        $recipe->updateToneHint('rzeczowy');
+        $builder = new AgentSystemPromptBuilder($this->emReturning($recipe));
+
+        $prompt = $builder->build($this->contentRun(['recipe_id' => Uuid::v7()->toRfc4122()]));
+
+        self::assertStringContainsString('Content recipe "Meta SEO"', $prompt);
+        self::assertStringContainsString('Target attribute: meta_description', $prompt);
+        self::assertStringContainsString('Output format: plain; max length 300 characters', $prompt);
+        self::assertStringContainsString('focus keyword "HDMI"', $prompt);
+        self::assertStringContainsString('title at most 60 characters', $prompt);
+        self::assertStringContainsString('meta description at most 155 characters', $prompt);
+        self::assertStringContainsString('No keyword stuffing', $prompt);
+        self::assertStringContainsString('Tone hint: rzeczowy', $prompt);
+        self::assertStringContainsString('ANTI-HALLUCINATION CONTRACT', $prompt);
+    }
+
+    #[Test]
+    public function recipeAttachedVoiceIsResolvedWhenContextOmitsIt(): void
+    {
+        $voiceId = Uuid::v7();
+        $recipe = new ContentRecipe('r', 'R', 'description');
+        $recipe->attachBrandVoice($voiceId);
+        $voice = new BrandVoiceProfile('Przypięty', 'swobodny');
+
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('find')->willReturnCallback(
+            static fn (string $class, mixed $id): ContentRecipe|BrandVoiceProfile|null => match ($class) {
+                ContentRecipe::class => $recipe,
+                BrandVoiceProfile::class => $id === $voiceId->toRfc4122() ? $voice : null,
+                default => null,
+            },
+        );
+
+        $prompt = new AgentSystemPromptBuilder($em)->build($this->contentRun(['recipe_id' => Uuid::v7()->toRfc4122()]));
+
+        self::assertStringContainsString('Brand voice "Przypięty"', $prompt);
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function contentRun(array $context): AgentRun
+    {
+        return new AgentRun(Uuid::v7(), AgentRunSurface::Chat, 'write the copy', $context);
+    }
+
+    private function emReturning(object $entity): EntityManagerInterface
+    {
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('find')->willReturnCallback(
+            static fn (string $class, mixed $id): ?object => $entity instanceof $class ? $entity : null,
+        );
+
+        return $em;
+    }
+}


### PR DESCRIPTION
## AICG-P2-03 — brand voice + przepis + kontrakt anty-halucynacyjny w system-prompcie

„Jak model pisze" (plan §3b): punkt wstrzyknięcia z §4 — `AgentSystemPromptBuilder`. Domyka **M2** (grounding + prompt).

### Zmiany
- **`AgentSystemPromptBuilder`** dostaje `EntityManagerInterface` i gdy kontekst runu niesie `recipe_id`/`brand_voice_id`, dokleja:
  - **sekcję przepisu**: target attribute, format wyjścia + budżet długości, reguły SEO z `constraints.seo` (keyword „naturally", limity title/meta, „No keyword stuffing"), tone hint;
  - **sekcję głosu marki**: ton, glosariusz narzucony (`"term" -> "use"`), banned words, pierwszy przykład GOOD/BAD;
  - **kontrakt anty-halucynacyjny** (zawsze przy treści): „use ONLY the facts provided… NEVER state a parameter absent from the facts… say what is missing instead of inventing it".
- **Backward compat twardo przetestowany**: run bez kluczy content → prompt **niezmieniony** (istniejący `AgentSystemPromptBuilderTest` 3/3 przechodzi bez modyfikacji asercji); nieznane id → baseline (tool odrzuci nieznany przepis wcześniej własnym błędem).
- Głos **przypięty do przepisu** (`recipe.brandVoiceId`) resolwowany, gdy kontekst nie nazywa głosu wprost.
- Lookupy tenant-scoped (TenantFilter); Agent czyta WŁASNE encje — zero cross-BC.
- Zaktualizowane 5 istniejących konstrukcji buildera (3× unit stub EM, 2× integration `$em`).

### Testy
`AgentSystemPromptContentTest` (5 case'ów, 28 asercji razem z istniejącą suitą): baseline bez kluczy (brak sekcji i kontraktu) · nieznane recipe_id → baseline · głos: ton+glosariusz+banned+BAD example+kontrakt · przepis: target/format/max_len/keyword/title 60/meta 155/No stuffing/tone hint · głos z przepisu gdy kontekst go nie niesie.

### Bramki lokalnie (pim-api-1)
PHPUnit unit suite **1546/1546** · PHPStan max 0 · Deptrac --no-cache 0 · cs-fixer czysto.

Smoke live nie dotyczy (prompt konsumowany przez pętlę — pierwszy żywy przebieg z sekcjami content = proof P3-02 #2335, tam wejdzie w skład end-to-end BYOK smoke).

Closes #2333
