### PR TITLE
fix(search): tenant RLS context w komendach maintenance — reindex/backfill działa

### DIFF
--- a/apps/api/src/Catalog/Presentation/Command/RecalculateCompletenessCommand.php
+++ b/apps/api/src/Catalog/Presentation/Command/RecalculateCompletenessCommand.php
@@ -8,6 +8,8 @@ use App\Catalog\Application\AttributesIndexedRebuilder;
 use App\Catalog\Application\BulkContext;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\ObjectKind;
+use App\Shared\Domain\Repository\TenantRepositoryInterface;
+use App\Shared\Infrastructure\Console\TenantConsoleBinder;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -38,6 +40,8 @@ final class RecalculateCompletenessCommand extends Command
         private readonly EntityManagerInterface $em,
         private readonly AttributesIndexedRebuilder $rebuilder,
         private readonly BulkContext $bulkContext,
+        private readonly TenantRepositoryInterface $tenants,
+        private readonly TenantConsoleBinder $tenantBinder,
     ) {
         parent::__construct();
     }
@@ -75,6 +79,17 @@ final class RecalculateCompletenessCommand extends Command
 
             return Command::INVALID;
         }
+
+        // #2466 — the RLS policies on `objects` read the `app.current_tenant`
+        // GUC, which console commands never set; without binding, the query
+        // below sees zero rows and the backfill silently no-ops.
+        $tenant = $this->tenants->findByCode($tenantCode);
+        if (null === $tenant) {
+            $io->error(\sprintf('Tenant "%s" not found.', $tenantCode));
+
+            return Command::INVALID;
+        }
+        $this->tenantBinder->bind($tenant);
 
         /** @var string $kindOption */
         $kindOption = $input->getOption('kind');
@@ -135,6 +150,7 @@ final class RecalculateCompletenessCommand extends Command
             }
         } finally {
             $this->bulkContext->setBulk(false);
+            $this->tenantBinder->release();
         }
 
         $io->success(\sprintf('Done. %d row(s) updated.', $totalChanged));

--- a/apps/api/src/Search/Presentation/Command/SearchReindexCommand.php
+++ b/apps/api/src/Search/Presentation/Command/SearchReindexCommand.php
@@ -9,6 +9,8 @@ use App\Catalog\Domain\ObjectKind;
 use App\Search\Application\BulkCatalogObjectIndexer;
 use App\Search\Application\IndexSettingsTemplate;
 use App\Search\Infrastructure\MeilisearchClientFactory;
+use App\Shared\Domain\Repository\TenantRepositoryInterface;
+use App\Shared\Infrastructure\Console\TenantConsoleBinder;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -46,6 +48,8 @@ final class SearchReindexCommand extends Command
         private readonly BulkCatalogObjectIndexer $indexer,
         private readonly BulkContext $bulkContext,
         private readonly MeilisearchClientFactory $clientFactory,
+        private readonly TenantRepositoryInterface $tenants,
+        private readonly TenantConsoleBinder $tenantBinder,
     ) {
         parent::__construct();
     }
@@ -71,6 +75,12 @@ final class SearchReindexCommand extends Command
                 null,
                 InputOption::VALUE_NONE,
                 'Delete every existing document from the targeted index before reindex. Use after pim:db:reset to drop orphans from previous tenants.',
+            )
+            ->addOption(
+                'tenant',
+                't',
+                InputOption::VALUE_REQUIRED,
+                'Tenant code to reindex. Omit to reindex every tenant (full rebuild).',
             );
     }
 
@@ -95,12 +105,37 @@ final class SearchReindexCommand extends Command
         $dryRun = true === $input->getOption('dry-run');
         $purge = true === $input->getOption('purge');
 
+        // #2466 — RLS policies read the `app.current_tenant` GUC, which no
+        // console command establishes; without binding a tenant the iterator
+        // sees zero rows (the app connects as `pim_app`). Resolve the target
+        // tenant(s) up front and reindex per tenant.
+        $tenantOption = $input->getOption('tenant');
+        if (\is_string($tenantOption) && '' !== $tenantOption) {
+            $tenant = $this->tenants->findByCode($tenantOption);
+            if (null === $tenant) {
+                $io->error(\sprintf('Tenant "%s" not found.', $tenantOption));
+
+                return Command::INVALID;
+            }
+            $targetTenants = [$tenant];
+        } else {
+            $targetTenants = $this->tenants->findAllOrderedByCode();
+            if ([] === $targetTenants) {
+                $io->error('No tenants found — run doctrine:fixtures:load first.');
+
+                return Command::INVALID;
+            }
+        }
+
         $io->title(\sprintf(
-            '%s reindex of %s into %s%s',
+            '%s reindex of %s into %s%s (%s)',
             $dryRun ? 'DRY-RUN' : 'Live',
             null === $kind ? 'every kind' : $kind->value,
             IndexSettingsTemplate::indexName(),
             $purge ? ' (purging existing docs first)' : '',
+            \is_string($tenantOption) && '' !== $tenantOption
+                ? 'tenant '.$tenantOption
+                : \sprintf('%d tenant(s)', \count($targetTenants)),
         ));
 
         if ($purge && !$dryRun) {
@@ -116,25 +151,41 @@ final class SearchReindexCommand extends Command
         // contract says "bulk = skip", and reindex IS bulk.
         $this->bulkContext->setBulk(true);
 
+        $totalCount = 0;
+        $totalBatches = 0;
+        $perTenant = [];
+
         try {
-            $stats = $this->indexer->reindex(
-                kind: $kind,
-                dryRun: $dryRun,
-                onProgress: static function (int $indexed, int $batchSize) use ($progress): void {
-                    $progress->advance($batchSize);
-                },
-            );
+            foreach ($targetTenants as $tenant) {
+                $this->tenantBinder->bind($tenant);
+                $stats = $this->indexer->reindex(
+                    kind: $kind,
+                    dryRun: $dryRun,
+                    onProgress: static function (int $indexed, int $batchSize) use ($progress): void {
+                        $progress->advance($batchSize);
+                    },
+                );
+                $totalCount += $stats['count'];
+                $totalBatches += $stats['batches'];
+                $perTenant[] = \sprintf('%s: %d row(s)', $tenant->getCode(), $stats['count']);
+            }
         } finally {
+            $this->tenantBinder->release();
             $this->bulkContext->setBulk(false);
             $progress->finish();
             $io->newLine(2);
         }
 
+        foreach ($perTenant as $line) {
+            $io->writeln('  '.$line);
+        }
+
         $io->success(\sprintf(
-            '%s — indexed %d row(s) in %d batch(es).',
+            '%s — indexed %d row(s) in %d batch(es) across %d tenant(s).',
             $dryRun ? 'Dry run complete' : 'Reindex complete',
-            $stats['count'],
-            $stats['batches'],
+            $totalCount,
+            $totalBatches,
+            \count($targetTenants),
         ));
 
         return Command::SUCCESS;

--- a/apps/api/src/Shared/Infrastructure/Console/TenantConsoleBinder.php
+++ b/apps/api/src/Shared/Infrastructure/Console/TenantConsoleBinder.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Console;
+
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\DBAL\Connection;
+
+/**
+ * #2466 — binds the full tenant context for a console (maintenance) command.
+ *
+ * The RLS policies on tenant-scoped tables read the Postgres GUC
+ * `app.current_tenant`, which is established by RlsContextListener on HTTP
+ * requests and by TenantRlsGucMiddleware in messenger workers. Console
+ * commands had neither, so with the app connecting as `pim_app` every
+ * SELECT against `objects` returned zero rows and maintenance commands
+ * (pim:search:reindex, pim:catalog:recalculate-completeness) silently
+ * processed nothing.
+ *
+ * bind() wires all three layers for one tenant:
+ *   1. PHP-side {@see TenantContext} (listeners / provenance / services),
+ *   2. the Doctrine tenant filter parameter ({@see TenantFilterConfigurator}),
+ *   3. the Postgres RLS GUC pair.
+ *
+ * release() clears them again so a command iterating several tenants never
+ * leaks the previous tenant into the next loop iteration.
+ */
+final readonly class TenantConsoleBinder
+{
+    public function __construct(
+        private TenantContext $tenantContext,
+        private TenantFilterConfigurator $filterConfigurator,
+        private Connection $connection,
+    ) {
+    }
+
+    public function bind(Tenant $tenant): void
+    {
+        $this->tenantContext->set($tenant);
+        $this->filterConfigurator->apply();
+
+        // tenant-safe: infrastructure (establishes the tenant_id the RLS policies read for a console command; this IS the tenant boundary, not a bypass)
+        $this->connection->executeStatement(
+            "SELECT set_config('app.current_tenant', :tenant_id, false)",
+            ['tenant_id' => $tenant->getId()->toRfc4122()],
+        );
+        // tenant-safe: infrastructure (maintenance commands never run as super-admin; pin the bypass flag off in case the connection carried it)
+        $this->connection->executeStatement("SELECT set_config('app.is_super_admin', 'false', false)");
+    }
+
+    public function release(): void
+    {
+        $this->tenantContext->clear();
+        $this->filterConfigurator->apply();
+
+        // tenant-safe: infrastructure (resets the RLS tenant marker so the connection cannot leak the previous tenant)
+        $this->connection->executeStatement("SELECT set_config('app.current_tenant', '', false)");
+    }
+}

--- a/apps/api/tests/Unit/Shared/Infrastructure/TenantConsoleBinderTest.php
+++ b/apps/api/tests/Unit/Shared/Infrastructure/TenantConsoleBinderTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Infrastructure;
+
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Console\TenantConsoleBinder;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilter;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query\FilterCollection;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #2466 — console maintenance commands must establish the same three-layer
+ * tenant context the HTTP/worker paths do (TenantContext, Doctrine filter,
+ * Postgres RLS GUC), otherwise RLS answers zero rows for `pim_app` and
+ * pim:search:reindex / recalculate-completeness silently process nothing.
+ */
+final class TenantConsoleBinderTest extends TestCase
+{
+    /** @var list<array{string, array<mixed>}> */
+    private array $statements = [];
+
+    #[Test]
+    public function bindSetsContextFilterAndRlsGuc(): void
+    {
+        $tenant = new Tenant('demo', 'Demo');
+        $context = new TenantContext();
+        [$configurator, $filters] = $this->realConfigurator($context);
+
+        $binder = new TenantConsoleBinder($context, $configurator, $this->recordingConnection());
+        $binder->bind($tenant);
+
+        self::assertSame($tenant, $context->get(), 'PHP-side TenantContext must carry the tenant');
+        self::assertTrue($filters->isEnabled('tenant'), 'Doctrine tenant filter must be enabled');
+
+        self::assertCount(2, $this->statements);
+        self::assertStringContainsString("set_config('app.current_tenant'", $this->statements[0][0]);
+        self::assertSame($tenant->getId()->toRfc4122(), $this->statements[0][1]['tenant_id'] ?? null);
+        self::assertStringContainsString("set_config('app.is_super_admin', 'false'", $this->statements[1][0]);
+    }
+
+    #[Test]
+    public function releaseClearsContextAndGuc(): void
+    {
+        $tenant = new Tenant('demo', 'Demo');
+        $context = new TenantContext();
+        $context->set($tenant);
+        [$configurator] = $this->realConfigurator($context);
+
+        $binder = new TenantConsoleBinder($context, $configurator, $this->recordingConnection());
+        $binder->release();
+
+        self::assertNull($context->get(), 'release must clear the PHP-side context');
+        self::assertCount(1, $this->statements);
+        self::assertStringContainsString("set_config('app.current_tenant', ''", $this->statements[0][0]);
+    }
+
+    /**
+     * TenantFilterConfigurator is final (cannot be doubled), so back it with
+     * a real FilterCollection over a mocked EntityManager — this also proves
+     * the filter genuinely gets enabled + parameterised.
+     *
+     * @return array{0: TenantFilterConfigurator, 1: FilterCollection}
+     */
+    private function realConfigurator(TenantContext $context): array
+    {
+        $configuration = new Configuration();
+        $configuration->addFilter('tenant', TenantFilter::class);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getConfiguration')->willReturn($configuration);
+        $filters = new FilterCollection($em);
+        $em->method('getFilters')->willReturn($filters);
+
+        return [new TenantFilterConfigurator($em, $context), $filters];
+    }
+
+    private function recordingConnection(): Connection
+    {
+        $this->statements = [];
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->method('executeStatement')
+            ->willReturnCallback(
+                /** @param array<string, mixed> $params */
+                function (string $sql, array $params = []): int {
+                    $this->statements[] = [$sql, $params];
+
+                    return 1;
+                },
+            );
+
+        return $connection;
+    }
+}


### PR DESCRIPTION
## Summary
Naprawia „Średnia kompletność → 0 wyników" z rundy smoke: backfill indeksu Meili był niemożliwy, bo komendy maintenance widziały 0 wierszy przez RLS.

## Root cause
Polityki RLS na tabelach tenant-scoped czytają GUC `app.current_tenant`, ustawiany przez `RlsContextListener` (HTTP) i `TenantRlsGucMiddleware` (workery). **Konsola nie ustawiała GUC**, a CLI łączy się jako `pim_app` → `SELECT count(*) FROM objects` = 0 → `pim:search:reindex` „indexed 0 row(s)", `recalculate-completeness` „0 processed".

## Backend changes
- Nowy `Shared\Infrastructure\Console\TenantConsoleBinder` — `bind(Tenant)` wiąże TenantContext + filtr Doctrine + GUC (`app.current_tenant`, `app.is_super_admin=false`); `release()` czyści (brak wycieku między iteracjami).
- `pim:search:reindex` — opcja `--tenant=CODE`; bez opcji iteruje **wszystkie** tenanty (pełny rebuild) z licznikami per tenant.
- `pim:catalog:recalculate-completeness` — bind przed iteracją.

## Quality gates
- PHPStan max: 0. php-cs-fixer: 0. Deptrac: 0 errors.
- PHPUnit: nowy `TenantConsoleBinderTest` (2 testy, realny FilterCollection — filtr faktycznie enabled+sparametryzowany, GUC-e emitowane, release czyści).

## Live-stack smoke (proof)
- `pim:search:reindex` → **404 wiersze / 2 tenanty** (demo: 401, acme: 3); wcześniej 0.
- Meili: `kind=product AND completeness_pct < 80` → **98** dokumentów; `>= 80` → 202.
- `GET /api/search/products?q=<blob completeness_pct < 80>` (dokładny deep-link kafla „Średnia kompletność") → **97 hitów** (było 0); `>= 80` → 197.
- `recalculate-completeness --tenant=demo --dry-run` → **294 processed** (było 0).

Kafle Pulpitu („Średnia kompletność", segmenty „Kompletności katalogu") zwracają teraz realne wyniki.

Closes #2466

🤖 Generated with [Claude Code](https://claude.com/claude-code)