### PR TITLE
feat(catalog): add text value materializer for pending_changes

### DIFF
--- a/apps/api/src/Catalog/Application/PendingChanges/ContentValueMaterializer.php
+++ b/apps/api/src/Catalog/Application/PendingChanges/ContentValueMaterializer.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\PendingChanges;
+
+use App\Catalog\Application\Validation\AttributeValueValidator;
+use App\Catalog\Contracts\Command\ContentValuePort;
+use App\Catalog\Contracts\Command\ContentValueProposal;
+use App\Catalog\Contracts\PendingChanges\PendingChangeDraft;
+use App\Catalog\Contracts\PendingChanges\PendingChangesPort;
+use App\Catalog\Contracts\PendingChanges\PendingChangeType;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use App\Channel\Contracts\ChannelResolverInterface;
+use App\Identity\Contracts\Policy\UserScopedPermissionCheckerInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * AICG-P3-01 (#2334, ADR-0030) — materializes one GENERATED text value
+ * as a pending diff, never touching the catalog (the sibling of
+ * BulkEditValuesMaterializer for the content tools):
+ *
+ *   1. target must be a text-family attribute (Text/Textarea/Wysiwyg) —
+ *      generated prose has no business landing in a price;
+ *   2. per-attribute + per-locale/channel RBAC BY USER ID (the same
+ *      P1-02 seam bulk edits re-check) — refusals are data
+ *      (ContentValueProposal::forbidden), mirroring the executor's
+ *      "forbidden as tool_result" semantics;
+ *   3. the SAME AttributeValueValidator manual edits use (max_length
+ *      etc. from validation_rules);
+ *   4. scope normalised like the write path will route it (locale only
+ *      when localizable, channel only when scopable) so the before
+ *      reading matches what the commit overwrites;
+ *   5. before = the exact-scope ObjectValue row (not the overlay
+ *      fallback — the diff must show what THIS row currently holds).
+ *
+ * The catalog write happens ONLY post-approval through
+ * PendingBatchCommitter -> BatchValueWriter, which stamps
+ * Provenance::Agent + the provenance_meta from `meta`.
+ */
+final readonly class ContentValueMaterializer implements ContentValuePort
+{
+    private const array TEXT_TYPES = [AttributeType::Text, AttributeType::Textarea, AttributeType::Wysiwyg];
+
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private TenantContext $tenantContext,
+        private ObjectValueRepositoryInterface $values,
+        private AttributeValueValidator $valueValidator,
+        private UserScopedPermissionCheckerInterface $permissions,
+        private ChannelResolverInterface $channels,
+        private PendingChangesPort $pendingChanges,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $meta
+     */
+    public function materializeGeneratedValue(
+        Uuid $batchId,
+        Uuid $userId,
+        Uuid $objectId,
+        string $attributeCode,
+        string $generatedText,
+        ?string $locale = null,
+        ?string $channel = null,
+        array $meta = [],
+    ): ContentValueProposal {
+        $tenant = $this->tenantContext->get();
+        if (!$tenant instanceof Tenant) {
+            throw new LogicException('Cannot materialize generated content without a current tenant.');
+        }
+
+        $object = $this->entityManager->find(CatalogObject::class, $objectId);
+        if (!$object instanceof CatalogObject) {
+            return ContentValueProposal::invalid(\sprintf('Unknown object "%s".', $objectId->toRfc4122()));
+        }
+
+        $attribute = $this->entityManager->getRepository(Attribute::class)->findOneBy(['code' => $attributeCode]);
+        if (!$attribute instanceof Attribute) {
+            return ContentValueProposal::invalid(\sprintf('Unknown attribute "%s".', $attributeCode));
+        }
+        if (!\in_array($attribute->getType(), self::TEXT_TYPES, true)) {
+            return ContentValueProposal::invalid(\sprintf(
+                'Attribute "%s" is %s — generated content targets text attributes (text/textarea/wysiwyg) only.',
+                $attributeCode,
+                $attribute->getType()->value,
+            ));
+        }
+
+        if (!$this->permissions->canEditAttribute($userId, $attribute->getId())) {
+            return ContentValueProposal::forbidden(\sprintf('Attribute "%s" is outside your edit scope.', $attributeCode));
+        }
+
+        // Normalise the scope the way the write path routes it, so the
+        // before reading matches the row the commit will overwrite.
+        $scopeLocale = $attribute->isLocalizable() ? $locale : null;
+        $scopeChannel = $attribute->isScopable() ? $channel : null;
+        if (null !== $scopeLocale && !$this->permissions->canEditLocale($userId, $scopeLocale)) {
+            return ContentValueProposal::forbidden(\sprintf('Locale "%s" is outside your edit scope.', $scopeLocale));
+        }
+        if (null !== $scopeChannel && !$this->permissions->canEditChannel($userId, $scopeChannel)) {
+            return ContentValueProposal::forbidden(\sprintf('Channel "%s" is outside your edit scope.', $scopeChannel));
+        }
+
+        $channelId = null;
+        if (null !== $scopeChannel) {
+            $channelId = $this->channels->resolveId($scopeChannel, $tenant);
+            if (null === $channelId) {
+                return ContentValueProposal::invalid(\sprintf('Unknown channel "%s".', $scopeChannel));
+            }
+        }
+
+        $after = ['value' => $generatedText];
+        try {
+            $errors = $this->valueValidator->validate($attribute, $after);
+        } catch (Throwable $failure) {
+            return ContentValueProposal::invalid('Validation failed: '.$failure->getMessage());
+        }
+        if ([] !== $errors) {
+            return ContentValueProposal::invalid($errors[0]->message);
+        }
+
+        $current = $this->values->findOneByScope($object, $attribute, $channelId, $scopeLocale);
+        $before = $current?->getValue();
+
+        $this->pendingChanges->materialize($batchId, 'agent', [new PendingChangeDraft(
+            changeType: PendingChangeType::Value,
+            targetObjectId: $object->getId(),
+            attributeCode: $attributeCode,
+            scopeLocale: $scopeLocale,
+            scopeChannel: $scopeChannel,
+            before: $before,
+            after: $after,
+            meta: $meta,
+        )]);
+
+        return ContentValueProposal::materialized($before, $after, $scopeLocale, $scopeChannel);
+    }
+}

--- a/apps/api/src/Catalog/Application/PendingChanges/PendingBatchCommitter.php
+++ b/apps/api/src/Catalog/Application/PendingChanges/PendingBatchCommitter.php
@@ -21,6 +21,7 @@ use App\Catalog\Domain\Entity\BulkLog;
 use App\Catalog\Domain\Entity\BulkSession;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Provenance;
+use App\Channel\Contracts\ChannelResolverInterface;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
 use Doctrine\DBAL\ArrayParameterType;
@@ -52,8 +53,13 @@ use const JSON_THROW_ON_ERROR;
  *     the multi_attribute_edit action shape, so the existing 24h
  *     rollback path (BulkRollbackHandler) can replay old values (P3-04).
  *
- * MVP: all-or-nothing (no partial accept), global values only — the
- * same basis P3-01 materialized.
+ * MVP: all-or-nothing (no partial accept).
+ *
+ * AICG-P3-01 (#2334) — value rows carry their scope: a pending change
+ * materialized with scope_locale / scope_channel commits to that exact
+ * ObjectValue row (BatchValueWriter routes through the same
+ * localizable/scopable rules as manual edits). Bulk-edit batches keep
+ * materializing global rows, so their behaviour is unchanged.
  */
 final readonly class PendingBatchCommitter implements PendingBatchCommitPort
 {
@@ -70,6 +76,7 @@ final readonly class PendingBatchCommitter implements PendingBatchCommitPort
         private BulkAddCategoryHandler $addCategories,
         private BulkRemoveCategoryHandler $removeCategories,
         private BulkMoveCategoryHandler $moveCategories,
+        private ChannelResolverInterface $channelResolver,
     ) {
     }
 
@@ -166,6 +173,17 @@ final readonly class PendingBatchCommitter implements PendingBatchCommitPort
         }
     }
 
+    /**
+     * AICG-P3-01 — scoped proposals persist the channel CODE (bare
+     * cross-BC data, ADR-0015); the write path needs the id. Resolved at
+     * commit time so a channel deleted between materialize and approve
+     * surfaces as an issue, not a broken row.
+     */
+    private function resolveChannelId(string $code, string $tenantId): ?Uuid
+    {
+        return $this->channelResolver->resolveId($code, $this->managedTenant($tenantId));
+    }
+
     private function managedTenant(string $tenantId): Tenant
     {
         $tenant = $this->entityManager->getReference(Tenant::class, Uuid::fromString($tenantId));
@@ -184,7 +202,7 @@ final readonly class PendingBatchCommitter implements PendingBatchCommitPort
      * status=accepted rows commit — a race that rejected/expired part of
      * the batch between accept() and here cannot leak rows in.
      *
-     * @return array{0: array<string, list<array{code: string, before: ?array<string, mixed>, after: array<string, mixed>}>>, 1: ?array{operation: string, categoryIds: list<string>, objectIds: list<string>}}
+     * @return array{0: array<string, list<array{code: string, before: ?array<string, mixed>, after: array<string, mixed>, locale: ?string, channel: ?string}>>, 1: ?array{operation: string, categoryIds: list<string>, objectIds: list<string>}}
      */
     private function collectAcceptedChanges(Uuid $batchId): array
     {
@@ -201,6 +219,9 @@ final readonly class PendingBatchCommitter implements PendingBatchCommitPort
                     'code' => $view->attributeCode,
                     'before' => $view->before,
                     'after' => $view->after,
+                    // AICG-P3-01 — scoped proposals commit to their exact row.
+                    'locale' => $view->scopeLocale,
+                    'channel' => $view->scopeChannel,
                 ];
                 continue;
             }
@@ -276,8 +297,8 @@ final readonly class PendingBatchCommitter implements PendingBatchCommitPort
     }
 
     /**
-     * @param array<string, list<array{code: string, before: ?array<string, mixed>, after: array<string, mixed>}>> $perObject
-     * @param array<string, mixed>                                                                                 $provenanceMeta
+     * @param array<string, list<array{code: string, before: ?array<string, mixed>, after: array<string, mixed>, locale: ?string, channel: ?string}>> $perObject
+     * @param array<string, mixed>                                                                                                                    $provenanceMeta
      *
      * @return array{0: int, 1: int, 2: int, 3: list<array{objectId: string, attributeCode: string, message: string}>}
      */
@@ -314,11 +335,20 @@ final readonly class PendingBatchCommitter implements PendingBatchCommitPort
                         $issues[] = ['objectId' => $objectId, 'attributeCode' => $change['code'], 'message' => 'Attribute no longer exists.'];
                         continue;
                     }
+                    $channelCode = $change['channel'] ?? null;
+                    $channelId = null;
+                    if (\is_string($channelCode) && '' !== $channelCode) {
+                        $channelId = $this->resolveChannelId($channelCode, $tenantId);
+                        if (null === $channelId) {
+                            $issues[] = ['objectId' => $objectId, 'attributeCode' => $change['code'], 'message' => \sprintf('Channel "%s" no longer exists.', $channelCode)];
+                            continue;
+                        }
+                    }
                     $writes[] = [
                         'attribute' => $attribute,
                         'envelope' => $change['after'],
-                        'locale' => null,
-                        'channelId' => null,
+                        'locale' => \is_string($change['locale'] ?? null) ? $change['locale'] : null,
+                        'channelId' => $channelId,
                     ];
                 }
 
@@ -394,8 +424,8 @@ final readonly class PendingBatchCommitter implements PendingBatchCommitPort
     }
 
     /**
-     * @param array<string, list<array{code: string, before: ?array<string, mixed>, after: array<string, mixed>}>> $perObject
-     * @param list<string>                                                                                         $chunkIds
+     * @param array<string, list<array{code: string, before: ?array<string, mixed>, after: array<string, mixed>, locale: ?string, channel: ?string}>> $perObject
+     * @param list<string>                                                                                                                            $chunkIds
      *
      * @return array<string, Attribute> code => attribute
      */

--- a/apps/api/src/Catalog/Contracts/Command/ContentValuePort.php
+++ b/apps/api/src/Catalog/Contracts/Command/ContentValuePort.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Command;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AICG-P3-01 (#2334, ADR-0030) — the ONLY write path of generated text:
+ * one proposed value materialized into `pending_changes` (diff = plan),
+ * committed to the catalog exclusively after human approval through the
+ * existing bulk-path. Nothing here touches `object_values` or the
+ * `attributes_indexed` cache directly.
+ *
+ * `meta` carries the content audit trail the batch commit later stamps
+ * into `provenance_meta` (docs/api/jsonb-schemas.md §5): agent_run_id,
+ * intent, source_attributes, recipe_id.
+ */
+interface ContentValuePort
+{
+    /**
+     * @param array<string, mixed> $meta
+     */
+    public function materializeGeneratedValue(
+        Uuid $batchId,
+        Uuid $userId,
+        Uuid $objectId,
+        string $attributeCode,
+        string $generatedText,
+        ?string $locale = null,
+        ?string $channel = null,
+        array $meta = [],
+    ): ContentValueProposal;
+}

--- a/apps/api/src/Catalog/Contracts/Command/ContentValueProposal.php
+++ b/apps/api/src/Catalog/Contracts/Command/ContentValueProposal.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Command;
+
+/**
+ * AICG-P3-01 (#2334, ADR-0030) — outcome of materializing one generated
+ * text value as a pending diff. Refusals are data, not exceptions: the
+ * content tools relay them as tool_results (the GuardedToolExecutor
+ * "forbidden" semantics), so the model can tell the operator what
+ * happened instead of crashing the run.
+ */
+final readonly class ContentValueProposal
+{
+    public const string MATERIALIZED = 'materialized';
+    public const string FORBIDDEN = 'forbidden';
+    public const string INVALID = 'invalid';
+
+    /**
+     * @param array<string, mixed>|null $before value envelope of the exact
+     *                                          scope before the proposal
+     * @param array<string, mixed>|null $after  proposed value envelope
+     */
+    private function __construct(
+        public string $status,
+        public ?string $message,
+        public ?array $before,
+        public ?array $after,
+        public ?string $scopeLocale,
+        public ?string $scopeChannel,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed>|null $before
+     * @param array<string, mixed>      $after
+     */
+    public static function materialized(?array $before, array $after, ?string $scopeLocale, ?string $scopeChannel): self
+    {
+        return new self(self::MATERIALIZED, null, $before, $after, $scopeLocale, $scopeChannel);
+    }
+
+    public static function forbidden(string $message): self
+    {
+        return new self(self::FORBIDDEN, $message, null, null, null, null);
+    }
+
+    public static function invalid(string $message): self
+    {
+        return new self(self::INVALID, $message, null, null, null, null);
+    }
+
+    public function isMaterialized(): bool
+    {
+        return self::MATERIALIZED === $this->status;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toToolResult(): array
+    {
+        $payload = ['status' => $this->status];
+        if (null !== $this->message) {
+            $payload['message'] = $this->message;
+        }
+        if (self::MATERIALIZED === $this->status) {
+            $payload['before'] = $this->before;
+            $payload['after'] = $this->after;
+            $payload['locale'] = $this->scopeLocale;
+            $payload['channel'] = $this->scopeChannel;
+        }
+
+        return $payload;
+    }
+}

--- a/apps/api/tests/Integration/Catalog/ContentValueCommitTest.php
+++ b/apps/api/tests/Integration/Catalog/ContentValueCommitTest.php
@@ -65,7 +65,11 @@ final class ContentValueCommitTest extends KernelTestCase
         );
 
         self::assertTrue($proposal->isMaterialized());
-        self::assertSame(['value' => 'Opis globalny.'], $proposal->before, 'before must be the exact-scope row (none in en -> global row is NOT the before)');
+        // before is the EXACT-scope row: no en row exists yet, so the diff
+        // shows null -> generated (row creation), not the global fallback —
+        // consistent with what the commit writes and what a rollback would
+        // restore. The global reading stays visible untouched below.
+        self::assertNull($proposal->before);
 
         // Materialize only — the catalog is untouched.
         $port = self::getContainer()->get(PendingChangesPort::class);

--- a/apps/api/tests/Integration/Catalog/ContentValueCommitTest.php
+++ b/apps/api/tests/Integration/Catalog/ContentValueCommitTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Catalog;
+
+use App\Catalog\Application\PendingChanges\ContentValueMaterializer;
+use App\Catalog\Application\PendingChanges\PendingBatchCommitter;
+use App\Catalog\Application\Validation\AttributeValueValidator;
+use App\Catalog\Contracts\Command\PendingBatchCommitPort;
+use App\Catalog\Contracts\PendingChanges\PendingChangesPort;
+use App\Catalog\Contracts\PendingChanges\PendingChangeStatus;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use App\Channel\Contracts\ChannelResolverInterface;
+use App\Identity\Contracts\Policy\UserScopedPermissionCheckerInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * AICG-P3-01 (#2334) — the generated-text write path end to end against
+ * real Postgres: materialize -> pending row ONLY (object_values
+ * untouched), accept+commit -> the exact SCOPED ObjectValue row with
+ * Provenance::Agent and the content provenance_meta
+ * (source_attributes + recipe_id, AICG-P0-02 envelope), global reading
+ * of the same attribute untouched.
+ */
+final class ContentValueCommitTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function generatedValueMaterializesAsPendingAndCommitsToTheScopedRow(): void
+    {
+        $tenant = $this->createTenant();
+        [$object, $attribute] = $this->seedProduct();
+        $em = $this->em();
+
+        $batchId = Uuid::v7();
+        $recipeId = Uuid::v7()->toRfc4122();
+        $proposal = $this->materializer()->materializeGeneratedValue(
+            $batchId,
+            Uuid::v7(),
+            $object->getId(),
+            'description',
+            'Generated English copy.',
+            locale: 'en',
+            meta: ['intent' => 'generate_product_description', 'recipe_id' => $recipeId],
+        );
+
+        self::assertTrue($proposal->isMaterialized());
+        self::assertSame(['value' => 'Opis globalny.'], $proposal->before, 'before must be the exact-scope row (none in en -> global row is NOT the before)');
+
+        // Materialize only — the catalog is untouched.
+        $port = self::getContainer()->get(PendingChangesPort::class);
+        $views = $port->listBatch($batchId);
+        self::assertCount(1, $views);
+        self::assertSame(PendingChangeStatus::Pending, $views[0]->status);
+        self::assertSame('en', $views[0]->scopeLocale);
+        self::assertNull(
+            self::getContainer()->get(ObjectValueRepositoryInterface::class)
+                ->findOneByScope($object, $attribute, null, 'en'),
+            'no ObjectValue row may exist before approval',
+        );
+
+        // Approve -> commit through the real bulk path.
+        $runId = Uuid::v7()->toRfc4122();
+        $result = $this->committer()->commitAcceptedBatch($batchId, Uuid::v7(), [
+            'agent_run_id' => $runId,
+            'model' => 'claude-sonnet-test',
+            'intent' => 'generate_product_description',
+            'source_attributes' => ['material', 'color'],
+            'recipe_id' => $recipeId,
+        ]);
+        $this->drainAsyncTransport();
+        self::assertSame(1, $result->committedValues);
+
+        $em->clear();
+        $this->activateTenantFilter($this->reloadTenant($tenant));
+        $reloadedObject = $em->find(CatalogObject::class, $object->getId());
+        $reloadedAttribute = $em->getRepository(Attribute::class)->findOneBy(['code' => 'description']);
+        \assert(null !== $reloadedObject && null !== $reloadedAttribute);
+
+        $scoped = self::getContainer()->get(ObjectValueRepositoryInterface::class)
+            ->findOneByScope($reloadedObject, $reloadedAttribute, null, 'en');
+        self::assertNotNull($scoped, 'the accepted proposal must land on the en row');
+        self::assertSame(['value' => 'Generated English copy.'], $scoped->getValue());
+        self::assertSame('agent', $scoped->getProvenance()->value);
+        $meta = $scoped->getProvenanceMeta();
+        self::assertSame($runId, $meta['agent_run_id'] ?? null);
+        self::assertSame(['material', 'color'], $meta['source_attributes'] ?? null);
+        self::assertSame($recipeId, $meta['recipe_id'] ?? null);
+
+        $global = self::getContainer()->get(ObjectValueRepositoryInterface::class)
+            ->findOneByScope($reloadedObject, $reloadedAttribute);
+        self::assertNotNull($global);
+        self::assertSame(['value' => 'Opis globalny.'], $global->getValue(), 'the global reading must stay untouched');
+    }
+
+    /**
+     * @return array{0: CatalogObject, 1: Attribute}
+     */
+    private function seedProduct(): array
+    {
+        $em = $this->em();
+        $type = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $em->persist($type);
+
+        $attribute = new Attribute('description', ['en' => 'Description'], AttributeType::Textarea);
+        $attribute->changeLocalizable(true);
+        $em->persist($attribute);
+
+        $object = new CatalogObject($type, 'CVC-1');
+        $em->persist($object);
+        $em->persist(new ObjectValue($object, $attribute, ['value' => 'Opis globalny.']));
+        $em->flush();
+
+        return [$object, $attribute];
+    }
+
+    private function materializer(): ContentValueMaterializer
+    {
+        // Constructed directly (no runtime consumer until AICG-P3-02);
+        // RBAC allow-all stub — the refusal matrix is unit-tested.
+        $permissions = new class implements UserScopedPermissionCheckerInterface {
+            public function canViewAttribute(Uuid $userId, Uuid $attributeId): bool
+            {
+                return true;
+            }
+
+            public function canEditAttribute(Uuid $userId, Uuid $attributeId): bool
+            {
+                return true;
+            }
+
+            public function canEditLocale(Uuid $userId, string $locale): bool
+            {
+                return true;
+            }
+
+            public function canEditChannel(Uuid $userId, string $channel): bool
+            {
+                return true;
+            }
+        };
+
+        return new ContentValueMaterializer(
+            $this->em(),
+            self::getContainer()->get(TenantContext::class),
+            self::getContainer()->get(ObjectValueRepositoryInterface::class),
+            self::getContainer()->get(AttributeValueValidator::class),
+            $permissions,
+            self::getContainer()->get(ChannelResolverInterface::class),
+            self::getContainer()->get(PendingChangesPort::class),
+        );
+    }
+
+    private function committer(): PendingBatchCommitPort
+    {
+        return self::getContainer()->get(PendingBatchCommitter::class);
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function createTenant(): Tenant
+    {
+        $em = $this->em();
+        $tenant = new Tenant('demo-cvc', 'Demo Tenant');
+        $em->persist($tenant);
+        $em->flush();
+        $this->activateTenantFilter($tenant);
+
+        return $tenant;
+    }
+
+    private function reloadTenant(Tenant $tenant): Tenant
+    {
+        $managed = $this->em()->find(Tenant::class, $tenant->getId()->toRfc4122());
+        \assert($managed instanceof Tenant);
+
+        return $managed;
+    }
+
+    private function activateTenantFilter(Tenant $tenant): void
+    {
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+    }
+
+    /**
+     * CI pins MESSENGER_TRANSPORT_DSN to in-memory:// — re-dispatch the
+     * queued rebuild messages so the projection runs (same helper as
+     * AgentProvenanceProjectionTest).
+     */
+    private function drainAsyncTransport(): void
+    {
+        $transport = self::getContainer()->get('messenger.transport.async');
+        if (!$transport instanceof InMemoryTransport) {
+            return;
+        }
+        $bus = self::getContainer()->get(MessageBusInterface::class);
+        foreach ($transport->getSent() as $envelope) {
+            $bus->dispatch($envelope->getMessage(), [new ReceivedStamp('async')]);
+        }
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Application/ContentValueMaterializerTest.php
+++ b/apps/api/tests/Unit/Catalog/Application/ContentValueMaterializerTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Application;
+
+use App\Catalog\Application\PendingChanges\ContentValueMaterializer;
+use App\Catalog\Application\Validation\AttributeValueValidator;
+use App\Catalog\Application\Validation\AttributeValueValidatorInterface;
+use App\Catalog\Contracts\Command\ContentValueProposal;
+use App\Catalog\Contracts\PendingChanges\PendingChangesPort;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use App\Channel\Contracts\ChannelResolverInterface;
+use App\Identity\Contracts\Policy\UserScopedPermissionCheckerInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AICG-P3-01 (#2334) — refusal paths of the content materializer:
+ * non-text targets, RBAC (attribute / locale / channel), unknown
+ * object/channel, and the scope normalisation that mirrors the write
+ * path's routing. Refusals are data (tool_result), never exceptions.
+ * The happy path against real Postgres lives in the integration suite.
+ */
+final class ContentValueMaterializerTest extends TestCase
+{
+    #[Test]
+    public function nonTextAttributeIsRejectedAsInvalid(): void
+    {
+        $proposal = $this->materializer(attributeType: AttributeType::Number)
+            ->materializeGeneratedValue(Uuid::v7(), Uuid::v7(), Uuid::v7(), 'price', 'generated');
+
+        self::assertSame(ContentValueProposal::INVALID, $proposal->status);
+        self::assertStringContainsString('text attributes', (string) $proposal->message);
+    }
+
+    #[Test]
+    public function attributeOutsideEditScopeIsForbidden(): void
+    {
+        $proposal = $this->materializer(canEditAttribute: false)
+            ->materializeGeneratedValue(Uuid::v7(), Uuid::v7(), Uuid::v7(), 'description', 'generated');
+
+        self::assertSame(ContentValueProposal::FORBIDDEN, $proposal->status);
+        self::assertStringContainsString('outside your edit scope', (string) $proposal->message);
+    }
+
+    #[Test]
+    public function localeOutsideEditScopeIsForbiddenOnlyWhenAttributeIsLocalizable(): void
+    {
+        $denied = $this->materializer(localizable: true, canEditLocale: false)
+            ->materializeGeneratedValue(Uuid::v7(), Uuid::v7(), Uuid::v7(), 'description', 'txt', locale: 'en');
+        self::assertSame(ContentValueProposal::FORBIDDEN, $denied->status);
+
+        // A non-localizable attribute routes to the global row — the
+        // locale permission is irrelevant (mirrors the write path).
+        $routed = $this->materializer(localizable: false, canEditLocale: false)
+            ->materializeGeneratedValue(Uuid::v7(), Uuid::v7(), Uuid::v7(), 'description', 'txt', locale: 'en');
+        self::assertSame(ContentValueProposal::MATERIALIZED, $routed->status);
+        self::assertNull($routed->scopeLocale);
+    }
+
+    #[Test]
+    public function unknownChannelIsInvalid(): void
+    {
+        $proposal = $this->materializer(scopable: true, channelResolves: false)
+            ->materializeGeneratedValue(Uuid::v7(), Uuid::v7(), Uuid::v7(), 'description', 'txt', channel: 'ghost');
+
+        self::assertSame(ContentValueProposal::INVALID, $proposal->status);
+        self::assertStringContainsString('Unknown channel', (string) $proposal->message);
+    }
+
+    #[Test]
+    public function unknownObjectIsInvalid(): void
+    {
+        $proposal = $this->materializer(objectExists: false)
+            ->materializeGeneratedValue(Uuid::v7(), Uuid::v7(), Uuid::v7(), 'description', 'txt');
+
+        self::assertSame(ContentValueProposal::INVALID, $proposal->status);
+        self::assertStringContainsString('Unknown object', (string) $proposal->message);
+    }
+
+    #[Test]
+    public function materializedProposalCarriesBeforeAfterAndScope(): void
+    {
+        $proposal = $this->materializer(localizable: true)
+            ->materializeGeneratedValue(Uuid::v7(), Uuid::v7(), Uuid::v7(), 'description', 'wygenerowany opis', locale: 'en');
+
+        self::assertTrue($proposal->isMaterialized());
+        self::assertSame(['value' => 'wygenerowany opis'], $proposal->after);
+        self::assertSame('en', $proposal->scopeLocale);
+        $payload = $proposal->toToolResult();
+        self::assertSame('materialized', $payload['status']);
+        self::assertSame('en', $payload['locale']);
+    }
+
+    private function materializer(
+        AttributeType $attributeType = AttributeType::Textarea,
+        bool $canEditAttribute = true,
+        bool $canEditLocale = true,
+        bool $localizable = false,
+        bool $scopable = false,
+        bool $channelResolves = true,
+        bool $objectExists = true,
+    ): ContentValueMaterializer {
+        $tenant = new Tenant('demo-test-'.bin2hex(random_bytes(2)), 'Demo');
+        $tenantContext = new TenantContext();
+        $tenantContext->set($tenant);
+
+        $objectType = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $objectType->assignTenant($tenant);
+        $object = new CatalogObject($objectType, 'SKU-CVM-1');
+
+        $attribute = new Attribute('description', ['en' => 'Description'], $attributeType);
+        $attribute->assignTenant($tenant);
+        $attribute->changeLocalizable($localizable);
+        $attribute->changeScopable($scopable);
+
+        $repository = $this->createStub(EntityRepository::class);
+        $repository->method('findOneBy')->willReturn($attribute);
+
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('find')->willReturn($objectExists ? $object : null);
+        $em->method('getRepository')->willReturn($repository);
+
+        $permissions = $this->createStub(UserScopedPermissionCheckerInterface::class);
+        $permissions->method('canEditAttribute')->willReturn($canEditAttribute);
+        $permissions->method('canEditLocale')->willReturn($canEditLocale);
+        $permissions->method('canEditChannel')->willReturn(true);
+
+        $channels = $this->createStub(ChannelResolverInterface::class);
+        $channels->method('resolveId')->willReturn($channelResolves ? Uuid::v7() : null);
+
+        // AttributeValueValidator is final — build the real one with a
+        // per-type stub that accepts everything.
+        $accepting = $this->createStub(AttributeValueValidatorInterface::class);
+        $accepting->method('validate')->willReturn([]);
+        $validator = new AttributeValueValidator([$attributeType->value => $accepting]);
+
+        return new ContentValueMaterializer(
+            $em,
+            $tenantContext,
+            $this->createStub(ObjectValueRepositoryInterface::class),
+            $validator,
+            $permissions,
+            $channels,
+            $this->createStub(PendingChangesPort::class),
+        );
+    }
+}


### PR DESCRIPTION
## AICG-P3-01 — materializer wartości tekstowej dla `pending_changes`

Wygenerowana treść to **propozycja** (diff = plan): nowy port + materializer obok `BulkEditValuesMaterializer`, wspólny dla wszystkich tooli treści (P3-02/P4-02/P6-01). Otwiera **M3**.

### Nowy seam Catalog/Contracts
- **`ContentValuePort` + `ContentValueProposal`** — materializacja JEDNEJ wygenerowanej wartości tekstowej do `pending_changes`; odmowy jako dane (`materialized|forbidden|invalid` + `toToolResult()`), semantyka „forbidden jako tool_result" z `GuardedToolExecutor`, nigdy wyjątki. `meta` niesie audyt treści (`agent_run_id`, `intent`, `source_attributes`, `recipe_id` — envelope z P0-02).

### `ContentValueMaterializer` (Catalog)
1. target tylko text-family (`Text`/`Textarea`/`Wysiwyg`) — proza nie ląduje w cenie;
2. RBAC by user id: per-attribute + per-locale/channel (seam P1-02, ten sam co bulk-edit);
3. ta sama walidacja co edycja ręczna (`AttributeValueValidator` — max_length itd. z validation_rules);
4. **scope znormalizowany jak w write-path** (locale tylko gdy localizable, channel tylko gdy scopable) — before pokazuje dokładnie ten wiersz, który commit nadpisze;
5. before = wiersz **exact-scope** (nie overlay fallback) — brak wiersza `en` ⇒ diff pokazuje `null → generated` (utworzenie wiersza), spójnie z tym, co commit zapisuje i co rollback by przywrócił; odczyt globalny pozostaje nietknięty i widoczny obok.

### Rozszerzenie commit-path (`PendingBatchCommitter`)
Dotąd hardcode `locale=null, channel=null` — zaakceptowane wiersze value niosą teraz swój `scope_locale`/`scope_channel` do `BatchValueWriter` (routing przez te same reguły localizable/scopable co edycja ręczna). Kod kanału (bare cross-BC, ADR-0015) rozwiązywany do id **w momencie commitu** — kanał skasowany między materializacją a akceptem = issue w wyniku, nie zepsuty wiersz. Batche bulk-edit dalej materializują global — zachowanie bez zmian.

### Testy
- **Unit (`ContentValueMaterializerTest`, 6/6):** nie-tekstowy atrybut → invalid · atrybut poza scope → forbidden · locale poza scope forbidden TYLKO gdy localizable (nie-localizable routuje do global — mirror write-path) · nieznany kanał/obiekt → invalid · zmaterializowana propozycja niesie before/after/scope + tool_result payload.
- **Kernel (`ContentValueCommitTest`, CI, real Postgres):** materialize → wiersz w `pending_changes` (scope `en`), **`object_values` nietknięte przed akceptem** · commit z provenanceMeta → **wiersz `en`** z `Provenance::Agent` + `provenance_meta.{agent_run_id, source_attributes, recipe_id}` · **wiersz globalny nietknięty** · zapis przez realny bulk-path (BulkSession + drain async rebuild).

### Bramki lokalnie (pim-api-1)
PHPUnit unit **1547/1547** · PHPStan max 0 · Deptrac --no-cache 0 · cs-fixer czysto.

Live smoke end-to-end = proof P3-02 (#2335) — pierwszy konsument portu (tool + BYOK + inbox).

Closes #2334
