### PR TITLE
feat(catalog): akcje zbiorcze obsługują atrybuty typu relacja (#2314)

### DIFF
--- a/apps/admin/src/components/catalog/bulk-wizard/bulk-value-input.tsx
+++ b/apps/admin/src/components/catalog/bulk-wizard/bulk-value-input.tsx
@@ -1,7 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { RelationCreateField } from '@/components/objects/relation-create-field';
 import { Input } from '@/components/ui/input';
+import type { AttributeMeta } from '@/features/catalog/products/components/types';
 import { jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
@@ -19,6 +22,7 @@ import { cn } from '@/lib/utils';
  *  - `color` → <input type=color> + hex <Input>
  *  - `select` → dropdown z `/api/attributes/{code}/options`
  *  - `multiselect` → chips picker z tej samej listy options
+ *  - `relation` → picker obiektów docelowych (#2314, reuse RelationCreateField)
  *  - typ undefined → fallback do `text`
  *
  * Wartość zwracana w `onChange` jest typowana per atrybut:
@@ -54,6 +58,80 @@ function labelOf(row: AttributeOptionRow): string {
   if (label === null || label === undefined) return row.code;
   if (typeof label === 'string') return label;
   return label.pl ?? label.en ?? Object.values(label)[0] ?? row.code;
+}
+
+interface AttributeApiRow {
+  id: string;
+  code: string;
+  label?: Record<string, string> | string | null;
+  relationTargetObjectTypeIds?: string[];
+  relationCardinality?: 'one' | 'many' | null;
+}
+
+/**
+ * #2314 — relation attributes pick target objects, not free text. Fetch the
+ * attribute's relation config (allowed target ObjectTypes + cardinality) and
+ * reuse the detail-form picker; the emitted value is a target object UUID
+ * (cardinality=one) or a UUID list (many) — exactly what the BE bulk
+ * relation lane expects.
+ */
+function BulkRelationValueInput({
+  attrCode,
+  value,
+  onChange,
+}: {
+  attrCode: string;
+  value: unknown;
+  onChange: (next: unknown) => void;
+}) {
+  const { t } = useTranslation();
+  const metaQuery = useQuery({
+    queryKey: ['attributes', 'relation-meta', attrCode],
+    staleTime: 60_000,
+    enabled: attrCode !== '',
+    queryFn: async (): Promise<AttributeMeta | null> => {
+      const res = await jsonFetch<{
+        'hydra:member'?: AttributeApiRow[];
+        member?: AttributeApiRow[];
+      }>('/api/attributes?itemsPerPage=200');
+      const rows = res['hydra:member'] ?? res.member ?? [];
+      const row = rows.find((r) => r.code === attrCode);
+      if (row === undefined) return null;
+      return {
+        id: row.id,
+        code: row.code,
+        type: 'relation',
+        label:
+          typeof row.label === 'object' && row.label !== null
+            ? row.label
+            : { pl: row.label ?? row.code },
+        is_system: false,
+        position: 0,
+        is_required_in_group: false,
+        relation_target_object_type_ids: row.relationTargetObjectTypeIds ?? [],
+        relation_cardinality: row.relationCardinality ?? 'many',
+      };
+    },
+  });
+
+  if (metaQuery.isLoading) {
+    return (
+      <p className="text-[12px] text-zinc-500">
+        {t('bulk_value.loading', { defaultValue: 'Ładuję…' })}
+      </p>
+    );
+  }
+  if (metaQuery.data == null) {
+    return (
+      <p className="text-[12px] text-zinc-500">
+        {t('bulk_value.relation_meta_missing', {
+          defaultValue: 'Nie udało się wczytać konfiguracji relacji',
+        })}
+      </p>
+    );
+  }
+
+  return <RelationCreateField attribute={metaQuery.data} value={value} onChange={onChange} />;
 }
 
 export function BulkValueInput({
@@ -94,6 +172,10 @@ export function BulkValueInput({
       cancelled = true;
     };
   }, [attrCode, isSelect]);
+
+  if (attrType === 'relation') {
+    return <BulkRelationValueInput attrCode={attrCode} value={value} onChange={onChange} />;
+  }
 
   if (attrType === 'boolean') {
     const boolValue = value === true || value === 'true';

--- a/apps/api/src/Catalog/Application/Bulk/BulkAppendValueHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkAppendValueHandler.php
@@ -12,6 +12,7 @@ use App\Catalog\Domain\Entity\BulkSession;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * VIEW-13 (#545) — `append_value` bulk action (multiselect-safe).
@@ -20,12 +21,16 @@ use Doctrine\ORM\EntityManagerInterface;
  * scalar, it is promoted to `[old, new]` (dedup). If the value is
  * already present, the row is skipped (no-op, info log). Locked
  * attributes (VIEW-33 / PRD §8.3) skip with a warning entry. Shared
- * lifecycle: {@see AbstractBulkHandler}.
+ * lifecycle: {@see AbstractBulkHandler}. Relation attributes append
+ * link rows instead (#2314).
  */
 final class BulkAppendValueHandler extends AbstractBulkHandler
 {
     private string $attrCode = '';
     private mixed $value = null;
+    private ?Uuid $relationAttributeId = null;
+    /** @var list<string> */
+    private array $relationTargetIds = [];
 
     public function __construct(
         CatalogObjectRepositoryInterface $catalogObjects,
@@ -33,6 +38,7 @@ final class BulkAppendValueHandler extends AbstractBulkHandler
         BulkContext $bulkContext,
         private readonly AttributeLockReader $lockReader,
         BulkReindexQueueInterface $reindexQueue,
+        private readonly BulkRelationApplier $relationApplier,
     ) {
         parent::__construct($catalogObjects, $em, $bulkContext, $reindexQueue);
     }
@@ -44,12 +50,29 @@ final class BulkAppendValueHandler extends AbstractBulkHandler
     {
         $this->attrCode = $attrCode;
         $this->value = $value;
+        $this->relationAttributeId = $this->relationApplier->relationAttributeId($attrCode);
+        $this->relationTargetIds = null !== $this->relationAttributeId
+            ? $this->relationApplier->parseTargetIds($value)
+            : [];
 
         return $this->runBatch($session);
     }
 
     protected function processObject(CatalogObject $object, BulkSession $session, BulkCounters $counters): void
     {
+        if (null !== $this->relationAttributeId) {
+            $this->relationApplier->apply(
+                BulkRelationApplier::MODE_APPEND,
+                $object,
+                $this->relationAttributeId,
+                $this->relationTargetIds,
+                $session,
+                $counters,
+            );
+
+            return;
+        }
+
         if ($this->lockReader->isLocked($object, $this->attrCode)) {
             ++$counters->skipped;
             $this->em->persist(new BulkLog(

--- a/apps/api/src/Catalog/Application/Bulk/BulkClearAttributeHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkClearAttributeHandler.php
@@ -12,6 +12,7 @@ use App\Catalog\Domain\Entity\BulkSession;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * VIEW-13 (#545) — `clear_attribute` bulk action.
@@ -20,10 +21,12 @@ use Doctrine\ORM\EntityManagerInterface;
  * for resetting a field across N products. BulkLog records `old_value`
  * for the 24h rollback path. Locked attributes (VIEW-33 / PRD §8.3)
  * skip with a warning entry. Shared lifecycle: {@see AbstractBulkHandler}.
+ * Relation attributes clear their link rows instead (#2314).
  */
 final class BulkClearAttributeHandler extends AbstractBulkHandler
 {
     private string $attrCode = '';
+    private ?Uuid $relationAttributeId = null;
 
     public function __construct(
         CatalogObjectRepositoryInterface $catalogObjects,
@@ -31,6 +34,7 @@ final class BulkClearAttributeHandler extends AbstractBulkHandler
         BulkContext $bulkContext,
         private readonly AttributeLockReader $lockReader,
         BulkReindexQueueInterface $reindexQueue,
+        private readonly BulkRelationApplier $relationApplier,
     ) {
         parent::__construct($catalogObjects, $em, $bulkContext, $reindexQueue);
     }
@@ -41,12 +45,26 @@ final class BulkClearAttributeHandler extends AbstractBulkHandler
     public function handle(BulkSession $session, string $attrCode): array
     {
         $this->attrCode = $attrCode;
+        $this->relationAttributeId = $this->relationApplier->relationAttributeId($attrCode);
 
         return $this->runBatch($session);
     }
 
     protected function processObject(CatalogObject $object, BulkSession $session, BulkCounters $counters): void
     {
+        if (null !== $this->relationAttributeId) {
+            $this->relationApplier->apply(
+                BulkRelationApplier::MODE_CLEAR,
+                $object,
+                $this->relationAttributeId,
+                [],
+                $session,
+                $counters,
+            );
+
+            return;
+        }
+
         if ($this->lockReader->isLocked($object, $this->attrCode)) {
             ++$counters->skipped;
             $this->em->persist(new BulkLog(

--- a/apps/api/src/Catalog/Application/Bulk/BulkRelationApplier.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkRelationApplier.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Bulk;
+
+use App\Catalog\Application\Lock\AttributeLockReader;
+use App\Catalog\Application\ObjectRelationService;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\BulkLog;
+use App\Catalog\Domain\Entity\BulkSession;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectRelation;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * #2314 — relation-attribute lane for the bulk value actions.
+ *
+ * Relation values live in the `object_relations` link table, not in
+ * `object_values`/`attributes_indexed`, so the scalar bulk handlers cannot
+ * write them (they would only pollute the denormalised JSONB with raw ids).
+ * Every bulk value handler (set / clear / append / remove) detects a
+ * relation attribute via {@see self::relationAttributeId()} and delegates
+ * the per-object mutation here, which routes through
+ * {@see ObjectRelationService::replaceForSourceAndAttribute()} — the same
+ * write path the detail page uses (target/tenant/cardinality guards
+ * included).
+ *
+ * Per-link metadata of targets that survive an append/remove is preserved
+ * by re-submitting the existing metadata map; targets added by the bulk
+ * action start with empty metadata.
+ *
+ * The attribute is re-resolved by id per object because the shared
+ * {@see AbstractBulkHandler} clears the EntityManager every chunk, which
+ * would detach an Attribute captured in handle().
+ */
+final readonly class BulkRelationApplier
+{
+    public const string MODE_REPLACE = 'replace';
+    public const string MODE_CLEAR = 'clear';
+    public const string MODE_APPEND = 'append';
+    public const string MODE_REMOVE = 'remove';
+
+    public function __construct(
+        private AttributeRepositoryInterface $attributes,
+        private ObjectRelationService $relations,
+        private AttributeLockReader $lockReader,
+        private TenantContext $tenantContext,
+        private EntityManagerInterface $em,
+    ) {
+    }
+
+    /**
+     * Resolve `$attrCode` to the Attribute id when (and only when) it is a
+     * relation-type attribute of the current tenant. Null → the caller
+     * stays on its scalar attributesIndexed path.
+     */
+    public function relationAttributeId(string $attrCode): ?Uuid
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant || '' === $attrCode) {
+            return null;
+        }
+
+        $attribute = $this->attributes->findByCode($attrCode, $tenant);
+        if (null === $attribute || AttributeType::Relation !== $attribute->getType()) {
+            return null;
+        }
+
+        return $attribute->getId();
+    }
+
+    /**
+     * Normalise the wizard payload into a list of target object UUIDs.
+     * Accepts a single UUID string (cardinality=one Combobox) or a list of
+     * UUID strings (MultiSelect). Anything else is a client bug → 400.
+     *
+     * @return list<string>
+     */
+    public function parseTargetIds(mixed $value): array
+    {
+        if (null === $value || '' === $value) {
+            return [];
+        }
+        $raw = \is_array($value) ? $value : [$value];
+
+        $ids = [];
+        foreach ($raw as $entry) {
+            if (!\is_string($entry) || !Uuid::isValid($entry)) {
+                throw new BadRequestHttpException(
+                    'Relation attribute value must be a target object UUID or an array of UUIDs.',
+                );
+            }
+            $ids[] = $entry;
+        }
+
+        return array_values(array_unique($ids));
+    }
+
+    /**
+     * Apply one bulk relation mutation to a single object, mirroring the
+     * scalar handlers' skip/log/counter semantics.
+     *
+     * @param self::MODE_* $mode
+     * @param list<string> $targetIds
+     */
+    public function apply(
+        string $mode,
+        CatalogObject $object,
+        Uuid $attributeId,
+        array $targetIds,
+        BulkSession $session,
+        BulkCounters $counters,
+    ): void {
+        $attribute = $this->attributes->findById($attributeId);
+        if (null === $attribute) {
+            ++$counters->error;
+            $this->em->persist(new BulkLog(
+                $session->getId(),
+                $object->getId(),
+                null,
+                null,
+                null,
+                BulkLog::LEVEL_ERROR,
+                'Relation attribute vanished mid-run',
+            ));
+
+            return;
+        }
+
+        $existing = $this->relations->listForSource($object, $attribute);
+        $old = array_map(
+            static fn (ObjectRelation $row): string => $row->getTarget()->getId()->toRfc4122(),
+            $existing,
+        );
+        $metadataByTarget = [];
+        foreach ($existing as $row) {
+            $metadataByTarget[$row->getTarget()->getId()->toRfc4122()] = $row->getMetadata();
+        }
+
+        if ($this->lockReader->isLocked($object, $attribute->getCode())) {
+            ++$counters->skipped;
+            $this->em->persist(new BulkLog(
+                $session->getId(),
+                $object->getId(),
+                null,
+                $old,
+                $old,
+                BulkLog::LEVEL_WARNING,
+                'Attribute locked',
+            ));
+
+            return;
+        }
+
+        $next = match ($mode) {
+            self::MODE_REPLACE => $targetIds,
+            self::MODE_CLEAR => [],
+            self::MODE_APPEND => array_values(array_unique([...$old, ...$targetIds])),
+            self::MODE_REMOVE => array_values(array_diff($old, $targetIds)),
+        };
+
+        if (self::MODE_APPEND === $mode && $next === $old) {
+            ++$counters->skipped;
+            $this->em->persist(new BulkLog(
+                $session->getId(),
+                $object->getId(),
+                null,
+                $old,
+                $old,
+                BulkLog::LEVEL_WARNING,
+                'Value already present',
+            ));
+
+            return;
+        }
+        if (self::MODE_REMOVE === $mode && $next === $old) {
+            ++$counters->skipped;
+            $this->em->persist(new BulkLog(
+                $session->getId(),
+                $object->getId(),
+                null,
+                $old,
+                $old,
+                BulkLog::LEVEL_WARNING,
+                'Value not present',
+            ));
+
+            return;
+        }
+
+        $this->relations->replaceForSourceAndAttribute(
+            $object,
+            $attribute,
+            array_map(
+                static fn (string $id): array => [
+                    'id' => Uuid::fromString($id),
+                    'metadata' => $metadataByTarget[$id] ?? [],
+                ],
+                $next,
+            ),
+        );
+        $object->markTouchedByBulkSession($session->getId());
+
+        $this->em->persist(new BulkLog(
+            $session->getId(),
+            $object->getId(),
+            null,
+            $old,
+            $next,
+            BulkLog::LEVEL_INFO,
+            null,
+        ));
+        ++$counters->success;
+    }
+
+    /**
+     * Rollback lane: restore the target set recorded as the BulkLog "old"
+     * value. Metadata of restored links is not recovered (the log stores
+     * ids only) — parity with the scalar rollback, which restores values
+     * without provenance history.
+     */
+    public function revertTo(CatalogObject $object, Uuid $attributeId, mixed $oldValue): bool
+    {
+        $attribute = $this->attributes->findById($attributeId);
+        if (null === $attribute) {
+            return false;
+        }
+
+        $ids = [];
+        if (\is_array($oldValue)) {
+            foreach ($oldValue as $entry) {
+                if (\is_string($entry) && Uuid::isValid($entry)) {
+                    $ids[] = ['id' => Uuid::fromString($entry), 'metadata' => []];
+                }
+            }
+        }
+
+        $this->relations->replaceForSourceAndAttribute($object, $attribute, $ids);
+
+        return true;
+    }
+}

--- a/apps/api/src/Catalog/Application/Bulk/BulkRemoveValueHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkRemoveValueHandler.php
@@ -12,6 +12,7 @@ use App\Catalog\Domain\Entity\BulkSession;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * VIEW-13 (#545) — `remove_value` bulk action (multiselect-safe).
@@ -20,12 +21,16 @@ use Doctrine\ORM\EntityManagerInterface;
  * the value, it becomes null (unset). If the value is not present, the
  * row is skipped (no-op, warning log). Locked attributes (VIEW-33 /
  * PRD §8.3) skip with a warning entry. Shared lifecycle:
- * {@see AbstractBulkHandler}.
+ * {@see AbstractBulkHandler}. Relation attributes drop the matching
+ * link rows instead (#2314).
  */
 final class BulkRemoveValueHandler extends AbstractBulkHandler
 {
     private string $attrCode = '';
     private mixed $value = null;
+    private ?Uuid $relationAttributeId = null;
+    /** @var list<string> */
+    private array $relationTargetIds = [];
 
     public function __construct(
         CatalogObjectRepositoryInterface $catalogObjects,
@@ -33,6 +38,7 @@ final class BulkRemoveValueHandler extends AbstractBulkHandler
         BulkContext $bulkContext,
         private readonly AttributeLockReader $lockReader,
         BulkReindexQueueInterface $reindexQueue,
+        private readonly BulkRelationApplier $relationApplier,
     ) {
         parent::__construct($catalogObjects, $em, $bulkContext, $reindexQueue);
     }
@@ -44,12 +50,29 @@ final class BulkRemoveValueHandler extends AbstractBulkHandler
     {
         $this->attrCode = $attrCode;
         $this->value = $value;
+        $this->relationAttributeId = $this->relationApplier->relationAttributeId($attrCode);
+        $this->relationTargetIds = null !== $this->relationAttributeId
+            ? $this->relationApplier->parseTargetIds($value)
+            : [];
 
         return $this->runBatch($session);
     }
 
     protected function processObject(CatalogObject $object, BulkSession $session, BulkCounters $counters): void
     {
+        if (null !== $this->relationAttributeId) {
+            $this->relationApplier->apply(
+                BulkRelationApplier::MODE_REMOVE,
+                $object,
+                $this->relationAttributeId,
+                $this->relationTargetIds,
+                $session,
+                $counters,
+            );
+
+            return;
+        }
+
         if ($this->lockReader->isLocked($object, $this->attrCode)) {
             ++$counters->skipped;
             $this->em->persist(new BulkLog(

--- a/apps/api/src/Catalog/Application/Bulk/BulkRollbackHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkRollbackHandler.php
@@ -51,6 +51,7 @@ final class BulkRollbackHandler
         private readonly EntityManagerInterface $em,
         private readonly BulkContext $bulkContext,
         private readonly BulkReindexQueueInterface $reindexQueue,
+        private readonly BulkRelationApplier $relationApplier,
     ) {
     }
 
@@ -83,6 +84,16 @@ final class BulkRollbackHandler
             $payload = $session->getActionPayload();
             $chunk = 0;
 
+            // #2314 — relation attributes were mutated through the link
+            // table, so their rollback replays the old target-id list via
+            // the relation write path instead of attributesIndexed.
+            $attrCode = \is_string($payload['attr'] ?? null) ? $payload['attr'] : null;
+            $relationAttributeId = null !== $attrCode && \in_array($action, [
+                'set_attribute', 'clear_attribute', 'append_value', 'remove_value',
+            ], true)
+                ? $this->relationApplier->relationAttributeId($attrCode)
+                : null;
+
             foreach ($logs as $log) {
                 $object = $this->catalogObjects->findById($log->getObjectId());
                 if (!$object instanceof CatalogObject) {
@@ -90,6 +101,11 @@ final class BulkRollbackHandler
                 }
 
                 $reverted = match (true) {
+                    null !== $relationAttributeId => $this->relationApplier->revertTo(
+                        $object,
+                        $relationAttributeId,
+                        $log->getOldValue(),
+                    ),
                     \in_array($action, [
                         'set_attribute',
                         'clear_attribute',
@@ -99,7 +115,7 @@ final class BulkRollbackHandler
                     ], true) => $this->revertAttributeSlot(
                         $object,
                         $log,
-                        \is_string($payload['attr'] ?? null) ? $payload['attr'] : null,
+                        $attrCode,
                     ),
                     'multi_attribute_edit' === $action => $this->revertAttributeSlot(
                         $object,

--- a/apps/api/src/Catalog/Application/Bulk/BulkSetAttributeHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkSetAttributeHandler.php
@@ -12,6 +12,7 @@ use App\Catalog\Domain\Entity\BulkSession;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * VIEW-12 (#543) — handler for `set_attribute` bulk action.
@@ -29,6 +30,10 @@ final class BulkSetAttributeHandler extends AbstractBulkHandler
 {
     private string $attrCode = '';
     private mixed $newValue = null;
+    /** #2314 — set when the attribute is relation-type; see BulkRelationApplier. */
+    private ?Uuid $relationAttributeId = null;
+    /** @var list<string> */
+    private array $relationTargetIds = [];
 
     public function __construct(
         CatalogObjectRepositoryInterface $catalogObjects,
@@ -36,6 +41,7 @@ final class BulkSetAttributeHandler extends AbstractBulkHandler
         BulkContext $bulkContext,
         private readonly AttributeLockReader $lockReader,
         BulkReindexQueueInterface $reindexQueue,
+        private readonly BulkRelationApplier $relationApplier,
     ) {
         parent::__construct($catalogObjects, $em, $bulkContext, $reindexQueue);
     }
@@ -52,11 +58,30 @@ final class BulkSetAttributeHandler extends AbstractBulkHandler
         $this->attrCode = $attrCode;
         $this->newValue = $newValue;
 
+        // #2314 — relation attributes write link rows, not attributesIndexed.
+        $this->relationAttributeId = $this->relationApplier->relationAttributeId($attrCode);
+        $this->relationTargetIds = null !== $this->relationAttributeId
+            ? $this->relationApplier->parseTargetIds($newValue)
+            : [];
+
         return $this->runBatch($session);
     }
 
     protected function processObject(CatalogObject $object, BulkSession $session, BulkCounters $counters): void
     {
+        if (null !== $this->relationAttributeId) {
+            $this->relationApplier->apply(
+                BulkRelationApplier::MODE_REPLACE,
+                $object,
+                $this->relationAttributeId,
+                $this->relationTargetIds,
+                $session,
+                $counters,
+            );
+
+            return;
+        }
+
         if ($this->lockReader->isLocked($object, $this->attrCode)) {
             ++$counters->skipped;
             $this->em->persist(new BulkLog(

--- a/apps/api/tests/Api/Catalog/BulkRelationActionsApiTest.php
+++ b/apps/api/tests/Api/Catalog/BulkRelationActionsApiTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\RelationCardinality;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * #2314 — bulk value actions on a relation-type attribute write link rows
+ * (object_relations) through the relation service instead of polluting
+ * attributesIndexed, and rollback replays the recorded target-id list.
+ */
+final class BulkRelationActionsApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function bulkRelationLifecycleSetAppendRemoveRollbackClear(): void
+    {
+        $attrCode = 'bulk_rel_'.substr(bin2hex(random_bytes(4)), 0, 6);
+        $this->seedRelationAttribute($attrCode);
+        $source1 = $this->seedProduct('REL-SRC-1-'.$attrCode);
+        $source2 = $this->seedProduct('REL-SRC-2-'.$attrCode);
+        $target1 = $this->seedProduct('REL-TGT-1-'.$attrCode);
+        $target2 = $this->seedProduct('REL-TGT-2-'.$attrCode);
+        $sourceIds = [$source1->getId()->toRfc4122(), $source2->getId()->toRfc4122()];
+        $t1 = $target1->getId()->toRfc4122();
+        $t2 = $target2->getId()->toRfc4122();
+
+        // set_attribute → replace with [t1] on both sources.
+        $set = $this->dispatch('set_attribute', $sourceIds, ['attr' => $attrCode, 'value' => [$t1]]);
+        self::assertSame(2, $set['success_count']);
+        self::assertSame([$t1], $this->relationTargets($sourceIds[0], $attrCode));
+        self::assertSame([$t1], $this->relationTargets($sourceIds[1], $attrCode));
+
+        // append_value → [t1, t2].
+        $append = $this->dispatch('append_value', $sourceIds, ['attr' => $attrCode, 'value' => [$t2]]);
+        self::assertSame(2, $append['success_count']);
+        self::assertSame([$t1, $t2], $this->relationTargets($sourceIds[0], $attrCode));
+
+        // remove_value → [t2].
+        $remove = $this->dispatch('remove_value', $sourceIds, ['attr' => $attrCode, 'value' => [$t1]]);
+        self::assertSame(2, $remove['success_count']);
+        self::assertSame([$t2], $this->relationTargets($sourceIds[0], $attrCode));
+
+        // rollback of the remove session → back to [t1, t2].
+        $removeSessionId = $remove['session_id'] ?? null;
+        \assert(\is_string($removeSessionId));
+        $client = $this->authenticatedClient();
+        $client->request('POST', \sprintf('/api/bulk-sessions/%s/rollback', $removeSessionId));
+        self::assertResponseIsSuccessful();
+        self::assertSame([$t1, $t2], $this->relationTargets($sourceIds[0], $attrCode));
+
+        // clear_attribute → [].
+        $clear = $this->dispatch('clear_attribute', $sourceIds, ['attr' => $attrCode]);
+        self::assertSame(2, $clear['success_count']);
+        self::assertSame([], $this->relationTargets($sourceIds[0], $attrCode));
+
+        // attributesIndexed must stay free of raw relation ids.
+        $this->em()->clear();
+        $fresh = $this->em()->find(CatalogObject::class, $source1->getId());
+        self::assertInstanceOf(CatalogObject::class, $fresh);
+        self::assertArrayNotHasKey($attrCode, $fresh->getAttributesIndexed());
+    }
+
+    #[Test]
+    public function bulkRelationRejectsNonUuidValue(): void
+    {
+        $attrCode = 'bulk_rel_'.substr(bin2hex(random_bytes(4)), 0, 6);
+        $this->seedRelationAttribute($attrCode);
+        $source = $this->seedProduct('REL-BAD-'.$attrCode);
+
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/products/bulk-actions/set_attribute', [
+            'headers' => ['Content-Type' => 'application/json'],
+            'body' => json_encode([
+                'target_ids' => [$source->getId()->toRfc4122()],
+                'payload' => ['attr' => $attrCode, 'value' => 'not-a-uuid'],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    /**
+     * @param list<string>         $targetIds
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    private function dispatch(string $action, array $targetIds, array $payload): array
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/products/bulk-actions/'.$action, [
+            'headers' => ['Content-Type' => 'application/json'],
+            'body' => json_encode([
+                'target_ids' => $targetIds,
+                'payload' => $payload,
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertSame(200, $response->getStatusCode(), $action.' must answer 200');
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = $response->toArray();
+
+        return $decoded;
+    }
+
+    /**
+     * Read the persisted target ids for (source, attribute) through the
+     * public relations endpoint — the same read path the detail tab uses.
+     *
+     * @return list<string>
+     */
+    private function relationTargets(string $sourceId, string $attrCode): array
+    {
+        $client = $this->authenticatedClient();
+        $body = $client->request('GET', \sprintf('/api/objects/%s/relations', $sourceId))->toArray();
+        $groups = $body['relationAttributes'] ?? [];
+        \assert(\is_array($groups));
+        foreach ($groups as $group) {
+            \assert(\is_array($group));
+            $attribute = $group['attribute'] ?? [];
+            \assert(\is_array($attribute));
+            if (($attribute['code'] ?? null) !== $attrCode) {
+                continue;
+            }
+            $relations = $group['relations'] ?? [];
+            \assert(\is_array($relations));
+            $ids = [];
+            foreach ($relations as $row) {
+                \assert(\is_array($row));
+                $target = $row['targetObjectId'] ?? null;
+                if (\is_string($target)) {
+                    $ids[] = $target;
+                }
+            }
+
+            return $ids;
+        }
+
+        return [];
+    }
+
+    private function seedRelationAttribute(string $code): void
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $tenantContext = self::getContainer()->get(TenantContext::class);
+        $tenantContext->set($tenant);
+
+        $productType = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $productType);
+
+        $attribute = new Attribute($code, ['en' => 'Bulk relation'], AttributeType::Relation);
+        $attribute->setRelationTargetObjectTypeIds([$productType->getId()->toRfc4122()]);
+        $attribute->setRelationCardinality(RelationCardinality::Many);
+
+        $em = $this->em();
+        $em->persist($attribute);
+        $em->persist(new ObjectTypeAttribute($productType, $attribute, false, 90));
+        $em->flush();
+
+        $tenantContext->clear();
+    }
+
+    private function seedProduct(string $code): CatalogObject
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $tenantContext = self::getContainer()->get(TenantContext::class);
+        $tenantContext->set($tenant);
+
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $type);
+
+        $object = new CatalogObject($type, $code);
+        $em = $this->em();
+        $em->persist($object);
+        $em->flush();
+
+        $tenantContext->clear();
+
+        return $object;
+    }
+}


### PR DESCRIPTION
## Summary
Domyka #2314 po rundzie smoke operatora: w akcji zbiorczej „Ustaw atrybut" pole „Nowa wartość" dla atrybutu typu **relacja** pokazuje teraz picker obiektów docelowych (z wartościami), a Zastosuj zapisuje **prawdziwe relacje** (link table), nie tekst.

## Root cause
Wartości relacji żyją w `object_relations`, nie w `object_values`/`attributes_indexed` — skalarne handlery bulk nie umiały ich zapisać, a `BulkValueInput` nie miał gałęzi `relation` (fallback do free-text).

## Backend changes
- Nowy `BulkRelationApplier` — wspólna ścieżka relacji dla 4 akcji: `set` (replace), `clear` (→ []), `append` (unia), `remove` (różnica). Pisze przez `ObjectRelationService::replaceForSourceAndAttribute` (te same guardy co detal: tenant, typ celu, cardinality), **zachowuje metadata** przeżywających linków, semantyka skip jak w skalarnych („Value already present"/„Value not present"/„Attribute locked"), BulkLog z listami id (rollback recipe).
- 4 handlery bulk delegują do appliera gdy atrybut jest relacją; walidacja payloadu (UUID/lista UUID → 400).
- `BulkRollbackHandler` — rollback relacji odtwarza zapisaną listę targetów przez ścieżkę relacji (nie attributesIndexed).

## Frontend changes
- `BulkValueInput` — gałąź `relation`: pobiera konfigurację relacji atrybutu i renderuje `RelationCreateField` (Combobox dla cardinality=one, MultiSelect dla many); emituje UUID/listę UUID.

## Quality gates
- PHPStan max 0, php-cs-fixer 0, tsc 0, biome (`src e2e`) 0, vitest bulk-value-input 5/5.
- **Nowy ApiTest `BulkRelationActionsApiTest` — 2/2 (18 asercji)**: pełny lifecycle set→append→remove→**rollback**→clear na realnym Postgresie + walidacja 400; asercja że `attributesIndexed` pozostaje czyste.

## Live-stack smoke (proof)
`POST /api/products/bulk-actions/set_attribute` z `attr=cross_sell` (relation, demo) na 2 produktach → **HTTP 200, success=2**; `GET /api/objects/{id}/relations` pokazuje dokładnie wybrany target. Dane smoke posprzątane (clear → 200).

## Świadome odejścia
- Preview (krok 3 kreatora) dla relacji pokazuje before/after jako listy id (nie kody) — kosmetyka, osobny polish jeśli potrzebny.
- Rollback relacji odtwarza targety bez per-link metadata (log przechowuje id) — parytet ze skalarnym rollbackiem.

Closes #2314

🤖 Generated with [Claude Code](https://claude.com/claude-code)