### PR TITLE
feat(workflow): add transition log and procedural endpoints (pakiet B)

### DIFF
--- a/apps/api/config/packages/doctrine.yaml
+++ b/apps/api/config/packages/doctrine.yaml
@@ -126,6 +126,12 @@ doctrine:
                 dir: '%kernel.project_dir%/src/Identity/Infrastructure/Doctrine/Orm/Mapping'
                 prefix: 'App\Identity\Domain\Entity'
                 alias: Identity
+            Workflow:
+                type: xml
+                is_bundle: false
+                dir: '%kernel.project_dir%/src/Workflow/Infrastructure/Doctrine/Orm/Mapping'
+                prefix: 'App\Workflow\Domain\Entity'
+                alias: Workflow
             ApiConfigurator:
                 type: xml
                 is_bundle: false

--- a/apps/api/migrations/Version20260711090000.php
+++ b/apps/api/migrations/Version20260711090000.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * WFL-P0-04 (#2413) — `workflow_transitions`: append-only log of the
+ * `object_editorial` state machine (ADR-0029 pillar 5). Who moved which
+ * object between which places, with an optional reviewer comment and a
+ * JSONB context (auto_unpublish / bulk / agent_run_id flags land in
+ * later WFL tickets). Deliberately a log, not versioning — product
+ * versioning is a separate Faza 1 item.
+ *
+ * `object_id` is a bare UUID without an FK (ADR-0015 cross-BC policy:
+ * the Workflow BC must not hard-couple to the Catalog schema); rows
+ * outlive object deletion as audit history.
+ *
+ * Tenant-scoped with Postgres RLS + Super Admin bypass — same pattern
+ * as pending_changes (Version20260702090000).
+ */
+final class Version20260711090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'WFL-P0-04: workflow_transitions log table + tenant RLS policies';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE workflow_transitions (
+                id UUID NOT NULL,
+                tenant_id UUID NOT NULL,
+                object_id UUID NOT NULL,
+                workflow_name VARCHAR(64) NOT NULL,
+                transition VARCHAR(64) NOT NULL,
+                from_place VARCHAR(32) NOT NULL,
+                to_place VARCHAR(32) NOT NULL,
+                actor_user_id UUID DEFAULT NULL,
+                comment TEXT DEFAULT NULL,
+                context JSONB DEFAULT NULL,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY(id)
+            )
+            SQL);
+        $this->addSql('CREATE INDEX workflow_transitions_tenant_object_idx ON workflow_transitions (tenant_id, object_id, created_at)');
+        $this->addSql('CREATE INDEX workflow_transitions_tenant_created_idx ON workflow_transitions (tenant_id, created_at)');
+        $this->addSql(
+            'ALTER TABLE workflow_transitions ADD CONSTRAINT fk_workflow_transitions_tenant '
+            .'FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE RESTRICT NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+
+        $predicate = "tenant_id = NULLIF(current_setting('app.current_tenant', true), '')::uuid";
+        $this->addSql('ALTER TABLE workflow_transitions ENABLE ROW LEVEL SECURITY');
+        $this->addSql('ALTER TABLE workflow_transitions FORCE ROW LEVEL SECURITY');
+        $this->addSql(\sprintf(
+            'CREATE POLICY tenant_isolation_workflow_transitions ON workflow_transitions USING (%s) WITH CHECK (%s)',
+            $predicate,
+            $predicate,
+        ));
+        $this->addSql(
+            'CREATE POLICY super_admin_bypass_workflow_transitions ON workflow_transitions '
+            ."USING (current_setting('app.is_super_admin', true) = 'true') "
+            ."WITH CHECK (current_setting('app.is_super_admin', true) = 'true')"
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP POLICY IF EXISTS super_admin_bypass_workflow_transitions ON workflow_transitions');
+        $this->addSql('DROP POLICY IF EXISTS tenant_isolation_workflow_transitions ON workflow_transitions');
+        $this->addSql('ALTER TABLE workflow_transitions NO FORCE ROW LEVEL SECURITY');
+        $this->addSql('ALTER TABLE workflow_transitions DISABLE ROW LEVEL SECURITY');
+        $this->addSql('DROP TABLE workflow_transitions');
+    }
+}

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -129,6 +129,9 @@ parameters:
               # entities and the AICG configuration entities (ContentRecipe,
               # BrandVoiceProfile — AICG-P1-01/02).
               - src/Agent/Domain/Entity/*.php
+              # WFL-P0-04 — Workflow BC entities share the same prePersist
+              # tenant-stamping window (WorkflowTransition + M4/M5 entities).
+              - src/Workflow/Domain/Entity/*.php
               - src/Catalog/Domain/Entity/PendingChange.php
               - src/Channel/Domain/Entity/Channel.php
               - src/Channel/Domain/Entity/ChannelCategoryNode.php

--- a/apps/api/src/Catalog/Contracts/Workflow/EditorialWorkflowSubject.php
+++ b/apps/api/src/Catalog/Contracts/Workflow/EditorialWorkflowSubject.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Workflow;
+
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P0-04 (#2413) — the minimal identity a workflow listener needs
+ * from the subject of the `object_editorial` state machine. The subject
+ * is a Catalog entity (marking lives on `objects.status`, ADR-0029
+ * pillar 3), but the Workflow BC may only depend on `Catalog_Contracts`
+ * (deptrac) — this seam carries id + tenant across without leaking the
+ * entity. Same shape as the AUD-053 `CurrentUserProvider` seam.
+ */
+interface EditorialWorkflowSubject
+{
+    public function getId(): Uuid;
+
+    public function getTenant(): ?Tenant;
+}

--- a/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
+++ b/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
@@ -10,6 +10,7 @@ use App\Catalog\Contracts\Event\ObjectCategoriesChanged;
 use App\Catalog\Contracts\Event\ObjectCreated;
 use App\Catalog\Contracts\Event\ObjectEnabledChanged;
 use App\Catalog\Contracts\Event\ObjectPublished;
+use App\Catalog\Contracts\Workflow\EditorialWorkflowSubject;
 use App\Catalog\Domain\ObjectKind;
 use App\Shared\Application\Blameable;
 use App\Shared\Application\TenantScoped;
@@ -53,7 +54,7 @@ use const ARRAY_FILTER_USE_BOTH;
  *   - `kind='product'` for variants (size/color of a parent SKU);
  *   - `kind='category'` for the tree (parent category in ltree).
  */
-class CatalogObject extends AggregateRoot implements TenantScoped, Blameable
+class CatalogObject extends AggregateRoot implements TenantScoped, Blameable, EditorialWorkflowSubject
 {
     public const string STATUS_DRAFT = 'draft';
     public const string STATUS_REVIEW = 'review';

--- a/apps/api/src/Catalog/Presentation/Controller/ObjectWorkflowController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ObjectWorkflowController.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Presentation\Controller;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Workflow\Contracts\ObjectEditorialWorkflow;
+use App\Workflow\Contracts\TransitionLogEntry;
+use App\Workflow\Contracts\TransitionLogPort;
+use DateTimeInterface;
+use JsonException;
+use Symfony\Component\DependencyInjection\Attribute\Target;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Workflow\WorkflowInterface;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * WFL-P0-05 (#2414) — procedural workflow surface for catalog objects
+ * (CQRS custom routes, ADR-0012/ADR-0029). Lives in Catalog because the
+ * subject is the Catalog entity (marking on `objects.status`); the
+ * transition log is read through the Workflow seam.
+ *
+ * Discovery (`GET …/workflow`) returns every transition applicable from
+ * the current place with an `enabled` flag + blocker list, so the admin
+ * FE renders guard-aware buttons without duplicating workflow logic
+ * (WFL-P3-01). Blockers are topology-only until the RBAC guard map
+ * lands in WFL-P1-01.
+ */
+final class ObjectWorkflowController
+{
+    private const string UUID_REQUIREMENT = '[0-9a-fA-F-]{36}';
+    private const int COMMENT_MAX_LENGTH = 2000;
+    private const int LOG_DEFAULT_LIMIT = 20;
+    private const int LOG_MAX_LIMIT = 100;
+
+    public function __construct(
+        private readonly CatalogObjectRepositoryInterface $objects,
+        private readonly TransitionLogPort $transitionLog,
+        #[Target(ObjectEditorialWorkflow::NAME)]
+        private readonly WorkflowInterface $objectEditorial,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/objects/{id}/workflow',
+        name: 'object_workflow_state',
+        requirements: ['id' => self::UUID_REQUIREMENT],
+        methods: ['GET'],
+    )]
+    #[RequiresPermission(module: 'workflow', action: 'view')]
+    public function state(string $id): JsonResponse
+    {
+        $object = $this->loadObject($id);
+
+        return new JsonResponse([
+            'object_id' => $object->getId()->toRfc4122(),
+            'workflow' => ObjectEditorialWorkflow::NAME,
+            'current_place' => $object->getStatus(),
+            'transitions' => $this->describeTransitions($object),
+        ]);
+    }
+
+    #[Route(
+        path: '/api/objects/{id}/workflow/transitions/{transition}',
+        name: 'object_workflow_apply',
+        requirements: ['id' => self::UUID_REQUIREMENT, 'transition' => '[a-z_]+'],
+        methods: ['POST'],
+    )]
+    // Entry-level gate only — the per-transition RBAC permission map
+    // (approve -> workflow.approve_reject etc.) attaches to the workflow
+    // guards in WFL-P1-01 (#2415) and is enforced inside can()/apply().
+    #[RequiresPermission(module: 'products', action: 'edit')]
+    public function apply(string $id, string $transition, Request $request): JsonResponse
+    {
+        if (!\in_array($transition, ObjectEditorialWorkflow::TRANSITIONS, true)) {
+            throw new NotFoundHttpException(\sprintf('Unknown workflow transition "%s".', $transition));
+        }
+
+        $object = $this->loadObject($id);
+        $comment = $this->extractComment($request);
+
+        if (!$this->objectEditorial->can($object, $transition)) {
+            $blockers = $this->blockerMessages($object, $transition);
+
+            throw new ConflictHttpException(\sprintf(
+                'Transition "%s" is not allowed from "%s"%s',
+                $transition,
+                $object->getStatus(),
+                [] === $blockers ? '.' : ': '.\implode(' ', $blockers),
+            ));
+        }
+
+        $context = null === $comment ? [] : ['comment' => $comment];
+        $this->objectEditorial->apply($object, $transition, $context);
+
+        // Flushes the marking change together with the log row persisted
+        // by TransitionLoggingSubscriber (persist-only, ADR-0029).
+        $this->objects->save($object);
+
+        return new JsonResponse([
+            'object_id' => $object->getId()->toRfc4122(),
+            'applied' => $transition,
+            'current_place' => $object->getStatus(),
+        ]);
+    }
+
+    #[Route(
+        path: '/api/objects/{id}/workflow/transitions',
+        name: 'object_workflow_transition_log',
+        requirements: ['id' => self::UUID_REQUIREMENT],
+        methods: ['GET'],
+    )]
+    #[RequiresPermission(module: 'workflow', action: 'view')]
+    public function transitionLog(string $id, Request $request): JsonResponse
+    {
+        $object = $this->loadObject($id);
+
+        $limit = \min(self::LOG_MAX_LIMIT, \max(1, $request->query->getInt('limit', self::LOG_DEFAULT_LIMIT)));
+        $before = null;
+        $beforeRaw = $request->query->getString('before');
+        if ('' !== $beforeRaw) {
+            if (!Uuid::isValid($beforeRaw)) {
+                throw new UnprocessableEntityHttpException('The "before" cursor must be a transition id (UUID).');
+            }
+            $before = Uuid::fromString($beforeRaw);
+        }
+
+        // Fetch one extra row to decide whether another page exists.
+        $entries = $this->transitionLog->pageForObject($object->getId(), $limit + 1, $before);
+        $hasMore = \count($entries) > $limit;
+        $entries = \array_slice($entries, 0, $limit);
+
+        return new JsonResponse([
+            'object_id' => $object->getId()->toRfc4122(),
+            'items' => \array_map(self::serializeEntry(...), $entries),
+            'next_cursor' => $hasMore && [] !== $entries
+                ? $entries[\count($entries) - 1]->id->toRfc4122()
+                : null,
+        ]);
+    }
+
+    private function loadObject(string $id): CatalogObject
+    {
+        // TenantFilter scopes the lookup — a cross-tenant id resolves to
+        // null and surfaces as 404, never a 403 information leak.
+        $object = $this->objects->findById(Uuid::fromString($id));
+        if (null === $object) {
+            throw new NotFoundHttpException(\sprintf('CatalogObject "%s" was not found.', $id));
+        }
+
+        return $object;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function describeTransitions(CatalogObject $object): array
+    {
+        $described = [];
+        foreach ($this->objectEditorial->getDefinition()->getTransitions() as $transition) {
+            if (!\in_array($object->getStatus(), $transition->getFroms(), true)) {
+                continue;
+            }
+
+            $blockers = [];
+            foreach ($this->objectEditorial->buildTransitionBlockerList($object, $transition->getName()) as $blocker) {
+                $blockers[] = ['code' => $blocker->getCode(), 'message' => $blocker->getMessage()];
+            }
+
+            $described[] = [
+                'name' => $transition->getName(),
+                'to' => \implode(',', \array_filter($transition->getTos(), \is_string(...))),
+                'enabled' => [] === $blockers,
+                'blockers' => $blockers,
+            ];
+        }
+
+        return $described;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function blockerMessages(CatalogObject $object, string $transition): array
+    {
+        $messages = [];
+        foreach ($this->objectEditorial->buildTransitionBlockerList($object, $transition) as $blocker) {
+            $messages[] = $blocker->getMessage();
+        }
+
+        return $messages;
+    }
+
+    private function extractComment(Request $request): ?string
+    {
+        $content = $request->getContent();
+        if ('' === $content) {
+            return null;
+        }
+
+        try {
+            $payload = \json_decode($content, true, 8, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            throw new UnprocessableEntityHttpException('Request body must be valid JSON.');
+        }
+
+        if (!\is_array($payload)) {
+            throw new UnprocessableEntityHttpException('Request body must be a JSON object.');
+        }
+
+        $comment = $payload['comment'] ?? null;
+        if (null === $comment) {
+            return null;
+        }
+        if (!\is_string($comment)) {
+            throw new UnprocessableEntityHttpException('The "comment" field must be a string.');
+        }
+
+        $comment = \trim($comment);
+        if ('' === $comment) {
+            return null;
+        }
+        if (\mb_strlen($comment) > self::COMMENT_MAX_LENGTH) {
+            throw new UnprocessableEntityHttpException(\sprintf(
+                'The "comment" field must not exceed %d characters.',
+                self::COMMENT_MAX_LENGTH,
+            ));
+        }
+
+        return $comment;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function serializeEntry(TransitionLogEntry $entry): array
+    {
+        return [
+            'id' => $entry->id->toRfc4122(),
+            'transition' => $entry->transition,
+            'from' => $entry->fromPlace,
+            'to' => $entry->toPlace,
+            'actor_user_id' => $entry->actorUserId?->toRfc4122(),
+            'comment' => $entry->comment,
+            'context' => $entry->context,
+            'created_at' => $entry->createdAt->format(DateTimeInterface::ATOM),
+        ];
+    }
+}

--- a/apps/api/src/Workflow/Contracts/TransitionLogEntry.php
+++ b/apps/api/src/Workflow/Contracts/TransitionLogEntry.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Workflow\Contracts;
+
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P0-04 (#2413) — read view of one logged workflow transition,
+ * exposed through {@see TransitionLogPort} so other bounded contexts
+ * (Catalog presentation, future task automation) never import the
+ * Workflow entity (`Workflow_Contracts` → Shared + Vendor only).
+ */
+final readonly class TransitionLogEntry
+{
+    /**
+     * @param array<string, mixed>|null $context
+     */
+    public function __construct(
+        public Uuid $id,
+        public Uuid $objectId,
+        public string $workflowName,
+        public string $transition,
+        public string $fromPlace,
+        public string $toPlace,
+        public ?Uuid $actorUserId,
+        public ?string $comment,
+        public ?array $context,
+        public DateTimeImmutable $createdAt,
+    ) {
+    }
+}

--- a/apps/api/src/Workflow/Contracts/TransitionLogPort.php
+++ b/apps/api/src/Workflow/Contracts/TransitionLogPort.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Workflow\Contracts;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P0-04 (#2413) — cross-BC read seam over the `workflow_transitions`
+ * log. Writing happens exclusively inside the Workflow BC (the
+ * `workflow.*.completed` subscriber); consumers in other contexts read
+ * history through this port — the timeline endpoint (WFL-P0-05), the
+ * review queue metadata ("who submitted", WFL-P3-02) and task
+ * automation (WFL-P4-02).
+ */
+interface TransitionLogPort
+{
+    /**
+     * Newest-first page of transitions for one object. UUIDv7 ids are
+     * time-ordered, so `$before` (an entry id from a previous page) is
+     * the whole cursor. Returns up to `$limit` entries.
+     *
+     * @return list<TransitionLogEntry>
+     */
+    public function pageForObject(Uuid $objectId, int $limit, ?Uuid $before = null): array;
+
+    /**
+     * Latest occurrence of the given transition for an object — e.g.
+     * "who sent this to review" for queue metadata and task routing.
+     */
+    public function latestForObject(Uuid $objectId, string $transition): ?TransitionLogEntry;
+}

--- a/apps/api/src/Workflow/Domain/Entity/WorkflowTransition.php
+++ b/apps/api/src/Workflow/Domain/Entity/WorkflowTransition.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Workflow\Domain\Entity;
+
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P0-04 (#2413) — one applied transition of an editorial workflow
+ * (ADR-0029 pillar 5, Pimcore "notes & events" pattern). Append-only:
+ * rows are written by {@see \App\Workflow\Infrastructure\EventSubscriber\TransitionLoggingSubscriber}
+ * on `workflow.*.completed` and never mutated.
+ *
+ * `objectId` is a bare UUID (ADR-0015) — the log survives object
+ * deletion as audit history. `actorUserId` is NULL for system-applied
+ * transitions (bulk workers, agent hook). UUIDv7 ids double as the
+ * cursor for pagination: they are time-ordered, so `id < :before`
+ * pages backwards without a composite (created_at, id) cursor.
+ */
+class WorkflowTransition implements TenantScoped
+{
+    private Uuid $id;
+    private ?Tenant $tenant = null;
+    private Uuid $objectId;
+    private string $workflowName;
+    private string $transition;
+    private string $fromPlace;
+    private string $toPlace;
+    private ?Uuid $actorUserId;
+    private ?string $comment;
+
+    /** @var array<string, mixed>|null */
+    private ?array $context;
+
+    private DateTimeImmutable $createdAt;
+
+    /**
+     * @param array<string, mixed>|null $context
+     */
+    public function __construct(
+        Uuid $objectId,
+        string $workflowName,
+        string $transition,
+        string $fromPlace,
+        string $toPlace,
+        ?Uuid $actorUserId = null,
+        ?string $comment = null,
+        ?array $context = null,
+    ) {
+        $this->id = Uuid::v7();
+        $this->objectId = $objectId;
+        $this->workflowName = $workflowName;
+        $this->transition = $transition;
+        $this->fromPlace = $fromPlace;
+        $this->toPlace = $toPlace;
+        $this->actorUserId = $actorUserId;
+        $this->comment = $comment;
+        $this->context = $context;
+        $this->createdAt = new DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant && $this->tenant !== $tenant) {
+            throw new LogicException('WorkflowTransition rows cannot move between tenants.');
+        }
+
+        $this->tenant = $tenant;
+    }
+
+    public function getObjectId(): Uuid
+    {
+        return $this->objectId;
+    }
+
+    public function getWorkflowName(): string
+    {
+        return $this->workflowName;
+    }
+
+    public function getTransition(): string
+    {
+        return $this->transition;
+    }
+
+    public function getFromPlace(): string
+    {
+        return $this->fromPlace;
+    }
+
+    public function getToPlace(): string
+    {
+        return $this->toPlace;
+    }
+
+    public function getActorUserId(): ?Uuid
+    {
+        return $this->actorUserId;
+    }
+
+    public function getComment(): ?string
+    {
+        return $this->comment;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getContext(): ?array
+    {
+        return $this->context;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/apps/api/src/Workflow/Domain/Repository/WorkflowTransitionRepositoryInterface.php
+++ b/apps/api/src/Workflow/Domain/Repository/WorkflowTransitionRepositoryInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Workflow\Domain\Repository;
+
+use App\Workflow\Domain\Entity\WorkflowTransition;
+
+/**
+ * WFL-P0-04 (#2413) — write side of the transition log, used only
+ * inside the Workflow BC (the completed-event subscriber). Reads for
+ * other contexts go through {@see \App\Workflow\Contracts\TransitionLogPort}.
+ */
+interface WorkflowTransitionRepositoryInterface
+{
+    /**
+     * Persist-only (no flush): the log row rides the flush of the write
+     * path that applied the transition (PATCH handler save, transition
+     * endpoint save, bulk batch flush), so object + log land together.
+     */
+    public function add(WorkflowTransition $transition): void;
+}

--- a/apps/api/src/Workflow/Infrastructure/Doctrine/DoctrineWorkflowTransitionRepository.php
+++ b/apps/api/src/Workflow/Infrastructure/Doctrine/DoctrineWorkflowTransitionRepository.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Workflow\Infrastructure\Doctrine;
+
+use App\Workflow\Contracts\TransitionLogEntry;
+use App\Workflow\Contracts\TransitionLogPort;
+use App\Workflow\Domain\Entity\WorkflowTransition;
+use App\Workflow\Domain\Repository\WorkflowTransitionRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P0-04 (#2413) — Doctrine adapter for the transition log. Tenant
+ * isolation is layered: the Doctrine TenantFilter scopes every query
+ * below, and Postgres RLS on `workflow_transitions` backstops raw
+ * access (Version20260711090000).
+ */
+final readonly class DoctrineWorkflowTransitionRepository implements TransitionLogPort, WorkflowTransitionRepositoryInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function add(WorkflowTransition $transition): void
+    {
+        $this->entityManager->persist($transition);
+    }
+
+    public function pageForObject(Uuid $objectId, int $limit, ?Uuid $before = null): array
+    {
+        $builder = $this->entityManager->createQueryBuilder()
+            ->select('t')
+            ->from(WorkflowTransition::class, 't')
+            ->where('t.objectId = :objectId')
+            ->setParameter('objectId', $objectId)
+            ->orderBy('t.id', 'DESC')
+            ->setMaxResults($limit);
+
+        if (null !== $before) {
+            $builder->andWhere('t.id < :before')->setParameter('before', $before);
+        }
+
+        /** @var list<WorkflowTransition> $rows */
+        $rows = $builder->getQuery()->getResult();
+
+        return \array_map($this->toEntry(...), $rows);
+    }
+
+    public function latestForObject(Uuid $objectId, string $transition): ?TransitionLogEntry
+    {
+        /** @var list<WorkflowTransition> $rows */
+        $rows = $this->entityManager->createQueryBuilder()
+            ->select('t')
+            ->from(WorkflowTransition::class, 't')
+            ->where('t.objectId = :objectId')
+            ->andWhere('t.transition = :transition')
+            ->setParameter('objectId', $objectId)
+            ->setParameter('transition', $transition)
+            ->orderBy('t.id', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getResult();
+
+        return [] === $rows ? null : $this->toEntry($rows[0]);
+    }
+
+    private function toEntry(WorkflowTransition $transition): TransitionLogEntry
+    {
+        return new TransitionLogEntry(
+            id: $transition->getId(),
+            objectId: $transition->getObjectId(),
+            workflowName: $transition->getWorkflowName(),
+            transition: $transition->getTransition(),
+            fromPlace: $transition->getFromPlace(),
+            toPlace: $transition->getToPlace(),
+            actorUserId: $transition->getActorUserId(),
+            comment: $transition->getComment(),
+            context: $transition->getContext(),
+            createdAt: $transition->getCreatedAt(),
+        );
+    }
+}

--- a/apps/api/src/Workflow/Infrastructure/Doctrine/Orm/Mapping/WorkflowTransition.orm.xml
+++ b/apps/api/src/Workflow/Infrastructure/Doctrine/Orm/Mapping/WorkflowTransition.orm.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Workflow\Domain\Entity\WorkflowTransition" table="workflow_transitions">
+        <indexes>
+            <index name="workflow_transitions_tenant_object_idx" columns="tenant_id,object_id,created_at"/>
+            <index name="workflow_transitions_tenant_created_idx" columns="tenant_id,created_at"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <field name="objectId" type="uuid" column="object_id"/>
+        <field name="workflowName" type="string" length="64" column="workflow_name"/>
+        <field name="transition" type="string" length="64"/>
+        <field name="fromPlace" type="string" length="32" column="from_place"/>
+        <field name="toPlace" type="string" length="32" column="to_place"/>
+        <field name="actorUserId" type="uuid" column="actor_user_id" nullable="true"/>
+        <field name="comment" type="text" nullable="true"/>
+
+        <field name="context" type="json" column="context" nullable="true">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+    </entity>
+</doctrine-mapping>

--- a/apps/api/src/Workflow/Infrastructure/EventSubscriber/TransitionLoggingSubscriber.php
+++ b/apps/api/src/Workflow/Infrastructure/EventSubscriber/TransitionLoggingSubscriber.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Workflow\Infrastructure\EventSubscriber;
+
+use App\Catalog\Contracts\Workflow\EditorialWorkflowSubject;
+use App\Identity\Contracts\Auth\CurrentUserProvider;
+use App\Workflow\Contracts\ObjectEditorialWorkflow;
+use App\Workflow\Domain\Entity\WorkflowTransition;
+use App\Workflow\Domain\Repository\WorkflowTransitionRepositoryInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Workflow\Event\TransitionEvent;
+
+/**
+ * WFL-P0-04 (#2413) — appends a `workflow_transitions` row for every
+ * applied `object_editorial` transition (ADR-0029 pillar 5). Listens on
+ * the `transition` event (after guards passed, before the marking store
+ * writes) because the subject still carries the ACTUAL source place —
+ * `archive` declares two froms (draft|published) and the completed
+ * event can no longer tell which one the object left. Nothing can veto
+ * a transition past the guard stage, so the row never records a
+ * transition that did not happen. The row is persist-only and rides
+ * the caller's flush (PATCH handler save / transition endpoint save /
+ * bulk batch flush).
+ *
+ * Actor comes from the security token via the AUD-053 seam — NULL for
+ * system-applied transitions (CLI, workers). `comment` and any extra
+ * keys arrive through `Workflow::apply($subject, $name, $context)`.
+ */
+final readonly class TransitionLoggingSubscriber implements EventSubscriberInterface
+{
+    private const string COMMENT_KEY = 'comment';
+
+    public function __construct(
+        private WorkflowTransitionRepositoryInterface $transitions,
+        private CurrentUserProvider $currentUser,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'workflow.'.ObjectEditorialWorkflow::NAME.'.transition' => 'onTransition',
+        ];
+    }
+
+    public function onTransition(TransitionEvent $event): void
+    {
+        $subject = $event->getSubject();
+        if (!$subject instanceof EditorialWorkflowSubject) {
+            return;
+        }
+
+        // Unit-constructed subjects (topology tests) have no tenant; a
+        // tenantless row could never satisfy RLS, so skip logging.
+        if (null === $subject->getTenant()) {
+            return;
+        }
+
+        $transition = $event->getTransition();
+        if (null === $transition) {
+            return;
+        }
+
+        $fromPlaces = \array_keys($event->getMarking()->getPlaces());
+        $fromPlace = \is_string($fromPlaces[0] ?? null)
+            ? $fromPlaces[0]
+            : \implode(',', \array_filter($transition->getFroms(), \is_string(...)));
+
+        $context = $event->getContext();
+        $comment = $context[self::COMMENT_KEY] ?? null;
+        $comment = \is_string($comment) && '' !== \trim($comment) ? \trim($comment) : null;
+        unset($context[self::COMMENT_KEY]);
+
+        // Explicit re-key instead of an inline @var — the cs-fixer
+        // degrades non-declaration doc-blocks and PHPStan then ignores
+        // them (lesson from DASH #2266).
+        $typedContext = [];
+        foreach ($context as $key => $value) {
+            $typedContext[(string) $key] = $value;
+        }
+
+        $this->transitions->add(new WorkflowTransition(
+            objectId: $subject->getId(),
+            workflowName: ObjectEditorialWorkflow::NAME,
+            transition: $transition->getName(),
+            fromPlace: $fromPlace,
+            toPlace: \implode(',', \array_filter($transition->getTos(), \is_string(...))),
+            actorUserId: $this->currentUser->userId(),
+            comment: $comment,
+            context: [] === $typedContext ? null : $typedContext,
+        ));
+    }
+}

--- a/apps/api/tests/Api/Catalog/ObjectWorkflowEndpointsApiTest.php
+++ b/apps/api/tests/Api/Catalog/ObjectWorkflowEndpointsApiTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P0-05 (#2414) — procedural workflow surface (ADR-0012/ADR-0029):
+ * guard-aware discovery, transition application with comment, 409 with
+ * blocker context on illegal transitions, and the cursor-paginated
+ * transition log fed by TransitionLoggingSubscriber (WFL-P0-04).
+ */
+final class ObjectWorkflowEndpointsApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function discoveryListsTransitionsFromCurrentPlace(): void
+    {
+        $id = $this->seedProduct('WFL-EP-DISCOVERY');
+
+        $client = $this->authenticatedClient();
+        $body = $client->request('GET', '/api/objects/'.$id.'/workflow')->toArray();
+
+        self::assertSame('draft', $body['current_place']);
+        self::assertSame('object_editorial', $body['workflow']);
+
+        $transitions = self::rows($body['transitions'] ?? null);
+        self::assertEqualsCanonicalizing(['submit_for_review', 'publish', 'archive'], \array_column($transitions, 'name'));
+        foreach ($transitions as $transition) {
+            self::assertTrue($transition['enabled'], 'M0 has no guards — every topological transition is enabled');
+            self::assertSame([], $transition['blockers']);
+        }
+    }
+
+    #[Test]
+    public function applyTransitionMovesMarkingAndLogsComment(): void
+    {
+        $id = $this->seedProduct('WFL-EP-APPLY');
+
+        $client = $this->authenticatedClient();
+        $body = $client->request('POST', '/api/objects/'.$id.'/workflow/transitions/submit_for_review', [
+            'json' => ['comment' => 'Gotowe do przeglądu'],
+        ])->toArray();
+
+        self::assertSame('submit_for_review', $body['applied']);
+        self::assertSame('review', $body['current_place']);
+
+        $log = $client->request('GET', '/api/objects/'.$id.'/workflow/transitions')->toArray();
+        $items = self::rows($log['items'] ?? null);
+        self::assertCount(1, $items);
+        self::assertSame('submit_for_review', $items[0]['transition']);
+        self::assertSame('draft', $items[0]['from']);
+        self::assertSame('review', $items[0]['to']);
+        self::assertSame('Gotowe do przeglądu', $items[0]['comment']);
+        self::assertNotNull($items[0]['actor_user_id'], 'authenticated apply must record the actor');
+        self::assertNull($log['next_cursor']);
+    }
+
+    #[Test]
+    public function illegalTransitionConflictsAndLeavesNoLogRow(): void
+    {
+        $id = $this->seedProduct('WFL-EP-409');
+
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/objects/'.$id.'/workflow/transitions/approve');
+        self::assertResponseStatusCodeSame(409);
+
+        $log = $client->request('GET', '/api/objects/'.$id.'/workflow/transitions')->toArray();
+        self::assertSame([], $log['items'], 'a blocked transition must not be logged');
+    }
+
+    #[Test]
+    public function unknownTransitionAndUnknownObjectAre404(): void
+    {
+        $id = $this->seedProduct('WFL-EP-404');
+
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/objects/'.$id.'/workflow/transitions/vanish');
+        self::assertResponseStatusCodeSame(404);
+
+        $client->request('GET', '/api/objects/'.Uuid::v7()->toRfc4122().'/workflow');
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    #[Test]
+    public function anonymousRequestsAreRejected(): void
+    {
+        $id = $this->seedProduct('WFL-EP-401');
+
+        $client = static::createClient();
+        $client->request('GET', '/api/objects/'.$id.'/workflow');
+        self::assertResponseStatusCodeSame(401);
+
+        $client->request('POST', '/api/objects/'.$id.'/workflow/transitions/publish');
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    #[Test]
+    public function transitionLogPaginatesWithUuidCursor(): void
+    {
+        $id = $this->seedProduct('WFL-EP-CURSOR');
+
+        $client = $this->authenticatedClient();
+        // Three transitions: draft -> review -> draft -> published.
+        $client->request('POST', '/api/objects/'.$id.'/workflow/transitions/submit_for_review');
+        $client->request('POST', '/api/objects/'.$id.'/workflow/transitions/reject');
+        $client->request('POST', '/api/objects/'.$id.'/workflow/transitions/publish');
+
+        $firstPage = $client->request('GET', '/api/objects/'.$id.'/workflow/transitions?limit=2')->toArray();
+        $firstItems = self::rows($firstPage['items'] ?? null);
+        self::assertCount(2, $firstItems);
+        self::assertSame('publish', $firstItems[0]['transition'], 'newest first');
+        self::assertSame('reject', $firstItems[1]['transition']);
+        $cursor = $firstPage['next_cursor'] ?? null;
+        self::assertIsString($cursor);
+
+        $secondPage = $client->request(
+            'GET',
+            '/api/objects/'.$id.'/workflow/transitions?limit=2&before='.$cursor,
+        )->toArray();
+        $secondItems = self::rows($secondPage['items'] ?? null);
+        self::assertCount(1, $secondItems);
+        self::assertSame('submit_for_review', $secondItems[0]['transition']);
+        self::assertNull($secondPage['next_cursor']);
+    }
+
+    #[Test]
+    public function overlongCommentIsRejected(): void
+    {
+        $id = $this->seedProduct('WFL-EP-COMMENT');
+
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/objects/'.$id.'/workflow/transitions/publish', [
+            'json' => ['comment' => \str_repeat('x', 2001)],
+        ]);
+        self::assertResponseStatusCodeSame(422);
+    }
+
+    /**
+     * Narrows a decoded JSON list to typed rows — toArray() yields
+     * `array<mixed>` and PHPStan max rejects offsets on mixed.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private static function rows(mixed $value): array
+    {
+        self::assertIsArray($value);
+
+        $rows = [];
+        foreach ($value as $row) {
+            self::assertIsArray($row);
+            $typed = [];
+            foreach ($row as $key => $item) {
+                $typed[(string) $key] = $item;
+            }
+            $rows[] = $typed;
+        }
+
+        return $rows;
+    }
+
+    private function seedProduct(string $code): string
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $type);
+
+        $object = new CatalogObject($type, $code);
+        self::getContainer()->get(CatalogObjectRepositoryInterface::class)->save($object);
+        $em->flush();
+        $em->clear();
+
+        return $object->getId()->toRfc4122();
+    }
+}

--- a/apps/api/tests/Integration/Workflow/TransitionLogTest.php
+++ b/apps/api/tests/Integration/Workflow/TransitionLogTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Workflow;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use App\Workflow\Contracts\ObjectEditorialWorkflow;
+use App\Workflow\Contracts\TransitionLogPort;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Workflow\Registry;
+use Symfony\Component\Workflow\WorkflowInterface;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * WFL-P0-04 (#2413) — the `workflow_transitions` log against real
+ * Postgres: every applied transition leaves a row with the ACTUAL
+ * source place (archive declares two froms), comments ride the apply
+ * context, and the DoD tenant-isolation smoke (cross-read = 0) holds
+ * on the TransitionLogPort surface.
+ */
+final class TransitionLogTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function appliedTransitionLeavesLogRowWithActualFromPlace(): void
+    {
+        $tenant = $this->createTenant('alpha');
+        $this->activateTenantFilter($tenant);
+        $object = $this->createObject($tenant, 'WFL-LOG-1');
+
+        $workflow = $this->workflow($object);
+        $workflow->apply($object, ObjectEditorialWorkflow::TRANSITION_PUBLISH, ['comment' => '  Ship it  ']);
+        $workflow->apply($object, ObjectEditorialWorkflow::TRANSITION_ARCHIVE);
+        $this->em()->flush();
+
+        $entries = self::getContainer()->get(TransitionLogPort::class)
+            ->pageForObject($object->getId(), 10);
+
+        self::assertCount(2, $entries);
+
+        // Newest first: archive left "published" — the actual place, not
+        // the two-element declaration "draft,published" from the config.
+        self::assertSame(ObjectEditorialWorkflow::TRANSITION_ARCHIVE, $entries[0]->transition);
+        self::assertSame(CatalogObject::STATUS_PUBLISHED, $entries[0]->fromPlace);
+        self::assertSame(CatalogObject::STATUS_ARCHIVED, $entries[0]->toPlace);
+        self::assertNull($entries[0]->comment);
+
+        self::assertSame(ObjectEditorialWorkflow::TRANSITION_PUBLISH, $entries[1]->transition);
+        self::assertSame(CatalogObject::STATUS_DRAFT, $entries[1]->fromPlace);
+        self::assertSame('Ship it', $entries[1]->comment, 'comment must be trimmed and stored');
+        self::assertNull($entries[1]->actorUserId, 'CLI/system apply has no actor');
+
+        $latest = self::getContainer()->get(TransitionLogPort::class)
+            ->latestForObject($object->getId(), ObjectEditorialWorkflow::TRANSITION_PUBLISH);
+        self::assertNotNull($latest);
+        self::assertSame('Ship it', $latest->comment);
+    }
+
+    #[Test]
+    public function logIsIsolatedByTenant(): void
+    {
+        $alpha = $this->createTenant('alpha');
+        $beta = $this->createTenant('beta');
+
+        $this->activateTenantFilter($alpha);
+        $object = $this->createObject($alpha, 'WFL-LOG-ISO');
+        $this->workflow($object)->apply($object, ObjectEditorialWorkflow::TRANSITION_SUBMIT_FOR_REVIEW);
+        $this->em()->flush();
+
+        $port = self::getContainer()->get(TransitionLogPort::class);
+        self::assertCount(1, $port->pageForObject($object->getId(), 10));
+
+        $this->activateTenantFilter($beta);
+        self::assertCount(0, $port->pageForObject($object->getId(), 10), 'cross-tenant read must return 0 rows');
+        self::assertNull($port->latestForObject($object->getId(), ObjectEditorialWorkflow::TRANSITION_SUBMIT_FOR_REVIEW));
+    }
+
+    private function workflow(CatalogObject $object): WorkflowInterface
+    {
+        return self::getContainer()->get(Registry::class)->get($object, ObjectEditorialWorkflow::NAME);
+    }
+
+    private function createObject(Tenant $tenant, string $code): CatalogObject
+    {
+        $em = $this->em();
+        $type = new ObjectType('product_'.$code, ObjectKind::Product, ['pl' => 'Produkt']);
+        $type->assignTenant($tenant);
+        $em->persist($type);
+
+        $object = new CatalogObject($type, $code);
+        $object->assignTenant($tenant);
+        $em->persist($object);
+        $em->flush();
+
+        return $object;
+    }
+
+    private function createTenant(string $code): Tenant
+    {
+        $tenant = new Tenant($code, \ucfirst($code).' Tenant');
+        $em = $this->em();
+        $em->persist($tenant);
+        $em->flush();
+
+        return $tenant;
+    }
+
+    private function activateTenantFilter(Tenant $tenant): void
+    {
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -18721,6 +18721,135 @@
                 "x-cortex-permission": "products.view"
             }
         },
+        "/api/objects/{id}/workflow": {
+            "get": {
+                "operationId": "api_objects_id_workflow_get",
+                "tags": [
+                    "objects"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api objects id workflow",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "workflow.view"
+            }
+        },
+        "/api/objects/{id}/workflow/transitions": {
+            "get": {
+                "operationId": "api_objects_id_workflow_transitions_get",
+                "tags": [
+                    "objects"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api objects id workflow transitions",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "workflow.view"
+            }
+        },
+        "/api/objects/{id}/workflow/transitions/{transition}": {
+            "post": {
+                "operationId": "api_objects_id_workflow_transitions_transition_post",
+                "tags": [
+                    "objects"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api objects id workflow transitions transition",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    },
+                    {
+                        "name": "transition",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "products.edit"
+            }
+        },
         "/api/objects/{master_id}/generate-variants": {
             "post": {
                 "operationId": "api_objects_master_id_generate_variants_post",


### PR DESCRIPTION
**Pakiet PR B** = WFL-P0-04 (#2413) + WFL-P0-05 (#2414) — jeden branch/PR/CI zgodnie z §Pakiety PR backlogu ([`Project Plan/feature-workflow-tickets.md`](https://github.com/malipie/PIM/blob/main/Project%20Plan/feature-workflow-tickets.md)). Buduje na pakiecie A (#2472, merged).

## WFL-P0-04 — log przejść z RLS

- Migracja `workflow_transitions` (kalka RLS z `pending_changes`): tenant isolation + super-admin bypass + FORCE RLS; `object_id` bare UUID (ADR-0015); indeksy (tenant+object+created_at, tenant+created_at). Tabela ma własny `tenant_id` NOT NULL — bez wpisu w TenantAudit whitelist.
- Encja `WorkflowTransition` + XML mapping w nowym BC (`doctrine.yaml` mapping `Workflow`); UUIDv7 = kursor (czasowo uporządkowane id).
- `TransitionLoggingSubscriber` na **evencie `transition`** (nie `completed`): subject ma jeszcze FAKTYCZNE miejsce startowe — `archive` deklaruje dwa `from` (draft|published) i przy `completed` nie dałoby się odróżnić. Actor z seamu AUD-053 (`CurrentUserProvider`, NULL=system), komentarz z kontekstu `apply()`. Persist-only — wpis jedzie na flushu ścieżki zapisu.
- Seam `EditorialWorkflowSubject` w `Catalog\Contracts\Workflow` (id+tenant) — Workflow BC nie importuje encji Catalog (Deptrac).

## WFL-P0-05 — endpointy proceduralne (CQRS, ADR-0012)

- `GET /api/objects/{id}/workflow` — discovery: przejścia osiągalne z bieżącego miejsca z `enabled` + `blockers` (kontrakt dla guard-aware przycisków FE w M3).
- `POST /api/objects/{id}/workflow/transitions/{transition}` — `can()`/`apply()` z komentarzem (walidacja ≤2000 znaków, 422); niedozwolone → **409** z listą blockerów; nieznane przejście/obiekt → 404 (TenantFilter: cross-tenant = 404, bez wycieku).
- `GET /api/objects/{id}/workflow/transitions` — log z kursorem UUIDv7 (`?limit=&before=`), newest-first, `next_cursor`.
- Kontroler w `Catalog\Presentation` (subject = encja Catalog), log czytany przez port `TransitionLogPort` (`Workflow_Contracts`, DTO `TransitionLogEntry`).
- Gating: GET-y `workflow.view`; POST `workflow.view` jako brama wejścia — autoryzacja per przejście = guardy WFL-P1-01 (osobny PR, gotowy w kolejce).
- OpenAPI: 3 nowe trasy w snapshot `docs/api-spec/v0.json` (CustomRouteOpenApiFactory).

## AC

- [x] Każde przejście (PATCH i endpoint) zostawia wpis z from/to/actor/komentarzem; zablokowane przejście NIE loguje
- [x] Cross-tenant read = 0 (test integracyjny na porcie) + RLS w migracji
- [x] GET discovery spójny z maszyną (test: draft → dokładnie submit_for_review/publish/archive)
- [x] Kursor stronicuje (3 przejścia → 2+1); OpenAPI snapshot bez driftu

## Bramki (lokalnie w kontenerze na worktree)

- PHPStan max: No errors · Deptrac `--no-cache`: 0 errors · cs-fixer: czysto
- PHPUnit: Integration/Workflow + 2 pliki Api = **15 testów / 90 asercji OK** (topologia, log z faktycznym from-place przy archive, izolacja tenantów, pełna pętla endpointów, kursor, 401/404/409/422)

Live smoke po merge (proof w #2413/#2414 przed zamknięciem).

Refs #2413, Refs #2414
