### PR TITLE
feat(admin): add bulk AI content generation from the product list

### DIFF
--- a/apps/admin/e2e/aicg-p5-bulk-generate.spec.ts
+++ b/apps/admin/e2e/aicg-p5-bulk-generate.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test } from '@playwright/test';
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * AICG-P5-03 (#2341) — bulk "Generuj treść AI" from the product list:
+ * selection -> modal (count + cost estimate) -> one agent run whose
+ * context carries the selection scope. The agent API is intercepted
+ * (CI has no BYOK key — the 2246/P5a convention).
+ */
+
+const RUN_ID = '019f0000-0000-7000-8000-0000000b1b1b';
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('i18nextLng', 'pl');
+  });
+});
+
+test('bulk generate starts one run with the selection scope in its context', async ({ page }) => {
+  let capturedStart: Record<string, unknown> | null = null;
+  await page.route(`**/api/agent/runs/${RUN_ID}`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: RUN_ID,
+        status: 'planning',
+        surface: 'cmdk',
+        intent: 'bulk e2e',
+        model: null,
+        pending_change_batch_id: null,
+        affected_count: null,
+        bulk_operation_id: null,
+        tokens_input: 0,
+        tokens_output: 0,
+        cost_usd: '0.000000',
+        approved_by: null,
+        approved_at: null,
+        started_at: new Date().toISOString(),
+        completed_at: null,
+        context: {},
+        error_message: null,
+        messages: [],
+        tool_calls: [],
+      }),
+    }),
+  );
+  await page.route('**/api/agent/runs', async (route) => {
+    if (route.request().method() !== 'POST') {
+      await route.fallback();
+      return;
+    }
+    capturedStart = route.request().postDataJSON() as Record<string, unknown>;
+    await route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: RUN_ID,
+        status: 'planning',
+        surface: 'cmdk',
+        intent: 'bulk e2e',
+        model: null,
+        pending_change_batch_id: null,
+        affected_count: null,
+        bulk_operation_id: null,
+        tokens_input: 0,
+        tokens_output: 0,
+        cost_usd: '0.000000',
+        approved_by: null,
+        approved_at: null,
+        started_at: new Date().toISOString(),
+        completed_at: null,
+      }),
+    });
+  });
+
+  await loginAsAdmin(page);
+  await page.goto('/products');
+
+  // Select two rows through their checkboxes.
+  const rows = page.locator('[data-testid^="products-grid-row-"]');
+  await expect(rows.first()).toBeVisible({ timeout: 30_000 });
+  await rows.nth(0).getByRole('checkbox').first().check();
+  await rows.nth(1).getByRole('checkbox').first().check();
+
+  // The bulk bar exposes the new action; the modal shows count + estimate.
+  await page.getByTestId('bulk-generate-content').click();
+  await expect(page.getByTestId('bulk-generate-count')).toContainText('2');
+  await expect(page.getByTestId('bulk-generate-estimate')).toContainText('USD');
+
+  // Switch to SEO mode and start.
+  await page.getByRole('button', { name: /meta seo/i }).click();
+  await page.getByRole('button', { name: /^generuj$/i }).click();
+
+  await expect.poll(() => capturedStart !== null).toBeTruthy();
+  const body = capturedStart as unknown as {
+    intent: string;
+    context: { selected_ids: string[]; total_matching: number; object_type_code: string };
+  };
+  expect(body.intent).toContain('generate_seo_text');
+  expect(body.context.selected_ids).toHaveLength(2);
+  expect(body.context.total_matching).toBe(2);
+  expect(body.context.object_type_code).toBe('product');
+
+  // The modal closed and the selection cleared.
+  await expect(page.getByTestId('bulk-generate-count')).toHaveCount(0);
+});
+
+test('over-cap selection disables the start button with an explanation', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/products');
+
+  const rows = page.locator('[data-testid^="products-grid-row-"]');
+  await expect(rows.first()).toBeVisible({ timeout: 30_000 });
+  const rowCount = Math.min(await rows.count(), 9);
+  test.skip(rowCount < 9, 'demo page holds fewer than 9 rows');
+  for (let i = 0; i < rowCount; i += 1) {
+    await rows.nth(i).getByRole('checkbox').first().check();
+  }
+
+  await page.getByTestId('bulk-generate-content').click();
+  await expect(page.getByTestId('bulk-generate-cap')).toBeVisible();
+  await expect(page.getByRole('button', { name: /^generuj$/i })).toBeDisabled();
+});

--- a/apps/admin/src/components/catalog/bulk-actions/generate-content-modal.tsx
+++ b/apps/admin/src/components/catalog/bulk-actions/generate-content-modal.tsx
@@ -1,0 +1,204 @@
+import { Sparkles, X } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { toast } from '@/components/ui/toast';
+import { startAgentRun } from '@/features/agent/api';
+import { OPEN_AGENT_CHAT_EVENT } from '@/features/agent/chat/AgentChatSheet';
+import { cn } from '@/lib/utils';
+
+/**
+ * AICG-P5-03 (#2341) — bulk "Generuj opisy / Generuj SEO" from the
+ * product list: the selection scope goes into ONE agent run whose
+ * write-tool calls accumulate into ONE pending batch (the multi-step
+ * plan mechanics of the loop), reviewed in the agent inbox.
+ *
+ * The cost preview is a client-side estimate from the live-measured
+ * per-product averages of the content tools; AICG-P6-03 replaces it
+ * with the dedicated backend preview and lifts the per-run cap.
+ */
+
+/**
+ * Live-measured on the dev stack (AICG-P3-02/P4-02 smokes): a grounded
+ * description round-trip lands around 1.3k input / 0.4k output tokens.
+ * Priced at the default-tier list rates ($3 / $15 per MTok).
+ */
+const EST_COST_PER_PRODUCT_USD = 0.012;
+
+/**
+ * The loop's tool-call budget per run is 10 — one grounding+generation
+ * call per product plus headroom. Larger selections need the dedicated
+ * bulk path (AICG-P6-03).
+ */
+const MVP_RUN_CAP = 8;
+
+export function BulkGenerateContentModal({
+  selectedIds,
+  totalMatching,
+  objectTypeCode,
+  filterDsl,
+  onClose,
+  onStarted,
+}: {
+  selectedIds: string[];
+  totalMatching: number;
+  objectTypeCode: string;
+  filterDsl: unknown;
+  onClose: () => void;
+  onStarted: () => void;
+}) {
+  const { t } = useTranslation();
+  const [mode, setMode] = useState<'descriptions' | 'seo'>('descriptions');
+  const [isStarting, setIsStarting] = useState(false);
+
+  const count = selectedIds.length;
+  const overCap = count > MVP_RUN_CAP;
+  const estimate = (count * EST_COST_PER_PRODUCT_USD).toFixed(2);
+
+  const start = async () => {
+    setIsStarting(true);
+    try {
+      const intent =
+        mode === 'descriptions'
+          ? `Dla KAŻDEGO z ${count} zaznaczonych produktów wywołaj narzędzie generate_product_description podając wyłącznie product_id (target i przepis są domyślne). Wszystkie propozycje mają trafić do jednego batcha. Nie zadawaj pytań — jeśli produktowi brakuje danych, narzędzie samo to zgłosi.`
+          : `Dla KAŻDEGO z ${count} zaznaczonych produktów wywołaj narzędzie generate_seo_text podając wyłącznie product_id (target i przepis są domyślne). Wszystkie propozycje mają trafić do jednego batcha. Nie zadawaj pytań — jeśli produktowi brakuje danych, narzędzie samo to zgłosi.`;
+      const run = await startAgentRun(intent, 'cmdk', {
+        object_type_code: objectTypeCode,
+        filter_dsl: filterDsl ?? null,
+        selected_ids: selectedIds,
+        total_matching: totalMatching,
+      });
+      window.dispatchEvent(new CustomEvent(OPEN_AGENT_CHAT_EVENT, { detail: { runId: run.id } }));
+      toast.success(
+        t('aicg.bulk.started', {
+          defaultValue: 'Generowanie wystartowało — propozycje trafią do skrzynki agenta.',
+        }),
+      );
+      onStarted();
+      onClose();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error));
+    } finally {
+      setIsStarting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 grid place-items-center bg-zinc-900/30 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="bulk-generate-title"
+    >
+      <div className="relative flex w-[520px] max-w-[94vw] flex-col overflow-hidden rounded-3xl bg-white shadow-2xl">
+        <div className="flex h-14 items-center gap-3 border-b border-zinc-100 px-6">
+          <span className="grid h-8 w-8 place-items-center rounded-xl bg-purple-50 text-purple-600">
+            <Sparkles className="size-4" aria-hidden />
+          </span>
+          <div className="leading-tight">
+            <div id="bulk-generate-title" className="text-[14.5px] font-semibold">
+              {t('aicg.bulk.title', { defaultValue: 'Akcja zbiorcza · Generuj treść AI' })}
+            </div>
+            <div className="text-[11.5px] text-zinc-500" data-testid="bulk-generate-count">
+              {t('aicg.bulk.count', {
+                defaultValue: '{{count}} produktów wybranych',
+                count,
+              })}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={t('app.close', { defaultValue: 'Zamknij' })}
+            className="ml-auto grid h-8 w-8 place-items-center rounded-lg text-zinc-500 hover:bg-zinc-100"
+          >
+            <X className="size-4" aria-hidden />
+          </button>
+        </div>
+
+        <div className="flex-1 space-y-4 overflow-y-auto p-6">
+          <div>
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-zinc-500">
+              {t('aicg.bulk.mode_label', { defaultValue: 'Co wygenerować' })}
+            </span>
+            <div className="mt-2 grid grid-cols-2 gap-2">
+              <button
+                type="button"
+                onClick={() => setMode('descriptions')}
+                aria-pressed={mode === 'descriptions'}
+                className={cn(
+                  'h-10 rounded-lg border px-3 text-[12px] font-medium',
+                  mode === 'descriptions'
+                    ? 'border-zinc-900 bg-zinc-900 text-white'
+                    : 'border-zinc-200 bg-white text-zinc-700 hover:border-zinc-300',
+                )}
+              >
+                {t('aicg.bulk.mode_descriptions', { defaultValue: 'Opisy produktów' })}
+              </button>
+              <button
+                type="button"
+                onClick={() => setMode('seo')}
+                aria-pressed={mode === 'seo'}
+                className={cn(
+                  'h-10 rounded-lg border px-3 text-[12px] font-medium',
+                  mode === 'seo'
+                    ? 'border-zinc-900 bg-zinc-900 text-white'
+                    : 'border-zinc-200 bg-white text-zinc-700 hover:border-zinc-300',
+                )}
+              >
+                {t('aicg.bulk.mode_seo', { defaultValue: 'Meta SEO' })}
+              </button>
+            </div>
+          </div>
+
+          <div
+            className="rounded-2xl border border-amber-200 bg-amber-50/60 px-4 py-3 text-[12.5px] text-amber-900"
+            data-testid="bulk-generate-estimate"
+          >
+            <div className="font-semibold">
+              {t('aicg.bulk.estimate_label', { defaultValue: 'Szacowany koszt' })}
+            </div>
+            <div>
+              {t('aicg.bulk.estimate', {
+                defaultValue:
+                  '≈{{estimate}} USD ({{count}} × ~0.012 USD za produkt, stawki modelu domyślnego)',
+                estimate,
+                count,
+              })}
+            </div>
+          </div>
+
+          {overCap ? (
+            <div
+              className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-[12.5px] text-red-900"
+              data-testid="bulk-generate-cap"
+            >
+              {t('aicg.bulk.cap', {
+                defaultValue:
+                  'W tej wersji jeden przebieg obsługuje do {{cap}} produktów (budżet narzędzi runu). Zawęź zaznaczenie.',
+                cap: MVP_RUN_CAP,
+              })}
+            </div>
+          ) : null}
+        </div>
+
+        <div className="flex h-14 items-center gap-3 border-t border-zinc-100 bg-zinc-50/50 px-6">
+          <span className="text-[11.5px] text-zinc-500">
+            {t('aicg.bulk.approval_hint', {
+              defaultValue:
+                'Propozycje trafiają do skrzynki agenta — nic nie zapisze się bez akceptacji.',
+            })}
+          </span>
+          <div className="ml-auto flex items-center gap-2">
+            <Button variant="ghost" onClick={onClose} disabled={isStarting}>
+              {t('app.cancel', { defaultValue: 'Anuluj' })}
+            </Button>
+            <Button onClick={() => void start()} disabled={isStarting || overCap || count === 0}>
+              {t('aicg.bulk.start', { defaultValue: 'Generuj' })}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/catalog/bulk-bar.tsx
+++ b/apps/admin/src/components/catalog/bulk-bar.tsx
@@ -26,6 +26,12 @@ interface BulkBarProps {
    * sync <100 SKU → BinaryFileResponse, ≥100 → async session.
    */
   onOpenExportModal?: () => void;
+  /**
+   * AICG-P5-03 (#2341) — opens the bulk "Generuj treść AI" modal
+   * (descriptions / SEO via the content tools, one pending batch in the
+   * agent inbox). Supplied only on product-kind lists.
+   */
+  onOpenGenerateContent?: () => void;
 }
 
 /**
@@ -46,6 +52,7 @@ export function BulkBar({
   onOpenDuplicateModal,
   onOpenCmdK,
   onOpenExportModal,
+  onOpenGenerateContent,
 }: BulkBarProps) {
   const { t } = useTranslation();
 
@@ -107,6 +114,20 @@ export function BulkBar({
             <Download className="size-3.5" aria-hidden="true" />
             {t('products.bulk.export', { defaultValue: 'Eksport' })}
           </button>
+          {onOpenGenerateContent !== undefined ? (
+            <button
+              type="button"
+              onClick={onOpenGenerateContent}
+              data-testid="bulk-generate-content"
+              className={cn(
+                'text-[13px] font-medium px-3 py-1.5 rounded-xl bg-purple-600 hover:bg-purple-500 inline-flex items-center gap-1.5',
+                'focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60',
+              )}
+            >
+              <Sparkles className="size-3.5" aria-hidden="true" />
+              {t('aicg.bulk.action', { defaultValue: 'Generuj treść AI' })}
+            </button>
+          ) : null}
           <button
             type="button"
             onClick={onOpenCmdK ?? placeholder('VIEW-05.5')}

--- a/apps/admin/src/components/objects/universal-list-page.tsx
+++ b/apps/admin/src/components/objects/universal-list-page.tsx
@@ -88,6 +88,11 @@ const BulkDuplicateModal = lazy(() =>
     default: m.BulkDuplicateModal,
   })),
 );
+const BulkGenerateContentModal = lazy(() =>
+  import('@/components/catalog/bulk-actions/generate-content-modal').then((m) => ({
+    default: m.BulkGenerateContentModal,
+  })),
+);
 const BulkDeleteConfirmModal = lazy(() =>
   import('@/components/catalog/bulk-actions/hard-confirm-modal').then((m) => ({
     default: m.BulkDeleteConfirmModal,
@@ -243,6 +248,8 @@ export function UniversalListPage({
   const [bulkCategoryOpen, setBulkCategoryOpen] = useState(false);
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const [bulkDuplicateOpen, setBulkDuplicateOpen] = useState(false);
+  // AICG-P5-03 (#2341) — bulk "Generuj treść AI" modal.
+  const [bulkGenerateOpen, setBulkGenerateOpen] = useState(false);
   const [cmdKOpen, setCmdKOpen] = useState(false);
   const [lastBulkSession, setLastBulkSession] = useState<RollbackSession | null>(null);
 
@@ -961,6 +968,7 @@ export function UniversalListPage({
         onOpenCategoryModal={isCategorizable ? () => setBulkCategoryOpen(true) : undefined}
         onOpenDeleteModal={() => setBulkDeleteOpen(true)}
         onOpenDuplicateModal={isProduct ? () => setBulkDuplicateOpen(true) : undefined}
+        onOpenGenerateContent={isProduct ? () => setBulkGenerateOpen(true) : undefined}
         onOpenCmdK={() => setCmdKOpen(true)}
         onOpenExportModal={
           isProduct || isCustomKind ? () => goToExport('selected', Array.from(selected)) : undefined
@@ -1017,6 +1025,22 @@ export function UniversalListPage({
               setSelected(new Set());
               setShowSelectedOnly(false);
               refetch();
+            }}
+          />
+        ) : null}
+
+        {bulkGenerateOpen ? (
+          <BulkGenerateContentModal
+            selectedIds={Array.from(selected)}
+            totalMatching={
+              crossPageSelection.active ? crossPageSelection.totalMatched : selected.size
+            }
+            objectTypeCode={objectTypeCode}
+            filterDsl={panelDsl}
+            onClose={() => setBulkGenerateOpen(false)}
+            onStarted={() => {
+              setSelected(new Set());
+              setShowSelectedOnly(false);
             }}
           />
         ) : null}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -3927,6 +3927,20 @@
     "proposal_title": "Agent proposal",
     "empty_proposal": "(empty proposal)",
     "accept": "Accept",
-    "reject": "Reject"
+    "reject": "Reject",
+    "bulk": {
+      "action": "Generate AI content",
+      "title": "Bulk action · Generate AI content",
+      "count": "{{count}} products selected",
+      "mode_label": "What to generate",
+      "mode_descriptions": "Product descriptions",
+      "mode_seo": "SEO meta",
+      "estimate_label": "Estimated cost",
+      "estimate": "≈{{estimate}} USD ({{count}} × ~0.012 USD per product, default model rates)",
+      "cap": "This version handles up to {{cap}} products per run (the run tool budget). Narrow the selection.",
+      "approval_hint": "Proposals land in the agent inbox — nothing is written without your approval.",
+      "start": "Generate",
+      "started": "Generation started — proposals will land in the agent inbox."
+    }
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -3947,6 +3947,20 @@
     "proposal_title": "Propozycja agenta",
     "empty_proposal": "(pusta propozycja)",
     "accept": "Akceptuj",
-    "reject": "Odrzuć"
+    "reject": "Odrzuć",
+    "bulk": {
+      "action": "Generuj treść AI",
+      "title": "Akcja zbiorcza · Generuj treść AI",
+      "count": "{{count}} produktów wybranych",
+      "mode_label": "Co wygenerować",
+      "mode_descriptions": "Opisy produktów",
+      "mode_seo": "Meta SEO",
+      "estimate_label": "Szacowany koszt",
+      "estimate": "≈{{estimate}} USD ({{count}} × ~0.012 USD za produkt, stawki modelu domyślnego)",
+      "cap": "W tej wersji jeden przebieg obsługuje do {{cap}} produktów (budżet narzędzi runu). Zawęź zaznaczenie.",
+      "approval_hint": "Propozycje trafiają do skrzynki agenta — nic nie zapisze się bez akceptacji.",
+      "start": "Generuj",
+      "started": "Generowanie wystartowało — propozycje trafią do skrzynki agenta."
+    }
   }
 }


### PR DESCRIPTION
## AICG-P5-03 — bulk „Generuj treść AI" z listy produktów

Skala dla redaktora (plan §5 zasada 1): zaznaczenie → modal → JEDEN run agenta → batch propozycji w istniejącym inboxie.

### Zmiany
- **`BulkGenerateContentModal`** (lazy w `bulk-actions/`): wybór trybu (Opisy / Meta SEO), licznik zaznaczenia (z obsługą cross-page `totalMatching`), **podgląd szacowanego kosztu** (client-side z żywo zmierzonych średnich tokenów per produkt ×stawki defaultModel — świadome odejście: dedykowany endpoint preview przynosi P6-03 i wtedy modal się przepina), hint „nic nie zapisze się bez akceptacji".
- **Cap 8 produktów/przebieg** (budżet 10 tool-calls runu) — komunikat + disabled „Generuj" powyżej; zdejmuje P6-03 dedykowanym bulk-path.
- Przycisk **„Generuj treść AI"** na bulk barze (tylko listy produktowe), obok istniejącego „Zleć agentowi".
- Kontekst runu = pełny selection scope jak Cmd+K: `{object_type_code, filter_dsl, selected_ids, total_matching}`; intent **dyrektywny** (product_id only, defaulty, zero pytań) — pierwsza żywa próba stanęła na dopytce modelu o target; poprawione i re-przetestowane.
- i18n `aicg.bulk.*` pl/en (12 kluczy, parytet).

### Testy
- **Playwright (`aicg-p5-bulk-generate.spec.ts`, 2/2 na żywym stacku):** happy (zaznacz 2 → modal count=2 + estymata → tryb SEO → Generuj → POST z `selected_ids`×2/`total_matching`/`object_type_code`, intent zawiera `generate_seo_text`; modal znika, selekcja czyszczona) + edge (>8 zaznaczonych → widoczny cap, „Generuj" disabled). Agent API intercepted (CI bez BYOK).
- vitest 147/147 · tsc 0 · biome 0 · build ✓ · jsonfetch-guard poniżej baseline.

### Live smoke na `pim.localhost` (BYOK Haiku, wykonany, bez mocków)
Zaznaczone 2 produkty → „Generuj treść AI" → Generuj → **1 run: 2 wywołania toola, 1 batch, 2 propozycje**, `awaiting_approval` (tokeny 1480/455, $0.034 — oba nested calle doliczone). Batch w inboxie:
- `6634 · description`: *„Produkt 6634 marki Butdam."* (ubogie fakty → treść tylko z faktów),
- `6635 · description`: model przy 1 fakcie napisał wprost „Brak wystarczających danych…" zamiast zmyślać — kontrakt działa; tenant może podnieść próg `constraints.grounding.min_facts` (mechanizm P2-02).
Reject → 200 (nic nie zapisane), artefakty posprzątane.

Closes #2341
