### PR TITLE
feat(agent): add generate_product_description tool (kind=Write)

### DIFF
--- a/apps/api/src/Agent/Application/Approval/AgentApprovalService.php
+++ b/apps/api/src/Agent/Application/Approval/AgentApprovalService.php
@@ -139,7 +139,10 @@ final readonly class AgentApprovalService
                     issues: array_map(static fn (string $m): array => ['objectId' => '', 'attributeCode' => '', 'message' => $m], $schemaResult->messages),
                 );
             } else {
-                $result = $this->commits->commitAcceptedBatch($batchId, $approvedBy, [
+                // AICG-P3-02 (#2335) — content batches carry the audit trail
+                // (source_attributes + recipe_id, jsonb-schemas §5) in the
+                // pending row meta; fold it into the batch provenance stamp.
+                $result = $this->commits->commitAcceptedBatch($batchId, $approvedBy, $this->contentMetaFromBatch($batchId) + [
                     'agent_run_id' => $run->getId()->toRfc4122(),
                     'model' => $run->getModel(),
                     'intent' => $run->getIntent(),
@@ -353,5 +356,30 @@ final readonly class AgentApprovalService
         }
 
         return $run;
+    }
+
+    /**
+     * AICG-P3-02 (#2335) — the content audit keys of the batch's first
+     * row (content tools write one homogeneous batch per run; bulk-edit
+     * rows carry no such meta, so this is a no-op for them).
+     *
+     * @return array<string, mixed>
+     */
+    private function contentMetaFromBatch(Uuid $batchId): array
+    {
+        foreach ($this->pendingChanges->iterateBatch($batchId) as $view) {
+            $meta = $view->meta ?? [];
+            $content = [];
+            if (\is_array($meta['source_attributes'] ?? null)) {
+                $content['source_attributes'] = $meta['source_attributes'];
+            }
+            if (\is_string($meta['recipe_id'] ?? null)) {
+                $content['recipe_id'] = $meta['recipe_id'];
+            }
+
+            return $content;
+        }
+
+        return [];
     }
 }

--- a/apps/api/src/Agent/Application/Run/AgentLoopRunner.php
+++ b/apps/api/src/Agent/Application/Run/AgentLoopRunner.php
@@ -162,6 +162,19 @@ final readonly class AgentLoopRunner
                     $outcome = $this->executor->execute($run, $toolUse['name'], $input, $context);
                     ++$toolCallCount;
 
+                    // AICG-P3-02 (#2335) — agent-native tools make a nested
+                    // LLM call and report its usage as `llm_usage`; add it
+                    // to the run's counters so the 8.5 budgets and the
+                    // per-run token limit see every generated token.
+                    $llmUsage = $outcome['content']['llm_usage'] ?? null;
+                    if (\is_array($llmUsage)) {
+                        $run->addUsage(
+                            \is_int($llmUsage['input_tokens'] ?? null) ? $llmUsage['input_tokens'] : 0,
+                            \is_int($llmUsage['output_tokens'] ?? null) ? $llmUsage['output_tokens'] : 0,
+                            \is_string($llmUsage['cost_usd'] ?? null) ? $llmUsage['cost_usd'] : '0',
+                        );
+                    }
+
                     $toolResults[] = [
                         'type' => 'tool_result',
                         'toolUseID' => $toolUse['id'],

--- a/apps/api/src/Agent/Application/Tool/GenerateProductDescriptionTool.php
+++ b/apps/api/src/Agent/Application/Tool/GenerateProductDescriptionTool.php
@@ -1,0 +1,331 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Tool;
+
+use App\Agent\Application\Content\ContentGrounding;
+use App\Agent\Application\Content\ContentGroundingService;
+use App\Agent\Application\Content\GroundingGate;
+use App\Agent\Application\Llm\AgentLlmClientInterface;
+use App\Agent\Application\Run\UsageCostCalculator;
+use App\Agent\Domain\Entity\BrandVoiceProfile;
+use App\Agent\Domain\Entity\ContentRecipe;
+use App\Agent\Infrastructure\Anthropic\AgentModelSelector;
+use App\Catalog\Contracts\Command\ContentValuePort;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+
+/**
+ * AICG-P3-02 (#2335, ADR-0030) — the flagship content tool: grounded
+ * product-description generation, end to end inside ONE tool call:
+ *
+ *   grounding (facts from the product's own attributes, P2-01)
+ *   -> completeness gate (insufficient_grounding instead of invention,
+ *      P2-02)
+ *   -> a nested LLM call on the default (Sonnet-tier) model with the
+ *      recipe + brand voice + the hard anti-hallucination contract
+ *   -> length/format check against the recipe
+ *   -> materialization into pending_changes (P3-01) — NOTHING is
+ *      applied by the tool itself; the operator approves the diff.
+ *
+ * The first "agent-native" tool (ADR-0030 decision 2): its engine is
+ * the LLM, so grounding + prompt + generation live HERE; reads and
+ * writes still go exclusively through `*\Contracts` ports.
+ *
+ * The nested call's usage is returned as `llm_usage` in the
+ * tool_result; the loop adds it to the run's counters so the §8.5
+ * budgets see every generated token (and the audit keeps a per-call
+ * copy in agent_tool_calls.result_summary).
+ */
+final readonly class GenerateProductDescriptionTool implements AgentToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private ContentGroundingService $grounding,
+        private GroundingGate $gate,
+        private ContentValuePort $contentValues,
+        private AgentLlmClientInterface $llm,
+        private AgentModelSelector $models,
+        private UsageCostCalculator $costs,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'generate_product_description';
+    }
+
+    public function description(): string
+    {
+        return 'Generate a product description (or other text attribute) STRICTLY from the product\'s own attribute values, following a content recipe and the tenant\'s brand voice. The proposal lands in pending_changes for human approval — nothing is written to the product by this call. Use when the user asks to write, improve or fill in descriptive copy for a specific product. Requires enough source facts: with too little data it returns insufficient_grounding and the list of attributes to fill first.';
+    }
+
+    public function parametersSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'product_id' => [
+                    'type' => 'string',
+                    'description' => 'UUID of the product object to describe.',
+                ],
+                'target_attribute' => [
+                    'type' => 'string',
+                    'description' => 'Code of the text attribute to fill (e.g. "description"). Defaults to the recipe\'s target.',
+                ],
+                'locale' => [
+                    'type' => 'string',
+                    'description' => 'Locale of the generated copy (short code, e.g. "pl"). Omit for the global value.',
+                ],
+                'channel' => [
+                    'type' => 'string',
+                    'description' => 'Channel code when the copy targets one channel; narrows facts to its publication profile.',
+                ],
+                'recipe_id' => [
+                    'type' => 'string',
+                    'description' => 'ContentRecipe UUID. Omit to use the recipe configured for the target attribute.',
+                ],
+                'tone_hint' => [
+                    'type' => 'string',
+                    'description' => 'Optional one-off tone adjustment on top of the recipe/brand voice.',
+                ],
+                'pending_change_batch_id' => [
+                    'type' => 'string',
+                    'description' => 'Append to an existing proposal batch (multi-step plans accumulate into one approval). Usually injected automatically.',
+                ],
+            ],
+            'required' => ['product_id'],
+        ];
+    }
+
+    public function requiredPermission(): string
+    {
+        return 'object.write';
+    }
+
+    public function kind(): ToolKind
+    {
+        return ToolKind::Write;
+    }
+
+    public function execute(array $arguments, AgentToolContext $context): array
+    {
+        $productId = $arguments['product_id'] ?? null;
+        if (!\is_string($productId) || !Uuid::isValid($productId)) {
+            return ['error' => 'product_id must be a valid UUID.'];
+        }
+
+        $recipe = $this->resolveRecipe($arguments);
+        if (null === $recipe) {
+            return ['error' => 'No content recipe found — pass recipe_id or configure one for the target attribute in Settings → AI content.'];
+        }
+        $targetAttribute = \is_string($arguments['target_attribute'] ?? null) && '' !== $arguments['target_attribute']
+            ? $arguments['target_attribute']
+            : $recipe->getTargetAttribute();
+        $locale = \is_string($arguments['locale'] ?? null) && '' !== $arguments['locale'] ? $arguments['locale'] : null;
+        $channel = \is_string($arguments['channel'] ?? null) && '' !== $arguments['channel'] ? $arguments['channel'] : null;
+
+        $grounding = $this->grounding->ground(
+            Uuid::fromString($productId),
+            $recipe,
+            $context->tenant,
+            $locale,
+            $channel,
+        );
+
+        $verdict = $this->gate->evaluate($grounding, $recipe);
+        if (!$verdict->isSufficient()) {
+            // Structured refusal, not an exception: the model relays which
+            // facts to fill instead of inventing them (SEC, P2-02).
+            return $verdict->toToolResult();
+        }
+
+        $voice = $this->resolveVoice($recipe);
+        $toneHint = \is_string($arguments['tone_hint'] ?? null) && '' !== $arguments['tone_hint'] ? $arguments['tone_hint'] : null;
+
+        $model = $this->models->defaultModel();
+        $response = $this->llm->create(
+            $context->tenant,
+            $model,
+            $this->systemPrompt($recipe, $voice, $toneHint),
+            [[
+                'role' => 'user',
+                'content' => [['type' => 'text', 'text' => $this->userPrompt($grounding, $recipe, $targetAttribute, $locale)]],
+            ]],
+            tools: [],
+            promptCaching: false,
+        );
+        $generated = trim($this->responseText($response->contentBlocks));
+        if ('' === $generated) {
+            return ['error' => 'The model returned no text — retry or adjust the recipe.'];
+        }
+
+        $warnings = [];
+        $maxLen = $recipe->getConstraints()['max_len'] ?? null;
+        if (\is_int($maxLen) && mb_strlen($generated) > $maxLen) {
+            $warnings[] = \sprintf('Generated %d characters against the recipe budget of %d — review before accepting.', mb_strlen($generated), $maxLen);
+        }
+
+        $batchId = $this->resolveBatch($arguments['pending_change_batch_id'] ?? null);
+        $proposal = $this->contentValues->materializeGeneratedValue(
+            $batchId,
+            $context->userId,
+            Uuid::fromString($productId),
+            $targetAttribute,
+            $generated,
+            $locale,
+            $channel,
+            meta: [
+                'intent' => 'generate_product_description',
+                'source_attributes' => $grounding->usedCodes,
+                'recipe_id' => $recipe->getId()->toRfc4122(),
+                'model' => $model,
+            ],
+        );
+
+        $usage = [
+            'input_tokens' => $response->inputTokens,
+            'output_tokens' => $response->outputTokens,
+            'cost_usd' => $this->costs->costUsd($model, $response->inputTokens, $response->outputTokens, $response->cacheReadTokens, $response->cacheCreationTokens),
+        ];
+
+        if (!$proposal->isMaterialized()) {
+            return $proposal->toToolResult() + ['llm_usage' => $usage];
+        }
+
+        return [
+            'status' => 'materialized',
+            'pending_change_batch_id' => $batchId->toRfc4122(),
+            'affected_count' => 1,
+            'product_id' => $productId,
+            'target_attribute' => $targetAttribute,
+            'locale' => $proposal->scopeLocale,
+            'channel' => $proposal->scopeChannel,
+            'generated_preview' => mb_substr($generated, 0, 300),
+            'source_attributes' => $grounding->usedCodes,
+            'recipe' => $recipe->getCode(),
+            'warnings' => $warnings,
+            'llm_usage' => $usage,
+            'note' => 'Proposal materialized for approval — nothing was written to the product.',
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $arguments
+     */
+    private function resolveRecipe(array $arguments): ?ContentRecipe
+    {
+        $recipeId = $arguments['recipe_id'] ?? null;
+        if (\is_string($recipeId) && Uuid::isValid($recipeId)) {
+            return $this->em->find(ContentRecipe::class, $recipeId);
+        }
+
+        $target = $arguments['target_attribute'] ?? null;
+        $criteria = \is_string($target) && '' !== $target ? ['targetAttribute' => $target] : ['code' => 'product_description'];
+        $repository = $this->em->getRepository(ContentRecipe::class);
+
+        return $repository->findOneBy($criteria + ['isBuiltIn' => true]) ?? $repository->findOneBy($criteria);
+    }
+
+    private function resolveVoice(ContentRecipe $recipe): ?BrandVoiceProfile
+    {
+        if (null !== $recipe->getBrandVoiceId()) {
+            $pinned = $this->em->find(BrandVoiceProfile::class, $recipe->getBrandVoiceId()->toRfc4122());
+            if ($pinned instanceof BrandVoiceProfile) {
+                return $pinned;
+            }
+        }
+
+        return $this->em->getRepository(BrandVoiceProfile::class)->findOneBy(['isDefault' => true]);
+    }
+
+    private function resolveBatch(mixed $requested): Uuid
+    {
+        return \is_string($requested) && Uuid::isValid($requested) ? Uuid::fromString($requested) : Uuid::v7();
+    }
+
+    private function systemPrompt(ContentRecipe $recipe, ?BrandVoiceProfile $voice, ?string $toneHint): string
+    {
+        $constraints = $recipe->getConstraints();
+        $format = \is_string($constraints['format'] ?? null) ? $constraints['format'] : 'plain';
+        $maxLen = $constraints['max_len'] ?? null;
+
+        $lines = [
+            'You are a product copywriter inside a PIM. You write from structured product data.',
+            '',
+            'ANTI-HALLUCINATION CONTRACT (hard rules):',
+            '- Use ONLY the facts provided in the user message. They are the complete ground truth.',
+            '- NEVER state a parameter, number, material, feature or property that is absent from the facts.',
+            '- Do not speculate, average, or "typically" anything. Missing means unmentioned.',
+            '',
+            \sprintf('Output format: %s.%s', 'html' === $format ? 'clean semantic HTML (p/ul/li/strong only, no styles, no scripts)' : 'plain text (no markup)', \is_int($maxLen) ? \sprintf(' Stay within ~%d characters.', $maxLen) : ''),
+            'Reply with the copy ONLY - no preamble, no commentary, no quotes around it.',
+        ];
+
+        if (null !== $recipe->getToneHint() && '' !== $recipe->getToneHint()) {
+            $lines[] = 'Tone (recipe): '.$recipe->getToneHint();
+        }
+        if (null !== $toneHint) {
+            $lines[] = 'Tone (one-off override for this request): '.$toneHint;
+        }
+
+        if (null !== $voice) {
+            $lines[] = '';
+            $lines[] = \sprintf('Brand voice "%s": %s', $voice->getName(), $voice->getTone());
+            foreach ($voice->getGlossary() as $entry) {
+                $lines[] = \sprintf('- Always phrase "%s" as "%s".', $entry['term'], $entry['use']);
+            }
+            if ([] !== $voice->getBannedWords()) {
+                $lines[] = '- Never use the words: '.implode(', ', $voice->getBannedWords()).'.';
+            }
+            $example = $voice->getExamples()[0] ?? null;
+            if (null !== $example) {
+                $lines[] = \sprintf('- GOOD copy example: "%s"', $example['good']);
+                $lines[] = \sprintf('- BAD copy example (never write like this): "%s"', $example['bad']);
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+
+    private function userPrompt(ContentGrounding $grounding, ContentRecipe $recipe, string $targetAttribute, ?string $locale): string
+    {
+        $facts = json_encode($grounding->facts, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        $siblings = [] === $grounding->siblingLocales
+            ? ''
+            : "\n\nExisting copy in other locales (keep the substance consistent with it):\n"
+                .json_encode($grounding->siblingLocales, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        $channelNote = [] === $grounding->channelContext
+            ? ''
+            : "\n\nChannel context: ".json_encode($grounding->channelContext, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        return \sprintf(
+            "Write the \"%s\" attribute%s for this product.\n\nProduct facts (the ONLY permissible source of claims):\n%s%s%s",
+            $targetAttribute,
+            null !== $locale ? \sprintf(' in locale "%s"', $locale) : '',
+            \is_string($facts) ? $facts : '{}',
+            $siblings,
+            $channelNote,
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $contentBlocks
+     */
+    private function responseText(array $contentBlocks): string
+    {
+        $text = '';
+        foreach ($contentBlocks as $block) {
+            if (($block['type'] ?? null) === 'text' && \is_string($block['text'] ?? null)) {
+                $text .= $block['text'];
+            }
+        }
+
+        return $text;
+    }
+}

--- a/apps/api/tests/Unit/Agent/Application/GenerateProductDescriptionToolTest.php
+++ b/apps/api/tests/Unit/Agent/Application/GenerateProductDescriptionToolTest.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Agent\Application;
+
+use App\Agent\Application\Content\ContentGrounding;
+use App\Agent\Application\Content\ContentGroundingService;
+use App\Agent\Application\Content\GroundingGate;
+use App\Agent\Application\Llm\AgentLlmClientInterface;
+use App\Agent\Application\Llm\AgentLlmResponse;
+use App\Agent\Application\Run\UsageCostCalculator;
+use App\Agent\Application\Tool\AgentToolContext;
+use App\Agent\Application\Tool\GenerateProductDescriptionTool;
+use App\Agent\Application\Tool\ToolKind;
+use App\Agent\Domain\Entity\BrandVoiceProfile;
+use App\Agent\Domain\Entity\ContentRecipe;
+use App\Agent\Infrastructure\Anthropic\AgentModelSelector;
+use App\Catalog\Contracts\Command\ContentValuePort;
+use App\Catalog\Contracts\Command\ContentValueProposal;
+use App\Catalog\Contracts\Query\ObjectFacts;
+use App\Catalog\Contracts\Query\ObjectFactsPort;
+use App\Channel\Contracts\ChannelPublicationResolverInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AICG-P3-02 (#2335) — the flagship tool's pipeline with a scripted
+ * LLM (external API is the only mock): grounding -> gate -> nested
+ * generation -> materialization, and the two hard guarantees:
+ *
+ *   - insufficient grounding NEVER reaches the model (no invention,
+ *     no spend),
+ *   - the prompt carries ONLY the grounded facts, and the audit meta
+ *     (source_attributes + recipe_id) mirrors them exactly.
+ */
+final class GenerateProductDescriptionToolTest extends TestCase
+{
+    #[Test]
+    public function insufficientGroundingShortCircuitsBeforeTheLlm(): void
+    {
+        $calls = new LlmCallRecorder();
+        $llm = $this->scriptedLlm('SHOULD NEVER BE CALLED', $calls);
+
+        $tool = $this->tool(
+            grounding: new ContentGrounding(facts: [], usedCodes: [], missingCodes: ['material', 'color']),
+            llm: $llm,
+        );
+        $result = $tool->execute(['product_id' => Uuid::v7()->toRfc4122()], $this->context());
+
+        self::assertSame('insufficient_grounding', $result['status']);
+        self::assertSame(['material', 'color'], $result['missing_source_attributes']);
+        self::assertSame(0, $calls->count, 'the gate must refuse BEFORE any model call');
+    }
+
+    #[Test]
+    public function happyPathMaterializesWithAuditMetaAndUsage(): void
+    {
+        $calls = new LlmCallRecorder();
+        $llm = $this->scriptedLlm('Rzeczowy opis z aluminium.', $calls);
+        $port = new class implements ContentValuePort {
+            /** @var array<string, mixed> */
+            public array $capturedMeta = [];
+            public ?string $capturedText = null;
+
+            public function materializeGeneratedValue(Uuid $batchId, Uuid $userId, Uuid $objectId, string $attributeCode, string $generatedText, ?string $locale = null, ?string $channel = null, array $meta = []): ContentValueProposal
+            {
+                $this->capturedMeta = $meta;
+                $this->capturedText = $generatedText;
+
+                return ContentValueProposal::materialized(null, ['value' => $generatedText], $locale, $channel);
+            }
+        };
+
+        $tool = $this->tool(
+            grounding: new ContentGrounding(
+                facts: ['material' => ['value' => 'aluminium'], 'color' => ['option_code' => 'red']],
+                usedCodes: ['material', 'color'],
+                missingCodes: [],
+            ),
+            llm: $llm,
+            port: $port,
+        );
+        $result = $tool->execute(
+            ['product_id' => Uuid::v7()->toRfc4122(), 'locale' => 'pl'],
+            $this->context(),
+        );
+
+        self::assertSame('materialized', $result['status']);
+        self::assertSame(1, $result['affected_count']);
+        self::assertIsString($result['pending_change_batch_id']);
+        self::assertSame(['material', 'color'], $result['source_attributes']);
+        $usage = $result['llm_usage'];
+        self::assertIsArray($usage);
+        self::assertSame(12, $usage['input_tokens']);
+        self::assertSame(34, $usage['output_tokens']);
+        self::assertSame('Rzeczowy opis z aluminium.', $port->capturedText);
+        self::assertSame(['material', 'color'], $port->capturedMeta['source_attributes']);
+        self::assertArrayHasKey('recipe_id', $port->capturedMeta);
+        self::assertSame('generate_product_description', $port->capturedMeta['intent']);
+    }
+
+    #[Test]
+    public function promptCarriesOnlyGroundedFactsAndTheContract(): void
+    {
+        $calls = new LlmCallRecorder();
+        $llm = $this->scriptedLlm('ok', $calls);
+
+        $tool = $this->tool(
+            grounding: new ContentGrounding(
+                facts: ['material' => ['value' => 'aluminium']],
+                usedCodes: ['material'],
+                missingCodes: ['size'],
+            ),
+            llm: $llm,
+        );
+        $tool->execute(['product_id' => Uuid::v7()->toRfc4122()], $this->context());
+
+        self::assertSame(1, $calls->count);
+        self::assertStringContainsString('ANTI-HALLUCINATION CONTRACT', $calls->system);
+        self::assertStringContainsString('Never use the words: tani', $calls->system);
+        self::assertStringContainsString('aluminium', $calls->userText);
+        self::assertStringNotContainsString('size', $calls->userText, 'missing codes must not leak into the facts payload');
+    }
+
+    #[Test]
+    public function overlongCopyIsFlaggedNotSilentlyAccepted(): void
+    {
+        $calls = new LlmCallRecorder();
+        $llm = $this->scriptedLlm(str_repeat('a', 50), $calls);
+
+        $tool = $this->tool(
+            grounding: new ContentGrounding(facts: ['material' => ['value' => 'x']], usedCodes: ['material'], missingCodes: []),
+            llm: $llm,
+            maxLen: 10,
+        );
+        $result = $tool->execute(['product_id' => Uuid::v7()->toRfc4122()], $this->context());
+
+        self::assertSame('materialized', $result['status']);
+        $warnings = $result['warnings'];
+        self::assertIsArray($warnings);
+        self::assertNotSame([], $warnings);
+        self::assertIsString($warnings[0]);
+        self::assertStringContainsString('budget of 10', $warnings[0]);
+    }
+
+    #[Test]
+    public function invalidProductIdIsAnErrorResult(): void
+    {
+        $calls = new LlmCallRecorder();
+        $llm = $this->scriptedLlm('x', $calls);
+        $result = $this->tool(
+            grounding: new ContentGrounding(facts: [], usedCodes: [], missingCodes: []),
+            llm: $llm,
+        )->execute(['product_id' => 'not-a-uuid'], $this->context());
+
+        self::assertArrayHasKey('error', $result);
+        self::assertSame(0, $calls->count);
+    }
+
+    #[Test]
+    public function toolIsAWriteToolNamedForTheRegistry(): void
+    {
+        $tool = $this->tool(
+            grounding: new ContentGrounding(facts: [], usedCodes: [], missingCodes: []),
+            llm: $this->scriptedLlm('x', $calls = new LlmCallRecorder()),
+        );
+
+        self::assertSame('generate_product_description', $tool->name());
+        self::assertSame(ToolKind::Write, $tool->kind());
+        self::assertSame('object.write', $tool->requiredPermission());
+        self::assertSame(['product_id'], $tool->parametersSchema()['required']);
+    }
+
+    private function tool(
+        ContentGrounding $grounding,
+        AgentLlmClientInterface $llm,
+        ?ContentValuePort $port = null,
+        ?int $maxLen = null,
+    ): GenerateProductDescriptionTool {
+        $constraints = ['format' => 'plain'];
+        if (null !== $maxLen) {
+            $constraints['max_len'] = $maxLen;
+        }
+        $recipe = new ContentRecipe(
+            code: 'product_description',
+            name: 'Opis produktu',
+            targetAttribute: 'description',
+            sourceAttributes: ['material', 'color', 'size'],
+            constraints: $constraints,
+        );
+        $voice = new BrandVoiceProfile('Ekspercki', 'ekspercki, zwięzły', bannedWords: ['tani']);
+        $voice->markDefault(true);
+
+        $recipeRepo = $this->createStub(EntityRepository::class);
+        $recipeRepo->method('findOneBy')->willReturn($recipe);
+        $voiceRepo = $this->createStub(EntityRepository::class);
+        $voiceRepo->method('findOneBy')->willReturn($voice);
+
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturnCallback(
+            static fn (string $class): EntityRepository => ContentRecipe::class === $class ? $recipeRepo : $voiceRepo,
+        );
+
+        $factsPort = $this->createStub(ObjectFactsPort::class);
+        $factsPort->method('facts')->willReturn(new ObjectFacts(
+            objectId: Uuid::v7(),
+            objectTypeId: Uuid::v7(),
+            values: $grounding->facts,
+            missingCodes: $grounding->missingCodes,
+            siblingLocales: $grounding->siblingLocales,
+        ));
+        $groundingService = new ContentGroundingService($factsPort, $this->createStub(ChannelPublicationResolverInterface::class));
+
+        $models = new AgentModelSelector('claude-sonnet-test', 'claude-opus-test');
+
+        $costs = new UsageCostCalculator($models, 3.0, 15.0, 5.0, 25.0);
+
+        return new GenerateProductDescriptionTool(
+            $em,
+            $groundingService,
+            new GroundingGate(),
+            $port ?? $this->acceptingPort(),
+            $llm,
+            $models,
+            $costs,
+        );
+    }
+
+    private function acceptingPort(): ContentValuePort
+    {
+        return new class implements ContentValuePort {
+            public function materializeGeneratedValue(Uuid $batchId, Uuid $userId, Uuid $objectId, string $attributeCode, string $generatedText, ?string $locale = null, ?string $channel = null, array $meta = []): ContentValueProposal
+            {
+                return ContentValueProposal::materialized(null, ['value' => $generatedText], $locale, $channel);
+            }
+        };
+    }
+
+    private function scriptedLlm(string $reply, LlmCallRecorder $calls): AgentLlmClientInterface
+    {
+        return new class($reply, $calls) implements AgentLlmClientInterface {
+            public function __construct(private readonly string $reply, private readonly LlmCallRecorder $calls)
+            {
+            }
+
+            public function create(Tenant $tenant, string $model, string $system, array $messages, array $tools, bool $promptCaching = true): AgentLlmResponse
+            {
+                ++$this->calls->count;
+                $this->calls->system = $system;
+                $encoded = json_encode($messages);
+                $this->calls->userText = false === $encoded ? '' : $encoded;
+
+                return new AgentLlmResponse(
+                    stopReason: AgentLlmResponse::STOP_END_TURN,
+                    contentBlocks: [['type' => 'text', 'text' => $this->reply]],
+                    inputTokens: 12,
+                    outputTokens: 34,
+                );
+            }
+        };
+    }
+
+    private function context(): AgentToolContext
+    {
+        return new AgentToolContext(Uuid::v7(), new Tenant('demo-test-'.bin2hex(random_bytes(2)), 'Demo'));
+    }
+}
+
+/**
+ * Captures what the tool's nested LLM call received.
+ */
+final class LlmCallRecorder
+{
+    public int $count = 0;
+    public string $system = '';
+    public string $userText = '';
+}


### PR DESCRIPTION
## AICG-P3-02 — tool `generate_product_description` (kind=Write) — flagowa funkcja epiku

Pierwszy tool treści end-to-end: spina grounding (P2-01) + bramkę (P2-02) + prompt z przepisem/głosem marki + zagnieżdżone wywołanie LLM + walidację długości + materializację (P3-01) w jeden `AgentToolInterface`. Wzorzec grounded-suggestion z `SuggestColumnMappingTool` — „nothing is applied by the tool itself".

### Pipeline `execute`
1. resolve przepisu (`recipe_id` albo default dla targetu: built-in first) i głosu (przypięty do przepisu → default tenanta);
2. `ContentGroundingService` → fakty (∩ publication profile przy kanale);
3. **bramka kompletności** — `insufficient_grounding` jako structured tool_result **PRZED** jakimkolwiek wywołaniem modelu (test pinuje: 0 calli LLM);
4. zagnieżdżony call na `AgentModelSelector::defaultModel()` (Sonnet-tier) przez BYOK (`AgentLlmClientInterface`), system = kontrakt anty-halucynacyjny + format/budżet + ton + głos marki, user = **wyłącznie fakty** (+ sibling locales + kontekst kanału);
5. przekroczenie `max_len` przepisu → warning w propozycji (nie cichy zapis);
6. materializacja przez `ContentValuePort` z meta `{intent, source_attributes, recipe_id, model}`.

### Dwa małe rozszerzenia szyn (w tym samym PR, uzasadnione)
- **Pętla dolicza `llm_usage` z tool_result do runu** — tokeny zagnieżdżonej generacji wchodzą do limitu per-run i budżetów §8.5 (audyt per-call zostaje w `agent_tool_calls.result_summary`). Generyczny seam dla wszystkich tooli agent-native (P4-02/P6-01 reuse).
- **`AgentApprovalService` merguje `source_attributes`+`recipe_id`** z meta wiersza batcha do batch-owego `provenance_meta` (no-op dla batchy bulk-edit).

### Testy (unit 6/6, LLM = jedyny mock — skryptowany `AgentLlmClientInterface`)
insufficient → **zero wywołań modelu** · happy path → materializacja + meta audytu + usage w tool_result · prompt zawiera WYŁĄCZNIE ugruntowane fakty + kontrakt + banned words (missing codes nie wyciekają) · przekroczony budżet → warning · invalid product_id → error bez calla · kontrakt rejestru (name/kind=Write/`object.write`/required).

### Live smoke na `pim.localhost` (BYOK Haiku, wykonany — SMOKE TEST RULE)
1. **Happy path:** przepis smoke (source = realne kody demo: name/brand/kolor/rozmiar/styl/ocieplenie) → `POST /api/agent/runs` → run `awaiting_approval` w 1 pollu, tokeny **1267/418, $0.031** (z zagnieżdżoną generacją); pending row: *„Botki Butdam wykonane ze skóry licowej w kolorze czarnym. Dostępne w rozmiarach 36–41. Fason w szpic z inspiracją stylem kowbojskim. Bez ocieplenia…"* — **każdy fakt z realnych atrybutów**;
2. **Approve → 200**, `object_values.description` z `provenance=agent` i `provenance_meta = {agent_run_id, model, intent, recipe_id, source_attributes:[name,brand,kolor,rozmiar,styl,ocieplenie]}` — envelope P0-02 na żywo;
3. **Insufficient:** przepis z nieistniejącymi źródłami (material/dimensions/features) → tool_result `{status: insufficient_grounding, present_facts: 0, missing…}`, **zero generacji**, run → `awaiting_input`;
4. **Rollback → 200**, wiersz description usunięty (istniejący undo-log działa dla treści);
5. artefakty smoke (2 przepisy) posprzątane przez API (204).

### Bramki lokalnie (pim-api-1)
PHPUnit unit 1558/1558 · PHPStan max 0 · Deptrac --no-cache 0 · cs-fixer czysto · tool widoczny w `debug:container --tag=agent.tool`.

Świadome odejście: SEO walidator (P4-01) nie jest tu wpięty — `generate_seo_text` (P4-02) go konsumuje; przekroczenie `max_len` w opisie = warning (regeneracja tylko w toolu SEO, zgodnie z backlogiem).

Closes #2335
