### PR TITLE
feat(admin): add Ask AI on text fields with inline proposal diff

### DIFF
--- a/apps/admin/e2e/aicg-p5-ask-ai-inline-diff.spec.ts
+++ b/apps/admin/e2e/aicg-p5-ask-ai-inline-diff.spec.ts
@@ -1,0 +1,201 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, type Page, test } from '@playwright/test';
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * AICG-P5-01/02 (#2339/#2340) — the "Ask AI" affordance on text fields
+ * and the inline proposal diff. The agent API is intercepted (the same
+ * convention as 2246-dashboard-agent-hero-live.spec.ts): CI has no BYOK
+ * key, and the LLM is the one seam e2e legitimately mocks — everything
+ * else (login, product form, field wiring) runs against the real stack.
+ */
+
+const RUN_ID = '019f0000-0000-7000-8000-00000000a5a5';
+
+function runSummary(overrides: Record<string, unknown> = {}) {
+  return {
+    id: RUN_ID,
+    status: 'planning',
+    surface: 'chat',
+    intent: 'aicg e2e',
+    model: null,
+    pending_change_batch_id: null,
+    affected_count: null,
+    bulk_operation_id: null,
+    tokens_input: 0,
+    tokens_output: 0,
+    cost_usd: '0.000000',
+    approved_by: null,
+    approved_at: null,
+    started_at: new Date().toISOString(),
+    completed_at: null,
+    ...overrides,
+  };
+}
+
+function runDetail(status: string, overrides: Record<string, unknown> = {}) {
+  return {
+    ...runSummary({ status }),
+    context: {},
+    error_message: null,
+    messages: [],
+    tool_calls: [],
+    ...overrides,
+  };
+}
+
+async function openFirstProduct(page: Page) {
+  await page.goto('/products');
+  const firstRow = page.locator('[data-testid^="products-grid-row-"]').first();
+  await expect(firstRow).toBeVisible({ timeout: 30_000 });
+  await firstRow.getByRole('link').first().click();
+  await expect(page).toHaveURL(/\/products\/[0-9a-f-]{36}/, { timeout: 30_000 });
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('i18nextLng', 'pl');
+  });
+});
+
+test('Ask AI on a text field starts a run with the field context and the accepted proposal resolves', async ({
+  page,
+}) => {
+  let runStatus = 'planning';
+  let capturedStart: Record<string, unknown> | null = null;
+  let approved = false;
+
+  await page.route(`**/api/agent/runs/${RUN_ID}/plan**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        items: [
+          {
+            id: '019f0000-0000-7000-8000-00000000p1a1',
+            change_type: 'value',
+            status: 'pending',
+            target_object_id: null,
+            target_object_code: null,
+            target_object_name: null,
+            attribute_code: capturedStart
+              ? ((capturedStart.context as Record<string, unknown>).target_attribute as string)
+              : 'description',
+            scope_locale: null,
+            scope_channel: null,
+            before: null,
+            after: { value: 'Wygenerowany opis e2e — czarne botki ze skóry.' },
+            provenance: 'agent',
+          },
+        ],
+        total: 1,
+        page: 1,
+        per_page: 50,
+      }),
+    }),
+  );
+  await page.route(`**/api/agent/runs/${RUN_ID}/approve`, (route) => {
+    approved = true;
+    runStatus = 'done';
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(runSummary({ status: 'done' })),
+    });
+  });
+  await page.route(`**/api/agent/runs/${RUN_ID}`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(runDetail(runStatus)),
+    }),
+  );
+  await page.route('**/api/agent/runs', async (route) => {
+    if (route.request().method() !== 'POST') {
+      await route.fallback();
+      return;
+    }
+    capturedStart = route.request().postDataJSON() as Record<string, unknown>;
+    // First poll sees planning, the next one the materialized proposal.
+    setTimeout(() => {
+      runStatus = 'awaiting_approval';
+    }, 500);
+    await route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify(runSummary()),
+    });
+  });
+
+  await loginAsAdmin(page);
+  await openFirstProduct(page);
+
+  // The affordance renders on editable text-family fields.
+  const askButton = page.locator('[data-testid^="ask-ai-"]').first();
+  await expect(askButton).toBeVisible({ timeout: 30_000 });
+  const askedCode = (await askButton.getAttribute('data-testid'))?.replace('ask-ai-', '');
+  await askButton.click();
+
+  // The run started with the field's context.
+  await expect.poll(() => capturedStart !== null).toBeTruthy();
+  const context = (capturedStart as unknown as { context: Record<string, unknown> }).context;
+  expect(context.target_attribute).toBe(askedCode);
+  expect(typeof context.product_id).toBe('string');
+
+  // Progress -> inline diff with the generated copy.
+  const proposal = page.getByTestId('ask-ai-proposal');
+  await expect(proposal).toBeVisible();
+  await expect(page.getByTestId('ask-ai-after')).toContainText('Wygenerowany opis e2e', {
+    timeout: 15_000,
+  });
+
+  // axe gate (WCAG A/AA) with the proposal card rendered — the affordance
+  // and the diff must introduce no serious/critical violations.
+  const axe = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']).analyze();
+  expect(
+    axe.violations
+      .filter((violation) => violation.impact === 'serious' || violation.impact === 'critical')
+      .map((violation) => violation.id),
+  ).toEqual([]);
+
+  // Accept resolves through the run-approval API and the card clears.
+  await page.getByRole('button', { name: /akceptuj/i }).click();
+  await expect.poll(() => approved).toBeTruthy();
+  await expect(proposal).toHaveCount(0, { timeout: 15_000 });
+});
+
+test('a failed run surfaces an inline error the operator can dismiss', async ({ page }) => {
+  await page.route(`**/api/agent/runs/${RUN_ID}`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(runDetail('error', { error_message: 'Brak przepisu dla tego pola.' })),
+    }),
+  );
+  await page.route('**/api/agent/runs', async (route) => {
+    if (route.request().method() !== 'POST') {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify(runSummary({ status: 'error' })),
+    });
+  });
+
+  await loginAsAdmin(page);
+  await openFirstProduct(page);
+
+  const askButton = page.locator('[data-testid^="ask-ai-"]').first();
+  await expect(askButton).toBeVisible({ timeout: 30_000 });
+  await askButton.click();
+
+  const proposal = page.getByTestId('ask-ai-proposal');
+  await expect(proposal).toBeVisible();
+  await expect(proposal).toContainText(/nie powiodło się/i, { timeout: 15_000 });
+  await expect(proposal).toContainText('Brak przepisu dla tego pola.');
+
+  await page.getByRole('button', { name: /zamknij/i }).click();
+  await expect(proposal).toHaveCount(0);
+});

--- a/apps/admin/src/components/provenance-badge.tsx
+++ b/apps/admin/src/components/provenance-badge.tsx
@@ -15,6 +15,13 @@ interface ProvenanceBadgeProps {
   provenance: Provenance;
   source?: string | null;
   occurredAt?: string | null;
+  /**
+   * AICG-P5-02 (#2340) — content-generation audit ("skąd ten fakt"):
+   * attribute codes the copy was generated from + the recipe id, read
+   * from provenance_meta (jsonb-schemas §5). Agent-only, optional.
+   */
+  sourceAttributes?: string[] | null;
+  recipeId?: string | null;
   className?: string;
 }
 
@@ -22,12 +29,22 @@ export function ProvenanceBadge({
   provenance,
   source,
   occurredAt,
+  sourceAttributes,
+  recipeId,
   className,
 }: ProvenanceBadgeProps) {
   const { t, i18n } = useTranslation();
   const tone = TONES[provenance];
   const label = t(`provenance.${provenance}`, { defaultValue: provenance });
-  const tooltip = buildTooltip(t, provenance, source, occurredAt, i18n.language);
+  const tooltip = buildTooltip(
+    t,
+    provenance,
+    source,
+    occurredAt,
+    i18n.language,
+    sourceAttributes,
+    recipeId,
+  );
 
   return (
     <span
@@ -56,12 +73,22 @@ function buildTooltip(
   source: string | null | undefined,
   occurredAt: string | null | undefined,
   locale: string,
+  sourceAttributes?: string[] | null,
+  recipeId?: string | null,
 ): string {
   const parts = [t(`provenance.${provenance}`, { defaultValue: provenance })];
   if (provenance === 'agent') {
     parts[0] = t('provenance.agent_tooltip', { defaultValue: 'Ustawione przez agenta' });
     if (source) {
       parts.push(`${t('provenance.agent_run', { defaultValue: 'run' })}: ${source}`);
+    }
+    if (sourceAttributes != null && sourceAttributes.length > 0) {
+      parts.push(
+        `${t('provenance.generated_from', { defaultValue: 'wygenerowano z' })}: ${sourceAttributes.join(', ')}`,
+      );
+    }
+    if (recipeId != null && recipeId !== '') {
+      parts.push(`${t('provenance.recipe', { defaultValue: 'przepis' })}: ${recipeId}`);
     }
   } else if (source) {
     parts.push(`${t('provenance.source', { defaultValue: 'Source' })}: ${source}`);

--- a/apps/admin/src/features/agent/hooks/use-content-recipes.ts
+++ b/apps/admin/src/features/agent/hooks/use-content-recipes.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import { jsonFetch } from '@/lib/http';
+
+/**
+ * AICG-P5-02 (#2340) — the recipe catalogue for provenance tooltips
+ * ("przepis: <nazwa>") and future recipe pickers. One cached read of
+ * /api/content-recipes (AICG-P1-03); transport isolated in this hook
+ * per the jsonFetch/useEffect lint guard.
+ */
+export interface ContentRecipeDto {
+  id: string;
+  code: string;
+  name: string;
+  targetAttribute: string;
+  builtIn: boolean;
+}
+
+export function useContentRecipes(enabled = true) {
+  const query = useQuery<{ member?: ContentRecipeDto[]; 'hydra:member'?: ContentRecipeDto[] }>({
+    queryKey: ['content-recipes'],
+    queryFn: () => jsonFetch('/api/content-recipes'),
+    enabled,
+    staleTime: 5 * 60_000,
+    retry: 1,
+  });
+
+  const recipes = query.data?.member ?? query.data?.['hydra:member'] ?? [];
+  const nameById = new Map(recipes.map((recipe) => [recipe.id, recipe.name]));
+
+  return { recipes, nameById, isLoading: query.isPending, error: query.error };
+}

--- a/apps/admin/src/features/catalog/products/components/ask-ai-proposal.tsx
+++ b/apps/admin/src/features/catalog/products/components/ask-ai-proposal.tsx
@@ -1,0 +1,142 @@
+import { Check, Loader2, MessageSquareText, Sparkles, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { OPEN_AGENT_CHAT_EVENT } from '@/features/agent/chat/AgentChatSheet';
+import type { AskAiState } from './use-ask-ai';
+
+/**
+ * AICG-P5-02 (#2340) — the inline proposal card under an asked field:
+ * a before/after diff with Accept/Reject wired to the SAME run-approval
+ * API the inbox uses (accept commits through pending_changes, backend
+ * P3-01). Progress and clarifying-question states link to the chat.
+ */
+export function AskAiProposal({
+  state,
+  onAccept,
+  onReject,
+  onDismiss,
+}: {
+  state: AskAiState;
+  onAccept: () => void;
+  onReject: () => void;
+  onDismiss: () => void;
+}) {
+  const { t } = useTranslation();
+
+  const openChat = () => {
+    window.dispatchEvent(
+      new CustomEvent(OPEN_AGENT_CHAT_EVENT, { detail: { runId: state.runId } }),
+    );
+  };
+
+  if (state.phase === 'running' || state.phase === 'deciding') {
+    return (
+      <div
+        className="mx-2 mb-2 flex items-center gap-2 rounded-lg border border-purple-200 bg-purple-50 px-3 py-2 text-sm text-purple-900"
+        data-testid="ask-ai-proposal"
+        role="status"
+      >
+        <Loader2 className="size-4 animate-spin" aria-hidden />
+        {state.phase === 'deciding'
+          ? t('aicg.deciding', { defaultValue: 'Zapisywanie decyzji…' })
+          : t('aicg.generating', { defaultValue: 'Agent pisze propozycję…' })}
+      </div>
+    );
+  }
+
+  if (state.phase === 'awaiting_input') {
+    return (
+      <div
+        className="mx-2 mb-2 flex items-center justify-between gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900"
+        data-testid="ask-ai-proposal"
+      >
+        <span>{t('aicg.needs_input', { defaultValue: 'Agent potrzebuje doprecyzowania.' })}</span>
+        <button
+          type="button"
+          onClick={openChat}
+          className="inline-flex items-center gap-1 rounded-md px-2 py-1 font-medium hover:bg-amber-100"
+        >
+          <MessageSquareText className="size-3.5" aria-hidden />
+          {t('aicg.open_chat', { defaultValue: 'Otwórz czat' })}
+        </button>
+      </div>
+    );
+  }
+
+  if (state.phase === 'error') {
+    return (
+      <div
+        className="mx-2 mb-2 flex items-center justify-between gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-900"
+        data-testid="ask-ai-proposal"
+      >
+        <span>
+          {t('aicg.error', { defaultValue: 'Generowanie nie powiodło się.' })}
+          {state.errorDetail !== null ? ` ${state.errorDetail}` : ''}
+        </span>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="rounded-md px-2 py-1 font-medium hover:bg-red-100"
+        >
+          {t('aicg.dismiss', { defaultValue: 'Zamknij' })}
+        </button>
+      </div>
+    );
+  }
+
+  const before = envelopeText(state.proposal?.before);
+  const after = envelopeText(state.proposal?.after);
+
+  return (
+    <div
+      className="mx-2 mb-2 rounded-lg border border-purple-200 bg-purple-50/60 p-3 text-sm"
+      data-testid="ask-ai-proposal"
+    >
+      <div className="mb-2 flex items-center gap-1.5 font-medium text-purple-900">
+        <Sparkles className="size-4" aria-hidden />
+        {t('aicg.proposal_title', { defaultValue: 'Propozycja agenta' })}
+      </div>
+      {before !== '' && (
+        <p className="mb-1 whitespace-pre-wrap rounded bg-red-50 px-2 py-1 text-red-900 line-through decoration-red-400">
+          {before}
+        </p>
+      )}
+      <p
+        className="whitespace-pre-wrap rounded bg-emerald-50 px-2 py-1 text-emerald-900"
+        data-testid="ask-ai-after"
+      >
+        {after !== '' ? after : t('aicg.empty_proposal', { defaultValue: '(pusta propozycja)' })}
+      </p>
+      <div className="mt-2 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onAccept}
+          className="inline-flex items-center gap-1 rounded-md bg-purple-600 px-3 py-1.5 font-medium text-white hover:bg-purple-700"
+        >
+          <Check className="size-3.5" aria-hidden />
+          {t('aicg.accept', { defaultValue: 'Akceptuj' })}
+        </button>
+        <button
+          type="button"
+          onClick={onReject}
+          className="inline-flex items-center gap-1 rounded-md border border-zinc-300 bg-white px-3 py-1.5 font-medium text-zinc-700 hover:bg-zinc-50"
+        >
+          <X className="size-3.5" aria-hidden />
+          {t('aicg.reject', { defaultValue: 'Odrzuć' })}
+        </button>
+        <button
+          type="button"
+          onClick={openChat}
+          className="ml-auto inline-flex items-center gap-1 rounded-md px-2 py-1 text-purple-700 hover:bg-purple-100"
+        >
+          <MessageSquareText className="size-3.5" aria-hidden />
+          {t('aicg.open_chat', { defaultValue: 'Otwórz czat' })}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function envelopeText(envelope: Record<string, unknown> | null | undefined): string {
+  const value = envelope?.value;
+  return typeof value === 'string' ? value : '';
+}

--- a/apps/admin/src/features/catalog/products/components/attr-row.tsx
+++ b/apps/admin/src/features/catalog/products/components/attr-row.tsx
@@ -1,4 +1,4 @@
-import { Copy, CornerDownRight, Link2, Lock } from 'lucide-react';
+import { Copy, CornerDownRight, Link2, Lock, Sparkles } from 'lucide-react';
 import { lazy, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { RelationCreateField } from '@/components/objects/relation-create-field';
@@ -40,6 +40,19 @@ export interface AttrRowProps {
   provenance: Provenance;
   /** AGENT-P6-05 (#1978) — agent run id for the badge tooltip. */
   provenanceSource?: string | null;
+  /**
+   * AICG-P5-02 (#2340) — content-generation audit for the badge tooltip:
+   * the attribute codes the copy was generated from + the recipe id
+   * (provenance_meta.source_attributes / recipe_id, jsonb-schemas §5).
+   */
+  provenanceSourceAttributes?: string[] | null;
+  provenanceRecipeId?: string | null;
+  /**
+   * AICG-P5-01 (#2339) — when present, an "Ask AI" affordance renders in
+   * the RHS slot (next to the provenance badge). The page supplies it
+   * only for editable text-family attributes.
+   */
+  onAskAI?: () => void;
   locale: ProductLocale;
   isEditing: boolean;
   isLocked: boolean;
@@ -105,6 +118,9 @@ export function AttrRow({
   value,
   provenance,
   provenanceSource,
+  provenanceSourceAttributes = null,
+  provenanceRecipeId = null,
+  onAskAI,
   locale,
   isEditing,
   isLocked,
@@ -444,6 +460,23 @@ export function AttrRow({
       </div>
 
       <div className="flex items-center gap-1 pt-1.5">
+        {onAskAI !== undefined && (
+          <button
+            type="button"
+            onClick={onAskAI}
+            title={t('aicg.ask_title', {
+              defaultValue: 'Zapytaj AI — wygeneruj treść z atrybutów produktu',
+            })}
+            aria-label={t('aicg.ask_aria', {
+              defaultValue: 'Wygeneruj treść pola {{label}} z atrybutów produktu',
+              label,
+            })}
+            data-testid={`ask-ai-${attribute.code}`}
+            className="rounded-md p-1.5 text-purple-500 transition-colors hover:bg-purple-100 hover:text-purple-700"
+          >
+            <Sparkles className="size-3.5" aria-hidden />
+          </button>
+        )}
         {onCopyToOthers !== undefined ? (
           <button
             type="button"
@@ -461,7 +494,12 @@ export function AttrRow({
             <Copy className="size-3.5" aria-hidden />
           </button>
         ) : (
-          <ProvenanceBadge provenance={provenance} source={provenanceSource ?? undefined} />
+          <ProvenanceBadge
+            provenance={provenance}
+            source={provenanceSource ?? undefined}
+            sourceAttributes={provenanceSourceAttributes ?? undefined}
+            recipeId={provenanceRecipeId ?? undefined}
+          />
         )}
       </div>
     </div>

--- a/apps/admin/src/features/catalog/products/components/product-detail-content.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-content.tsx
@@ -9,6 +9,7 @@ import {
   GROUP_ICONS,
   isSpecialTab,
   resolveProvenance,
+  resolveProvenanceContentMeta,
   resolveProvenanceRunId,
   type TabKey,
 } from './product-detail-helpers';
@@ -50,6 +51,16 @@ export interface ProductDetailContentProps {
   fieldValue: (code: string) => unknown;
   onFieldChange: (code: string, value: unknown) => void;
   onToggleGroup: (groupId: string) => void;
+  /**
+   * AICG-P5-01/02 (#2339/#2340) — supplied by the page in edit mode:
+   * `onAskAI(code)` starts a content run for the field;
+   * `askAiProposalFor(code)` returns the inline proposal node rendered
+   * under the asked row (null elsewhere);
+   * `recipeNameById` feeds the badge tooltip's "przepis: <nazwa>".
+   */
+  onAskAI?: (attributeCode: string) => void;
+  askAiProposalFor?: (attributeCode: string) => import('react').ReactNode;
+  recipeNameById?: Map<string, string>;
 }
 
 /**
@@ -82,7 +93,16 @@ export function ProductDetailContent({
   fieldValue,
   onFieldChange,
   onToggleGroup,
+  onAskAI,
+  askAiProposalFor,
+  recipeNameById,
 }: ProductDetailContentProps) {
+  // AICG-P5-01 — the affordance targets editable text-family fields only.
+  const TEXT_FAMILY = new Set(['text', 'textarea', 'wysiwyg']);
+  const askAiFor = (attr: GroupMeta['attributes'][number]) =>
+    onAskAI !== undefined && isEditMode && !attr.is_system && TEXT_FAMILY.has(attr.type)
+      ? () => onAskAI(attr.code)
+      : undefined;
   // DP-08 (#2039) — conditional visibility: a member whose `visible_when`
   // rule fails against the CURRENT form values is not rendered. Reactive by
   // construction (fieldValue reads the live draft), and hidden values are
@@ -102,28 +122,40 @@ export function ProductDetailContent({
       onToggle={() => onToggleGroup(group.id)}
       isSystem={isLegacyOptionalSystemGroupCode(group.code)}
     >
-      {visibleAttributes(group).map((attr) => (
-        <AttrRow
-          key={attr.id}
-          attribute={attr}
-          value={fieldValue(attr.code)}
-          provenance={resolveProvenance(attr, product)}
-          provenanceSource={resolveProvenanceRunId(attr, product)}
-          locale={locale}
-          channel={channel}
-          isEditing={isEditing}
-          isLocked={attr.is_system}
-          onChange={(next) => onFieldChange(attr.code, next)}
-          createMode={mode === 'create'}
-          relationContextProductId={isEditMode ? id : undefined}
-          isInherited={
-            scopeStatus[attr.code]?.has_override === false &&
-            scopeStatus[attr.code]?.inherited_from != null
-          }
-          inheritedFrom={scopeStatus[attr.code]?.inherited_from ?? null}
-          requiredError={requiredErrors.has(attr.code)}
-        />
-      ))}
+      {visibleAttributes(group).map((attr) => {
+        const contentMeta = resolveProvenanceContentMeta(attr, product);
+        return (
+          <div key={attr.id}>
+            <AttrRow
+              attribute={attr}
+              value={fieldValue(attr.code)}
+              provenance={resolveProvenance(attr, product)}
+              provenanceSource={resolveProvenanceRunId(attr, product)}
+              provenanceSourceAttributes={contentMeta.sourceAttributes}
+              provenanceRecipeId={
+                contentMeta.recipeId !== null
+                  ? (recipeNameById?.get(contentMeta.recipeId) ?? contentMeta.recipeId)
+                  : null
+              }
+              onAskAI={askAiFor(attr)}
+              locale={locale}
+              channel={channel}
+              isEditing={isEditing}
+              isLocked={attr.is_system}
+              onChange={(next) => onFieldChange(attr.code, next)}
+              createMode={mode === 'create'}
+              relationContextProductId={isEditMode ? id : undefined}
+              isInherited={
+                scopeStatus[attr.code]?.has_override === false &&
+                scopeStatus[attr.code]?.inherited_from != null
+              }
+              inheritedFrom={scopeStatus[attr.code]?.inherited_from ?? null}
+              requiredError={requiredErrors.has(attr.code)}
+            />
+            {askAiProposalFor?.(attr.code)}
+          </div>
+        );
+      })}
     </AttrGroupCard>
   );
 

--- a/apps/admin/src/features/catalog/products/components/product-detail-helpers.ts
+++ b/apps/admin/src/features/catalog/products/components/product-detail-helpers.ts
@@ -193,3 +193,29 @@ export function resolveProvenanceRunId(
   const runId = indexed?.[attr.code]?.provenance_meta?.agent_run_id;
   return typeof runId === 'string' ? runId : null;
 }
+
+/**
+ * AICG-P5-02 (#2340) — the content-generation audit from the indexed
+ * projection's provenance_meta (jsonb-schemas §5): which attribute
+ * codes the copy was generated from + the recipe id. Both optional —
+ * pre-AICG agent writes carry neither.
+ */
+export function resolveProvenanceContentMeta(
+  attr: AttributeMeta,
+  product: CatalogObjectDto | null | undefined,
+): { sourceAttributes: string[] | null; recipeId: string | null } {
+  const indexed = product?.attributesIndexed as
+    | Record<string, { provenance_meta?: { source_attributes?: unknown; recipe_id?: unknown } }>
+    | undefined;
+  const meta = indexed?.[attr.code]?.provenance_meta;
+  const rawSources = meta?.source_attributes;
+  const sourceAttributes = Array.isArray(rawSources)
+    ? rawSources.filter((code): code is string => typeof code === 'string')
+    : null;
+  const recipeId = typeof meta?.recipe_id === 'string' ? meta.recipe_id : null;
+  return {
+    sourceAttributes:
+      sourceAttributes !== null && sourceAttributes.length > 0 ? sourceAttributes : null,
+    recipeId,
+  };
+}

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -6,6 +6,8 @@ import { DetailLoadingState } from '@/components/catalog/detail-loading-state';
 import { DetailNotFoundState } from '@/components/catalog/detail-not-found-state';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
+import { useContentRecipes } from '@/features/agent/hooks/use-content-recipes';
+import { AskAiProposal } from './ask-ai-proposal';
 import { ProductDetailContent } from './product-detail-content';
 import { ProductDetailHeader } from './product-detail-header';
 import type { TabKey } from './product-detail-helpers';
@@ -13,6 +15,7 @@ import { TabLoadingFallback } from './product-detail-other-tabs';
 import { ProductDetailSidebar } from './product-detail-sidebar';
 import { scopedCompleteness } from './scope';
 import type { ProductChannel, ProductDetailMode, ProductLocale } from './types';
+import { useAskAi } from './use-ask-ai';
 import { useProductDetailData } from './use-product-detail-data';
 import { useProductDetailForm } from './use-product-detail-form';
 
@@ -181,6 +184,26 @@ export function ProductDetailPage({
     backHref,
     detailPathFor,
   });
+
+  // AICG-P5-01/02 (#2339/#2340) — the "Ask AI" lifecycle: a content run
+  // per asked text field, its inline proposal, and the recipe names for
+  // the badge tooltip. Edit mode only (a fresh create has no facts yet).
+  const askAi = useAskAi({
+    productId: isEditMode ? id : undefined,
+    locale,
+    channel,
+    onAccepted: () => productQuery.refetch(),
+  });
+  const { nameById: recipeNameById } = useContentRecipes(isEditMode);
+  const askAiProposalFor = (attributeCode: string) =>
+    askAi.state !== null && askAi.state.attributeCode === attributeCode ? (
+      <AskAiProposal
+        state={askAi.state}
+        onAccept={() => void askAi.accept()}
+        onReject={() => void askAi.reject()}
+        onDismiss={askAi.dismiss}
+      />
+    ) : null;
 
   // #1149 — default the locale selection to the tenant default once the
   // enabled-locale list arrives (shipped by effective-attribute-groups),
@@ -426,6 +449,9 @@ export function ProductDetailPage({
               fieldValue={fieldValue}
               onFieldChange={setFieldValue}
               onToggleGroup={toggleGroup}
+              onAskAI={isEditMode ? askAi.start : undefined}
+              askAiProposalFor={askAiProposalFor}
+              recipeNameById={recipeNameById}
             />
           </Suspense>
 

--- a/apps/admin/src/features/catalog/products/components/use-ask-ai.ts
+++ b/apps/admin/src/features/catalog/products/components/use-ask-ai.ts
@@ -1,0 +1,150 @@
+import { useQuery } from '@tanstack/react-query';
+import { useCallback, useState } from 'react';
+import {
+  type AgentPlanRow,
+  type AgentRunStatus,
+  approveAgentRun,
+  getAgentPlan,
+  getAgentRun,
+  isRunBusy,
+  rejectAgentRun,
+  startAgentRun,
+} from '@/features/agent/api';
+
+/**
+ * AICG-P5-01/02 (#2339/#2340) — the "Ask AI" lifecycle of one product
+ * field: start a content run with the field's context, poll it while
+ * the loop works, surface the materialized proposal as an inline diff,
+ * and resolve it through the SAME approval API the inbox uses.
+ *
+ * One active ask per page (mirrors the backend's one-active-run rule);
+ * starting on another field replaces the tracked run, the previous one
+ * stays reachable from the inbox.
+ */
+export interface AskAiState {
+  attributeCode: string;
+  runId: string;
+  phase: 'running' | 'awaiting_approval' | 'awaiting_input' | 'deciding' | 'error';
+  errorDetail: string | null;
+  /** The plan row targeting the asked attribute (when awaiting approval). */
+  proposal: AgentPlanRow | null;
+}
+
+interface UseAskAiArgs {
+  productId: string | undefined;
+  locale: string | null;
+  channel: string | null;
+  onAccepted: () => Promise<unknown>;
+}
+
+export function useAskAi({ productId, locale, channel, onAccepted }: UseAskAiArgs) {
+  const [active, setActive] = useState<{ attributeCode: string; runId: string } | null>(null);
+  const [startError, setStartError] = useState<string | null>(null);
+  const [deciding, setDeciding] = useState(false);
+
+  const runQuery = useQuery({
+    queryKey: ['aicg-ask-run', active?.runId],
+    queryFn: () => getAgentRun(active?.runId ?? ''),
+    enabled: active !== null,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status === undefined || isRunBusy(status) ? 2500 : false;
+    },
+    retry: 1,
+  });
+  const status: AgentRunStatus | undefined = runQuery.data?.status;
+
+  const planQuery = useQuery({
+    queryKey: ['aicg-ask-plan', active?.runId],
+    queryFn: () => getAgentPlan(active?.runId ?? ''),
+    enabled: active !== null && status === 'awaiting_approval',
+    retry: 1,
+  });
+
+  const start = useCallback(
+    async (attributeCode: string) => {
+      if (productId === undefined) {
+        return;
+      }
+      setStartError(null);
+      try {
+        const run = await startAgentRun(
+          `Wygeneruj treść pola "${attributeCode}" tego produktu na podstawie jego atrybutów (użyj narzędzia treści z domyślnym przepisem).`,
+          'chat',
+          {
+            product_id: productId,
+            target_attribute: attributeCode,
+            ...(locale !== null ? { locale } : {}),
+            ...(channel !== null ? { channel } : {}),
+          },
+        );
+        setActive({ attributeCode, runId: run.id });
+      } catch (error) {
+        setStartError(error instanceof Error ? error.message : String(error));
+        setActive(null);
+      }
+    },
+    [productId, locale, channel],
+  );
+
+  const accept = useCallback(async () => {
+    if (active === null) {
+      return;
+    }
+    setDeciding(true);
+    try {
+      await approveAgentRun(active.runId);
+      await onAccepted();
+      setActive(null);
+    } finally {
+      setDeciding(false);
+    }
+  }, [active, onAccepted]);
+
+  const reject = useCallback(async () => {
+    if (active === null) {
+      return;
+    }
+    setDeciding(true);
+    try {
+      await rejectAgentRun(active.runId);
+      setActive(null);
+    } finally {
+      setDeciding(false);
+    }
+  }, [active]);
+
+  const dismiss = useCallback(() => {
+    setActive(null);
+    setStartError(null);
+  }, []);
+
+  let state: AskAiState | null = null;
+  if (active !== null) {
+    const proposal =
+      planQuery.data?.items.find(
+        (row) => row.change_type === 'value' && row.attribute_code === active.attributeCode,
+      ) ??
+      planQuery.data?.items.find((row) => row.change_type === 'value') ??
+      null;
+    let phase: AskAiState['phase'] = 'running';
+    if (deciding) {
+      phase = 'deciding';
+    } else if (status === 'awaiting_approval') {
+      phase = 'awaiting_approval';
+    } else if (status === 'awaiting_input') {
+      phase = 'awaiting_input';
+    } else if (status === 'error' || runQuery.isError) {
+      phase = 'error';
+    }
+    state = {
+      attributeCode: active.attributeCode,
+      runId: active.runId,
+      phase,
+      errorDetail: runQuery.data?.error_message ?? null,
+      proposal,
+    };
+  }
+
+  return { state, startError, start, accept, reject, dismiss };
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1626,7 +1626,9 @@
     "source": "Source",
     "timestamp": "Updated",
     "agent_tooltip": "Set by the agent",
-    "agent_run": "run"
+    "agent_run": "run",
+    "generated_from": "generated from",
+    "recipe": "recipe"
   },
   "search": {
     "placeholder": "Search…",
@@ -3912,5 +3914,19 @@
       "materializing": "Materializing the plan…",
       "committing": "Committing…"
     }
+  },
+  "aicg": {
+    "ask_title": "Ask AI — generate content from product attributes",
+    "ask_aria": "Generate the {{label}} field from product attributes",
+    "generating": "The agent is writing a proposal…",
+    "deciding": "Saving the decision…",
+    "needs_input": "The agent needs clarification.",
+    "open_chat": "Open chat",
+    "error": "Generation failed.",
+    "dismiss": "Dismiss",
+    "proposal_title": "Agent proposal",
+    "empty_proposal": "(empty proposal)",
+    "accept": "Accept",
+    "reject": "Reject"
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1638,7 +1638,9 @@
     "source": "Źródło",
     "timestamp": "Zaktualizowano",
     "agent_tooltip": "Ustawione przez agenta",
-    "agent_run": "run"
+    "agent_run": "run",
+    "generated_from": "wygenerowano z",
+    "recipe": "przepis"
   },
   "search": {
     "placeholder": "Szukaj…",
@@ -3932,5 +3934,19 @@
       "materializing": "Przygotowuję plan zmian…",
       "committing": "Zapisuję…"
     }
+  },
+  "aicg": {
+    "ask_title": "Zapytaj AI — wygeneruj treść z atrybutów produktu",
+    "ask_aria": "Wygeneruj treść pola {{label}} z atrybutów produktu",
+    "generating": "Agent pisze propozycję…",
+    "deciding": "Zapisywanie decyzji…",
+    "needs_input": "Agent potrzebuje doprecyzowania.",
+    "open_chat": "Otwórz czat",
+    "error": "Generowanie nie powiodło się.",
+    "dismiss": "Zamknij",
+    "proposal_title": "Propozycja agenta",
+    "empty_proposal": "(pusta propozycja)",
+    "accept": "Akceptuj",
+    "reject": "Odrzuć"
   }
 }


### PR DESCRIPTION
## AICG-P5-01 + P5-02 — „Ask AI" na polu + inline-diff propozycji + badge pochodzenia (bundle za zgodą operatora)

Para blocked-by w tym samym obszarze komponentów (formularz produktu) — bundle uzgodniony w czacie 2026-07-10; proof zamknięcia osobno na #2339 i #2340.

### P5-01 — afordancja „Ask AI" (#2339)
- Ikona **Sparkles** w slocie RHS `AttrRow` — wyłącznie edytowalne pola text-family (`text`/`textarea`/`wysiwyg`), nie-systemowe, tylko edit mode (create nie ma jeszcze faktów).
- Klik → `startAgentRun` z kontekstem pola: `{product_id, target_attribute, locale?, channel?}` (surface `chat`); wybór przepisu = domyślna resolucja po targecie w toolu (backlog: „lub domyślny" — bez pickera, świadome uproszczenie MVP; tone_hint pominięty).
- `useAskAi` (transport w hooku — guard jsonFetch/useEffect nienaruszony, baseline 59<61): poll runu (`refetchInterval` gdy busy), plan po `awaiting_approval`, jeden aktywny ask per strona.

### P5-02 — inline-diff + badge (#2340)
- **`AskAiProposal`** pod zapytanym wierszem: progress → diff before (przekreślony) / after (zielony) → **Accept/Reject przez TE SAME endpointy co inbox** (`/approve` commituje przez pending_changes — backend P3-01; po Accept `productQuery.refetch()` wciąga wartość + badge); `awaiting_input` → handoff do czatu (`OPEN_AGENT_CHAT_EVENT`); error → dismissable karta z detail.
- **Badge „agent" + tooltip pochodzenia**: `wygenerowano z: <source_attributes> · przepis: <nazwa>` — czyta `provenance_meta.{source_attributes, recipe_id}` z projekcji `attributes_indexed` (P0-02), nazwy przepisów z `useContentRecipes` (`/api/content-recipes`, P1-03).
- i18n: nowy namespace `aicg.*` + `provenance.generated_from`/`provenance.recipe` (pl+en, parytet).

### Testy
- **Playwright (`aicg-p5-ask-ai-inline-diff.spec.ts`, 2/2 lokalnie na żywym stacku):** happy path (run startuje z kontekstem pola → diff → **axe WCAG A/AA gate na wyrenderowanej karcie** → Accept → karta znika) + edge (run error → inline error + dismiss). Agent API intercepted konwencją 2246 — CI nie ma klucza BYOK; LLM to jedyny mockowany seam, login/formularz/wiring realne.
- vitest 147/147 · tsc 0 · biome 0 · build OK.

### Live smoke na `pim.localhost` (BYOK Haiku, wykonany — SMOKE TEST RULE, pełny flow UI BEZ mocków)
1. Login → produkt `BD-BWC-LICO-CZARNY` → klik **Ask AI** na `description` → karta „Agent pisze propozycję…";
2. realna generacja (przepis dopasowany do kodów demo): *„Botki skórzane licowe marki Buty Butdam w kolorze czarnym. Wykonane ze skóry licowej, dostępne w rozmiarach 36–41."*;
3. **Accept → 200**, pole ma treść, **badge „agent" z tooltipem**: `Ustawione przez agenta · run: 019f4cf7-… · wygenerowano z: name, brand, kolor, rozmiar, styl, ocieplenie · przepis: Opis produktu`;
4. **Console: 0 errorów** (asercja w smoke); całość 15,2 s;
5. Edge na żywo: produkt bez źródeł przepisu → bramka odmawia, run `awaiting_input`, karta amber z handoffem do czatu (dokładnie zaprojektowane zachowanie);
6. Sprzątanie: rollback 200 (pole puste), 2 osierocone runy cancel 200, builtin przepis przywrócony do seedowych źródeł.

**Finding produktowy (nie bug):** seedowany builtin `product_description` używa generycznych kodów (material/dimensions/…), które nie występują w danych IdoSell demo — realny tenant dostosuje źródła w Settings (P5b #2342). Warte wzmianki w docs onboardingu.

Closes #2339
Closes #2340
