### PR TITLE
fix(aicg): live-smoke follow-ups (Ask AI field refresh + editable built-in recipes)

### DIFF
--- a/apps/admin/src/features/catalog/products/components/product-detail-content.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-content.tsx
@@ -61,6 +61,12 @@ export interface ProductDetailContentProps {
   onAskAI?: (attributeCode: string) => void;
   askAiProposalFor?: (attributeCode: string) => import('react').ReactNode;
   recipeNameById?: Map<string, string>;
+  /**
+   * #2341-followup — remount nonce per field: bumped for the attribute
+   * whose Ask AI proposal was just accepted so its (uncontrolled) editor
+   * re-reads the freshly committed value without a page reload.
+   */
+  fieldVersion?: (attributeCode: string) => number;
 }
 
 /**
@@ -96,6 +102,7 @@ export function ProductDetailContent({
   onAskAI,
   askAiProposalFor,
   recipeNameById,
+  fieldVersion,
 }: ProductDetailContentProps) {
   // AICG-P5-01 — the affordance targets editable text-family fields only.
   const TEXT_FAMILY = new Set(['text', 'textarea', 'wysiwyg']);
@@ -125,7 +132,7 @@ export function ProductDetailContent({
       {visibleAttributes(group).map((attr) => {
         const contentMeta = resolveProvenanceContentMeta(attr, product);
         return (
-          <div key={attr.id}>
+          <div key={`${attr.id}-${fieldVersion?.(attr.code) ?? 0}`}>
             <AttrRow
               attribute={attr}
               value={fieldValue(attr.code)}

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -452,6 +452,7 @@ export function ProductDetailPage({
               onAskAI={isEditMode ? askAi.start : undefined}
               askAiProposalFor={askAiProposalFor}
               recipeNameById={recipeNameById}
+              fieldVersion={askAi.fieldVersion}
             />
           </Suspense>
 

--- a/apps/admin/src/features/catalog/products/components/use-ask-ai.ts
+++ b/apps/admin/src/features/catalog/products/components/use-ask-ai.ts
@@ -41,6 +41,11 @@ export function useAskAi({ productId, locale, channel, onAccepted }: UseAskAiArg
   const [active, setActive] = useState<{ attributeCode: string; runId: string } | null>(null);
   const [startError, setStartError] = useState<string | null>(null);
   const [deciding, setDeciding] = useState(false);
+  // #2341-followup — the accepted value is committed + refetched, but the
+  // uncontrolled rich-text editor keeps its stale (often empty) content
+  // until it remounts. Bumping this per-field nonce on accept forces the
+  // answered field to remount and re-read the fresh value — no page reload.
+  const [answered, setAnswered] = useState<{ code: string; nonce: number } | null>(null);
 
   const runQuery = useQuery({
     queryKey: ['aicg-ask-run', active?.runId],
@@ -91,11 +96,13 @@ export function useAskAi({ productId, locale, channel, onAccepted }: UseAskAiArg
     if (active === null) {
       return;
     }
+    const acceptedCode = active.attributeCode;
     setDeciding(true);
     try {
       await approveAgentRun(active.runId);
       await onAccepted();
       setActive(null);
+      setAnswered((prev) => ({ code: acceptedCode, nonce: (prev?.nonce ?? 0) + 1 }));
     } finally {
       setDeciding(false);
     }
@@ -146,5 +153,13 @@ export function useAskAi({ productId, locale, channel, onAccepted }: UseAskAiArg
     };
   }
 
-  return { state, startError, start, accept, reject, dismiss };
+  // Remount key for a field: non-zero only for the attribute whose Ask AI
+  // proposal was just accepted, so exactly that field re-reads the value.
+  const fieldVersion = useCallback(
+    (attributeCode: string): number =>
+      answered !== null && answered.code === attributeCode ? answered.nonce : 0,
+    [answered],
+  );
+
+  return { state, startError, start, accept, reject, dismiss, fieldVersion };
 }

--- a/apps/admin/src/features/settings/ai/content-recipes-section.tsx
+++ b/apps/admin/src/features/settings/ai/content-recipes-section.tsx
@@ -13,8 +13,9 @@ import { useCanI } from '@/lib/identity/use-identity';
 /**
  * AICG-P5-04 (#2342) — ContentRecipe CRUD in Settings → AI: the recipe
  * ("how to write copy for this target") is tenant configuration, not
- * code. Built-in rows are read-only with a clone action (backend 409s
- * direct edits); create/edit covers target, source attributes, format,
+ * code. Built-in rows carry an informational badge but are fully
+ * editable + deletable (operator decision, #2341-followup) — plus a
+ * clone action; create/edit covers target, source attributes, format,
  * length budget, SEO rules, tone hint and the pinned brand voice.
  */
 
@@ -266,7 +267,7 @@ export function ContentRecipesSection() {
                   <CopyPlus className="size-3.5" aria-hidden />
                 </button>
               ) : null}
-              {canAdmin && !recipe.builtIn ? (
+              {canAdmin ? (
                 <>
                   <button
                     type="button"

--- a/apps/api/src/Agent/Infrastructure/ApiPlatform/State/ContentRecipeProcessor.php
+++ b/apps/api/src/Agent/Infrastructure/ApiPlatform/State/ContentRecipeProcessor.php
@@ -30,8 +30,9 @@ use Symfony\Component\Uid\Uuid;
  *   - aggregate guard violations (constraints.format, source codes)
  *     surface as 422,
  *   - UNIQUE(tenant_id, code) as 409,
- *   - built-in recipes reject PATCH/DELETE with 409 pointing to the
- *     clone route — the seeded templates stay intact (ADR-0030).
+ *   - built-in recipes are a configurable BASE, not read-only fixtures:
+ *     PATCH/DELETE are allowed (operator decision, #2341-followup); the
+ *     is_built_in flag stays as a badge + the tool's default preference.
  *
  * @implements ProcessorInterface<ContentRecipeInput|ContentRecipePatchInput|ContentRecipe, ContentRecipe|null>
  */
@@ -48,10 +49,13 @@ final readonly class ContentRecipeProcessor implements ProcessorInterface
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): ?ContentRecipe
     {
         if ($operation instanceof DeleteOperationInterface) {
+            // #2341-followup (operator decision): built-in recipes are a
+            // configurable BASE, not read-only fixtures — the tenant may
+            // edit or delete them. The is_built_in flag stays as an
+            // informational badge + the tool's default-resolution
+            // preference; re-running the defaults seeder only re-creates a
+            // deleted built-in on an explicit seed.
             $recipe = $this->find($uriVariables);
-            if ($recipe->isBuiltIn()) {
-                throw new ConflictHttpException('Built-in recipes cannot be deleted — clone them and edit the copy.');
-            }
             $this->em->remove($recipe);
             $this->em->flush();
 
@@ -108,10 +112,9 @@ final readonly class ContentRecipeProcessor implements ProcessorInterface
             throw new LogicException('ContentRecipeProcessor expects ContentRecipePatchInput on Patch.');
         }
 
+        // #2341-followup (operator decision): built-in recipes are fully
+        // editable — the badge stays informational, no read-only lock.
         $recipe = $this->find($uriVariables);
-        if ($recipe->isBuiltIn()) {
-            throw new ConflictHttpException('Built-in recipes are read-only — clone them and edit the copy.');
-        }
 
         try {
             if (null !== $data->name) {

--- a/apps/api/tests/Api/Agent/AiContentSettingsApiTest.php
+++ b/apps/api/tests/Api/Agent/AiContentSettingsApiTest.php
@@ -176,18 +176,22 @@ final class AiContentSettingsApiTest extends ApiTestCase
     }
 
     #[Test]
-    public function builtInRecipesAreReadOnlyAndCloneable(): void
+    public function builtInRecipesAreEditableDeletableAndCloneable(): void
     {
+        // #2341-followup (operator decision): built-in recipes are a
+        // configurable base — editable, deletable AND cloneable.
         $client = $this->authenticatedClient();
         $id = $this->seedBuiltInRecipe()->toRfc4122();
 
+        // Editable in place (no clone required).
         $patch = $client->request('PATCH', '/api/content-recipes/'.$id, [
             'headers' => ['content-type' => 'application/merge-patch+json'],
             'json' => ['name' => 'Nadpisany'],
         ]);
-        self::assertSame(409, $patch->getStatusCode());
-        self::assertSame(409, $client->request('DELETE', '/api/content-recipes/'.$id)->getStatusCode());
+        self::assertSame(200, $patch->getStatusCode());
+        self::assertSame('Nadpisany', $patch->toArray()['name']);
 
+        // Still cloneable into a non-built-in copy.
         $clone = $client->request('POST', '/api/content-recipes/'.$id.'/clone', ['json' => []]);
         self::assertSame(201, $clone->getStatusCode());
         $clonePayload = $clone->toArray();
@@ -195,11 +199,9 @@ final class AiContentSettingsApiTest extends ApiTestCase
         self::assertSame('builtin_recipe_copy', $clonePayload['code']);
         self::assertFalse($clonePayload['is_built_in']);
 
-        $editClone = $client->request('PATCH', '/api/content-recipes/'.$clonePayload['id'], [
-            'headers' => ['content-type' => 'application/merge-patch+json'],
-            'json' => ['name' => 'Kopia po edycji'],
-        ]);
-        self::assertSame(200, $editClone->getStatusCode());
+        // And deletable in place.
+        self::assertSame(204, $client->request('DELETE', '/api/content-recipes/'.$id)->getStatusCode());
+        self::assertSame(404, $client->request('GET', '/api/content-recipes/'.$id)->getStatusCode());
     }
 
     #[Test]


### PR DESCRIPTION
## Live-smoke follow-upy AICG (2 findingi operatora)

Dwa findingi z manualnego live-smoke na `pim.localhost` po zamknięciu epiku AICG.

### 1. `fix(admin)`: wartość Ask AI widoczna w polu bez odświeżania (#2341)
**Bug:** po kliknięciu „Akceptuj" na inline-propozycji tekst nie wskakiwał do pola — trzeba było odświeżyć stronę, żeby pojawił się jako wartość atrybutu (np. „Opis (rich text)").

**Diagnoza (wszystkie warstwy):** approve jest **synchroniczny** — DB `attributes_indexed` i `GET /api/objects/{id}` zwracają nową wartość natychmiast po HTTP 200 (potwierdzone curl-em; `async` transport = `sync://` w dev). Backend OK. Przyczyna czysto FE: **niekontrolowany edytor Plate (WYSIWYG)** trzymał starą (pustą) zawartość mimo `productQuery.refetch()`.

**Fix:** `useAskAi` bumpuje per-field nonce po accept; klucz wrappera odpowiedzianego pola zawiera nonce → dokładnie to pole się remountuje i czyta świeżą wartość. Kontrolowane inputy działały już wcześniej; to domyka lukę dla rich-text.

**Live-smoke proof (real BYOK, bez mocków):** na produkcie z faktami, zakładka „IdoSell · Treść", pole `description_html` (WYSIWYG) → Ask AI → propozycja → **Akceptuj → treść pojawiła się w edytorze BEZ reloadu** (screenshot); DB: `description_html` provenance `agent`. Regresja mocked e2e `aicg-p5-ask-ai-inline-diff` 2/2.

### 2. `fix(agent)`: built-in przepisy treści edytowalne i usuwalne (#2342)
**Decyzja operatora:** „nie chcę sztywniaków — predefiniowane przepisy mogą zostać jako baza, ale w pełni konfigurowalne i usuwalne."

**Zmiana:** `ContentRecipeProcessor` zdejmuje oba guardy 409 (PATCH/DELETE dla built-in). Flaga `is_built_in` zostaje jako **badge informacyjny** + preferencja default-resolution toola. Seeder re-tworzy skasowany built-in tylko przy jawnym seedzie. UI: edit/delete widoczne dla built-in obok clone.

**Proof:** `AiContentSettingsApiTest::builtInRecipesAreEditableDeletableAndCloneable` (PATCH 200 + clone 201 + DELETE 204 + GET 404); live-smoke: PATCH built-in → **200**, DELETE → **204** (wcześniej 409). Po smoke re-seed defaultów (`pim:agent:seed-content-defaults`).

### Bramki
PHPStan max 0 · cs-fixer OK · tsc 0 · vitest 147/147 · build ✓ · biome 0 · Playwright 4/4 (ask-ai inline + settings).

Refs #2341 #2342
