### PR TITLE
feat(agent): add SEO rules validator and generate_seo_text tool

### DIFF
--- a/apps/api/src/Agent/Application/Content/SeoRulesValidator.php
+++ b/apps/api/src/Agent/Application/Content/SeoRulesValidator.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Content;
+
+/**
+ * AICG-P4-01 (#2337, ADR-0030 decision C) — SEO rules are CONTENT
+ * validation parametrised by the recipe, not a data-model concern:
+ * length budget, focus-keyword presence, and a keyword-stuffing
+ * density ceiling. A violation is data for the caller (regenerate or
+ * flag the proposal), never an exception.
+ */
+final readonly class SeoRulesValidator
+{
+    /**
+     * Fraction of words the focus keyword may make up before the copy
+     * reads as stuffing (industry rule of thumb ~2-3%; 8% is already
+     * unnatural for the short meta formats this validates).
+     */
+    private const float STUFFING_DENSITY_CEILING = 0.08;
+    private const int STUFFING_MIN_OCCURRENCES = 3;
+
+    /**
+     * @param array<string, mixed> $seoRules the recipe's constraints.seo
+     *                                       slot: {keyword?, title_len?, meta_len?}
+     * @param int|null             $maxLen   the applicable length budget picked
+     *                                       by the caller (title vs meta)
+     *
+     * @return list<string> violations; [] = valid
+     */
+    public function validate(string $text, array $seoRules, ?int $maxLen = null): array
+    {
+        $violations = [];
+        $length = mb_strlen(trim($text));
+
+        if (\is_int($maxLen) && $length > $maxLen) {
+            $violations[] = \sprintf('too_long: %d characters against the budget of %d', $length, $maxLen);
+        }
+
+        $keyword = $seoRules['keyword'] ?? null;
+        if (\is_string($keyword) && '' !== trim($keyword)) {
+            $keyword = trim($keyword);
+            $occurrences = mb_substr_count(mb_strtolower($text), mb_strtolower($keyword));
+            if (0 === $occurrences) {
+                $violations[] = \sprintf('missing_keyword: "%s" does not appear in the copy', $keyword);
+            } else {
+                $keywordSplit = preg_split('/\\s+/', $keyword);
+                $keywordWords = max(1, \count(false === $keywordSplit ? [] : $keywordSplit));
+                $textSplit = preg_split('/\\s+/', trim($text));
+                $totalWords = max(1, \count(false === $textSplit ? [] : $textSplit));
+                $density = ($occurrences * $keywordWords) / $totalWords;
+                if ($occurrences >= self::STUFFING_MIN_OCCURRENCES && $density > self::STUFFING_DENSITY_CEILING) {
+                    $violations[] = \sprintf(
+                        'keyword_stuffing: "%s" appears %d times (density %.0f%%, ceiling %.0f%%)',
+                        $keyword,
+                        $occurrences,
+                        $density * 100,
+                        self::STUFFING_DENSITY_CEILING * 100,
+                    );
+                }
+            }
+        }
+
+        return $violations;
+    }
+
+    /**
+     * The applicable budget for a target attribute: title-ish targets
+     * use title_len, everything else meta_len. Parametrised by the
+     * recipe, never hard-coded (decision C).
+     *
+     * @param array<string, mixed> $seoRules
+     */
+    public function budgetFor(string $targetAttribute, array $seoRules): ?int
+    {
+        $isTitle = str_contains(mb_strtolower($targetAttribute), 'title');
+        $budget = $isTitle ? ($seoRules['title_len'] ?? null) : ($seoRules['meta_len'] ?? null);
+
+        return \is_int($budget) ? $budget : null;
+    }
+}

--- a/apps/api/src/Agent/Application/Tool/GenerateSeoTextTool.php
+++ b/apps/api/src/Agent/Application/Tool/GenerateSeoTextTool.php
@@ -1,0 +1,340 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Tool;
+
+use App\Agent\Application\Content\ContentGrounding;
+use App\Agent\Application\Content\ContentGroundingService;
+use App\Agent\Application\Content\GroundingGate;
+use App\Agent\Application\Content\SeoRulesValidator;
+use App\Agent\Application\Llm\AgentLlmClientInterface;
+use App\Agent\Application\Run\UsageCostCalculator;
+use App\Agent\Domain\Entity\BrandVoiceProfile;
+use App\Agent\Domain\Entity\ContentRecipe;
+use App\Agent\Infrastructure\Anthropic\AgentModelSelector;
+use App\Catalog\Contracts\Command\ContentValuePort;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+
+/**
+ * AICG-P4-02 (#2338, ADR-0030) — SEO copy (meta title / description /
+ * SEO text) as the second variant of the same grounded mechanism
+ * (plan §5 rule 3): the pipeline of generate_product_description plus
+ * the recipe-parametrised SEO rules (P4-01, decision C — rules live in
+ * the recipe, the target stays a plain text attribute).
+ *
+ * A violation triggers ONE regeneration with the violations spelled
+ * out; a copy that still violates is materialized WITH the flags — the
+ * operator sees them in the proposal and decides.
+ */
+final readonly class GenerateSeoTextTool implements AgentToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private ContentGroundingService $grounding,
+        private GroundingGate $gate,
+        private SeoRulesValidator $seoRules,
+        private ContentValuePort $contentValues,
+        private AgentLlmClientInterface $llm,
+        private AgentModelSelector $models,
+        private UsageCostCalculator $costs,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'generate_seo_text';
+    }
+
+    public function description(): string
+    {
+        return 'Generate SEO copy (meta title, meta description, SEO text) for a product STRICTLY from its own attribute values, enforcing the recipe\'s SEO rules: length budget, focus keyword presence, no keyword stuffing. The proposal lands in pending_changes for human approval. Use for meta_* / SEO attributes; use generate_product_description for regular descriptive copy.';
+    }
+
+    public function parametersSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'product_id' => [
+                    'type' => 'string',
+                    'description' => 'UUID of the product object.',
+                ],
+                'target_attribute' => [
+                    'type' => 'string',
+                    'description' => 'Code of the SEO text attribute to fill (e.g. "meta_description"). Defaults to the recipe\'s target.',
+                ],
+                'locale' => [
+                    'type' => 'string',
+                    'description' => 'Locale of the generated copy (short code). Omit for the global value.',
+                ],
+                'channel' => [
+                    'type' => 'string',
+                    'description' => 'Channel code when the copy targets one channel.',
+                ],
+                'recipe_id' => [
+                    'type' => 'string',
+                    'description' => 'ContentRecipe UUID. Omit to use the recipe configured for the target attribute.',
+                ],
+                'keyword' => [
+                    'type' => 'string',
+                    'description' => 'Focus keyword override for this request (defaults to the recipe\'s constraints.seo.keyword).',
+                ],
+                'pending_change_batch_id' => [
+                    'type' => 'string',
+                    'description' => 'Append to an existing proposal batch. Usually injected automatically.',
+                ],
+            ],
+            'required' => ['product_id'],
+        ];
+    }
+
+    public function requiredPermission(): string
+    {
+        return 'object.write';
+    }
+
+    public function kind(): ToolKind
+    {
+        return ToolKind::Write;
+    }
+
+    public function execute(array $arguments, AgentToolContext $context): array
+    {
+        $productId = $arguments['product_id'] ?? null;
+        if (!\is_string($productId) || !Uuid::isValid($productId)) {
+            return ['error' => 'product_id must be a valid UUID.'];
+        }
+
+        $recipe = $this->resolveRecipe($arguments);
+        if (null === $recipe) {
+            return ['error' => 'No content recipe found — pass recipe_id or configure one for the target attribute in Settings → AI content.'];
+        }
+        $targetAttribute = \is_string($arguments['target_attribute'] ?? null) && '' !== $arguments['target_attribute']
+            ? $arguments['target_attribute']
+            : $recipe->getTargetAttribute();
+        $locale = \is_string($arguments['locale'] ?? null) && '' !== $arguments['locale'] ? $arguments['locale'] : null;
+        $channel = \is_string($arguments['channel'] ?? null) && '' !== $arguments['channel'] ? $arguments['channel'] : null;
+
+        $seo = $this->seoRulesOf($recipe);
+        if (\is_string($arguments['keyword'] ?? null) && '' !== $arguments['keyword']) {
+            $seo['keyword'] = $arguments['keyword'];
+        }
+        $budget = $this->seoRules->budgetFor($targetAttribute, $seo);
+
+        $grounding = $this->grounding->ground(Uuid::fromString($productId), $recipe, $context->tenant, $locale, $channel);
+        $verdict = $this->gate->evaluate($grounding, $recipe);
+        if (!$verdict->isSufficient()) {
+            return $verdict->toToolResult();
+        }
+
+        $voice = $this->resolveVoice($recipe);
+        $model = $this->models->defaultModel();
+        $usage = ['input_tokens' => 0, 'output_tokens' => 0];
+
+        $generated = $this->generate($context, $model, $grounding, $targetAttribute, $locale, $seo, $budget, $voice, null, $usage);
+        if ('' === $generated) {
+            return ['error' => 'The model returned no text — retry or adjust the recipe.'];
+        }
+
+        $violations = $this->seoRules->validate($generated, $seo, $budget);
+        if ([] !== $violations) {
+            // ONE regeneration with the violations spelled out (backlog:
+            // "naruszenie -> jedna regeneracja lub flag").
+            $regenerated = $this->generate($context, $model, $grounding, $targetAttribute, $locale, $seo, $budget, $voice, $violations, $usage);
+            if ('' !== $regenerated) {
+                $generated = $regenerated;
+                $violations = $this->seoRules->validate($generated, $seo, $budget);
+            }
+        }
+
+        $batchId = \is_string($arguments['pending_change_batch_id'] ?? null) && Uuid::isValid($arguments['pending_change_batch_id'])
+            ? Uuid::fromString($arguments['pending_change_batch_id'])
+            : Uuid::v7();
+        $proposal = $this->contentValues->materializeGeneratedValue(
+            $batchId,
+            $context->userId,
+            Uuid::fromString($productId),
+            $targetAttribute,
+            $generated,
+            $locale,
+            $channel,
+            meta: [
+                'intent' => 'generate_seo_text',
+                'source_attributes' => $grounding->usedCodes,
+                'recipe_id' => $recipe->getId()->toRfc4122(),
+                'model' => $model,
+            ],
+        );
+
+        $llmUsage = $usage + ['cost_usd' => $this->costs->costUsd($model, $usage['input_tokens'], $usage['output_tokens'], 0, 0)];
+
+        if (!$proposal->isMaterialized()) {
+            return $proposal->toToolResult() + ['llm_usage' => $llmUsage];
+        }
+
+        return [
+            'status' => 'materialized',
+            'pending_change_batch_id' => $batchId->toRfc4122(),
+            'affected_count' => 1,
+            'product_id' => $productId,
+            'target_attribute' => $targetAttribute,
+            'locale' => $proposal->scopeLocale,
+            'channel' => $proposal->scopeChannel,
+            'generated_preview' => mb_substr($generated, 0, 300),
+            'source_attributes' => $grounding->usedCodes,
+            'recipe' => $recipe->getCode(),
+            'seo_violations' => $violations,
+            'llm_usage' => $llmUsage,
+            'note' => [] === $violations
+                ? 'Proposal materialized for approval — nothing was written to the product.'
+                : 'Proposal materialized WITH unresolved SEO violations — point them out to the user.',
+        ];
+    }
+
+    /**
+     * @param array<string, mixed>                         $seo
+     * @param list<string>|null                            $violations
+     * @param array{input_tokens: int, output_tokens: int} $usage
+     */
+    private function generate(
+        AgentToolContext $context,
+        string $model,
+        ContentGrounding $grounding,
+        string $targetAttribute,
+        ?string $locale,
+        array $seo,
+        ?int $budget,
+        ?BrandVoiceProfile $voice,
+        ?array $violations,
+        array &$usage,
+    ): string {
+        $response = $this->llm->create(
+            $context->tenant,
+            $model,
+            $this->systemPrompt($seo, $budget, $voice),
+            [[
+                'role' => 'user',
+                'content' => [['type' => 'text', 'text' => $this->userPrompt($grounding, $targetAttribute, $locale, $violations)]],
+            ]],
+            tools: [],
+            promptCaching: false,
+        );
+        $usage['input_tokens'] += $response->inputTokens;
+        $usage['output_tokens'] += $response->outputTokens;
+
+        $text = '';
+        foreach ($response->contentBlocks as $block) {
+            if (($block['type'] ?? null) === 'text' && \is_string($block['text'] ?? null)) {
+                $text .= $block['text'];
+            }
+        }
+
+        return trim($text);
+    }
+
+    /**
+     * @param array<string, mixed> $seo
+     */
+    private function systemPrompt(array $seo, ?int $budget, ?BrandVoiceProfile $voice): string
+    {
+        $lines = [
+            'You are an SEO copywriter inside a PIM. You write short SEO copy from structured product data.',
+            '',
+            'ANTI-HALLUCINATION CONTRACT (hard rules):',
+            '- Use ONLY the facts provided in the user message. They are the complete ground truth.',
+            '- NEVER state a parameter, number, material, feature or property that is absent from the facts.',
+            '- Do not speculate, average, or "typically" anything. Missing means unmentioned.',
+            '',
+            'Output: plain text only, one line, no markup, no quotes, no preamble.',
+        ];
+        if (\is_int($budget)) {
+            $lines[] = \sprintf('HARD length budget: at most %d characters.', $budget);
+        }
+        $keyword = $seo['keyword'] ?? null;
+        if (\is_string($keyword) && '' !== $keyword) {
+            $lines[] = \sprintf('The focus keyword "%s" must appear exactly once, naturally. Never repeat it — keyword stuffing is forbidden.', $keyword);
+        }
+        if (null !== $voice) {
+            $lines[] = \sprintf('Brand voice "%s": %s', $voice->getName(), $voice->getTone());
+            if ([] !== $voice->getBannedWords()) {
+                $lines[] = '- Never use the words: '.implode(', ', $voice->getBannedWords()).'.';
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @param list<string>|null $violations
+     */
+    private function userPrompt(ContentGrounding $grounding, string $targetAttribute, ?string $locale, ?array $violations): string
+    {
+        $facts = json_encode($grounding->facts, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        $retry = null === $violations || [] === $violations
+            ? ''
+            : "\n\nYour previous attempt violated these SEO rules — fix ALL of them:\n- ".implode("\n- ", $violations);
+
+        return \sprintf(
+            "Write the \"%s\" SEO attribute%s for this product.\n\nProduct facts (the ONLY permissible source of claims):\n%s%s",
+            $targetAttribute,
+            null !== $locale ? \sprintf(' in locale "%s"', $locale) : '',
+            \is_string($facts) ? $facts : '{}',
+            $retry,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $arguments
+     */
+    private function resolveRecipe(array $arguments): ?ContentRecipe
+    {
+        $recipeId = $arguments['recipe_id'] ?? null;
+        if (\is_string($recipeId) && Uuid::isValid($recipeId)) {
+            return $this->em->find(ContentRecipe::class, $recipeId);
+        }
+
+        $target = $arguments['target_attribute'] ?? null;
+        $criteria = \is_string($target) && '' !== $target ? ['targetAttribute' => $target] : ['code' => 'meta_seo'];
+        $repository = $this->em->getRepository(ContentRecipe::class);
+
+        return $repository->findOneBy($criteria + ['isBuiltIn' => true]) ?? $repository->findOneBy($criteria);
+    }
+
+    private function resolveVoice(ContentRecipe $recipe): ?BrandVoiceProfile
+    {
+        if (null !== $recipe->getBrandVoiceId()) {
+            $pinned = $this->em->find(BrandVoiceProfile::class, $recipe->getBrandVoiceId()->toRfc4122());
+            if ($pinned instanceof BrandVoiceProfile) {
+                return $pinned;
+            }
+        }
+
+        return $this->em->getRepository(BrandVoiceProfile::class)->findOneBy(['isDefault' => true]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function seoRulesOf(ContentRecipe $recipe): array
+    {
+        $seo = $recipe->getConstraints()['seo'] ?? [];
+        if (!\is_array($seo)) {
+            return [];
+        }
+
+        $rules = [];
+        foreach ($seo as $key => $value) {
+            if (\is_string($key)) {
+                $rules[$key] = $value;
+            }
+        }
+
+        return $rules;
+    }
+}

--- a/apps/api/tests/Unit/Agent/Application/GenerateSeoTextToolTest.php
+++ b/apps/api/tests/Unit/Agent/Application/GenerateSeoTextToolTest.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Agent\Application;
+
+use App\Agent\Application\Content\ContentGroundingService;
+use App\Agent\Application\Content\GroundingGate;
+use App\Agent\Application\Content\SeoRulesValidator;
+use App\Agent\Application\Llm\AgentLlmClientInterface;
+use App\Agent\Application\Llm\AgentLlmResponse;
+use App\Agent\Application\Run\UsageCostCalculator;
+use App\Agent\Application\Tool\AgentToolContext;
+use App\Agent\Application\Tool\GenerateSeoTextTool;
+use App\Agent\Application\Tool\ToolKind;
+use App\Agent\Domain\Entity\BrandVoiceProfile;
+use App\Agent\Domain\Entity\ContentRecipe;
+use App\Agent\Infrastructure\Anthropic\AgentModelSelector;
+use App\Catalog\Contracts\Command\ContentValuePort;
+use App\Catalog\Contracts\Command\ContentValueProposal;
+use App\Catalog\Contracts\Query\ObjectFacts;
+use App\Catalog\Contracts\Query\ObjectFactsPort;
+use App\Channel\Contracts\ChannelPublicationResolverInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AICG-P4-02 (#2338) — the SEO variant of the grounded pipeline: the
+ * recipe's SEO rules are enforced post-generation, one violation
+ * triggers exactly ONE regeneration with the violations spelled out,
+ * and copy that still violates materializes WITH the flags (the
+ * operator decides — never a silent write, never a silent drop).
+ */
+final class GenerateSeoTextToolTest extends TestCase
+{
+    #[Test]
+    public function validCopyMaterializesWithNoViolationsAndOneCall(): void
+    {
+        $recorder = new SeoLlmRecorder(['Kabel HDMI 2.1 do konsol i telewizorów 4K.']);
+
+        $result = $this->tool($recorder)->execute(
+            ['product_id' => Uuid::v7()->toRfc4122()],
+            $this->context(),
+        );
+
+        self::assertSame('materialized', $result['status']);
+        self::assertSame([], $result['seo_violations']);
+        self::assertSame(1, $recorder->calls);
+        self::assertSame(1, $result['affected_count']);
+    }
+
+    #[Test]
+    public function violationTriggersExactlyOneRegenerationWithTheViolationsSpelledOut(): void
+    {
+        $recorder = new SeoLlmRecorder([
+            'Przewód wideo wysokiej jakości.', // missing keyword
+            'Kabel HDMI 2.1 do konsol i telewizorów 4K.', // fixed
+        ]);
+
+        $result = $this->tool($recorder)->execute(
+            ['product_id' => Uuid::v7()->toRfc4122()],
+            $this->context(),
+        );
+
+        self::assertSame(2, $recorder->calls);
+        self::assertStringContainsString('missing_keyword', $recorder->lastUserText);
+        self::assertSame([], $result['seo_violations']);
+        self::assertSame('materialized', $result['status']);
+    }
+
+    #[Test]
+    public function stillViolatingCopyMaterializesWithFlagsNotSilently(): void
+    {
+        $recorder = new SeoLlmRecorder([
+            str_repeat('za dlugi opis bez slowa kluczowego ', 8),
+            str_repeat('nadal za dlugi opis bez slowa kluczowego ', 8),
+        ]);
+
+        $result = $this->tool($recorder)->execute(
+            ['product_id' => Uuid::v7()->toRfc4122()],
+            $this->context(),
+        );
+
+        self::assertSame(2, $recorder->calls, 'exactly one regeneration, never a loop');
+        self::assertSame('materialized', $result['status']);
+        $violations = $result['seo_violations'];
+        self::assertIsArray($violations);
+        self::assertNotSame([], $violations);
+        $note = $result['note'];
+        self::assertIsString($note);
+        self::assertStringContainsString('unresolved SEO violations', $note);
+    }
+
+    #[Test]
+    public function insufficientGroundingShortCircuitsBeforeTheLlm(): void
+    {
+        $recorder = new SeoLlmRecorder(['never']);
+
+        $result = $this->tool($recorder, facts: [])->execute(
+            ['product_id' => Uuid::v7()->toRfc4122()],
+            $this->context(),
+        );
+
+        self::assertSame('insufficient_grounding', $result['status']);
+        self::assertSame(0, $recorder->calls);
+    }
+
+    #[Test]
+    public function keywordOverrideAndUsageAggregationAcrossRegeneration(): void
+    {
+        $recorder = new SeoLlmRecorder([
+            'Przewod bez slowa.', // missing overridden keyword "4K"
+            'Telewizor 4K z kablem.',
+        ]);
+
+        $result = $this->tool($recorder)->execute(
+            ['product_id' => Uuid::v7()->toRfc4122(), 'keyword' => '4K'],
+            $this->context(),
+        );
+
+        self::assertSame('materialized', $result['status']);
+        $usage = $result['llm_usage'];
+        self::assertIsArray($usage);
+        self::assertSame(20, $usage['input_tokens'], 'both calls must be accounted (2 x 10)');
+        self::assertSame(40, $usage['output_tokens']);
+        self::assertStringContainsString('"4K" must appear exactly once', $recorder->lastSystem);
+    }
+
+    #[Test]
+    public function toolContractForTheRegistry(): void
+    {
+        $tool = $this->tool(new SeoLlmRecorder(['x']));
+
+        self::assertSame('generate_seo_text', $tool->name());
+        self::assertSame(ToolKind::Write, $tool->kind());
+        self::assertSame('object.write', $tool->requiredPermission());
+    }
+
+    /**
+     * @param array<string, array<string, mixed>>|null $facts
+     */
+    private function tool(SeoLlmRecorder $recorder, ?array $facts = null): GenerateSeoTextTool
+    {
+        $facts ??= ['name' => ['value' => 'Kabel HDMI 2.1'], 'brand' => ['value' => 'Vento']];
+
+        $recipe = new ContentRecipe(
+            code: 'meta_seo',
+            name: 'Meta SEO',
+            targetAttribute: 'meta_description',
+            sourceAttributes: ['name', 'brand'],
+            constraints: ['format' => 'plain', 'seo' => ['keyword' => 'HDMI', 'title_len' => 60, 'meta_len' => 155]],
+        );
+        $voice = new BrandVoiceProfile('Ekspercki', 'rzeczowy');
+
+        $recipeRepo = $this->createStub(EntityRepository::class);
+        $recipeRepo->method('findOneBy')->willReturn($recipe);
+        $voiceRepo = $this->createStub(EntityRepository::class);
+        $voiceRepo->method('findOneBy')->willReturn($voice);
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturnCallback(
+            static fn (string $class): EntityRepository => ContentRecipe::class === $class ? $recipeRepo : $voiceRepo,
+        );
+
+        $factsPort = $this->createStub(ObjectFactsPort::class);
+        $factsPort->method('facts')->willReturn(new ObjectFacts(
+            objectId: Uuid::v7(),
+            objectTypeId: Uuid::v7(),
+            values: $facts,
+            missingCodes: [] === $facts ? ['name', 'brand'] : [],
+        ));
+
+        $port = new class implements ContentValuePort {
+            public function materializeGeneratedValue(Uuid $batchId, Uuid $userId, Uuid $objectId, string $attributeCode, string $generatedText, ?string $locale = null, ?string $channel = null, array $meta = []): ContentValueProposal
+            {
+                return ContentValueProposal::materialized(null, ['value' => $generatedText], $locale, $channel);
+            }
+        };
+
+        $models = new AgentModelSelector('claude-sonnet-test', 'claude-opus-test');
+
+        return new GenerateSeoTextTool(
+            $em,
+            new ContentGroundingService($factsPort, $this->createStub(ChannelPublicationResolverInterface::class)),
+            new GroundingGate(),
+            new SeoRulesValidator(),
+            $port,
+            $recorder->client(),
+            $models,
+            new UsageCostCalculator($models, 3.0, 15.0, 5.0, 25.0),
+        );
+    }
+
+    private function context(): AgentToolContext
+    {
+        return new AgentToolContext(Uuid::v7(), new Tenant('demo-test-'.bin2hex(random_bytes(2)), 'Demo'));
+    }
+}
+
+/**
+ * Scripted LLM replies + captured prompts across regeneration rounds.
+ */
+final class SeoLlmRecorder
+{
+    public int $calls = 0;
+    public string $lastSystem = '';
+    public string $lastUserText = '';
+
+    /**
+     * @param list<string> $replies
+     */
+    public function __construct(private readonly array $replies)
+    {
+    }
+
+    public function client(): AgentLlmClientInterface
+    {
+        $recorder = $this;
+
+        return new class($recorder) implements AgentLlmClientInterface {
+            public function __construct(private readonly SeoLlmRecorder $recorder)
+            {
+            }
+
+            public function create(Tenant $tenant, string $model, string $system, array $messages, array $tools, bool $promptCaching = true): AgentLlmResponse
+            {
+                $reply = $this->recorder->reply();
+                $this->recorder->lastSystem = $system;
+                $encoded = json_encode($messages);
+                $this->recorder->lastUserText = false === $encoded ? '' : $encoded;
+
+                return new AgentLlmResponse(
+                    stopReason: AgentLlmResponse::STOP_END_TURN,
+                    contentBlocks: [['type' => 'text', 'text' => $reply]],
+                    inputTokens: 10,
+                    outputTokens: 20,
+                );
+            }
+        };
+    }
+
+    public function reply(): string
+    {
+        $reply = $this->replies[$this->calls] ?? $this->replies[array_key_last($this->replies)] ?? '';
+        ++$this->calls;
+
+        return $reply;
+    }
+}

--- a/apps/api/tests/Unit/Agent/Application/SeoRulesValidatorTest.php
+++ b/apps/api/tests/Unit/Agent/Application/SeoRulesValidatorTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Agent\Application;
+
+use App\Agent\Application\Content\SeoRulesValidator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * AICG-P4-01 (#2337, decision C) — SEO rules parametrised by the
+ * recipe: length budget, keyword presence, stuffing ceiling. Structured
+ * violations, never exceptions.
+ */
+final class SeoRulesValidatorTest extends TestCase
+{
+    #[Test]
+    public function validCopyPassesEveryRule(): void
+    {
+        $violations = new SeoRulesValidator()->validate(
+            'Kabel HDMI 2.1 o długości 2 m do konsol i telewizorów 4K.',
+            ['keyword' => 'HDMI'],
+            maxLen: 155,
+        );
+
+        self::assertSame([], $violations);
+    }
+
+    #[Test]
+    public function overlongCopyViolatesTheBudget(): void
+    {
+        $violations = new SeoRulesValidator()->validate(str_repeat('a', 200), [], maxLen: 155);
+
+        self::assertCount(1, $violations);
+        self::assertStringContainsString('too_long: 200', $violations[0]);
+    }
+
+    #[Test]
+    public function missingKeywordIsAViolation(): void
+    {
+        $violations = new SeoRulesValidator()->validate(
+            'Przewód wideo wysokiej jakości.',
+            ['keyword' => 'HDMI'],
+        );
+
+        self::assertCount(1, $violations);
+        self::assertStringContainsString('missing_keyword: "HDMI"', $violations[0]);
+    }
+
+    #[Test]
+    public function keywordMatchIsCaseInsensitive(): void
+    {
+        $violations = new SeoRulesValidator()->validate('Kabel hdmi 2.1.', ['keyword' => 'HDMI']);
+
+        self::assertSame([], $violations);
+    }
+
+    #[Test]
+    public function stuffingIsFlaggedAboveTheDensityCeiling(): void
+    {
+        $violations = new SeoRulesValidator()->validate(
+            'HDMI HDMI HDMI kabel HDMI do HDMI.',
+            ['keyword' => 'HDMI'],
+        );
+
+        self::assertCount(1, $violations);
+        self::assertStringContainsString('keyword_stuffing', $violations[0]);
+    }
+
+    #[Test]
+    public function repeatedKeywordInLongNaturalCopyIsNotStuffing(): void
+    {
+        $copy = 'Kabel HDMI 2.1 obsługuje rozdzielczość 4K przy 120 Hz. Złącze HDMI pasuje do konsol, '
+            .'komputerów i telewizorów. Oplot nylonowy chroni przewód przed uszkodzeniami, a pozłacane '
+            .'styki zapewniają stabilny sygnał przez lata codziennego użytkowania bez zakłóceń obrazu.';
+
+        self::assertSame([], new SeoRulesValidator()->validate($copy, ['keyword' => 'HDMI'], maxLen: 300));
+    }
+
+    #[Test]
+    public function multipleViolationsAreAllReported(): void
+    {
+        $violations = new SeoRulesValidator()->validate(
+            str_repeat('opis produktu bez slowa kluczowego ', 6),
+            ['keyword' => 'HDMI'],
+            maxLen: 100,
+        );
+
+        self::assertCount(2, $violations);
+    }
+
+    #[Test]
+    public function budgetPicksTitleLenForTitleTargetsAndMetaLenOtherwise(): void
+    {
+        $validator = new SeoRulesValidator();
+        $rules = ['title_len' => 60, 'meta_len' => 155];
+
+        self::assertSame(60, $validator->budgetFor('meta_title', $rules));
+        self::assertSame(60, $validator->budgetFor('seo_title', $rules));
+        self::assertSame(155, $validator->budgetFor('meta_description', $rules));
+        self::assertSame(155, $validator->budgetFor('seo_text', $rules));
+        self::assertNull($validator->budgetFor('meta_description', ['title_len' => 60]));
+    }
+}


### PR DESCRIPTION
## AICG-P4-01 + P4-02 — `SeoRulesValidator` + tool `generate_seo_text` (bundle za zgodą operatora)

Para producer–consumer w jednym milestone (walidator ma dokładnie jednego konsumenta) — **bundle uzgodniony w czacie 2026-07-10**, żeby nie palić rundy CI; commity per ticket, proof zamknięcia osobno na #2337 i #2338. Domyka **M4**.

### AICG-P4-01 — `SeoRulesValidator` (#2337, decyzja C)
Reguły SEO to walidacja treści parametryzowana przepisem, nie model danych:
- **długość** wg budżetu (`budgetFor`: target zawierający „title" → `title_len`, reszta → `meta_len`; brak w przepisie → brak limitu — zero hardcode);
- **obecność keyworda** (case-insensitive);
- **keyword-stuffing**: próg gęstości 8% przy ≥3 wystąpieniach (rule-of-thumb 2–3%, 8% w krótkich formatach = ewidentnie nienaturalne).
Structured violations (`too_long`/`missing_keyword`/`keyword_stuffing`), nigdy wyjątki. Testy: 8 case'ów (w tym „powtórzony keyword w długim naturalnym tekście ≠ stuffing" i parametryzacja budżetów per przepis).

### AICG-P4-02 — `generate_seo_text` (kind=Write) (#2338)
Pipeline 1:1 z `generate_product_description` (grounding → bramka → nested call defaultModel/BYOK → kontrakt anty-halucynacyjny) + reguły SEO:
- system-prompt wymusza: twardy budżet znaków, „keyword exactly once, naturally, stuffing forbidden";
- **naruszenie → dokładnie JEDNA regeneracja** z wypisanymi naruszeniami; wciąż łamie → **materializacja Z FLAGAMI** (`seo_violations` + note dla modelu) — operator decyduje, nigdy cichy zapis ani cichy drop;
- `keyword` z argumentu nadpisuje przepis; target = zwykły atrybut `meta_*` (bez sztywnych typów);
- usage OBU wywołań zagregowane w `llm_usage` (pętla dolicza do runu — seam z P3-02).
Testy: 6 case'ów (valid 1 call · violation → 2 calle z naruszeniami w promptcie retry · still-violating → flagi + note · insufficient → 0 calli · keyword override + agregacja usage 2×10/2×20 · kontrakt rejestru).

### Live smoke na `pim.localhost` (BYOK Haiku, wykonany — SMOKE TEST RULE)
Przepis smoke (target `meta_description`, keyword „botki damskie", meta_len 155, źródła name/brand/kolor/styl) → run → `awaiting_approval` w 2 pollach. Propozycja:
> „Czarne botki damskie Butdam ze skóry licowej – szpiczasty nosek w stylu kowbojek. Idealne na jesień, zimę i wiosnę."
**115 znaków ≤ 155 ✓, keyword obecny ✓, każdy fakt z atrybutów ✓**, `intent=generate_seo_text`, `source_attributes=[name,brand,kolor,styl]` w meta. Reject → 200, `meta_description` bez wiersza (0), przepis smoke usunięty (204).

### Bramki lokalnie (pim-api-1)
PHPUnit unit **1576/1576** (14 nowych) · PHPStan max 0 · Deptrac --no-cache 0 · cs-fixer czysto · tool w `debug:container --tag=agent.tool` ✓.

Closes #2337
Closes #2338
