### PR TITLE
perf(agent): bulk content cost preview and memory-bounded batch

### DIFF
--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -14,10 +14,14 @@
 - **✅ AICG-P1-04 #2330 (PR #2449):** seeder built-in przepisów + default głosu, komenda `pim:agent:seed-content-defaults`, fix RLS GUC w konsoli. **M1 KOMPLET.**
 - **✅ AICG-P2-01 #2331 (PR #2450):** `ObjectFactsPort` (seam Catalog/Contracts, read-only fakty + overlay locale/channel + sibling locales, provenance stripped) + `ContentGroundingService` (∩ recipe.sourceAttributes, zawężenie publication profile). Gotcha: port bez runtime-konsumenta inline'owany przez kontener → w kernel teście konstrukcja wprost.
 - **✅ AICG-P2-02 #2332 (PR #2451, SEC):** `GroundingGate`+`GroundingVerdict` — failing-first w historii; verdict jako structured tool_result; progi z przepisu (`constraints.grounding.{min_facts,required}`, default min_facts=1).
-- **🔄 AICG-P2-03 #2333 (w toku):** `AgentSystemPromptBuilder` + sekcje content (recipe: target/format/max_len/SEO/tone; brand voice: ton/glosariusz/banned/przykłady; kontrakt anty-halucynacyjny) gdy run niesie `recipe_id`/`brand_voice_id`; backward compat (prompt niezmieniony bez kluczy); głos przypięty do przepisu resolwowany gdy kontekst go nie nazywa.
+- **✅ AICG-P2-03 #2333 → M3–M5 komplet** (PR-y do #2461): `AgentSystemPromptBuilder` sekcje content, materializer tekstowy `ContentValueMaterializer` (P3-01, PendingChanges scoped), `GenerateProductDescriptionTool` (P3-02, flagowy agent-native) + `GenerateSeoTextTool` (P4-02, SEO w przepisie), `SeoRulesValidator` (P4-01), FE: Ask AI inline (P5-01/02), bulk modal (P5-03 #2341), Settings→AI recipes+voice (P5-04/05 #2342/#2343 bundle).
+- **✅ M6 — DOMKNIĘCIE EPIKU (2026-07-10):**
+  - **P6-01 #2344 `translate_value`** (PR #2463, merged): trzeci wariant grounded — fakt=wartość@source_locale, output@target_locale, recipe-less, `insufficient_grounding` gdy brak źródła. Live smoke PL→EN (HTML zachowany 1:1) + negatywny (brak wartości → skip). ✅ closed z proofem.
+  - **P6-02 #2345 `[SEC]` red-team** (PR #2464, merged): `PromptInjectionRedTeamTest` +3 scenariusze tooli treści (injection nie przekierowuje targetu · grounding code-driven nie wycieka sekretu · sfałszowany batch/wyciek promptu → tylko pending), 6/6. Świadome odejście: potwierdził istniejące zabezpieczenia (brak luki, brak zmiany produkcyjnej). ✅ closed z proofem.
+  - **P6-03 #2346 perf** (PR #2465, w CI): `ContentCostEstimator` + `POST /api/agent/content/cost-preview` + `POST /api/agent/content/bulk-generate` (dedykowana ścieżka: `BulkGenerateContentHandler extends AbstractBatchHandler`, batch 200 + `clear()`, reuse tooli 1:1, jeden batch approval) + day-cap gate 2-stopniowy (429). Modal zdjął cap 8 + client-estymatę. Live smoke: preview 200, bulk 2 prod → 202 → awaiting_approval, reject → 0 zapisu.
 - **Decyzja operatora (2026-07-10, czat):** selektywne bundle PR-ów dla par producer–consumer: P4-01+P4-02, P5-01+P5-02, P5-04+P5-05 (~3 rundy CI mniej); [SEC] i granice BC bez zmian — osobno.
-- **Ostatnie 3 akcje:** (1) merge #2451 + close #2332, (2) P2-03 builder + 8 testów (28 asercji), (3) unit suite 1546 zielone.
-- **Następny krok:** PR P2-03 → CI → merge → **M3** (P3-01 materializer).
+- **Ostatnie 3 akcje:** (1) merge #2463/#2464 + close #2344/#2345 z proofem, (2) P6-03 backend+FE+3 test-suity (12 testów) + live smoke bulk, (3) rebase P5b (#2462) po konflikcie locales.
+- **Następny krok:** CI zielone #2462 (P5b) + #2465 (P6-03) → merge → close #2342/#2343/#2346 z proofem → **EPIK AICG ZAMKNIĘTY (22/22)** → podsumowanie.
 - **Blokery:** brak.
 
 ## 2026-07-10: ✅ EPIK CPDF ZAMKNIĘTY — Katalogi PDF (27/27 ticketów, M0–M6, #2282–#2308)

--- a/agent/lessons.md
+++ b/agent/lessons.md
@@ -3012,3 +3012,20 @@ M4 (P4-01..08) + M5 Hardening (P5-01..05) — wszystkie zmergowane. Epik APIC ko
 - **`paginationItemsPerPage` (AP4 XML) NIE trafia do OpenAPI snapshotu** — zmiana cap 200→1000 nie ruszyła `docs/api-spec/v0.json` (to runtime pagination default, nie schema). Nie ma bramki spec-drift dla tej zmiany.
 - **PHPStan „Ignored error pattern … was not matched in reported errors" przy `analyse <podzbiór-plików>`** = artefakt analizy podzbioru (baseline dotyczy plików spoza zestawu), NIE realny błąd. Potwierdź pełnym `phpstan analyse` (jak CI) zanim zaczniesz „naprawiać".
 - **Rzut `(mixed) → (string|int)` pada na PHPStan max** w testach czytających `array<string,mixed>` z `execute()`/`toArray()`. Wyciągnij do zmiennej + `assertIsString`/`assertIsInt`/`assertIsArray` (narrowing), nie `(string) $x`.
+
+## Lessons z AICG M6 (#2344–#2346 — translate/red-team/perf, domknięcie epiku)
+
+### Patterns to Follow (nowe)
+- **Reuse istniejącego toola w nowej ścieżce zamiast duplikować orkiestrację.** P6-03 bulk-path: `BulkGenerateContentHandler` NIE kopiuje ground→gate→llm→materialize — wywołuje `GenerateProductDescriptionTool::execute()` per produkt w pętli memory-bounded (batch 200 + `clear()`, `AbstractBatchHandler`). Efekt: identyczny kontrakt anty-halucynacyjny + provenance, zero refaktoru zmergowanego P3-02, zero drift ryzyka. Duplikacja promptu = drift; reuse = jedna prawda.
+- **Handler pętlujący po encjach z `flushAndClear()` MUSI re-find'ować run+tenant po każdym clear** (jak `AgentLoopRunner` linie 199-208). Usage sumuj w lokalnych zmiennych i zaaplikuj RAZ na końcu po ponownym find'zie — inaczej `addUsage` na detachowanej encji po clear.
+- **Red-team validating existing defenses = additive regression, nie failing→green.** [SEC] P6-02: gdy architektura już chroni (target z przepisu, grounding code-driven, approval-only), test od razu zielony. Nie ma tranzycji failing-first bo nie ma luki. Odnotuj to explicite w PR („potwierdził istniejące zabezpieczenia, brak zmiany produkcyjnej") zamiast sztucznie psuć kod.
+
+### Toolchain quirks (nowe)
+- **`php-cs-fixer fix <plik1> <plik2> ...` (wiele ścieżek) wymaga `--config`** — inaczej „For multiple paths config parameter is required" i przy `--quiet` NIC nie naprawia (błąd schowany). Fix per-plik (pojedyncza ścieżka działa) albo `--config .php-cs-fixer.dist.php`. Pre-commit lint-staged łapie potem to, co „naprawiłeś" a nie zapisało się.
+- **`pim.localhost` NIE resolvuje się w Pythonie na hoście (urllib/socket ENOTFOUND)** — ta sama pułapka co Node (memory: playwright-local-gotchas-dns-lang). Do live-smoke: `curl -sk` (Docker DNS) → zapis do pliku → parse `python3 json.load(..., strict=False)` z `PYTHONUTF8=1` (polskie znaki + control chars w JSON).
+- **Nowe custom `#[Route]` w Agent BC → regen `docs/api-spec/v0.json`**: `docker exec pim-api-1 php bin/console api:openapi:export | python3 -m json.tool > docs/api-spec/v0.json` (host — `docs/` nie jest bind-mountowane do kontenera, eksport przez stdout). `CustomRouteOpenApiFactory` dorzuca trasy automatycznie; brak regen = czerwona bramka spec-drift.
+
+### Decyzje świadome (nowe)
+- **Bulk selekcja przez `selected_ids` (ścieżka modala); `filter_dsl`-only „wszystkie pasujące" cross-page odłożone** — dedykowany resolver poza zakresem P6-03, `selected_ids` pokrywa flow UI.
+- **Bundle P5-04+P5-05 (#2342/#2343) za zgodą operatora** — para producer-consumer na jednym ekranie Settings→AI, jeden CI, osobne proofy na każdym issue. [SEC]/granice BC nadal osobno.
+- **`noLabelWithoutControl` w biome.json dostał `inputComponents: [Input,Textarea,Combobox,MultiSelect]`** — idiom label-owija-custom-kontrolkę jest poprawny a11y (implicit association), reguła statycznie nie widziała przez design-system komponenty; renderowany DOM waliduje axe w e2e.

--- a/apps/admin/e2e/aicg-p5-bulk-generate.spec.ts
+++ b/apps/admin/e2e/aicg-p5-bulk-generate.spec.ts
@@ -2,13 +2,27 @@ import { expect, test } from '@playwright/test';
 import { loginAsAdmin } from './helpers/auth';
 
 /**
- * AICG-P5-03 (#2341) — bulk "Generuj treść AI" from the product list:
- * selection -> modal (count + cost estimate) -> one agent run whose
- * context carries the selection scope. The agent API is intercepted
- * (CI has no BYOK key — the 2246/P5a convention).
+ * AICG-P5-03 (#2341) / AICG-P6-03 (#2346) — bulk "Generuj treść AI" from
+ * the product list: selection -> modal (count + backend cost preview) ->
+ * the dedicated bulk path (POST /api/agent/content/bulk-generate, 202).
+ * The agent content API is intercepted (CI has no BYOK key — the 2246/P5a
+ * convention).
  */
 
 const RUN_ID = '019f0000-0000-7000-8000-0000000b1b1b';
+const BATCH_ID = '019f0000-0000-7000-8000-0000000ba7c1';
+
+function estimateBody(count: number) {
+  return {
+    product_count: count,
+    input_tokens_per_product: 1260,
+    output_tokens_per_product: 400,
+    est_input_tokens: 1260 * count,
+    est_output_tokens: 400 * count,
+    est_cost_usd: (count * 0.012).toFixed(6),
+    model: 'claude-sonnet-test',
+  };
+}
 
 test.beforeEach(async ({ page }) => {
   await page.addInitScript(() => {
@@ -16,8 +30,32 @@ test.beforeEach(async ({ page }) => {
   });
 });
 
-test('bulk generate starts one run with the selection scope in its context', async ({ page }) => {
-  let capturedStart: Record<string, unknown> | null = null;
+test('bulk generate previews the cost and starts one run via the bulk path', async ({ page }) => {
+  let capturedPreview: Record<string, unknown> | null = null;
+  let capturedGenerate: Record<string, unknown> | null = null;
+
+  await page.route('**/api/agent/content/cost-preview', async (route) => {
+    capturedPreview = route.request().postDataJSON() as Record<string, unknown>;
+    const count = Number((capturedPreview as { product_count?: number }).product_count ?? 0);
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(estimateBody(count)),
+    });
+  });
+  await page.route('**/api/agent/content/bulk-generate', async (route) => {
+    capturedGenerate = route.request().postDataJSON() as Record<string, unknown>;
+    await route.fulfill({
+      status: 202,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        run_id: RUN_ID,
+        pending_change_batch_id: BATCH_ID,
+        product_count: 2,
+        estimate: estimateBody(2),
+      }),
+    });
+  });
   await page.route(`**/api/agent/runs/${RUN_ID}`, (route) =>
     route.fulfill({
       status: 200,
@@ -45,80 +83,72 @@ test('bulk generate starts one run with the selection scope in its context', asy
       }),
     }),
   );
-  await page.route('**/api/agent/runs', async (route) => {
-    if (route.request().method() !== 'POST') {
-      await route.fallback();
-      return;
-    }
-    capturedStart = route.request().postDataJSON() as Record<string, unknown>;
-    await route.fulfill({
-      status: 201,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        id: RUN_ID,
-        status: 'planning',
-        surface: 'cmdk',
-        intent: 'bulk e2e',
-        model: null,
-        pending_change_batch_id: null,
-        affected_count: null,
-        bulk_operation_id: null,
-        tokens_input: 0,
-        tokens_output: 0,
-        cost_usd: '0.000000',
-        approved_by: null,
-        approved_at: null,
-        started_at: new Date().toISOString(),
-        completed_at: null,
-      }),
-    });
-  });
 
   await loginAsAdmin(page);
   await page.goto('/products');
 
-  // Select two rows through their checkboxes.
   const rows = page.locator('[data-testid^="products-grid-row-"]');
   await expect(rows.first()).toBeVisible({ timeout: 30_000 });
   await rows.nth(0).getByRole('checkbox').first().check();
   await rows.nth(1).getByRole('checkbox').first().check();
 
-  // The bulk bar exposes the new action; the modal shows count + estimate.
   await page.getByTestId('bulk-generate-content').click();
   await expect(page.getByTestId('bulk-generate-count')).toContainText('2');
+  // The backend preview drives the estimate line.
   await expect(page.getByTestId('bulk-generate-estimate')).toContainText('USD');
+  await expect.poll(() => capturedPreview !== null).toBeTruthy();
+  expect((capturedPreview as { product_count?: number })?.product_count).toBe(2);
 
-  // Switch to SEO mode and start.
+  // Switch to SEO mode and start via the bulk-generate endpoint.
   await page.getByRole('button', { name: /meta seo/i }).click();
   await page.getByRole('button', { name: /^generuj$/i }).click();
 
-  await expect.poll(() => capturedStart !== null).toBeTruthy();
-  const body = capturedStart as unknown as {
-    intent: string;
-    context: { selected_ids: string[]; total_matching: number; object_type_code: string };
+  await expect.poll(() => capturedGenerate !== null).toBeTruthy();
+  const body = capturedGenerate as unknown as {
+    mode: string;
+    selected_ids: string[];
+    object_type_code: string;
   };
-  expect(body.intent).toContain('generate_seo_text');
-  expect(body.context.selected_ids).toHaveLength(2);
-  expect(body.context.total_matching).toBe(2);
-  expect(body.context.object_type_code).toBe('product');
+  expect(body.mode).toBe('seo');
+  expect(body.selected_ids).toHaveLength(2);
+  expect(body.object_type_code).toBe('product');
 
-  // The modal closed and the selection cleared.
   await expect(page.getByTestId('bulk-generate-count')).toHaveCount(0);
 });
 
-test('over-cap selection disables the start button with an explanation', async ({ page }) => {
+test('the day-cap 429 from the backend surfaces as an error and keeps the modal open', async ({
+  page,
+}) => {
+  await page.route('**/api/agent/content/cost-preview', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(estimateBody(2)),
+    }),
+  );
+  await page.route('**/api/agent/content/bulk-generate', (route) =>
+    route.fulfill({
+      status: 429,
+      contentType: 'application/problem+json',
+      body: JSON.stringify({
+        type: 'https://pim.dev/problems/agent-budget-exceeded',
+        title: 'Estimated bulk cost exceeds the remaining daily budget.',
+        status: 429,
+      }),
+    }),
+  );
+
   await loginAsAdmin(page);
   await page.goto('/products');
 
   const rows = page.locator('[data-testid^="products-grid-row-"]');
   await expect(rows.first()).toBeVisible({ timeout: 30_000 });
-  const rowCount = Math.min(await rows.count(), 9);
-  test.skip(rowCount < 9, 'demo page holds fewer than 9 rows');
-  for (let i = 0; i < rowCount; i += 1) {
-    await rows.nth(i).getByRole('checkbox').first().check();
-  }
+  await rows.nth(0).getByRole('checkbox').first().check();
+  await rows.nth(1).getByRole('checkbox').first().check();
 
   await page.getByTestId('bulk-generate-content').click();
-  await expect(page.getByTestId('bulk-generate-cap')).toBeVisible();
-  await expect(page.getByRole('button', { name: /^generuj$/i })).toBeDisabled();
+  await page.getByRole('button', { name: /^generuj$/i }).click();
+
+  // The modal stays open (the run never started); the count is still shown.
+  await expect(page.getByTestId('bulk-generate-count')).toBeVisible();
 });

--- a/apps/admin/src/components/catalog/bulk-actions/generate-content-modal.tsx
+++ b/apps/admin/src/components/catalog/bulk-actions/generate-content-modal.tsx
@@ -1,74 +1,57 @@
+import { useQuery } from '@tanstack/react-query';
 import { Sparkles, X } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { toast } from '@/components/ui/toast';
-import { startAgentRun } from '@/features/agent/api';
+import {
+  type BulkContentMode,
+  bulkGenerateContent,
+  previewContentCost,
+} from '@/features/agent/api';
 import { OPEN_AGENT_CHAT_EVENT } from '@/features/agent/chat/AgentChatSheet';
 import { cn } from '@/lib/utils';
 
 /**
- * AICG-P5-03 (#2341) — bulk "Generuj opisy / Generuj SEO" from the
- * product list: the selection scope goes into ONE agent run whose
- * write-tool calls accumulate into ONE pending batch (the multi-step
- * plan mechanics of the loop), reviewed in the agent inbox.
- *
- * The cost preview is a client-side estimate from the live-measured
- * per-product averages of the content tools; AICG-P6-03 replaces it
- * with the dedicated backend preview and lifts the per-run cap.
+ * AICG-P5-03 (#2341) / AICG-P6-03 (#2346) — bulk "Generuj opisy /
+ * Generuj SEO" from the product list. The selection goes to the
+ * dedicated bulk path (/api/agent/content/bulk-generate): ONE run whose
+ * write tool runs per product in a memory-bounded worker batch, all
+ * proposals in ONE pending batch reviewed in the agent inbox. The cost
+ * is a real backend pre-flight (/cost-preview) and the §8.5 day cap is
+ * enforced server-side (429 → surfaced as an error toast).
  */
-
-/**
- * Live-measured on the dev stack (AICG-P3-02/P4-02 smokes): a grounded
- * description round-trip lands around 1.3k input / 0.4k output tokens.
- * Priced at the default-tier list rates ($3 / $15 per MTok).
- */
-const EST_COST_PER_PRODUCT_USD = 0.012;
-
-/**
- * The loop's tool-call budget per run is 10 — one grounding+generation
- * call per product plus headroom. Larger selections need the dedicated
- * bulk path (AICG-P6-03).
- */
-const MVP_RUN_CAP = 8;
 
 export function BulkGenerateContentModal({
   selectedIds,
-  totalMatching,
   objectTypeCode,
-  filterDsl,
   onClose,
   onStarted,
 }: {
   selectedIds: string[];
-  totalMatching: number;
   objectTypeCode: string;
-  filterDsl: unknown;
   onClose: () => void;
   onStarted: () => void;
 }) {
   const { t } = useTranslation();
-  const [mode, setMode] = useState<'descriptions' | 'seo'>('descriptions');
+  const [mode, setMode] = useState<BulkContentMode>('descriptions');
   const [isStarting, setIsStarting] = useState(false);
 
   const count = selectedIds.length;
-  const overCap = count > MVP_RUN_CAP;
-  const estimate = (count * EST_COST_PER_PRODUCT_USD).toFixed(2);
+
+  const { data: estimate, isLoading: isEstimating } = useQuery({
+    queryKey: ['content-cost-preview', count, mode],
+    queryFn: () => previewContentCost(count, mode),
+    enabled: count > 0,
+  });
 
   const start = async () => {
     setIsStarting(true);
     try {
-      const intent =
-        mode === 'descriptions'
-          ? `Dla KAŻDEGO z ${count} zaznaczonych produktów wywołaj narzędzie generate_product_description podając wyłącznie product_id (target i przepis są domyślne). Wszystkie propozycje mają trafić do jednego batcha. Nie zadawaj pytań — jeśli produktowi brakuje danych, narzędzie samo to zgłosi.`
-          : `Dla KAŻDEGO z ${count} zaznaczonych produktów wywołaj narzędzie generate_seo_text podając wyłącznie product_id (target i przepis są domyślne). Wszystkie propozycje mają trafić do jednego batcha. Nie zadawaj pytań — jeśli produktowi brakuje danych, narzędzie samo to zgłosi.`;
-      const run = await startAgentRun(intent, 'cmdk', {
-        object_type_code: objectTypeCode,
-        filter_dsl: filterDsl ?? null,
-        selected_ids: selectedIds,
-        total_matching: totalMatching,
-      });
-      window.dispatchEvent(new CustomEvent(OPEN_AGENT_CHAT_EVENT, { detail: { runId: run.id } }));
+      const result = await bulkGenerateContent({ objectTypeCode, mode, selectedIds });
+      window.dispatchEvent(
+        new CustomEvent(OPEN_AGENT_CHAT_EVENT, { detail: { runId: result.run_id } }),
+      );
       toast.success(
         t('aicg.bulk.started', {
           defaultValue: 'Generowanie wystartowało — propozycje trafią do skrzynki agenta.',
@@ -159,27 +142,18 @@ export function BulkGenerateContentModal({
               {t('aicg.bulk.estimate_label', { defaultValue: 'Szacowany koszt' })}
             </div>
             <div>
-              {t('aicg.bulk.estimate', {
-                defaultValue:
-                  '≈{{estimate}} USD ({{count}} × ~0.012 USD za produkt, stawki modelu domyślnego)',
-                estimate,
-                count,
-              })}
+              {isEstimating || !estimate
+                ? t('aicg.bulk.estimate_loading', { defaultValue: 'Liczę szacunek…' })
+                : t('aicg.bulk.estimate_backend', {
+                    defaultValue:
+                      '≈{{estimate}} USD ({{count}} produktów · ~{{tokens}} tokenów, model {{model}})',
+                    estimate: Number(estimate.est_cost_usd).toFixed(2),
+                    count,
+                    tokens: estimate.est_input_tokens + estimate.est_output_tokens,
+                    model: estimate.model,
+                  })}
             </div>
           </div>
-
-          {overCap ? (
-            <div
-              className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-[12.5px] text-red-900"
-              data-testid="bulk-generate-cap"
-            >
-              {t('aicg.bulk.cap', {
-                defaultValue:
-                  'W tej wersji jeden przebieg obsługuje do {{cap}} produktów (budżet narzędzi runu). Zawęź zaznaczenie.',
-                cap: MVP_RUN_CAP,
-              })}
-            </div>
-          ) : null}
         </div>
 
         <div className="flex h-14 items-center gap-3 border-t border-zinc-100 bg-zinc-50/50 px-6">
@@ -193,7 +167,7 @@ export function BulkGenerateContentModal({
             <Button variant="ghost" onClick={onClose} disabled={isStarting}>
               {t('app.cancel', { defaultValue: 'Anuluj' })}
             </Button>
-            <Button onClick={() => void start()} disabled={isStarting || overCap || count === 0}>
+            <Button onClick={() => void start()} disabled={isStarting || count === 0}>
               {t('aicg.bulk.start', { defaultValue: 'Generuj' })}
             </Button>
           </div>

--- a/apps/admin/src/components/objects/universal-list-page.tsx
+++ b/apps/admin/src/components/objects/universal-list-page.tsx
@@ -1032,11 +1032,7 @@ export function UniversalListPage({
         {bulkGenerateOpen ? (
           <BulkGenerateContentModal
             selectedIds={Array.from(selected)}
-            totalMatching={
-              crossPageSelection.active ? crossPageSelection.totalMatched : selected.size
-            }
             objectTypeCode={objectTypeCode}
-            filterDsl={panelDsl}
             onClose={() => setBulkGenerateOpen(false)}
             onStarted={() => {
               setSelected(new Set());

--- a/apps/admin/src/features/agent/api.ts
+++ b/apps/admin/src/features/agent/api.ts
@@ -79,6 +79,60 @@ export function startAgentRun(
   });
 }
 
+export interface ContentCostEstimate {
+  product_count: number;
+  input_tokens_per_product: number;
+  output_tokens_per_product: number;
+  est_input_tokens: number;
+  est_output_tokens: number;
+  est_cost_usd: string;
+  model: string;
+}
+
+export interface BulkGenerateContentResult {
+  run_id: string;
+  pending_change_batch_id: string;
+  product_count: number;
+  estimate: ContentCostEstimate;
+}
+
+export type BulkContentMode = 'descriptions' | 'seo';
+
+/**
+ * AICG-P6-03 (#2346) — the deterministic pre-flight estimate for a bulk
+ * content run (tokens + USD), so the modal shows the price before spending.
+ */
+export function previewContentCost(
+  productCount: number,
+  mode: BulkContentMode,
+): Promise<ContentCostEstimate> {
+  return jsonFetch<ContentCostEstimate>('/api/agent/content/cost-preview', {
+    ...JSON_OPTS,
+    method: 'POST',
+    body: { product_count: productCount, mode },
+  });
+}
+
+/**
+ * AICG-P6-03 (#2346) — the dedicated bulk path: one run whose write tool
+ * runs per product in a memory-bounded worker batch (no 10-tool-call cap).
+ */
+export function bulkGenerateContent(input: {
+  objectTypeCode: string;
+  mode: BulkContentMode;
+  selectedIds: string[];
+}): Promise<BulkGenerateContentResult> {
+  return jsonFetch<BulkGenerateContentResult>('/api/agent/content/bulk-generate', {
+    ...JSON_OPTS,
+    method: 'POST',
+    body: {
+      object_type_code: input.objectTypeCode,
+      mode: input.mode,
+      selected_ids: input.selectedIds,
+    },
+  });
+}
+
 export function getAgentRun(id: string): Promise<AgentRunDetail> {
   return jsonFetch<AgentRunDetail>(`/api/agent/runs/${id}`, JSON_OPTS);
 }

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -3936,11 +3936,11 @@
       "mode_descriptions": "Product descriptions",
       "mode_seo": "SEO meta",
       "estimate_label": "Estimated cost",
-      "estimate": "≈{{estimate}} USD ({{count}} × ~0.012 USD per product, default model rates)",
-      "cap": "This version handles up to {{cap}} products per run (the run tool budget). Narrow the selection.",
       "approval_hint": "Proposals land in the agent inbox — nothing is written without your approval.",
       "start": "Generate",
-      "started": "Generation started — proposals will land in the agent inbox."
+      "started": "Generation started — proposals will land in the agent inbox.",
+      "estimate_loading": "Estimating…",
+      "estimate_backend": "≈{{estimate}} USD ({{count}} products · ~{{tokens}} tokens, model {{model}})"
     },
     "settings": {
       "no_voice": "(tenant default voice)",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -3956,11 +3956,11 @@
       "mode_descriptions": "Opisy produktów",
       "mode_seo": "Meta SEO",
       "estimate_label": "Szacowany koszt",
-      "estimate": "≈{{estimate}} USD ({{count}} × ~0.012 USD za produkt, stawki modelu domyślnego)",
-      "cap": "W tej wersji jeden przebieg obsługuje do {{cap}} produktów (budżet narzędzi runu). Zawęź zaznaczenie.",
       "approval_hint": "Propozycje trafiają do skrzynki agenta — nic nie zapisze się bez akceptacji.",
       "start": "Generuj",
-      "started": "Generowanie wystartowało — propozycje trafią do skrzynki agenta."
+      "started": "Generowanie wystartowało — propozycje trafią do skrzynki agenta.",
+      "estimate_loading": "Liczę szacunek…",
+      "estimate_backend": "≈{{estimate}} USD ({{count}} produktów · ~{{tokens}} tokenów, model {{model}})"
     },
     "settings": {
       "no_voice": "(domyślny głos tenanta)",

--- a/apps/api/config/packages/agent.yaml
+++ b/apps/api/config/packages/agent.yaml
@@ -30,6 +30,10 @@ framework:
             # dev/prod worker already consumes; TenantAwareMessage rebinds
             # tenant + RLS GUC in the worker middlewares.
             App\Agent\Application\Run\AgentRunMessage: import
+            # AICG-P6-03 (#2346) — the dedicated bulk content path runs on
+            # the same worker queue; the handler is memory-bounded (batch
+            # of 200 + clear), so a large selection cannot OOM the worker.
+            App\Agent\Application\Content\BulkGenerateContentMessage: import
     serializer:
         mapping:
             paths:

--- a/apps/api/src/Agent/Application/Content/BulkGenerateContentHandler.php
+++ b/apps/api/src/Agent/Application/Content/BulkGenerateContentHandler.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Content;
+
+use App\Agent\Application\AgentFeatureGuard;
+use App\Agent\Application\Tool\AgentToolContext;
+use App\Agent\Application\Tool\AgentToolInterface;
+use App\Agent\Domain\Entity\AgentRun;
+use App\Agent\Domain\Exception\AgentUnavailableException;
+use App\Shared\Application\AbstractBatchHandler;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * AICG-P6-03 (#2346, ADR-0030) — the dedicated bulk content path.
+ *
+ * Unlike the P5-03 agent-run loop (bounded by 10 tool-calls/run), this
+ * scales to hundreds of products: it runs the SAME content write tool
+ * per product (identical grounding + anti-hallucination contract +
+ * pending_changes materialization), aggregating every proposal into the
+ * ONE batch the run shows for approval — never a catalog write.
+ *
+ * Memory-bounded per §3.10: the ids are processed in batches of
+ * {@see AbstractBatchHandler::$batchSize} with flush+clear, so worker
+ * memory stays flat (not linear in the selection size). Usage is summed
+ * locally and applied once at the end (the run detaches on every clear).
+ * A single product that fails to ground or errors is SKIPPED, never
+ * fatal — the rest of the batch still reaches approval.
+ */
+#[AsMessageHandler]
+final class BulkGenerateContentHandler extends AbstractBatchHandler
+{
+    /** @var array<string, AgentToolInterface> */
+    private array $tools;
+
+    /**
+     * @param iterable<AgentToolInterface> $tools
+     */
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        #[AutowireIterator('agent.tool')]
+        iterable $tools,
+        private readonly AgentFeatureGuard $guard,
+        int $batchSize = 200,
+    ) {
+        parent::__construct($entityManager, $batchSize);
+        $indexed = [];
+        foreach ($tools as $tool) {
+            $indexed[$tool->name()] = $tool;
+        }
+        $this->tools = $indexed;
+    }
+
+    public function __invoke(BulkGenerateContentMessage $message): void
+    {
+        $run = $this->findRun($message->runId);
+        if (!$run instanceof AgentRun) {
+            return;
+        }
+        $tenant = $run->getTenant();
+        if (!$tenant instanceof Tenant) {
+            return;
+        }
+
+        try {
+            $this->guard->assertEnabled($tenant);
+        } catch (AgentUnavailableException $unavailable) {
+            $run->markError($unavailable->getMessage());
+            $this->entityManager->flush();
+
+            return;
+        }
+
+        $tool = $this->tools[$message->toolName] ?? null;
+        if (null === $tool) {
+            $run->markError(\sprintf('Unknown content tool "%s".', $message->toolName));
+            $this->entityManager->flush();
+
+            return;
+        }
+
+        $userId = $run->getUserId();
+        $context = new AgentToolContext($userId, $tenant, $run->getContext());
+
+        $affected = 0;
+        $processed = 0;
+        $tokensIn = 0;
+        $tokensOut = 0;
+        $costUsd = 0.0;
+        foreach ($message->productIds as $productId) {
+            ++$processed;
+            try {
+                $result = $tool->execute($this->arguments($message, $productId), $context);
+            } catch (Throwable) {
+                // One poisoned/broken product must not sink the batch.
+                $result = ['status' => 'error'];
+            }
+
+            $usage = $result['llm_usage'] ?? null;
+            if (\is_array($usage)) {
+                $tokensIn += \is_int($usage['input_tokens'] ?? null) ? $usage['input_tokens'] : 0;
+                $tokensOut += \is_int($usage['output_tokens'] ?? null) ? $usage['output_tokens'] : 0;
+                $costUsd += \is_string($usage['cost_usd'] ?? null) ? (float) $usage['cost_usd'] : 0.0;
+            }
+            if (($result['status'] ?? null) === 'materialized') {
+                ++$affected;
+            }
+
+            if ($this->shouldFlush($processed)) {
+                $this->flushAndClear();
+                // The clear detached the tenant used by the tool context;
+                // rebind it (same rule the loop runner follows).
+                $tenant = $this->entityManager->find(Tenant::class, $message->tenantId->toRfc4122());
+                if (!$tenant instanceof Tenant) {
+                    return;
+                }
+                $context = new AgentToolContext($userId, $tenant, $context->viewContext);
+            }
+        }
+
+        $run = $this->findRun($message->runId);
+        if (!$run instanceof AgentRun) {
+            return;
+        }
+        $run->addUsage($tokensIn, $tokensOut, number_format($costUsd, 6, '.', ''));
+        if ($affected > 0) {
+            $run->markAwaitingApproval($message->batchId, $affected);
+        } else {
+            // Nothing grounded well enough to propose — hand control back
+            // rather than open an empty approval.
+            $run->markAwaitingInput();
+        }
+        $this->entityManager->flush();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function arguments(BulkGenerateContentMessage $message, string $productId): array
+    {
+        $arguments = [
+            'product_id' => $productId,
+            'pending_change_batch_id' => $message->batchId->toRfc4122(),
+        ];
+        if (null !== $message->recipeId) {
+            $arguments['recipe_id'] = $message->recipeId;
+        }
+        if (null !== $message->locale) {
+            $arguments['locale'] = $message->locale;
+        }
+        if (null !== $message->channel) {
+            $arguments['channel'] = $message->channel;
+        }
+
+        return $arguments;
+    }
+
+    private function findRun(Uuid $runId): ?AgentRun
+    {
+        $run = $this->entityManager->createQueryBuilder()
+            ->select('r')
+            ->from(AgentRun::class, 'r')
+            ->where('r.id = :id')
+            ->setParameter('id', $runId, 'uuid')
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $run instanceof AgentRun ? $run : null;
+    }
+}

--- a/apps/api/src/Agent/Application/Content/BulkGenerateContentMessage.php
+++ b/apps/api/src/Agent/Application/Content/BulkGenerateContentMessage.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Content;
+
+use App\Shared\Application\TenantAwareMessage;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AICG-P6-03 (#2346, ADR-0030) — the async unit of a bulk content run.
+ *
+ * The dedicated bulk path (as opposed to the P5-03 agent-run loop) sizes
+ * to hundreds of products: it does NOT spend the loop's 10-tool-call
+ * budget, and the handler processes the ids memory-bounded (batch of 200
+ * + EntityManager::clear, worker-memory rule §3.10). All proposals land
+ * in the ONE batch the run will show for approval — never a catalog
+ * write.
+ *
+ * @see BulkGenerateContentHandler
+ */
+final readonly class BulkGenerateContentMessage implements TenantAwareMessage
+{
+    /**
+     * @param list<string> $productIds RFC-4122 UUIDs of the target objects
+     * @param string       $toolName   the content write tool to run per product
+     *                                 (generate_product_description | generate_seo_text)
+     */
+    public function __construct(
+        public Uuid $runId,
+        public Uuid $tenantId,
+        public Uuid $batchId,
+        public array $productIds,
+        public string $toolName,
+        public ?string $recipeId = null,
+        public ?string $locale = null,
+        public ?string $channel = null,
+    ) {
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenantId;
+    }
+}

--- a/apps/api/src/Agent/Application/Cost/ContentCostEstimate.php
+++ b/apps/api/src/Agent/Application/Cost/ContentCostEstimate.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Cost;
+
+/**
+ * AICG-P6-03 (#2346, ADR-0030) — the deterministic pre-flight estimate
+ * a bulk content run costs, so the UI can show it and the day-cap gate
+ * can refuse BEFORE any tokens are spent (plan §8 R3).
+ */
+final readonly class ContentCostEstimate
+{
+    /**
+     * @param numeric-string $estCostUsd
+     */
+    public function __construct(
+        public int $productCount,
+        public int $inputTokensPerProduct,
+        public int $outputTokensPerProduct,
+        public int $estInputTokens,
+        public int $estOutputTokens,
+        public string $estCostUsd,
+        public string $model,
+    ) {
+    }
+}

--- a/apps/api/src/Agent/Application/Cost/ContentCostEstimator.php
+++ b/apps/api/src/Agent/Application/Cost/ContentCostEstimator.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Application\Cost;
+
+use App\Agent\Application\Run\UsageCostCalculator;
+use App\Agent\Domain\Entity\ContentRecipe;
+use App\Agent\Infrastructure\Anthropic\AgentModelSelector;
+
+/**
+ * AICG-P6-03 (#2346, ADR-0030) — estimates the token/USD footprint of a
+ * bulk content run (N products × one recipe) up front, so the modal can
+ * preview it and the day-cap gate can refuse before spending (plan §8
+ * R3). Deliberately deterministic (no model call): a conservative
+ * over-estimate is the right bias for a spend guard.
+ *
+ * The per-product baseline is the live-measured envelope of the content
+ * tools (AICG-P3-02/P4-02 dev-stack smokes: ~1.2k input / ~0.4k output
+ * for a grounded round-trip); the recipe refines it — more source
+ * attributes widen the facts payload, the length budget bounds output.
+ */
+final readonly class ContentCostEstimator
+{
+    private const int BASE_INPUT_TOKENS = 1_200;
+    private const int PER_SOURCE_INPUT_TOKENS = 60;
+    private const int FALLBACK_OUTPUT_TOKENS = 400;
+    private const int DEFAULT_SOURCE_COUNT = 4;
+    private const int MIN_OUTPUT_TOKENS = 120;
+    private const int MAX_OUTPUT_TOKENS = 2_000;
+
+    public function __construct(
+        private AgentModelSelector $models,
+        private UsageCostCalculator $costs,
+    ) {
+    }
+
+    public function estimate(int $productCount, ?ContentRecipe $recipe): ContentCostEstimate
+    {
+        $count = max(0, $productCount);
+        $model = $this->models->defaultModel();
+
+        $sourceCount = null !== $recipe ? \count($recipe->getSourceAttributes()) : self::DEFAULT_SOURCE_COUNT;
+        $inputPerProduct = self::BASE_INPUT_TOKENS + $sourceCount * self::PER_SOURCE_INPUT_TOKENS;
+        $outputPerProduct = $this->outputTokensForRecipe($recipe);
+
+        $estInput = $inputPerProduct * $count;
+        $estOutput = $outputPerProduct * $count;
+        $cost = $this->costs->costUsd($model, $estInput, $estOutput);
+
+        return new ContentCostEstimate(
+            productCount: $count,
+            inputTokensPerProduct: $inputPerProduct,
+            outputTokensPerProduct: $outputPerProduct,
+            estInputTokens: $estInput,
+            estOutputTokens: $estOutput,
+            estCostUsd: $cost,
+            model: $model,
+        );
+    }
+
+    private function outputTokensForRecipe(?ContentRecipe $recipe): int
+    {
+        $maxLen = $recipe?->getConstraints()['max_len'] ?? null;
+        if (!\is_int($maxLen)) {
+            return self::FALLBACK_OUTPUT_TOKENS;
+        }
+
+        // ~4 characters per token, +20% headroom for markup/whitespace.
+        $estimate = (int) round($maxLen / 4 * 1.2);
+
+        return max(self::MIN_OUTPUT_TOKENS, min(self::MAX_OUTPUT_TOKENS, $estimate));
+    }
+}

--- a/apps/api/src/Agent/Presentation/Controller/AgentContentController.php
+++ b/apps/api/src/Agent/Presentation/Controller/AgentContentController.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agent\Presentation\Controller;
+
+use App\Agent\Application\AgentFeatureGuard;
+use App\Agent\Application\Content\BulkGenerateContentMessage;
+use App\Agent\Application\Cost\AgentCostAggregator;
+use App\Agent\Application\Cost\ContentCostEstimate;
+use App\Agent\Application\Cost\ContentCostEstimator;
+use App\Agent\Application\Limits\AgentLimitGuard;
+use App\Agent\Domain\AgentRunSurface;
+use App\Agent\Domain\Entity\AgentRun;
+use App\Agent\Domain\Entity\ContentRecipe;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\TenantContext;
+use App\Shared\Application\UserIdentityAware;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AICG-P6-03 (#2346, ADR-0030) — the bulk content surface (plan §8 R3):
+ *
+ *  - cost-preview: a deterministic pre-flight estimate (tokens + USD)
+ *    for N products × recipe, plus the tenant's remaining day budget,
+ *    so the modal shows the price and blocks BEFORE spending;
+ *  - bulk-generate: the dedicated bulk path — one AgentRun whose write
+ *    tool runs per product in a memory-bounded worker batch (not the
+ *    10-tool-call agent loop), all proposals in ONE approval batch.
+ *
+ * The §8.5 day cap is enforced twice: the already-spent check
+ * (AgentLimitGuard, shared with run start) AND the estimate-vs-remaining
+ * check here — either over the cap answers 429 before any tokens burn.
+ */
+final readonly class AgentContentController
+{
+    /** @var array<string, array{tool: string, recipe: string}> */
+    private const array MODES = [
+        'descriptions' => ['tool' => 'generate_product_description', 'recipe' => 'product_description'],
+        'seo' => ['tool' => 'generate_seo_text', 'recipe' => 'meta_seo'],
+    ];
+
+    public function __construct(
+        private AgentFeatureGuard $featureGuard,
+        private ContentCostEstimator $estimator,
+        private AgentCostAggregator $costAggregator,
+        private AgentLimitGuard $limits,
+        private EntityManagerInterface $entityManager,
+        private MessageBusInterface $messageBus,
+        private TenantContext $tenantContext,
+        private Security $security,
+    ) {
+    }
+
+    #[Route('/api/agent/content/cost-preview', name: 'pim_agent_content_cost_preview', methods: ['POST'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'settings', action: 'ai_content.read')]
+    public function costPreview(Request $request): JsonResponse
+    {
+        $this->featureGuard->assertEnabled($this->tenant());
+
+        /** @var array<string, mixed> $body */
+        $body = json_decode($request->getContent(), true) ?? [];
+
+        $count = $this->productCount($body);
+        [, $recipe] = $this->resolveMode($body);
+
+        $estimate = $this->estimator->estimate($count, $recipe);
+
+        return new JsonResponse($this->serializeEstimate($estimate));
+    }
+
+    #[Route('/api/agent/content/bulk-generate', name: 'pim_agent_content_bulk_generate', methods: ['POST'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'settings', action: 'ai_content.create')]
+    public function bulkGenerate(Request $request): JsonResponse
+    {
+        $tenant = $this->tenant();
+        $this->featureGuard->assertEnabled($tenant);
+
+        /** @var array<string, mixed> $body */
+        $body = json_decode($request->getContent(), true) ?? [];
+
+        $productIds = $this->productIds($body);
+        if ([] === $productIds) {
+            throw new BadRequestHttpException('selected_ids must be a non-empty list of product UUIDs.');
+        }
+        [$toolName, $recipe] = $this->resolveMode($body);
+        $locale = \is_string($body['locale'] ?? null) && '' !== $body['locale'] ? $body['locale'] : null;
+        $channel = \is_string($body['channel'] ?? null) && '' !== $body['channel'] ? $body['channel'] : null;
+
+        // §8.5 day cap, part 1: what is already spent this UTC day (throws
+        // 429 when the tenant is at the cap regardless of this request).
+        $userId = $this->userId();
+        $this->limits->assertWithinLimits($tenant, $userId);
+
+        // §8.5 day cap, part 2: would THIS run's estimate overshoot the
+        // remaining budget? Refuse before spending a token.
+        $estimate = $this->estimator->estimate(\count($productIds), $recipe);
+        $report = $this->costAggregator->report();
+        $remaining = max(0.0, $report->dayCapUsd - (float) $report->costTodayUsd);
+        if ((float) $estimate->estCostUsd > $remaining) {
+            return new JsonResponse([
+                'type' => 'https://pim.dev/problems/agent-budget-exceeded',
+                'title' => 'Estimated bulk cost exceeds the remaining daily budget.',
+                'status' => Response::HTTP_TOO_MANY_REQUESTS,
+                'estimated_cost_usd' => $estimate->estCostUsd,
+                'day_budget_remaining_usd' => number_format($remaining, 6, '.', ''),
+            ], Response::HTTP_TOO_MANY_REQUESTS, ['content-type' => 'application/problem+json']);
+        }
+
+        $batchId = Uuid::v7();
+        $run = new AgentRun(
+            $userId,
+            AgentRunSurface::CmdK,
+            \sprintf('Bulk content generation (%s) for %d products.', $toolName, \count($productIds)),
+            ['bulk_content' => ['tool' => $toolName, 'product_count' => \count($productIds)]],
+        );
+        $this->entityManager->persist($run);
+        $this->entityManager->flush();
+
+        $this->messageBus->dispatch(new BulkGenerateContentMessage(
+            runId: $run->getId(),
+            tenantId: $tenant->getId(),
+            batchId: $batchId,
+            productIds: $productIds,
+            toolName: $toolName,
+            recipeId: null !== $recipe ? $recipe->getId()->toRfc4122() : null,
+            locale: $locale,
+            channel: $channel,
+        ));
+
+        return new JsonResponse([
+            'run_id' => $run->getId()->toRfc4122(),
+            'pending_change_batch_id' => $batchId->toRfc4122(),
+            'product_count' => \count($productIds),
+            'estimate' => $this->serializeEstimate($estimate),
+        ], Response::HTTP_ACCEPTED, ['Location' => \sprintf('/api/agent/runs/%s', $run->getId()->toRfc4122())]);
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    private function productCount(array $body): int
+    {
+        if (\is_int($body['product_count'] ?? null)) {
+            return max(0, $body['product_count']);
+        }
+
+        return \count($this->productIds($body));
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     *
+     * @return list<string>
+     */
+    private function productIds(array $body): array
+    {
+        $ids = $body['selected_ids'] ?? null;
+        if (!\is_array($ids)) {
+            return [];
+        }
+
+        $valid = [];
+        foreach ($ids as $id) {
+            if (\is_string($id) && Uuid::isValid($id)) {
+                $valid[] = $id;
+            }
+        }
+
+        return array_values(array_unique($valid));
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     *
+     * @return array{0: string, 1: ContentRecipe|null}
+     */
+    private function resolveMode(array $body): array
+    {
+        $mode = \is_string($body['mode'] ?? null) ? $body['mode'] : 'descriptions';
+        $config = self::MODES[$mode] ?? self::MODES['descriptions'];
+
+        $repository = $this->entityManager->getRepository(ContentRecipe::class);
+        $recipeId = $body['recipe_id'] ?? null;
+        if (\is_string($recipeId) && Uuid::isValid($recipeId)) {
+            $recipe = $repository->find($recipeId);
+            if ($recipe instanceof ContentRecipe) {
+                return [$config['tool'], $recipe];
+            }
+        }
+
+        $recipe = $repository->findOneBy(['code' => $config['recipe'], 'isBuiltIn' => true])
+            ?? $repository->findOneBy(['code' => $config['recipe']]);
+
+        return [$config['tool'], $recipe instanceof ContentRecipe ? $recipe : null];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializeEstimate(ContentCostEstimate $estimate): array
+    {
+        return [
+            'product_count' => $estimate->productCount,
+            'input_tokens_per_product' => $estimate->inputTokensPerProduct,
+            'output_tokens_per_product' => $estimate->outputTokensPerProduct,
+            'est_input_tokens' => $estimate->estInputTokens,
+            'est_output_tokens' => $estimate->estOutputTokens,
+            'est_cost_usd' => $estimate->estCostUsd,
+            'model' => $estimate->model,
+        ];
+    }
+
+    private function tenant(): Tenant
+    {
+        $tenant = $this->tenantContext->get();
+        if (!$tenant instanceof Tenant) {
+            throw new BadRequestHttpException('No tenant resolved for this request.');
+        }
+
+        return $tenant;
+    }
+
+    private function userId(): Uuid
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof UserIdentityAware) {
+            throw new BadRequestHttpException('The agent API requires a user principal (API keys are not user-scoped).');
+        }
+
+        return $user->getId();
+    }
+}

--- a/apps/api/tests/Api/Agent/AgentContentBulkApiTest.php
+++ b/apps/api/tests/Api/Agent/AgentContentBulkApiTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Agent;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Agent\Domain\AgentRunSurface;
+use App\Agent\Domain\Entity\AgentRun;
+use App\DataFixtures\Identity\PrdPermissionFixtures;
+use App\Identity\Application\ByokKeyManager;
+use App\Identity\Application\RbacSeeder;
+use App\Identity\Application\SeedTenantPrdRolesService;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\ORM\EntityManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * AICG-P6-03 (#2346) — the bulk content HTTP surface: cost-preview
+ * (deterministic estimate, gated read) and bulk-generate (202 + one run
+ * + one batch, gated create), plus the §8.5 day-cap refusal (429) when
+ * the tenant is already at the spend cap.
+ */
+final class AgentContentBulkApiTest extends ApiTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    protected static ?bool $alwaysBootKernel = true;
+
+    private const string TENANT_CODE = 'demo';
+    private const string ADMIN_EMAIL = 'admin@demo.localhost';
+    private const string VIEWER_EMAIL = 'viewer@demo.localhost';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $em = $this->em();
+        self::getContainer()->get(RbacSeeder::class)->seed();
+        new PrdPermissionFixtures()->load($em);
+        $em->flush();
+
+        $tenant = new Tenant(self::TENANT_CODE, 'Demo Tenant');
+        $em->persist($tenant);
+        $em->flush();
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+
+        self::getContainer()->get(SeedTenantPrdRolesService::class)->seed($tenant);
+        $this->createUser($tenant, self::ADMIN_EMAIL, 'tenant_owner');
+        $this->createUser($tenant, self::VIEWER_EMAIL, 'viewer');
+        self::getContainer()->get(ByokKeyManager::class)->setKey($tenant, 'sk-ant-api03-canned-test-key');
+    }
+
+    #[Test]
+    public function costPreviewRejectsAnonymousAndTheModulelessViewer(): void
+    {
+        $anon = static::createClient()->request('POST', '/api/agent/content/cost-preview', ['json' => ['product_count' => 5]]);
+        self::assertSame(401, $anon->getStatusCode());
+
+        $viewer = $this->authenticatedClient(self::VIEWER_EMAIL)
+            ->request('POST', '/api/agent/content/cost-preview', ['json' => ['product_count' => 5]]);
+        self::assertSame(403, $viewer->getStatusCode());
+    }
+
+    #[Test]
+    public function costPreviewReturnsADeterministicScalingEstimate(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $response = $client->request('POST', '/api/agent/content/cost-preview', ['json' => [
+            'product_count' => 10,
+            'mode' => 'descriptions',
+        ]]);
+        self::assertSame(200, $response->getStatusCode());
+
+        $data = $response->toArray();
+        self::assertSame(10, $data['product_count']);
+        self::assertIsInt($data['est_input_tokens']);
+        self::assertIsInt($data['est_output_tokens']);
+        self::assertIsInt($data['input_tokens_per_product']);
+        self::assertGreaterThan(0, $data['est_input_tokens']);
+        self::assertGreaterThan(0, $data['est_output_tokens']);
+        self::assertArrayHasKey('est_cost_usd', $data);
+        self::assertSame($data['input_tokens_per_product'] * 10, $data['est_input_tokens']);
+    }
+
+    #[Test]
+    public function bulkGenerateAcceptsAndReturnsOneRunAndOneBatch(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $response = $client->request('POST', '/api/agent/content/bulk-generate', ['json' => [
+            'object_type_code' => 'product',
+            'mode' => 'descriptions',
+            'selected_ids' => [Uuid::v7()->toRfc4122(), Uuid::v7()->toRfc4122()],
+        ]]);
+
+        self::assertSame(202, $response->getStatusCode());
+        $data = $response->toArray();
+        self::assertArrayHasKey('run_id', $data);
+        self::assertArrayHasKey('pending_change_batch_id', $data);
+        self::assertSame(2, $data['product_count']);
+        self::assertIsArray($data['estimate']);
+        self::assertSame(2, $data['estimate']['product_count']);
+    }
+
+    #[Test]
+    public function bulkGenerateRefusesWith400WhenNothingSelected(): void
+    {
+        $response = $this->authenticatedClient()->request('POST', '/api/agent/content/bulk-generate', ['json' => [
+            'object_type_code' => 'product',
+            'mode' => 'descriptions',
+            'selected_ids' => [],
+        ]]);
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function bulkGenerateRefusesWith429WhenTheDayCapIsExhausted(): void
+    {
+        // Seed a run today that already spent the whole $20 day cap.
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+        $spent = new AgentRun(Uuid::v7(), AgentRunSurface::Chat, 'earlier run');
+        $spent->addUsage(0, 0, '20.000000');
+        $em->persist($spent);
+        $em->flush();
+
+        $response = $this->authenticatedClient()->request('POST', '/api/agent/content/bulk-generate', ['json' => [
+            'object_type_code' => 'product',
+            'mode' => 'descriptions',
+            'selected_ids' => [Uuid::v7()->toRfc4122()],
+        ]]);
+
+        self::assertSame(429, $response->getStatusCode());
+    }
+
+    private function createUser(Tenant $tenant, string $email, string $roleCode): void
+    {
+        $em = $this->em();
+        $role = self::getContainer()->get(RoleRepositoryInterface::class)->findByCode($roleCode, $tenant);
+        \assert(null !== $role);
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $stub = new User($tenant, $email, '', ['ROLE_USER']);
+        $user = new User($tenant, $email, $hasher->hashPassword($stub, 'changeme'), ['ROLE_USER']);
+        $user->addRole($role);
+        $em->persist($user);
+        $em->flush();
+    }
+
+    private function authenticatedClient(string $email = self::ADMIN_EMAIL): Client
+    {
+        $user = self::getContainer()->get(UserRepositoryInterface::class)->findByEmail($email);
+        \assert(null !== $user);
+
+        $jwt = self::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+
+        $client = static::createClient();
+        $client->setDefaultOptions(['headers' => ['Authorization' => 'Bearer '.$jwt]]);
+
+        return $client;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}

--- a/apps/api/tests/Integration/Agent/BulkGenerateContentHandlerTest.php
+++ b/apps/api/tests/Integration/Agent/BulkGenerateContentHandlerTest.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Agent;
+
+use App\Agent\Application\AgentFeatureGuard;
+use App\Agent\Application\Content\BulkGenerateContentHandler;
+use App\Agent\Application\Content\BulkGenerateContentMessage;
+use App\Agent\Application\Content\ContentGroundingService;
+use App\Agent\Application\Content\GroundingGate;
+use App\Agent\Application\Llm\AgentLlmClientInterface;
+use App\Agent\Application\Llm\AgentLlmResponse;
+use App\Agent\Application\Run\UsageCostCalculator;
+use App\Agent\Application\Tool\GenerateProductDescriptionTool;
+use App\Agent\Domain\AgentRunStatus;
+use App\Agent\Domain\AgentRunSurface;
+use App\Agent\Domain\Entity\AgentRun;
+use App\Agent\Domain\Entity\ContentRecipe;
+use App\Agent\Infrastructure\Anthropic\AgentModelSelector;
+use App\Catalog\Application\PendingChanges\ContentValueMaterializer;
+use App\Catalog\Application\Validation\AttributeValueValidator;
+use App\Catalog\Contracts\PendingChanges\PendingChangesPort;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use App\Channel\Contracts\ChannelResolverInterface;
+use App\Identity\Contracts\Byok\ByokKeyResolverInterface;
+use App\Identity\Contracts\Policy\UserScopedPermissionCheckerInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * AICG-P6-03 (#2346) — the dedicated bulk content handler against real
+ * Postgres with a scripted LLM (external API is the only mock):
+ *
+ *   - every product's proposal lands in the ONE run batch, run ->
+ *     awaiting_approval, nothing applied to the catalog (approval-only);
+ *   - with batchSize=1 the flush+clear fires between every product and
+ *     the run still finalizes correctly (the memory-bounded path re-
+ *     resolves the detached run + tenant, §3.10);
+ *   - a product with no facts is SKIPPED (insufficient grounding), never
+ *     invented, and never sinks the rest of the batch.
+ */
+final class BulkGenerateContentHandlerTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function everyProductMaterializesIntoTheOneBatchAndNothingIsApplied(): void
+    {
+        [$tenant, $em] = $this->fixture();
+        $recipe = $this->recipe($em);
+        $productA = $this->product($em, 'BULK-A', material: 'aluminium');
+        $productB = $this->product($em, 'BULK-B', material: 'stal');
+        $run = $this->seedRun($em);
+        $batchId = Uuid::v7();
+
+        $this->handler($em, reply: 'Rzeczowy opis produktu.', batchSize: 200)(
+            new BulkGenerateContentMessage(
+                runId: $run->getId(),
+                tenantId: $tenant->getId(),
+                batchId: $batchId,
+                productIds: [$productA->getId()->toRfc4122(), $productB->getId()->toRfc4122()],
+                toolName: 'generate_product_description',
+                recipeId: $recipe->getId()->toRfc4122(),
+            ),
+        );
+
+        $run = $em->find(AgentRun::class, $run->getId());
+        self::assertInstanceOf(AgentRun::class, $run);
+        self::assertSame(AgentRunStatus::AwaitingApproval, $run->getStatus());
+        self::assertSame($batchId->toRfc4122(), $run->getPendingChangeBatchId()?->toRfc4122());
+
+        $rows = self::getContainer()->get(PendingChangesPort::class)->listBatch($batchId);
+        self::assertCount(2, $rows, 'both products propose into the single batch');
+        foreach ($rows as $row) {
+            self::assertSame('description', $row->attributeCode);
+        }
+
+        // Only the seeded source values exist; the generated description
+        // is a PENDING proposal, never an applied object_value.
+        $applied = $em->getConnection()->fetchOne(
+            "SELECT COUNT(*) FROM object_values ov JOIN attributes a ON a.id = ov.attribute_id WHERE a.code = 'description'",
+        );
+        self::assertSame(0, (int) (\is_scalar($applied) ? $applied : -1), 'approval-only: nothing written to the catalog');
+    }
+
+    #[Test]
+    public function flushAndClearBetweenProductsStillFinalizesTheRun(): void
+    {
+        [$tenant, $em] = $this->fixture();
+        $recipe = $this->recipe($em);
+        $ids = [];
+        foreach (['C1', 'C2', 'C3'] as $code) {
+            $ids[] = $this->product($em, $code, material: 'aluminium')->getId()->toRfc4122();
+        }
+        $run = $this->seedRun($em);
+        $batchId = Uuid::v7();
+
+        // batchSize=1 forces a flush+clear after EVERY product.
+        $this->handler($em, reply: 'Opis.', batchSize: 1)(
+            new BulkGenerateContentMessage(
+                runId: $run->getId(),
+                tenantId: $tenant->getId(),
+                batchId: $batchId,
+                productIds: $ids,
+                toolName: 'generate_product_description',
+                recipeId: $recipe->getId()->toRfc4122(),
+            ),
+        );
+
+        $run = $em->find(AgentRun::class, $run->getId());
+        self::assertInstanceOf(AgentRun::class, $run);
+        self::assertSame(AgentRunStatus::AwaitingApproval, $run->getStatus());
+        self::assertSame(3, $run->getAffectedCount());
+        self::assertCount(3, self::getContainer()->get(PendingChangesPort::class)->listBatch($batchId));
+    }
+
+    #[Test]
+    public function aProductWithoutFactsIsSkippedNotInvented(): void
+    {
+        [$tenant, $em] = $this->fixture();
+        $recipe = $this->recipe($em);
+        $withFacts = $this->product($em, 'HAS-FACTS', material: 'aluminium');
+        $empty = $this->product($em, 'NO-FACTS', material: null);
+        $run = $this->seedRun($em);
+        $batchId = Uuid::v7();
+
+        $this->handler($em, reply: 'Opis.', batchSize: 200)(
+            new BulkGenerateContentMessage(
+                runId: $run->getId(),
+                tenantId: $tenant->getId(),
+                batchId: $batchId,
+                productIds: [$withFacts->getId()->toRfc4122(), $empty->getId()->toRfc4122()],
+                toolName: 'generate_product_description',
+                recipeId: $recipe->getId()->toRfc4122(),
+            ),
+        );
+
+        $rows = self::getContainer()->get(PendingChangesPort::class)->listBatch($batchId);
+        self::assertCount(1, $rows, 'only the grounded product proposes; the empty one is skipped, not invented');
+        self::assertSame($withFacts->getId()->toRfc4122(), $rows[0]->targetObjectId?->toRfc4122());
+    }
+
+    /**
+     * @return array{0: Tenant, 1: EntityManagerInterface}
+     */
+    private function fixture(): array
+    {
+        $tenant = new Tenant('alpha', 'Alpha Tenant');
+        $em = $this->em();
+        $em->persist($tenant);
+        $em->flush();
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+
+        return [$tenant, $em];
+    }
+
+    private function recipe(EntityManagerInterface $em): ContentRecipe
+    {
+        $recipe = new ContentRecipe(
+            code: 'product_description',
+            name: 'Opis produktu',
+            targetAttribute: 'description',
+            sourceAttributes: ['material'],
+            constraints: ['format' => 'plain'],
+        );
+        $em->persist($recipe);
+        $em->flush();
+
+        return $recipe;
+    }
+
+    private function product(EntityManagerInterface $em, string $code, ?string $material): CatalogObject
+    {
+        $type = $em->getRepository(ObjectType::class)->findOneBy(['code' => 'product']);
+        if (!$type instanceof ObjectType) {
+            $type = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+            $em->persist($type);
+            $em->persist(new Attribute('material', ['en' => 'Material'], AttributeType::Text));
+            $em->persist(new Attribute('description', ['en' => 'Description'], AttributeType::Text));
+            $em->flush();
+        }
+        $object = new CatalogObject($type, $code);
+        $em->persist($object);
+        if (null !== $material) {
+            $attribute = $em->getRepository(Attribute::class)->findOneBy(['code' => 'material']);
+            \assert($attribute instanceof Attribute);
+            $em->persist(new ObjectValue($object, $attribute, ['value' => $material]));
+        }
+        $em->flush();
+
+        return $object;
+    }
+
+    private function seedRun(EntityManagerInterface $em): AgentRun
+    {
+        $run = new AgentRun(Uuid::v7(), AgentRunSurface::CmdK, 'bulk content');
+        $em->persist($run);
+        $em->flush();
+
+        return $run;
+    }
+
+    private function handler(EntityManagerInterface $em, string $reply, int $batchSize): BulkGenerateContentHandler
+    {
+        $keyResolver = $this->createStub(ByokKeyResolverInterface::class);
+        $keyResolver->method('hasActiveKey')->willReturn(true);
+        $guard = new AgentFeatureGuard($keyResolver, true);
+
+        return new BulkGenerateContentHandler($em, [$this->contentTool($em, $reply)], $guard, $batchSize);
+    }
+
+    private function contentTool(EntityManagerInterface $em, string $reply): GenerateProductDescriptionTool
+    {
+        $selector = new AgentModelSelector('claude-sonnet-test', 'claude-opus-test');
+        $rbac = new class implements UserScopedPermissionCheckerInterface {
+            public function canViewAttribute(Uuid $userId, Uuid $attributeId): bool
+            {
+                return true;
+            }
+
+            public function canEditAttribute(Uuid $userId, Uuid $attributeId): bool
+            {
+                return true;
+            }
+
+            public function canEditLocale(Uuid $userId, string $locale): bool
+            {
+                return true;
+            }
+
+            public function canEditChannel(Uuid $userId, string $channel): bool
+            {
+                return true;
+            }
+        };
+        $materializer = new ContentValueMaterializer(
+            $em,
+            self::getContainer()->get(TenantContext::class),
+            self::getContainer()->get(ObjectValueRepositoryInterface::class),
+            self::getContainer()->get(AttributeValueValidator::class),
+            $rbac,
+            self::getContainer()->get(ChannelResolverInterface::class),
+            self::getContainer()->get(PendingChangesPort::class),
+        );
+
+        return new GenerateProductDescriptionTool(
+            $em,
+            self::getContainer()->get(ContentGroundingService::class),
+            new GroundingGate(),
+            $materializer,
+            $this->scriptedLlm($reply),
+            $selector,
+            new UsageCostCalculator($selector, 3.0, 15.0, 5.0, 25.0),
+        );
+    }
+
+    private function scriptedLlm(string $reply): AgentLlmClientInterface
+    {
+        return new class($reply) implements AgentLlmClientInterface {
+            public function __construct(private readonly string $reply)
+            {
+            }
+
+            public function create(Tenant $tenant, string $model, string $system, array $messages, array $tools, bool $promptCaching = true): AgentLlmResponse
+            {
+                return new AgentLlmResponse('end_turn', [['type' => 'text', 'text' => $this->reply]], 12, 34);
+            }
+        };
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}

--- a/apps/api/tests/Unit/Agent/Application/ContentCostEstimatorTest.php
+++ b/apps/api/tests/Unit/Agent/Application/ContentCostEstimatorTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Agent\Application;
+
+use App\Agent\Application\Cost\ContentCostEstimator;
+use App\Agent\Application\Run\UsageCostCalculator;
+use App\Agent\Domain\Entity\ContentRecipe;
+use App\Agent\Infrastructure\Anthropic\AgentModelSelector;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * AICG-P6-03 (#2346) — the pre-flight estimate is deterministic and
+ * scales linearly with the product count, so the day-cap gate and the
+ * modal preview can trust it before any tokens are spent.
+ */
+final class ContentCostEstimatorTest extends TestCase
+{
+    #[Test]
+    public function estimateScalesLinearlyWithTheProductCount(): void
+    {
+        $estimator = $this->estimator();
+        $recipe = $this->recipe(sources: ['material', 'color'], maxLen: 800);
+
+        $one = $estimator->estimate(1, $recipe);
+        $fifty = $estimator->estimate(50, $recipe);
+
+        self::assertSame(50, $fifty->productCount);
+        self::assertSame($one->inputTokensPerProduct * 50, $fifty->estInputTokens);
+        self::assertSame($one->outputTokensPerProduct * 50, $fifty->estOutputTokens);
+        // 2 sources -> 1200 + 2*60 input; 800 chars/4*1.2 = 240 output.
+        self::assertSame(1_320, $one->inputTokensPerProduct);
+        self::assertSame(240, $one->outputTokensPerProduct);
+    }
+
+    #[Test]
+    public function theLengthBudgetBoundsTheOutputEstimate(): void
+    {
+        $estimator = $this->estimator();
+
+        $noRecipe = $estimator->estimate(1, null);
+        self::assertSame(400, $noRecipe->outputTokensPerProduct, 'no recipe falls back to the measured average');
+
+        $huge = $estimator->estimate(1, $this->recipe(sources: [], maxLen: 40_000));
+        self::assertSame(2_000, $huge->outputTokensPerProduct, 'output is capped so a silly budget cannot explode the estimate');
+
+        $tiny = $estimator->estimate(1, $this->recipe(sources: [], maxLen: 10));
+        self::assertSame(120, $tiny->outputTokensPerProduct, 'and floored so a tiny budget still bills the base call');
+    }
+
+    #[Test]
+    public function zeroProductsCostNothing(): void
+    {
+        $estimate = $this->estimator()->estimate(0, $this->recipe(sources: ['x'], maxLen: 500));
+
+        self::assertSame(0, $estimate->productCount);
+        self::assertSame(0, $estimate->estInputTokens);
+        self::assertSame('0.000000', $estimate->estCostUsd);
+    }
+
+    #[Test]
+    public function costUsesTheDefaultTierRates(): void
+    {
+        // 1200+60 input, 240 output per product at $3/$15 per MTok.
+        $estimate = $this->estimator()->estimate(10, $this->recipe(sources: ['material'], maxLen: 800));
+
+        $expectedInput = (1_200 + 60) * 10;
+        $expectedOutput = 240 * 10;
+        $expectedCost = ($expectedInput * 3.0 + $expectedOutput * 15.0) / 1_000_000;
+        self::assertSame(number_format($expectedCost, 6, '.', ''), $estimate->estCostUsd);
+    }
+
+    private function estimator(): ContentCostEstimator
+    {
+        $models = new AgentModelSelector('claude-sonnet-test', 'claude-opus-test');
+
+        return new ContentCostEstimator($models, new UsageCostCalculator($models, 3.0, 15.0, 5.0, 25.0));
+    }
+
+    /**
+     * @param list<string> $sources
+     */
+    private function recipe(array $sources, int $maxLen): ContentRecipe
+    {
+        return new ContentRecipe(
+            code: 'product_description',
+            name: 'Opis',
+            targetAttribute: 'description',
+            sourceAttributes: $sources,
+            constraints: ['format' => 'plain', 'max_len' => $maxLen],
+        );
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -10889,6 +10889,58 @@
                 "x-cortex-permission": "agent.bulk_actions"
             }
         },
+        "/api/agent/content/bulk-generate": {
+            "post": {
+                "operationId": "api_agent_content_bulk_generate_post",
+                "tags": [
+                    "agent"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api agent content bulk generate",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "settings.ai_content.create"
+            }
+        },
+        "/api/agent/content/cost-preview": {
+            "post": {
+                "operationId": "api_agent_content_cost_preview_post",
+                "tags": [
+                    "agent"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api agent content cost preview",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "settings.ai_content.read"
+            }
+        },
         "/api/agent/cost": {
             "get": {
                 "operationId": "api_agent_cost_get",


### PR DESCRIPTION
## AICG-P6-03 — bulk cost-preview + memory-bounded batch path (hardening bulk, plan §8 R3)

Bulk (setki produktów) miał cap 8/run (budżet 10 tool-calli pętli) i client-side estymatę kosztu. Ten ticket dodaje dedykowaną ścieżkę bulk i domyka hardening.

### Backend
- **`POST /api/agent/content/cost-preview`** (`settings.ai_content.read`) — deterministyczna estymata pre-flight (`ContentCostEstimator`): tokeny in/out per produkt (liczba źródeł przepisu poszerza input, `max_len` ogranicza output) × stawki `defaultModel`, ×liczba produktów. Zero wywołania modelu — konserwatywna estymata to właściwy bias dla gate'a budżetu.
- **`POST /api/agent/content/bulk-generate`** (`settings.ai_content.create`, 202) — dedykowana ścieżka: jeden `AgentRun`, którego tool treści (`generate_product_description` / `generate_seo_text`) uruchamiany jest **per produkt** w memory-bounded batchu workera (`BulkGenerateContentHandler extends AbstractBatchHandler` — batch 200 + `EntityManager::clear()`, §3.10). **Reuse tooli 1:1** → identyczny grounding + kontrakt anty-halucynacyjny + provenance. Wszystkie propozycje w **jednym batchu** do approvala, **zero zapisu do katalogu**.
- **Limit §8.5 `$/dzień/tenant` egzekwowany przed startem, dwustopniowo:** (1) `AgentLimitGuard.assertWithinLimits` (co już wydano dziś) + (2) estymata-vs-remaining — oba dają **429** przed spaleniem tokenu.
- Message `BulkGenerateContentMessage` (TenantAwareMessage) routowany na transport `import`; usage zagnieżdżonych generacji sumowany i doliczany do runu (budżety widzą tokeny). Nowe custom trasy w `docs/api-spec/v0.json` (regen OpenAPI).

### Frontend
- Modal P5-03 woła **realny backend**: `cost-preview` (zdjęta client-side stała ~0.012 USD) + `bulk-generate` (zdjęty cap 8 i `startAgentRun`). 429 z backendu → error toast, modal zostaje otwarty.

### Testy
- **PHPUnit 12/12:** `ContentCostEstimatorTest` (4, skalowanie liniowe + floor/cap output + $ ze stawek), `BulkGenerateContentHandlerTest` (3 integ.: wszystko do jednego batcha bez zapisu · flush+clear per produkt @ batchSize=1 wciąż finalizuje run · brak faktów → skip nie zmyślanie), `AgentContentBulkApiTest` (5 API: 401/403 · 200 preview skalujący · 202 bulk · 400 pusta selekcja · **429 przy wyczerpanym day-capie**).
- **Playwright 2/2 na żywym stacku:** preview zasila estymatę + start via bulk-generate (payload `mode`/`selected_ids`/`object_type_code`) · 429 zostawia modal otwarty. Agent API intercepted (CI bez BYOK).
- PHPStan max 0, Deptrac 0, cs-fixer OK · tsc/vitest 147/147/build/biome zielone.

### Live smoke na `pim.localhost` (BYOK Haiku, bez mocków)
- `cost-preview` 25 produktów → **200**, `est_cost_usd=0.285750`, model `claude-sonnet-4-6`.
- `bulk-generate` 2 realne produkty → **202** (run+batch); run `awaiting_approval`, `affected_count=2`, tokeny 430/57, $0.002145; batch = 2 propozycje `description` provenance `agent`; reject → 200, **0 wierszy `description` w `object_values`** (approval-only potwierdzone). Artefakty posprzątane.

### Świadome odejście
- Selekcja przez `selected_ids` (ścieżka modala); rozwiązywanie `filter_dsl`-only („wszystkie pasujące" cross-page) do dedykowanego resolvera — poza zakresem tego ticketu, `selected_ids` pokrywa flow UI.
- Duplikacja ~pętli orkiestracji uniknięta przez reuse tooli — bez refaktoru zmergowanego P3-02.

Closes #2346
