### PR TITLE
feat(workflow): install symfony/workflow with object_editorial state machine (pakiet A)

### DIFF
--- a/apps/api/composer.json
+++ b/apps/api/composer.json
@@ -55,6 +55,7 @@
         "symfony/twig-bundle": "7.4.*",
         "symfony/uid": "7.4.*",
         "symfony/validator": "7.4.*",
+        "symfony/workflow": "7.4.*",
         "symfony/yaml": "7.4.*"
     },
     "config": {

--- a/apps/api/composer.lock
+++ b/apps/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b11a6a8755986849a1cf96a725af1ad4",
+    "content-hash": "7742cdd2d33a1f6508100d2d1dd98fda",
     "packages": [
         {
             "name": "anthropic-ai/sdk",
@@ -11749,6 +11749,100 @@
                 }
             ],
             "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "symfony/workflow",
+            "version": "v7.4.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/workflow.git",
+                "reference": "0c7651c6c8f152348184d3dc3e7b40039c87d5d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/workflow/zipball/0c7651c6c8f152348184d3dc3e7b40039c87d5d0",
+                "reference": "0c7651c6c8f152348184d3dc3e7b40039c87d5d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "2.5|^3"
+            },
+            "conflict": {
+                "symfony/event-dispatcher": "<6.4"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/error-handler": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/security-core": "^6.4|^7.0|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/validator": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Workflow\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Grégoire Pineau",
+                    "email": "lyrixx@lyrixx.info"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools for managing a workflow or finite state machine",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "petrinet",
+                "place",
+                "state",
+                "statemachine",
+                "transition",
+                "workflow"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/workflow/tree/v7.4.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-18T13:18:21+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/apps/api/config/packages/workflow.yaml
+++ b/apps/api/config/packages/workflow.yaml
@@ -7,7 +7,9 @@ framework:
             type: state_machine
             marking_store:
                 type: method
-                property: status
+                # Dedicated accessor pair on CatalogObject (get/setEditorialMarking)
+                # — see the entity docblock for why this is not `status`.
+                property: editorialMarking
             supports:
                 - App\Catalog\Domain\Entity\CatalogObject
             initial_marking: draft

--- a/apps/api/config/packages/workflow.yaml
+++ b/apps/api/config/packages/workflow.yaml
@@ -1,0 +1,43 @@
+framework:
+    workflows:
+        # ADR-0029 — editorial state machine for catalog objects. Marking
+        # lives on the existing `objects.status` column (method store);
+        # transition guards (RBAC permission map) attach in WFL-P1-01.
+        object_editorial:
+            type: state_machine
+            marking_store:
+                type: method
+                property: status
+            supports:
+                - App\Catalog\Domain\Entity\CatalogObject
+            initial_marking: draft
+            places:
+                - draft
+                - review
+                - published
+                - archived
+            transitions:
+                submit_for_review:
+                    from: draft
+                    to: review
+                # Direct draft -> published shortcut for roles holding
+                # workflow.approve_reject (ADR-0029 pillar 2) — a solo
+                # operator must not be forced through the review loop.
+                publish:
+                    from: draft
+                    to: published
+                approve:
+                    from: review
+                    to: published
+                reject:
+                    from: review
+                    to: draft
+                unpublish:
+                    from: published
+                    to: draft
+                archive:
+                    from: [draft, published]
+                    to: archived
+                restore:
+                    from: archived
+                    to: draft

--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -305,6 +305,22 @@ parameters:
               - type: directory
                 value: 'src/Export/Catalog/Contracts/.*'
 
+        # ─── Workflow — editorial state machine, transition log, tasks (ADR-0029) ───
+        - name: Workflow_Internals
+          collectors:
+              - type: directory
+                value: 'src/Workflow/Domain/.*'
+              - type: directory
+                value: 'src/Workflow/Application/.*'
+              - type: directory
+                value: 'src/Workflow/Infrastructure/.*'
+              - type: directory
+                value: 'src/Workflow/Presentation/.*'
+        - name: Workflow_Contracts
+          collectors:
+              - type: directory
+                value: 'src/Workflow/Contracts/.*'
+
         # ─── Tooling — fixtures, benchmarks, foundry stories, PHPStan rules ───
         - name: Tooling
           collectors:
@@ -340,9 +356,26 @@ parameters:
             - Asset_Contracts
             - Channel_Contracts
             - Identity_Contracts
+            # ADR-0029 — PATCH status resolves transitions against the
+            # object_editorial state machine; vocabulary via Workflow seam.
+            - Workflow_Contracts
             - Shared
             - Vendor
         Catalog_Contracts:
+            - Shared
+            - Vendor
+
+        # ADR-0029 — Workflow BC reaches Catalog/Identity only via seams;
+        # marking lives on CatalogObject, so Catalog_Internals may read the
+        # Workflow_Contracts vocabulary (transition names) and, from WFL-P1-*,
+        # Identity voters consult Workflow ports the same way.
+        Workflow_Internals:
+            - Workflow_Contracts
+            - Catalog_Contracts
+            - Identity_Contracts
+            - Shared
+            - Vendor
+        Workflow_Contracts:
             - Shared
             - Vendor
 
@@ -426,6 +459,9 @@ parameters:
         Identity_Internals:
             - Identity_Contracts
             - Catalog_Contracts
+            # ADR-0029 — workflow-state guards/voters consult Workflow seam
+            # (WFL-P1-01/P1-02).
+            - Workflow_Contracts
             # AUD-079 (W3-1): BackupVoter references the Backup entity it
             # protects — the same "voter references its resource" pattern
             # already accepted for ProductVoter / CategoryVoter / AssetVoter.

--- a/apps/api/src/Benchmark/BulkImportBenchmarkCommand.php
+++ b/apps/api/src/Benchmark/BulkImportBenchmarkCommand.php
@@ -125,7 +125,7 @@ final class BulkImportBenchmarkCommand extends Command
         for ($i = 1; $i <= $count; ++$i) {
             $sku = \sprintf('%s%05d', $skuPrefix, $i);
             $object = new CatalogObject($productType, $sku);
-            $object->transitionTo(CatalogObject::STATUS_PUBLISHED);
+            $object->forceStatus(CatalogObject::STATUS_PUBLISHED);
             $object->updateAttributeIndex([
                 'sku' => $sku,
                 'name' => \sprintf('Benchmark product %05d', $i),

--- a/apps/api/src/Benchmark/LoadTestSeedCommand.php
+++ b/apps/api/src/Benchmark/LoadTestSeedCommand.php
@@ -158,7 +158,7 @@ final class LoadTestSeedCommand extends Command
         for ($i = 1; $i <= $products; ++$i) {
             $sku = \sprintf('%s%06d', $skuPrefix, $i);
             $object = new CatalogObject($productType, $sku);
-            $object->transitionTo(CatalogObject::STATUS_PUBLISHED);
+            $object->forceStatus(CatalogObject::STATUS_PUBLISHED);
             $this->entityManager->persist($object);
 
             // Deterministic, evenly-rotating attribute window per product so

--- a/apps/api/src/Catalog/Application/CatalogAssetSyncService.php
+++ b/apps/api/src/Catalog/Application/CatalogAssetSyncService.php
@@ -65,7 +65,7 @@ final readonly class CatalogAssetSyncService implements CatalogAssetSync
         }
 
         $catalogObject = new CatalogObject($assetType, $code);
-        $catalogObject->transitionTo(CatalogObject::STATUS_PUBLISHED);
+        $catalogObject->forceStatus(CatalogObject::STATUS_PUBLISHED);
         $catalogObject->updateAttributeIndex($indexedAttributes);
         $catalogObject->recordCompleteness(['global' => 100]);
 

--- a/apps/api/src/Catalog/Application/Command/UpdateCatalogObject/UpdateCatalogObjectHandler.php
+++ b/apps/api/src/Catalog/Application/Command/UpdateCatalogObject/UpdateCatalogObjectHandler.php
@@ -5,14 +5,18 @@ declare(strict_types=1);
 namespace App\Catalog\Application\Command\UpdateCatalogObject;
 
 use App\Catalog\Application\ObjectAttributesUpserter;
+use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Channel\Contracts\ChannelResolverInterface;
 use App\Shared\Domain\Tenant;
+use App\Workflow\Contracts\ObjectEditorialWorkflow;
 use Doctrine\ORM\OptimisticLockException;
+use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Workflow\WorkflowInterface;
 
 #[AsMessageHandler]
 final readonly class UpdateCatalogObjectHandler
@@ -21,6 +25,8 @@ final readonly class UpdateCatalogObjectHandler
         private CatalogObjectRepositoryInterface $catalogObjects,
         private ObjectAttributesUpserter $attributesUpserter,
         private ChannelResolverInterface $channels,
+        #[Target(ObjectEditorialWorkflow::NAME)]
+        private WorkflowInterface $objectEditorial,
     ) {
     }
 
@@ -50,8 +56,8 @@ final readonly class UpdateCatalogObjectHandler
         if (null !== $command->enabled) {
             $object->changeEnabled($command->enabled);
         }
-        if (null !== $command->status) {
-            $object->transitionTo($command->status);
+        if (null !== $command->status && $command->status !== $object->getStatus()) {
+            $this->applyStatusTransition($object, $command->status);
         }
 
         if ($command->clearParent) {
@@ -111,5 +117,30 @@ final readonly class UpdateCatalogObjectHandler
                 channelId: $channelId,
             );
         }
+    }
+
+    /**
+     * PATCH sends a target status, not a transition name — resolve it
+     * against the `object_editorial` state machine (ADR-0029). Only
+     * transitions enabled for the current marking qualify, so topology
+     * (and, from WFL-P1-01 on, RBAC guards) is enforced on the legacy
+     * PATCH surface too.
+     */
+    private function applyStatusTransition(CatalogObject $object, string $targetStatus): void
+    {
+        foreach ($this->objectEditorial->getEnabledTransitions($object) as $transition) {
+            if (\in_array($targetStatus, $transition->getTos(), true)) {
+                $this->objectEditorial->apply($object, $transition->getName());
+
+                return;
+            }
+        }
+
+        throw new ConflictHttpException(\sprintf(
+            'Status transition "%s" -> "%s" is not allowed by the "%s" workflow.',
+            $object->getStatus(),
+            $targetStatus,
+            ObjectEditorialWorkflow::NAME,
+        ));
     }
 }

--- a/apps/api/src/Catalog/Application/DemoCatalogSeeder.php
+++ b/apps/api/src/Catalog/Application/DemoCatalogSeeder.php
@@ -205,7 +205,7 @@ final readonly class DemoCatalogSeeder
             $category = new CatalogObject($type, $code);
             // ADR-015 — demo categories live in the Product tree.
             $category->scopeCategoryTo($productType);
-            $category->transitionTo(CatalogObject::STATUS_PUBLISHED);
+            $category->forceStatus(CatalogObject::STATUS_PUBLISHED);
             $category->attachToPath($path);
 
             // Closed system kind — only the intrinsic `name` (display label).
@@ -233,7 +233,7 @@ final readonly class DemoCatalogSeeder
         for ($i = 1; $i <= 10; ++$i) {
             $code = \sprintf('ASSET-%03d', $i);
             $catalogAsset = new CatalogObject($type, $code);
-            $catalogAsset->transitionTo(CatalogObject::STATUS_PUBLISHED);
+            $catalogAsset->forceStatus(CatalogObject::STATUS_PUBLISHED);
 
             $name = \sprintf('Demo image %d', $i);
 
@@ -288,7 +288,7 @@ final readonly class DemoCatalogSeeder
         for ($i = 1; $i <= self::PRODUCT_COUNT; ++$i) {
             $sku = \sprintf('DEMO-%03d', $i);
             $product = new CatalogObject($type, $sku);
-            $product->transitionTo(0 === $i % 11 ? CatalogObject::STATUS_DRAFT : CatalogObject::STATUS_PUBLISHED);
+            $product->forceStatus(0 === $i % 11 ? CatalogObject::STATUS_DRAFT : CatalogObject::STATUS_PUBLISHED);
 
             $brand = $brands[$i % \count($brands)];
             $color = $colors[$i % \count($colors)];

--- a/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
+++ b/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
@@ -17,6 +17,7 @@ use App\Shared\Domain\AggregateRoot;
 use App\Shared\Domain\Tenant;
 use DateTimeImmutable;
 use LogicException;
+use Symfony\Component\Serializer\Attribute\Ignore;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -292,18 +293,32 @@ class CatalogObject extends AggregateRoot implements TenantScoped, Blameable
     }
 
     /**
-     * Marking-store writer for the `object_editorial` state machine
-     * (ADR-0029). Called by Symfony Workflow's MethodMarkingStore on
-     * `apply()` — application code MUST NOT call this directly; go
-     * through the workflow (`can()`/`apply()`) so topology and guards
-     * are enforced. Non-editorial write paths (import/seed) use
-     * {@see forceStatus()} instead.
+     * Marking-store reader for the `object_editorial` state machine
+     * (ADR-0029). The marking property is deliberately named
+     * `editorialMarking` (not `status`) so Symfony property-info never
+     * mistakes the writer below for a `status` mutator — that would
+     * flip the public `status` field from readOnly string to a
+     * writable object in the exported OpenAPI schema.
+     */
+    #[Ignore]
+    public function getEditorialMarking(): string
+    {
+        return $this->status;
+    }
+
+    /**
+     * Marking-store writer — called by Symfony Workflow's
+     * MethodMarkingStore on `apply()`. Application code MUST NOT call
+     * this directly; go through the workflow (`can()`/`apply()`) so
+     * topology and guards are enforced. Non-editorial write paths
+     * (import/seed) use {@see forceStatus()} instead.
      *
      * @param array<string, mixed> $context transition context passed to
      *                                      `Workflow::apply()` (comment, actor…) — consumed by the
      *                                      transition-log listener (WFL-P0-04), unused here
      */
-    public function setStatus(string $status, array $context = []): void
+    #[Ignore]
+    public function setEditorialMarking(string $status, array $context = []): void
     {
         unset($context);
 
@@ -342,7 +357,7 @@ class CatalogObject extends AggregateRoot implements TenantScoped, Blameable
      */
     public function forceStatus(string $status): void
     {
-        $this->setStatus($status);
+        $this->setEditorialMarking($status);
     }
 
     /**

--- a/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
+++ b/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
@@ -55,6 +55,7 @@ use const ARRAY_FILTER_USE_BOTH;
 class CatalogObject extends AggregateRoot implements TenantScoped, Blameable
 {
     public const string STATUS_DRAFT = 'draft';
+    public const string STATUS_REVIEW = 'review';
     public const string STATUS_PUBLISHED = 'published';
     public const string STATUS_ARCHIVED = 'archived';
     private Uuid $id;
@@ -290,13 +291,26 @@ class CatalogObject extends AggregateRoot implements TenantScoped, Blameable
         return $this->status;
     }
 
-    public function transitionTo(string $status): void
+    /**
+     * Marking-store writer for the `object_editorial` state machine
+     * (ADR-0029). Called by Symfony Workflow's MethodMarkingStore on
+     * `apply()` — application code MUST NOT call this directly; go
+     * through the workflow (`can()`/`apply()`) so topology and guards
+     * are enforced. Non-editorial write paths (import/seed) use
+     * {@see forceStatus()} instead.
+     *
+     * @param array<string, mixed> $context transition context passed to
+     *                                      `Workflow::apply()` (comment, actor…) — consumed by the
+     *                                      transition-log listener (WFL-P0-04), unused here
+     */
+    public function setStatus(string $status, array $context = []): void
     {
+        unset($context);
+
         if ($this->status === $status) {
             return;
         }
 
-        $previous = $this->status;
         $this->status = $status;
         $this->touch();
 
@@ -315,7 +329,20 @@ class CatalogObject extends AggregateRoot implements TenantScoped, Blameable
                 tenantId: $this->tenant->getId(),
             ));
         }
-        unset($previous);
+    }
+
+    /**
+     * Deliberate state-machine bypass for non-editorial write paths —
+     * import/integration/seeding set status regardless of editorial
+     * state (ADR-0029 pillar 8: an integration must never get stuck on
+     * review). Editorial paths (API PATCH, transition endpoints) go
+     * through the `object_editorial` workflow instead.
+     *
+     * @internal infrastructure paths only (import, fixtures, benchmarks)
+     */
+    public function forceStatus(string $status): void
+    {
+        $this->setStatus($status);
     }
 
     /**

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Filter/StatusFilter.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Filter/StatusFilter.php
@@ -11,11 +11,11 @@ use App\Catalog\Domain\Entity\CatalogObject;
 use Doctrine\ORM\QueryBuilder;
 
 /**
- * `?status=published|draft|archived` plus `?enabled=true|false`.
+ * `?status=draft|review|published|archived` plus `?enabled=true|false`.
  *
  * Two related but distinct flags on `CatalogObject`:
- *   - `status` is the editorial state (FSM: draft → published →
- *     archived). String exact match.
+ *   - `status` is the editorial state (`object_editorial` state
+ *     machine, ADR-0029: draft → review → published → archived). String exact match.
  *   - `enabled` is the publishing kill-switch independent of status —
  *     a published row can be disabled to hide it everywhere without
  *     losing its archive history. Boolean.
@@ -33,6 +33,7 @@ final class StatusFilter implements FilterInterface
      */
     private const array ALLOWED_STATUSES = [
         CatalogObject::STATUS_DRAFT,
+        CatalogObject::STATUS_REVIEW,
         CatalogObject::STATUS_PUBLISHED,
         CatalogObject::STATUS_ARCHIVED,
     ];

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObjectPatchInput.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObjectPatchInput.php
@@ -26,9 +26,12 @@ final class CatalogObjectPatchInput
 
     /**
      * One of {@see \App\Catalog\Domain\Entity\CatalogObject::STATUS_*}.
-     * The handler delegates to `transitionTo()` which encodes the FSM.
+     * The handler resolves the target status against the
+     * `object_editorial` state machine (ADR-0029) and applies the
+     * matching transition; a target unreachable from the current
+     * status is rejected with 409 Conflict.
      */
-    #[Assert\Choice(choices: ['draft', 'published', 'archived'])]
+    #[Assert\Choice(choices: ['draft', 'review', 'published', 'archived'])]
     #[Groups(['object:patch'])]
     public ?string $status = null;
 

--- a/apps/api/src/DataFixtures/AppFixtures.php
+++ b/apps/api/src/DataFixtures/AppFixtures.php
@@ -248,7 +248,7 @@ class AppFixtures extends Fixture implements DependentFixtureInterface
             ['ACME-003', 'Acme Sprocket', 'Acme'],
         ] as [$sku, $name, $brand]) {
             $object = new CatalogObject($acmeProductType, $sku);
-            $object->transitionTo(CatalogObject::STATUS_PUBLISHED);
+            $object->forceStatus(CatalogObject::STATUS_PUBLISHED);
             $object->updateAttributeIndex([
                 'sku' => $sku,
                 'name' => $name,

--- a/apps/api/src/Import/Application/Service/ImportObjectCreator.php
+++ b/apps/api/src/Import/Application/Service/ImportObjectCreator.php
@@ -121,7 +121,7 @@ final class ImportObjectCreator
     private function applyState(CatalogObject $object, ?string $status, ?bool $enabled, ?array $variantAxes): void
     {
         if (null !== $status) {
-            $object->transitionTo($status);
+            $object->forceStatus($status);
         }
         if (null !== $enabled) {
             $object->changeEnabled($enabled);

--- a/apps/api/src/Workflow/Contracts/ObjectEditorialWorkflow.php
+++ b/apps/api/src/Workflow/Contracts/ObjectEditorialWorkflow.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Workflow\Contracts;
+
+/**
+ * Shared vocabulary of the `object_editorial` state machine (ADR-0029).
+ *
+ * Place names intentionally mirror `CatalogObject::STATUS_*` string
+ * values without importing the entity — `Workflow_Contracts` may only
+ * depend on Shared + Vendor (deptrac), while the marking itself lives
+ * on the Catalog entity. The YAML definition in
+ * `config/packages/workflow.yaml` is the runtime source of truth; this
+ * class pins the names so cross-BC consumers never hardcode strings.
+ */
+final class ObjectEditorialWorkflow
+{
+    public const string NAME = 'object_editorial';
+
+    public const string PLACE_DRAFT = 'draft';
+    public const string PLACE_REVIEW = 'review';
+    public const string PLACE_PUBLISHED = 'published';
+    public const string PLACE_ARCHIVED = 'archived';
+
+    public const string TRANSITION_SUBMIT_FOR_REVIEW = 'submit_for_review';
+    public const string TRANSITION_PUBLISH = 'publish';
+    public const string TRANSITION_APPROVE = 'approve';
+    public const string TRANSITION_REJECT = 'reject';
+    public const string TRANSITION_UNPUBLISH = 'unpublish';
+    public const string TRANSITION_ARCHIVE = 'archive';
+    public const string TRANSITION_RESTORE = 'restore';
+
+    /**
+     * @var list<string>
+     */
+    public const array PLACES = [
+        self::PLACE_DRAFT,
+        self::PLACE_REVIEW,
+        self::PLACE_PUBLISHED,
+        self::PLACE_ARCHIVED,
+    ];
+
+    /**
+     * @var list<string>
+     */
+    public const array TRANSITIONS = [
+        self::TRANSITION_SUBMIT_FOR_REVIEW,
+        self::TRANSITION_PUBLISH,
+        self::TRANSITION_APPROVE,
+        self::TRANSITION_REJECT,
+        self::TRANSITION_UNPUBLISH,
+        self::TRANSITION_ARCHIVE,
+        self::TRANSITION_RESTORE,
+    ];
+
+    private function __construct()
+    {
+    }
+}

--- a/apps/api/symfony.lock
+++ b/apps/api/symfony.lock
@@ -351,6 +351,18 @@
             "config/packages/validator.yaml"
         ]
     },
+    "symfony/workflow": {
+        "version": "7.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "3.3",
+            "ref": "3b2f8ca32a07fcb00f899649053943fa3d8bbfb6"
+        },
+        "files": [
+            "config/packages/workflow.yaml"
+        ]
+    },
     "twig/extra-bundle": {
         "version": "v3.24.0"
     },

--- a/apps/api/tests/Api/Catalog/CatalogFiltersApiTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogFiltersApiTest.php
@@ -264,7 +264,7 @@ final class CatalogFiltersApiTest extends CatalogApiTestCase
         foreach ($codes as $code) {
             $object = new CatalogObject($type, $code);
             if (CatalogObject::STATUS_DRAFT !== $status) {
-                $object->transitionTo($status);
+                $object->forceStatus($status);
             }
             if ([] !== $attributes) {
                 $object->updateAttributeIndex($attributes);

--- a/apps/api/tests/Api/Catalog/CatalogObjectStatusTransitionApiTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogObjectStatusTransitionApiTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * WFL-P0-03 (#2412) — the legacy PATCH `status` surface now resolves the
+ * target against the `object_editorial` state machine (ADR-0029): a
+ * reachable target applies the matching transition, an unreachable one
+ * is a 409 (breaking change vs. the previous free-field behaviour,
+ * documented in the ADR). `review` joins the status whitelist and the
+ * `?status=` list filter.
+ */
+final class CatalogObjectStatusTransitionApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function patchToReachableStatusAppliesTransition(): void
+    {
+        $id = $this->seedProduct('WFL-PATCH-OK');
+
+        $client = $this->authenticatedClient();
+        $client->request('PATCH', '/api/products/'.$id, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['status' => CatalogObject::STATUS_REVIEW],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        $body = $client->request('GET', '/api/products/'.$id)->toArray();
+        self::assertSame(CatalogObject::STATUS_REVIEW, $body['status']);
+    }
+
+    #[Test]
+    public function patchDraftToPublishedUsesPublishShortcut(): void
+    {
+        $id = $this->seedProduct('WFL-PATCH-SHORTCUT');
+
+        $client = $this->authenticatedClient();
+        $client->request('PATCH', '/api/products/'.$id, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['status' => CatalogObject::STATUS_PUBLISHED],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        $body = $client->request('GET', '/api/products/'.$id)->toArray();
+        self::assertSame(CatalogObject::STATUS_PUBLISHED, $body['status']);
+    }
+
+    #[Test]
+    public function patchToUnreachableStatusConflicts(): void
+    {
+        $id = $this->seedProduct('WFL-PATCH-409', CatalogObject::STATUS_PUBLISHED);
+
+        $client = $this->authenticatedClient();
+        $client->request('PATCH', '/api/products/'.$id, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['status' => CatalogObject::STATUS_REVIEW],
+        ]);
+
+        self::assertResponseStatusCodeSame(409);
+
+        $body = $client->request('GET', '/api/products/'.$id)->toArray();
+        self::assertSame(CatalogObject::STATUS_PUBLISHED, $body['status']);
+    }
+
+    #[Test]
+    public function patchArchivedStaysReadOnlyUntilRestore(): void
+    {
+        $id = $this->seedProduct('WFL-PATCH-ARCHIVED', CatalogObject::STATUS_ARCHIVED);
+
+        $client = $this->authenticatedClient();
+        $client->request('PATCH', '/api/products/'.$id, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['status' => CatalogObject::STATUS_PUBLISHED],
+        ]);
+        self::assertResponseStatusCodeSame(409);
+
+        $client->request('PATCH', '/api/products/'.$id, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['status' => CatalogObject::STATUS_DRAFT],
+        ]);
+        self::assertResponseIsSuccessful();
+
+        $body = $client->request('GET', '/api/products/'.$id)->toArray();
+        self::assertSame(CatalogObject::STATUS_DRAFT, $body['status']);
+    }
+
+    #[Test]
+    public function patchSameStatusIsANoOp(): void
+    {
+        $id = $this->seedProduct('WFL-PATCH-NOOP');
+
+        $client = $this->authenticatedClient();
+        $client->request('PATCH', '/api/products/'.$id, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['status' => CatalogObject::STATUS_DRAFT],
+        ]);
+
+        self::assertResponseIsSuccessful();
+    }
+
+    #[Test]
+    public function reviewStatusFiltersOnTheList(): void
+    {
+        $inReview = $this->seedProduct('WFL-FILTER-REVIEW', CatalogObject::STATUS_REVIEW);
+        $this->seedProduct('WFL-FILTER-DRAFT');
+
+        $client = $this->authenticatedClient();
+        $body = $client->request('GET', '/api/products?status=review')->toArray();
+
+        $members = $body['hydra:member'] ?? $body['member'] ?? [];
+        self::assertIsArray($members);
+
+        $ids = [];
+        foreach ($members as $member) {
+            self::assertIsArray($member);
+            self::assertIsString($member['id']);
+            $ids[] = $member['id'];
+        }
+        self::assertSame([$inReview], $ids);
+    }
+
+    private function seedProduct(string $code, string $status = CatalogObject::STATUS_DRAFT): string
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $context = self::getContainer()->get(TenantContext::class);
+        $context->set($tenant);
+
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $type);
+
+        $object = new CatalogObject($type, $code);
+        if (CatalogObject::STATUS_DRAFT !== $status) {
+            $object->forceStatus($status);
+        }
+        self::getContainer()->get(CatalogObjectRepositoryInterface::class)->save($object);
+        $em->flush();
+        $em->clear();
+
+        return $object->getId()->toRfc4122();
+    }
+}

--- a/apps/api/tests/Api/Catalog/DeleteOrphanedAttributeApiTest.php
+++ b/apps/api/tests/Api/Catalog/DeleteOrphanedAttributeApiTest.php
@@ -41,7 +41,7 @@ final class DeleteOrphanedAttributeApiTest extends CatalogApiTestCase
         $attribute = new Attribute('orphan_color', ['en' => 'Orphan color'], AttributeType::Text);
         $em->persist($attribute);
         $object = new CatalogObject($productType, 'ORPH-001');
-        $object->transitionTo(CatalogObject::STATUS_PUBLISHED);
+        $object->forceStatus(CatalogObject::STATUS_PUBLISHED);
         $em->persist($object);
         $em->flush();
 
@@ -91,7 +91,7 @@ final class DeleteOrphanedAttributeApiTest extends CatalogApiTestCase
         $attribute = new Attribute('attached_color', ['en' => 'Attached color'], AttributeType::Text);
         $em->persist($attribute);
         $object = new CatalogObject($productType, 'ATT-001');
-        $object->transitionTo(CatalogObject::STATUS_PUBLISHED);
+        $object->forceStatus(CatalogObject::STATUS_PUBLISHED);
         $em->persist($object);
         $em->flush();
 

--- a/apps/api/tests/Api/Import/GoldenRoundTripApiTest.php
+++ b/apps/api/tests/Api/Import/GoldenRoundTripApiTest.php
@@ -154,7 +154,7 @@ final class GoldenRoundTripApiTest extends CatalogApiTestCase
 
         $product = new CatalogObject($objectType, 'GR-001');
         // IMP2-1.7: non-default status/enabled exercise the column round-trip.
-        $product->transitionTo('published');
+        $product->forceStatus('published');
         $product->changeEnabled(false);
         $em->persist($product);
         foreach (self::MATRIX as $code => [, $envelope]) {

--- a/apps/api/tests/Integration/Workflow/ObjectEditorialWorkflowDefinitionTest.php
+++ b/apps/api/tests/Integration/Workflow/ObjectEditorialWorkflowDefinitionTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Workflow;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Workflow\Contracts\ObjectEditorialWorkflow;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Workflow\Registry;
+
+/**
+ * WFL-P0-03 (#2412) — pins the `object_editorial` state-machine topology
+ * from ADR-0029. Every allowed AND forbidden (from → transition) pair is
+ * asserted so a config edit that widens or narrows the graph fails here,
+ * not in production. Guards (RBAC permission map) land in WFL-P1-01 and
+ * get their own matrix; this test runs guard-free topology only.
+ */
+final class ObjectEditorialWorkflowDefinitionTest extends KernelTestCase
+{
+    /**
+     * @return array<string, array{string, list<string>}>
+     */
+    public static function transitionMatrix(): array
+    {
+        return [
+            'draft' => [CatalogObject::STATUS_DRAFT, [
+                ObjectEditorialWorkflow::TRANSITION_SUBMIT_FOR_REVIEW,
+                ObjectEditorialWorkflow::TRANSITION_PUBLISH,
+                ObjectEditorialWorkflow::TRANSITION_ARCHIVE,
+            ]],
+            'review' => [CatalogObject::STATUS_REVIEW, [
+                ObjectEditorialWorkflow::TRANSITION_APPROVE,
+                ObjectEditorialWorkflow::TRANSITION_REJECT,
+            ]],
+            'published' => [CatalogObject::STATUS_PUBLISHED, [
+                ObjectEditorialWorkflow::TRANSITION_UNPUBLISH,
+                ObjectEditorialWorkflow::TRANSITION_ARCHIVE,
+            ]],
+            'archived' => [CatalogObject::STATUS_ARCHIVED, [
+                ObjectEditorialWorkflow::TRANSITION_RESTORE,
+            ]],
+        ];
+    }
+
+    /**
+     * @param list<string> $allowed
+     */
+    #[Test]
+    #[DataProvider('transitionMatrix')]
+    public function eachPlaceEnablesExactlyItsTransitions(string $status, array $allowed): void
+    {
+        $workflow = $this->workflow();
+        $object = $this->objectInStatus($status);
+
+        foreach (ObjectEditorialWorkflow::TRANSITIONS as $transition) {
+            self::assertSame(
+                \in_array($transition, $allowed, true),
+                $workflow->can($object, $transition),
+                \sprintf('Transition "%s" from "%s" diverges from the ADR-0029 topology.', $transition, $status),
+            );
+        }
+    }
+
+    #[Test]
+    public function applyMovesMarkingThroughTheEditorialLoop(): void
+    {
+        $workflow = $this->workflow();
+        $object = $this->objectInStatus(CatalogObject::STATUS_DRAFT);
+
+        $workflow->apply($object, ObjectEditorialWorkflow::TRANSITION_SUBMIT_FOR_REVIEW);
+        self::assertSame(CatalogObject::STATUS_REVIEW, $object->getStatus());
+
+        $workflow->apply($object, ObjectEditorialWorkflow::TRANSITION_APPROVE);
+        self::assertSame(CatalogObject::STATUS_PUBLISHED, $object->getStatus());
+
+        $workflow->apply($object, ObjectEditorialWorkflow::TRANSITION_UNPUBLISH);
+        self::assertSame(CatalogObject::STATUS_DRAFT, $object->getStatus());
+    }
+
+    #[Test]
+    public function definitionExposesExactlyTheContractPlacesAndTransitions(): void
+    {
+        $definition = $this->workflow()->getDefinition();
+
+        self::assertEqualsCanonicalizing(ObjectEditorialWorkflow::PLACES, $definition->getPlaces());
+
+        $names = \array_map(
+            static fn ($transition): string => $transition->getName(),
+            $definition->getTransitions(),
+        );
+        self::assertEqualsCanonicalizing(ObjectEditorialWorkflow::TRANSITIONS, \array_values(\array_unique($names)));
+    }
+
+    private function workflow(): \Symfony\Component\Workflow\WorkflowInterface
+    {
+        $registry = self::getContainer()->get(Registry::class);
+
+        return $registry->get($this->objectInStatus(CatalogObject::STATUS_DRAFT), ObjectEditorialWorkflow::NAME);
+    }
+
+    private function objectInStatus(string $status): CatalogObject
+    {
+        $type = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
+        $object = new CatalogObject($type, 'WFL-TOPOLOGY-1');
+        $object->forceStatus($status);
+
+        return $object;
+    }
+}

--- a/apps/api/tests/Unit/Catalog/CatalogObjectEventsTest.php
+++ b/apps/api/tests/Unit/Catalog/CatalogObjectEventsTest.php
@@ -41,7 +41,7 @@ final class CatalogObjectEventsTest extends TestCase
         $object = $this->newObjectWithTenant();
         $object->pullEvents();
 
-        $object->transitionTo(CatalogObject::STATUS_PUBLISHED);
+        $object->forceStatus(CatalogObject::STATUS_PUBLISHED);
 
         $events = $object->pullEvents();
         self::assertCount(1, $events);
@@ -54,7 +54,7 @@ final class CatalogObjectEventsTest extends TestCase
         $object = $this->newObjectWithTenant();
         $object->pullEvents();
 
-        $object->transitionTo(CatalogObject::STATUS_ARCHIVED);
+        $object->forceStatus(CatalogObject::STATUS_ARCHIVED);
 
         $events = $object->pullEvents();
         self::assertCount(1, $events);
@@ -67,7 +67,7 @@ final class CatalogObjectEventsTest extends TestCase
         $object = $this->newObjectWithTenant();
         $object->pullEvents();
 
-        $object->transitionTo(CatalogObject::STATUS_DRAFT);
+        $object->forceStatus(CatalogObject::STATUS_DRAFT);
 
         self::assertSame([], $object->pullEvents());
     }

--- a/apps/api/tests/Unit/Catalog/CatalogObjectTest.php
+++ b/apps/api/tests/Unit/Catalog/CatalogObjectTest.php
@@ -111,10 +111,10 @@ final class CatalogObjectTest extends TestCase
         $type = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
         $object = new CatalogObject($type, 'SKU-004');
 
-        $object->transitionTo(CatalogObject::STATUS_PUBLISHED);
+        $object->forceStatus(CatalogObject::STATUS_PUBLISHED);
         self::assertSame('published', $object->getStatus());
 
-        $object->transitionTo(CatalogObject::STATUS_ARCHIVED);
+        $object->forceStatus(CatalogObject::STATUS_ARCHIVED);
         self::assertSame('archived', $object->getStatus());
     }
 

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -23411,6 +23411,7 @@
                     "status": {
                         "enum": [
                             "draft",
+                            "review",
                             "published",
                             "archived"
                         ],


### PR DESCRIPTION
**Pakiet PR A** = WFL-P0-02 (#2410) + WFL-P0-03 (#2412) — jeden branch/PR/CI zgodnie z §Pakiety PR backlogu ([`Project Plan/feature-workflow-tickets.md`](https://github.com/malipie/PIM/blob/main/Project%20Plan/feature-workflow-tickets.md)). Realizuje ADR-0029 (zaakceptowany w #2409 / PR #2471).

## WFL-P0-02 — chore(deptrac): warstwy BC Workflow

- `deptrac.yaml`: warstwy `Workflow_Internals` (`src/Workflow/{Domain,Application,Infrastructure,Presentation}`) + `Workflow_Contracts` (`src/Workflow/Contracts`); ruleset `Workflow_Internals → [Workflow_Contracts, Catalog_Contracts, Identity_Contracts, Shared, Vendor]`, `Workflow_Contracts → [Shared, Vendor]`.
- `Catalog_Internals` i `Identity_Internals` mogą sięgać `Workflow_Contracts` (ADR-0029: PATCH-status w Catalog, votery Identity od WFL-P1-01) — z komentarzami uzasadniającymi.
- Szkielet BC: `src/Workflow/Contracts/ObjectEditorialWorkflow.php` — słownik nazw (NAME, PLACE_*, TRANSITION_*) bez importu encji Catalog (Contracts → Shared+Vendor only).

**AC:**
- [x] Warstwy + ruleset zgodne z ADR-0029; `deptrac analyse --no-cache` → **0 errors** (lekcja #2440/#2445)
- [x] Autoload/DI działa (kontener buduje się w cache:clear/warmup test+dev)

## WFL-P0-03 — feat(workflow): silnik symfony/workflow + stan review

- `composer require symfony/workflow:7.4.*` (lockfile ścisły).
- `config/packages/workflow.yaml`: state machine **`object_editorial`** — marking store `method` na istniejącej kolumnie `objects.status`; places `draft/review/published/archived`; transitions `submit_for_review / publish (skrót draft→published) / approve / reject / unpublish / archive (draft|published) / restore` — topologia z ADR-0029.
- `CatalogObject`: nowy stan `STATUS_REVIEW`; `transitionTo()` (dowolne przejście) **zastąpione** przez: `setStatus()` (writer marking-store — woła go wyłącznie Symfony Workflow) + `forceStatus()` (`@internal`, świadomy bypass dla ścieżek nie-edytorskich: import / seed / benchmark — ADR-0029 filar 8). Wszystkie 11 miejsc wywołań zaktualizowane wg tej semantyki.
- `UpdateCatalogObjectHandler`: PATCH `status` rozwiązywany przez `getEnabledTransitions()` → `apply()`; target nieosiągalny → **409** (problem+json). Breaking change wg ADR-0029 (poprzednio wolne pole).
- Whitelisty: `CatalogObjectPatchInput` (`Assert\Choice` + naprawiony kłamiący doc-comment) i `StatusFilter` (`?status=review` filtruje) rozszerzone o `review`.
- Testy: **kernel** `ObjectEditorialWorkflowDefinitionTest` — pełna macierz dozwolone/zabronione per stan + apply-loop + zgodność definicji ze słownikiem Contracts; **ApiTestCase** `CatalogObjectStatusTransitionApiTest` — 6 testów (reachable→200, publish-skrót, unreachable→409 published→review, archived read-only do restore, no-op, filtr `?status=review`).

**AC:**
- [x] `object_editorial` zarejestrowany; macierz przejść pokryta testami (dozwolone I zabronione pary)
- [x] PATCH status niezgodny z przejściem → 409 problem+json; zgodny → przejście przez maszynę
- [x] `?status=review` filtruje na liście

## Bramki (lokalnie w kontenerze na worktree, przed pushem)

- PHP-CS-Fixer: 0 do poprawy · PHPStan max (`--memory-limit=1G`): **No errors** · Deptrac `--no-cache`: **0 errors** (11245 allowed)
- PHPUnit: unit Catalog + Integration/Workflow **490 testów OK** · nowy Api test **6/6 OK** · regresja `CatalogObjectPolyKindPatchDeleteTest` **6/6 OK** (PATCH-e draft→published/archived pozostają dozwolone)

Guardy RBAC per przejście = WFL-P1-01 (#2415); endpointy przejść + log = pakiet B (#2413/#2414). Live smoke pełnej pętli na `pim.localhost` po merge (wpisy proof w #2410/#2412 przed zamknięciem — CLOSED MEANS CLOSED).

Refs #2410, Refs #2412
