### PR TITLE
feat(agent): add translate_value tool (source-locale value as fact)

### DIFF
--- a/apps/api/src/Agent/Application/Tool/TranslateValueTool.php
+++ b/apps/api/src/Agent/Application/Tool/TranslateValueTool.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Tool;
+
+use App\Agent\Application\Llm\AgentLlmClientInterface;
+use App\Agent\Application\Run\UsageCostCalculator;
+use App\Agent\Domain\Entity\BrandVoiceProfile;
+use App\Agent\Infrastructure\Anthropic\AgentModelSelector;
+use App\Catalog\Contracts\Command\ContentValuePort;
+use App\Catalog\Contracts\Query\ObjectFactsPort;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AICG-P6-01 (#2344, ADR-0030) — translation as the third variant of
+ * the grounded mechanism (plan §3a pkt 2-3): the FACT is the existing
+ * value in the source locale, the output is the same attribute in the
+ * target locale — consistency, not re-invention. No source value means
+ * insufficient grounding, never a from-scratch generation.
+ *
+ * Recipe-less by design: what to write is fully determined by the
+ * source value; only the brand voice (pinned or tenant default) shapes
+ * HOW it reads in the target language.
+ */
+final readonly class TranslateValueTool implements AgentToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private ObjectFactsPort $facts,
+        private ContentValuePort $contentValues,
+        private AgentLlmClientInterface $llm,
+        private AgentModelSelector $models,
+        private UsageCostCalculator $costs,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'translate_value';
+    }
+
+    public function description(): string
+    {
+        return 'Translate an existing text attribute value from one locale to another, preserving its substance exactly (no added or dropped claims). The proposal lands in pending_changes for human approval. Use when the user asks to translate or localise a field; the source-locale value must exist — with no source value the tool returns insufficient_grounding.';
+    }
+
+    public function parametersSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'product_id' => [
+                    'type' => 'string',
+                    'description' => 'UUID of the product object.',
+                ],
+                'target_attribute' => [
+                    'type' => 'string',
+                    'description' => 'Code of the text attribute to translate (e.g. "description").',
+                ],
+                'source_locale' => [
+                    'type' => 'string',
+                    'description' => 'Locale the existing value is read from (short code, e.g. "pl").',
+                ],
+                'target_locale' => [
+                    'type' => 'string',
+                    'description' => 'Locale the translation is written to (short code, e.g. "en").',
+                ],
+                'channel' => [
+                    'type' => 'string',
+                    'description' => 'Channel code when the value is channel-scoped.',
+                ],
+                'brand_voice_id' => [
+                    'type' => 'string',
+                    'description' => 'BrandVoiceProfile UUID. Omit to use the tenant default.',
+                ],
+                'pending_change_batch_id' => [
+                    'type' => 'string',
+                    'description' => 'Append to an existing proposal batch. Usually injected automatically.',
+                ],
+            ],
+            'required' => ['product_id', 'target_attribute', 'source_locale', 'target_locale'],
+        ];
+    }
+
+    public function requiredPermission(): string
+    {
+        return 'object.write';
+    }
+
+    public function kind(): ToolKind
+    {
+        return ToolKind::Write;
+    }
+
+    public function execute(array $arguments, AgentToolContext $context): array
+    {
+        $productId = $arguments['product_id'] ?? null;
+        if (!\is_string($productId) || !Uuid::isValid($productId)) {
+            return ['error' => 'product_id must be a valid UUID.'];
+        }
+        $targetAttribute = $arguments['target_attribute'] ?? null;
+        $sourceLocale = $arguments['source_locale'] ?? null;
+        $targetLocale = $arguments['target_locale'] ?? null;
+        if (!\is_string($targetAttribute) || '' === $targetAttribute
+            || !\is_string($sourceLocale) || '' === $sourceLocale
+            || !\is_string($targetLocale) || '' === $targetLocale) {
+            return ['error' => 'target_attribute, source_locale and target_locale are required.'];
+        }
+        if ($sourceLocale === $targetLocale) {
+            return ['error' => 'source_locale and target_locale must differ.'];
+        }
+        $channel = \is_string($arguments['channel'] ?? null) && '' !== $arguments['channel'] ? $arguments['channel'] : null;
+
+        try {
+            $facts = $this->facts->facts(Uuid::fromString($productId), [$targetAttribute], $sourceLocale, $channel);
+        } catch (InvalidArgumentException $e) {
+            return ['error' => $e->getMessage()];
+        }
+        $sourceEnvelope = $facts->values[$targetAttribute] ?? null;
+        $sourceText = \is_array($sourceEnvelope) && \is_string($sourceEnvelope['value'] ?? null)
+            ? trim($sourceEnvelope['value'])
+            : '';
+        if ('' === $sourceText) {
+            // The anti-hallucination fuse of translation: no source value
+            // means nothing to translate — never invent (P2-02 semantics).
+            return [
+                'status' => 'insufficient_grounding',
+                'missing_source_attributes' => [\sprintf('%s@%s', $targetAttribute, $sourceLocale)],
+                'present_facts' => 0,
+            ];
+        }
+
+        $voice = $this->resolveVoice($arguments['brand_voice_id'] ?? null);
+        $model = $this->models->defaultModel();
+        $response = $this->llm->create(
+            $context->tenant,
+            $model,
+            $this->systemPrompt($sourceLocale, $targetLocale, $voice),
+            [[
+                'role' => 'user',
+                'content' => [['type' => 'text', 'text' => $sourceText]],
+            ]],
+            tools: [],
+            promptCaching: false,
+        );
+        $translated = '';
+        foreach ($response->contentBlocks as $block) {
+            if (($block['type'] ?? null) === 'text' && \is_string($block['text'] ?? null)) {
+                $translated .= $block['text'];
+            }
+        }
+        $translated = trim($translated);
+        if ('' === $translated) {
+            return ['error' => 'The model returned no text — retry.'];
+        }
+
+        $batchId = \is_string($arguments['pending_change_batch_id'] ?? null) && Uuid::isValid($arguments['pending_change_batch_id'])
+            ? Uuid::fromString($arguments['pending_change_batch_id'])
+            : Uuid::v7();
+        $sourceRef = \sprintf('%s@%s', $targetAttribute, $sourceLocale);
+        $proposal = $this->contentValues->materializeGeneratedValue(
+            $batchId,
+            $context->userId,
+            Uuid::fromString($productId),
+            $targetAttribute,
+            $translated,
+            $targetLocale,
+            $channel,
+            meta: [
+                'intent' => 'translate',
+                'source_attributes' => [$sourceRef],
+                'model' => $model,
+            ],
+        );
+
+        $usage = [
+            'input_tokens' => $response->inputTokens,
+            'output_tokens' => $response->outputTokens,
+            'cost_usd' => $this->costs->costUsd($model, $response->inputTokens, $response->outputTokens, $response->cacheReadTokens, $response->cacheCreationTokens),
+        ];
+
+        if (!$proposal->isMaterialized()) {
+            return $proposal->toToolResult() + ['llm_usage' => $usage];
+        }
+
+        return [
+            'status' => 'materialized',
+            'pending_change_batch_id' => $batchId->toRfc4122(),
+            'affected_count' => 1,
+            'product_id' => $productId,
+            'target_attribute' => $targetAttribute,
+            'source_locale' => $sourceLocale,
+            'locale' => $targetLocale,
+            'channel' => $proposal->scopeChannel,
+            'generated_preview' => mb_substr($translated, 0, 300),
+            'source_attributes' => [$sourceRef],
+            'llm_usage' => $usage,
+            'note' => 'Translation proposal materialized for approval — nothing was written to the product.',
+        ];
+    }
+
+    private function resolveVoice(mixed $brandVoiceId): ?BrandVoiceProfile
+    {
+        if (\is_string($brandVoiceId) && Uuid::isValid($brandVoiceId)) {
+            $pinned = $this->em->find(BrandVoiceProfile::class, $brandVoiceId);
+            if ($pinned instanceof BrandVoiceProfile) {
+                return $pinned;
+            }
+        }
+
+        return $this->em->getRepository(BrandVoiceProfile::class)->findOneBy(['isDefault' => true]);
+    }
+
+    private function systemPrompt(string $sourceLocale, string $targetLocale, ?BrandVoiceProfile $voice): string
+    {
+        $lines = [
+            \sprintf('You are a product-copy translator inside a PIM. Translate the user message from locale "%s" to locale "%s".', $sourceLocale, $targetLocale),
+            '',
+            'HARD RULES:',
+            '- Preserve the substance EXACTLY: every claim, number, dimension and property of the source appears in the translation; nothing is added, dropped or "improved".',
+            '- Keep the original formatting (plain text stays plain, HTML tags stay as they are).',
+            '- Reply with the translation ONLY - no preamble, no commentary, no quotes around it.',
+        ];
+        if (null !== $voice) {
+            $lines[] = \sprintf('Brand voice "%s": %s', $voice->getName(), $voice->getTone());
+            if ([] !== $voice->getBannedWords()) {
+                $lines[] = '- Never use the words: '.implode(', ', $voice->getBannedWords()).'.';
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+}

--- a/apps/api/tests/Unit/Agent/Application/TranslateValueToolTest.php
+++ b/apps/api/tests/Unit/Agent/Application/TranslateValueToolTest.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Agent\Application;
+
+use App\Agent\Application\Llm\AgentLlmClientInterface;
+use App\Agent\Application\Llm\AgentLlmResponse;
+use App\Agent\Application\Run\UsageCostCalculator;
+use App\Agent\Application\Tool\AgentToolContext;
+use App\Agent\Application\Tool\ToolKind;
+use App\Agent\Application\Tool\TranslateValueTool;
+use App\Agent\Domain\Entity\BrandVoiceProfile;
+use App\Agent\Infrastructure\Anthropic\AgentModelSelector;
+use App\Catalog\Contracts\Command\ContentValuePort;
+use App\Catalog\Contracts\Command\ContentValueProposal;
+use App\Catalog\Contracts\Query\ObjectFacts;
+use App\Catalog\Contracts\Query\ObjectFactsPort;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AICG-P6-01 (#2344) — translation as the third grounded variant: the
+ * only fact is the value in the source locale. The two guarantees under
+ * test mirror the flagship tool's:
+ *
+ *   - no source value -> insufficient_grounding BEFORE any model call
+ *     (translation never invents a source),
+ *   - the nested call receives the source text alone, and the proposal
+ *     lands in the TARGET locale with intent=translate + the
+ *     "attr@source_locale" audit ref.
+ */
+final class TranslateValueToolTest extends TestCase
+{
+    #[Test]
+    public function missingSourceValueShortCircuitsBeforeTheLlm(): void
+    {
+        $calls = new TranslationLlmCallRecorder();
+        $tool = $this->tool(sourceValues: [], llm: $this->scriptedLlm('SHOULD NEVER BE CALLED', $calls));
+
+        $result = $tool->execute([
+            'product_id' => Uuid::v7()->toRfc4122(),
+            'target_attribute' => 'description',
+            'source_locale' => 'pl',
+            'target_locale' => 'en',
+        ], $this->context());
+
+        self::assertSame('insufficient_grounding', $result['status']);
+        self::assertSame(['description@pl'], $result['missing_source_attributes']);
+        self::assertSame(0, $calls->count, 'no source value means NO model call — nothing to translate');
+    }
+
+    #[Test]
+    public function happyPathMaterializesInTheTargetLocaleWithAuditMeta(): void
+    {
+        $calls = new TranslationLlmCallRecorder();
+        $port = new class implements ContentValuePort {
+            /** @var array<string, mixed> */
+            public array $capturedMeta = [];
+            public ?string $capturedText = null;
+            public ?string $capturedLocale = null;
+
+            public function materializeGeneratedValue(Uuid $batchId, Uuid $userId, Uuid $objectId, string $attributeCode, string $generatedText, ?string $locale = null, ?string $channel = null, array $meta = []): ContentValueProposal
+            {
+                $this->capturedMeta = $meta;
+                $this->capturedText = $generatedText;
+                $this->capturedLocale = $locale;
+
+                return ContentValueProposal::materialized(null, ['value' => $generatedText], $locale, $channel);
+            }
+        };
+
+        $tool = $this->tool(
+            sourceValues: ['description' => ['value' => 'Kurtka z aluminiową membraną.']],
+            llm: $this->scriptedLlm('A jacket with an aluminium membrane.', $calls),
+            port: $port,
+        );
+        $result = $tool->execute([
+            'product_id' => Uuid::v7()->toRfc4122(),
+            'target_attribute' => 'description',
+            'source_locale' => 'pl',
+            'target_locale' => 'en',
+        ], $this->context());
+
+        self::assertSame('materialized', $result['status']);
+        self::assertSame(1, $result['affected_count']);
+        self::assertSame('pl', $result['source_locale']);
+        self::assertSame('en', $result['locale']);
+        self::assertSame(['description@pl'], $result['source_attributes']);
+        self::assertSame('en', $port->capturedLocale, 'the proposal must land in the TARGET locale');
+        self::assertSame('A jacket with an aluminium membrane.', $port->capturedText);
+        self::assertSame('translate', $port->capturedMeta['intent']);
+        self::assertSame(['description@pl'], $port->capturedMeta['source_attributes']);
+        $usage = $result['llm_usage'];
+        self::assertIsArray($usage);
+        self::assertSame(12, $usage['input_tokens']);
+        self::assertSame(34, $usage['output_tokens']);
+    }
+
+    #[Test]
+    public function promptCarriesTheSourceTextAndThePreservationContract(): void
+    {
+        $calls = new TranslationLlmCallRecorder();
+        $tool = $this->tool(
+            sourceValues: ['description' => ['value' => 'Kurtka z membraną.']],
+            llm: $this->scriptedLlm('ok', $calls),
+        );
+
+        $tool->execute([
+            'product_id' => Uuid::v7()->toRfc4122(),
+            'target_attribute' => 'description',
+            'source_locale' => 'pl',
+            'target_locale' => 'en',
+        ], $this->context());
+
+        self::assertSame(1, $calls->count);
+        self::assertStringContainsString('Preserve the substance EXACTLY', $calls->system);
+        self::assertStringContainsString('from locale "pl" to locale "en"', $calls->system);
+        self::assertStringContainsString('Never use the words: tani', $calls->system, 'the default brand voice applies to translations too');
+        // The recorder json_encodes the messages, so assert on the
+        // ASCII-safe prefix of the source text.
+        self::assertStringContainsString('Kurtka z membran', $calls->userText);
+    }
+
+    #[Test]
+    public function identicalLocalesAndInvalidIdsAreErrorResults(): void
+    {
+        $calls = new TranslationLlmCallRecorder();
+        $tool = $this->tool(
+            sourceValues: ['description' => ['value' => 'x']],
+            llm: $this->scriptedLlm('x', $calls),
+        );
+
+        $samLocale = $tool->execute([
+            'product_id' => Uuid::v7()->toRfc4122(),
+            'target_attribute' => 'description',
+            'source_locale' => 'pl',
+            'target_locale' => 'pl',
+        ], $this->context());
+        self::assertArrayHasKey('error', $samLocale);
+
+        $badId = $tool->execute([
+            'product_id' => 'not-a-uuid',
+            'target_attribute' => 'description',
+            'source_locale' => 'pl',
+            'target_locale' => 'en',
+        ], $this->context());
+        self::assertArrayHasKey('error', $badId);
+
+        $missingParams = $tool->execute([
+            'product_id' => Uuid::v7()->toRfc4122(),
+        ], $this->context());
+        self::assertArrayHasKey('error', $missingParams);
+
+        self::assertSame(0, $calls->count);
+    }
+
+    #[Test]
+    public function toolIsAWriteToolNamedForTheRegistry(): void
+    {
+        $tool = $this->tool(sourceValues: [], llm: $this->scriptedLlm('x', new TranslationLlmCallRecorder()));
+
+        self::assertSame('translate_value', $tool->name());
+        self::assertSame(ToolKind::Write, $tool->kind());
+        self::assertSame('object.write', $tool->requiredPermission());
+        self::assertSame(
+            ['product_id', 'target_attribute', 'source_locale', 'target_locale'],
+            $tool->parametersSchema()['required'],
+        );
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $sourceValues
+     */
+    private function tool(
+        array $sourceValues,
+        AgentLlmClientInterface $llm,
+        ?ContentValuePort $port = null,
+    ): TranslateValueTool {
+        $voice = new BrandVoiceProfile('Ekspercki', 'ekspercki, zwięzły', bannedWords: ['tani']);
+        $voice->markDefault(true);
+        $voiceRepo = $this->createStub(EntityRepository::class);
+        $voiceRepo->method('findOneBy')->willReturn($voice);
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturn($voiceRepo);
+
+        $factsPort = $this->createStub(ObjectFactsPort::class);
+        $factsPort->method('facts')->willReturn(new ObjectFacts(
+            objectId: Uuid::v7(),
+            objectTypeId: Uuid::v7(),
+            values: $sourceValues,
+            missingCodes: [] === $sourceValues ? ['description'] : [],
+        ));
+
+        $models = new AgentModelSelector('claude-sonnet-test', 'claude-opus-test');
+
+        return new TranslateValueTool(
+            $em,
+            $factsPort,
+            $port ?? $this->acceptingPort(),
+            $llm,
+            $models,
+            new UsageCostCalculator($models, 3.0, 15.0, 5.0, 25.0),
+        );
+    }
+
+    private function acceptingPort(): ContentValuePort
+    {
+        return new class implements ContentValuePort {
+            public function materializeGeneratedValue(Uuid $batchId, Uuid $userId, Uuid $objectId, string $attributeCode, string $generatedText, ?string $locale = null, ?string $channel = null, array $meta = []): ContentValueProposal
+            {
+                return ContentValueProposal::materialized(null, ['value' => $generatedText], $locale, $channel);
+            }
+        };
+    }
+
+    private function scriptedLlm(string $reply, TranslationLlmCallRecorder $calls): AgentLlmClientInterface
+    {
+        return new class($reply, $calls) implements AgentLlmClientInterface {
+            public function __construct(private readonly string $reply, private readonly TranslationLlmCallRecorder $calls)
+            {
+            }
+
+            public function create(Tenant $tenant, string $model, string $system, array $messages, array $tools, bool $promptCaching = true): AgentLlmResponse
+            {
+                ++$this->calls->count;
+                $this->calls->system = $system;
+                $encoded = json_encode($messages);
+                $this->calls->userText = false === $encoded ? '' : $encoded;
+
+                return new AgentLlmResponse(
+                    stopReason: AgentLlmResponse::STOP_END_TURN,
+                    contentBlocks: [['type' => 'text', 'text' => $this->reply]],
+                    inputTokens: 12,
+                    outputTokens: 34,
+                );
+            }
+        };
+    }
+
+    private function context(): AgentToolContext
+    {
+        return new AgentToolContext(Uuid::v7(), new Tenant('demo-test-'.bin2hex(random_bytes(2)), 'Demo'));
+    }
+}
+
+/**
+ * Captures what the tool's nested LLM call received.
+ */
+final class TranslationLlmCallRecorder
+{
+    public int $count = 0;
+    public string $system = '';
+    public string $userText = '';
+}


### PR DESCRIPTION
## AICG-P6-01 — tool `translate_value` (wartość w locale-źródłowym jako fakt)

Trzeci wariant mechanizmu grounded content (plan §3a pkt 2-3): faktem jest **istniejąca wartość w `source_locale`**, wynik ląduje w tym samym atrybucie w `target_locale` — spójność z tym co tenant już opublikował, nie re-wymyślanie.

### Zmiany
- **`TranslateValueTool`** (`kind=Write`, `object.write`) — auto-rejestracja w `ToolRegistry` przez `AgentToolInterface`; schema `{product_id, target_attribute, source_locale, target_locale, channel?, brand_voice_id?, pending_change_batch_id?}`.
- **Bez przepisu** (świadomie): CO pisać wyznacza w 100% wartość źródłowa; tylko głos marki (pinned lub default tenanta) kształtuje JAK brzmi w języku docelowym. Kontrakt w system prompcie: substancja 1:1 (nic nie dodane/utracone), formatowanie zachowane (HTML zostaje HTML-em).
- **Brak wartości źródłowej → `insufficient_grounding`** z `missing_source_attributes: ["attr@locale"]` — zero wywołania modelu, zero wymyślania (semantyka P2-02).
- Propozycja przez `ContentValuePort` do `pending_changes` w **target locale** z meta `{intent: translate, source_attributes: ["attr@source_locale"], model}` — zero auto-zapisu; nested `llm_usage` doliczany do runu (budżety §8.5).

### Testy (PHPUnit 5/5, PHPStan max 0, Deptrac --no-cache 0, cs-fixer OK)
- brak wartości źródłowej → insufficient_grounding **przed** wywołaniem modelu (0 calli),
- happy path: propozycja w target locale + meta audytowe + llm_usage,
- prompt niesie kontrakt zachowania substancji + tekst źródłowy + banned words głosu,
- identyczne locale / złe UUID / brakujące parametry → error result (0 calli),
- rejestr: name/kind/permission/required schema.

### Live smoke na `pim.localhost` (BYOK Haiku loop + Sonnet nested, bez mocków)
- **Happy**: produkt DEMO z opisem PL `<p>Produkt marki <strong>Festo</strong> w kolorze <strong>czerwonym</strong>.</p>` → run `awaiting_approval`, batch z `scope_locale=en`, `after_state`: `<p>Product by <strong>Festo</strong> brand in <strong>red</strong>.</p>` (HTML zachowany, substancja 1:1), meta `{intent: translate, source_attributes: ["description@pl"]}`; tokeny 1104/329, $0.0117; reject → 200, nic nie zapisane.
- **Negative**: `meta_title` bez wartości → tool_result `{"status":"insufficient_grounding","present_facts":0,...}`, **żaden batch nie powstał**, model zrelacjonował brak danych zamiast zmyślać.
- Finding operacyjny (nie kod): pierwszy run wymagał `rm -rf var/cache/dev` + restart, żeby worker zobaczył nowy tool (znany gotcha FrankenPHP dev cache). Drugi finding: przy degenerackim opisie-placeholderze („Opis produktu 6634") nested Sonnet dopytał zamiast tłumaczyć — na realnej treści zachowanie poprawne.

Closes #2344
