### PR TITLE
feat(identity): map workflow transition guards to RBAC permissions (WFL-P1-01)

### DIFF
--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -934,7 +934,12 @@
           "crud": "CRUD",
           "view_revoke": "View / revoke",
           "list": "List",
-          "break_glass_recovery": "Break-glass"
+          "break_glass_recovery": "Break-glass",
+          "edit_in_review": "Edit (in review)",
+          "manage_definitions": "Manage definitions",
+          "transition": {
+            "unpublish": "Unpublish (auto)"
+          }
         }
       }
     }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -944,7 +944,12 @@
           "crud": "CRUD",
           "view_revoke": "Podgląd / unieważnij",
           "list": "Lista",
-          "break_glass_recovery": "Break-glass"
+          "break_glass_recovery": "Break-glass",
+          "edit_in_review": "Edycja (w przeglądzie)",
+          "manage_definitions": "Zarządzanie definicjami",
+          "transition": {
+            "unpublish": "Cofnięcie publikacji (auto)"
+          }
         }
       }
     }

--- a/apps/api/src/Catalog/Presentation/Controller/ObjectWorkflowController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ObjectWorkflowController.php
@@ -77,9 +77,10 @@ final class ObjectWorkflowController
         methods: ['POST'],
     )]
     // Entry-level gate only — the per-transition RBAC permission map
-    // (approve -> workflow.approve_reject etc.) attaches to the workflow
-    // guards in WFL-P1-01 (#2415) and is enforced inside can()/apply().
-    #[RequiresPermission(module: 'products', action: 'edit')]
+    // (WFL-P1-01: approve -> workflow.approve_reject etc.) is enforced
+    // inside can()/apply() by TransitionPermissionGuard and reported
+    // back as 409 blockers carrying the missing permission code.
+    #[RequiresPermission(module: 'workflow', action: 'view')]
     public function apply(string $id, string $transition, Request $request): JsonResponse
     {
         if (!\in_array($transition, ObjectEditorialWorkflow::TRANSITIONS, true)) {

--- a/apps/api/src/DataFixtures/Identity/PrdPermissionFixtures.php
+++ b/apps/api/src/DataFixtures/Identity/PrdPermissionFixtures.php
@@ -98,6 +98,11 @@ final class PrdPermissionFixtures extends Fixture
         'workflow.view',
         'workflow.approve_reject',
         'workflow.edit_any_state',
+        // WFL-P1-01 (#2415) — PRD §3.8 state-policy codes, seeded dormant
+        // by RBAC Phase 3 docs and activated by the object_editorial guards.
+        'workflow.edit_in_review',
+        'workflow.transition.unpublish',
+        'workflow.manage_definitions',
 
         // Cmd+K agent
         'agent.schema_ops',

--- a/apps/api/src/Identity/Domain/Rbac/PrdRoleTemplates.php
+++ b/apps/api/src/Identity/Domain/Rbac/PrdRoleTemplates.php
@@ -83,6 +83,7 @@ final class PrdRoleTemplates
                 'imports.view_own', 'imports.view_all', 'imports.run',
                 'exports.view_own', 'exports.view_all', 'exports.run',
                 'workflow.view', 'workflow.approve_reject', 'workflow.edit_any_state',
+                'workflow.edit_in_review', 'workflow.transition.unpublish', 'workflow.manage_definitions',
                 'agent.schema_ops', 'agent.bulk_actions', 'agent.approve_pending',
                 'settings.users.manage', 'settings.roles.manage', 'settings.tenant.manage',
                 'settings.locales.manage',
@@ -109,6 +110,7 @@ final class PrdRoleTemplates
                 'imports.view_own', 'imports.view_all', 'imports.run',
                 'exports.view_own', 'exports.view_all', 'exports.run',
                 'workflow.view', 'workflow.approve_reject', 'workflow.edit_any_state',
+                'workflow.edit_in_review', 'workflow.transition.unpublish', 'workflow.manage_definitions',
                 'agent.schema_ops', 'agent.bulk_actions', 'agent.approve_pending',
                 'settings.users.manage', 'settings.roles.manage', 'settings.tenant.manage',
                 'settings.locales.manage',
@@ -128,7 +130,7 @@ final class PrdRoleTemplates
                 'multimedia.view', 'multimedia.add_edit_own', 'multimedia.add_edit_any', 'multimedia.delete',
                 'imports.view_own', 'imports.view_all', 'imports.run',
                 'exports.view_own', 'exports.view_all', 'exports.run',
-                'workflow.view', 'workflow.approve_reject',
+                'workflow.view', 'workflow.approve_reject', 'workflow.edit_in_review',
                 'agent.bulk_actions',
                 // AICG-P1-03 (#2329) — recipes/voice are content-team
                 // config: read + create (incl. clone); admin stays with
@@ -193,6 +195,7 @@ final class PrdRoleTemplates
                 'modeling.view', 'modeling.approve_schema_ops',
                 'agent.approve_pending',
                 'workflow.view', 'workflow.approve_reject',
+                'workflow.edit_in_review', 'workflow.transition.unpublish',
                 'audit.view_own', 'audit.view_cross_user',
                 'api_tokens.own.crud',
             ],

--- a/apps/api/src/Workflow/Application/ActingUserContext.php
+++ b/apps/api/src/Workflow/Application/ActingUserContext.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Workflow\Application;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P1-01 (#2415) — request-/message-scoped holder for "whose
+ * permissions gate this transition" when there is no security token.
+ *
+ * HTTP requests resolve the actor from the token (CurrentUserProvider);
+ * Messenger workers (bulk change_status, WFL-P1-05) act WITHIN the
+ * initiating user's permissions (same model as the agent loop,
+ * ADR-0024 b) and set this context before applying transitions.
+ * When neither source yields a user the guard treats the caller as a
+ * trusted system path (CLI, fixtures) — HTTP can never reach that
+ * branch because every workflow endpoint requires authentication.
+ */
+final class ActingUserContext
+{
+    private ?Uuid $userId = null;
+
+    public function set(?Uuid $userId): void
+    {
+        $this->userId = $userId;
+    }
+
+    public function userId(): ?Uuid
+    {
+        return $this->userId;
+    }
+}

--- a/apps/api/src/Workflow/Infrastructure/EventSubscriber/TransitionPermissionGuard.php
+++ b/apps/api/src/Workflow/Infrastructure/EventSubscriber/TransitionPermissionGuard.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Workflow\Infrastructure\EventSubscriber;
+
+use App\Identity\Contracts\Auth\CurrentUserProvider;
+use App\Identity\Contracts\Policy\PermissionCheckerInterface;
+use App\Workflow\Application\ActingUserContext;
+use App\Workflow\Contracts\ObjectEditorialWorkflow;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Workflow\Event\GuardEvent;
+use Symfony\Component\Workflow\TransitionBlocker;
+
+/**
+ * WFL-P1-01 (#2415) — RBAC guard map for the `object_editorial` state
+ * machine (ADR-0029 pillar 4). Guards are DATA (permission codes), not
+ * config expressions — the Pimcore lesson: rule changes must not need
+ * a deploy, and the M5 tenant definition builder reuses the same codes.
+ *
+ * The blocker carries the missing permission code so 409 responses and
+ * the discovery endpoint (GET …/workflow) tell the user WHICH grant is
+ * missing, per the PRD §3.8 UX ("nie generyczne 403").
+ *
+ * Actor resolution: security token first, then ActingUserContext
+ * (Messenger workers acting within the initiating user's permissions).
+ * No actor at all = trusted system path (CLI/fixtures) — allowed; HTTP
+ * cannot reach that branch because the endpoints require auth.
+ */
+final readonly class TransitionPermissionGuard implements EventSubscriberInterface
+{
+    /**
+     * Transition -> required permission code (PRD-PIM-rbac §3.8).
+     *
+     * @var array<string, string>
+     */
+    private const array PERMISSION_MAP = [
+        ObjectEditorialWorkflow::TRANSITION_SUBMIT_FOR_REVIEW => 'products.edit',
+        ObjectEditorialWorkflow::TRANSITION_PUBLISH => 'workflow.approve_reject',
+        ObjectEditorialWorkflow::TRANSITION_APPROVE => 'workflow.approve_reject',
+        ObjectEditorialWorkflow::TRANSITION_REJECT => 'workflow.approve_reject',
+        ObjectEditorialWorkflow::TRANSITION_ARCHIVE => 'workflow.approve_reject',
+        ObjectEditorialWorkflow::TRANSITION_RESTORE => 'workflow.approve_reject',
+        ObjectEditorialWorkflow::TRANSITION_UNPUBLISH => 'workflow.transition.unpublish',
+    ];
+
+    public function __construct(
+        private CurrentUserProvider $currentUser,
+        private ActingUserContext $actingUser,
+        private PermissionCheckerInterface $permissions,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'workflow.'.ObjectEditorialWorkflow::NAME.'.guard' => 'onGuard',
+        ];
+    }
+
+    public function onGuard(GuardEvent $event): void
+    {
+        $transition = $event->getTransition()->getName();
+        $permission = self::PERMISSION_MAP[$transition] ?? null;
+        if (null === $permission) {
+            return;
+        }
+
+        $userId = $this->currentUser->userId() ?? $this->actingUser->userId();
+        if (null === $userId) {
+            return;
+        }
+
+        if ($this->permissions->userHasPermission($userId, $permission)) {
+            return;
+        }
+
+        $event->addTransitionBlocker(new TransitionBlocker(
+            \sprintf('Missing permission "%s" required for transition "%s".', $permission, $transition),
+            $permission,
+        ));
+    }
+}

--- a/apps/api/tests/Api/Catalog/ObjectWorkflowGuardsApiTest.php
+++ b/apps/api/tests/Api/Catalog/ObjectWorkflowGuardsApiTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * WFL-P1-01 (#2415, SEC) — the RBAC guard map on `object_editorial`
+ * transitions, asserted per PRD-PIM-rbac §3.8 role matrix. Written
+ * failing-first against the unguarded M0 machine: every deny case in
+ * this file returned 200 before TransitionPermissionGuard attached.
+ *
+ * Map under test: submit_for_review -> products.edit · publish/approve/
+ * reject/archive/restore -> workflow.approve_reject · unpublish ->
+ * workflow.transition.unpublish.
+ */
+final class ObjectWorkflowGuardsApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function marketingCanSubmitButCannotPublish(): void
+    {
+        $this->createUserWithRole('marketing@demo.localhost', 'marketing');
+        $id = $this->seedProduct('WFL-G-MARKETING');
+
+        $client = $this->authenticatedClient('marketing@demo.localhost');
+
+        $response = $client->request('POST', '/api/objects/'.$id.'/workflow/transitions/publish');
+        self::assertResponseStatusCodeSame(409);
+        self::assertStringContainsString(
+            'workflow.approve_reject',
+            $response->getContent(false),
+            '409 must name the missing permission',
+        );
+
+        $client->request('POST', '/api/objects/'.$id.'/workflow/transitions/submit_for_review');
+        self::assertResponseIsSuccessful();
+    }
+
+    #[Test]
+    public function discoveryDisablesBlockedTransitionsPerRole(): void
+    {
+        $this->createUserWithRole('marketing2@demo.localhost', 'marketing');
+        $id = $this->seedProduct('WFL-G-DISCOVERY');
+
+        $body = $this->authenticatedClient('marketing2@demo.localhost')
+            ->request('GET', '/api/objects/'.$id.'/workflow')->toArray();
+
+        $byName = [];
+        foreach (self::rows($body['transitions'] ?? null) as $transition) {
+            $name = $transition['name'];
+            self::assertIsString($name);
+            $byName[$name] = $transition;
+        }
+
+        self::assertTrue($byName['submit_for_review']['enabled']);
+        self::assertFalse($byName['publish']['enabled']);
+        $blockers = self::rows($byName['publish']['blockers']);
+        self::assertSame('workflow.approve_reject', $blockers[0]['code']);
+
+        // Admin sees everything from draft enabled.
+        $adminBody = $this->authenticatedClient()
+            ->request('GET', '/api/objects/'.$id.'/workflow')->toArray();
+        foreach (self::rows($adminBody['transitions'] ?? null) as $transition) {
+            $name = $transition['name'];
+            self::assertIsString($name);
+            self::assertTrue($transition['enabled'], \sprintf('admin should pass guard for "%s"', $name));
+        }
+    }
+
+    #[Test]
+    public function approverApprovesButCannotSubmit(): void
+    {
+        $this->createUserWithRole('approver@demo.localhost', 'approver');
+        $inReview = $this->seedProduct('WFL-G-APPROVE', CatalogObject::STATUS_REVIEW);
+        $draft = $this->seedProduct('WFL-G-NOSUBMIT');
+
+        $client = $this->authenticatedClient('approver@demo.localhost');
+
+        $client->request('POST', '/api/objects/'.$draft.'/workflow/transitions/submit_for_review');
+        self::assertResponseStatusCodeSame(409, 'approver has no products.edit — submit is blocked');
+
+        $client->request('POST', '/api/objects/'.$inReview.'/workflow/transitions/approve', [
+            'json' => ['comment' => 'Zatwierdzam'],
+        ]);
+        self::assertResponseIsSuccessful();
+    }
+
+    #[Test]
+    public function unpublishRequiresDedicatedPermission(): void
+    {
+        $this->createUserWithRole('cm@demo.localhost', 'catalog_manager');
+        $this->createUserWithRole('approver2@demo.localhost', 'approver');
+        $id = $this->seedProduct('WFL-G-UNPUBLISH', CatalogObject::STATUS_PUBLISHED);
+
+        $client = $this->authenticatedClient('cm@demo.localhost');
+        $response = $client->request('POST', '/api/objects/'.$id.'/workflow/transitions/unpublish');
+        self::assertResponseStatusCodeSame(409, 'catalog_manager approves but must not auto-unpublish (PRD §3.8)');
+        self::assertStringContainsString('workflow.transition.unpublish', $response->getContent(false));
+
+        $this->authenticatedClient('approver2@demo.localhost')
+            ->request('POST', '/api/objects/'.$id.'/workflow/transitions/unpublish');
+        self::assertResponseIsSuccessful();
+    }
+
+    /**
+     * Layering note: the legacy PATCH surface is gated by
+     * `is_granted('UPDATE', object)` (CatalogObjectVoter, legacy
+     * `object.write`) BEFORE the workflow guard can run — a marketing
+     * user is stopped at 403 and never reaches the state machine. That
+     * is defence in depth, not a bypass: guard parity for the PATCH
+     * path itself is pinned by the acting-user kernel test in
+     * tests/Integration/Workflow (getEnabledTransitions honours guards
+     * for whoever DOES pass the endpoint gate).
+     */
+    #[Test]
+    public function patchStatusSurfaceIsGatedBeforeTheGuards(): void
+    {
+        $this->createUserWithRole('marketing3@demo.localhost', 'marketing');
+        $id = $this->seedProduct('WFL-G-PATCH');
+
+        $client = $this->authenticatedClient('marketing3@demo.localhost');
+        $client->request('PATCH', '/api/products/'.$id, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['status' => CatalogObject::STATUS_PUBLISHED],
+        ]);
+        self::assertResponseStatusCodeSame(403, 'endpoint RBAC fires before the workflow guard');
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private static function rows(mixed $value): array
+    {
+        self::assertIsArray($value);
+
+        $rows = [];
+        foreach ($value as $row) {
+            self::assertIsArray($row);
+            $typed = [];
+            foreach ($row as $key => $item) {
+                $typed[(string) $key] = $item;
+            }
+            $rows[] = $typed;
+        }
+
+        return $rows;
+    }
+
+    private function createUserWithRole(string $email, string $roleCode): void
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $role = self::getContainer()->get(RoleRepositoryInterface::class)->findByCode($roleCode, $tenant);
+        \assert(null !== $role);
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $stub = new User($tenant, $email, '', ['ROLE_USER']);
+        $user = new User($tenant, $email, $hasher->hashPassword($stub, 'changeme'), ['ROLE_USER']);
+        $user->addRole($role);
+        $em->persist($user);
+        $em->flush();
+    }
+
+    private function seedProduct(string $code, string $status = CatalogObject::STATUS_DRAFT): string
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $type);
+
+        $object = new CatalogObject($type, $code);
+        if (CatalogObject::STATUS_DRAFT !== $status) {
+            $object->forceStatus($status);
+        }
+        self::getContainer()->get(CatalogObjectRepositoryInterface::class)->save($object);
+        $em->flush();
+        $em->clear();
+
+        return $object->getId()->toRfc4122();
+    }
+}

--- a/apps/api/tests/Integration/Workflow/TransitionGuardActingUserTest.php
+++ b/apps/api/tests/Integration/Workflow/TransitionGuardActingUserTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Workflow;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\DataFixtures\Identity\PrdPermissionFixtures;
+use App\Identity\Application\SeedTenantPrdRolesService;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use App\Workflow\Application\ActingUserContext;
+use App\Workflow\Contracts\ObjectEditorialWorkflow;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Workflow\Registry;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * WFL-P1-01 (#2415, SEC) — the guard consults ActingUserContext when
+ * there is no security token: the exact path the async bulk worker
+ * (WFL-P1-05) takes, acting WITHIN the initiating user's permissions
+ * (agent-loop model, ADR-0024 b). Also pins guard parity for any
+ * non-HTTP `can()` caller — including the PATCH handler's
+ * getEnabledTransitions() — independent of endpoint RBAC layers.
+ */
+final class TransitionGuardActingUserTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function guardBlocksActingUserWithoutPermissionAndAllowsSystem(): void
+    {
+        $em = $this->em();
+        new PrdPermissionFixtures()->load($em);
+        $em->flush();
+
+        $tenant = new Tenant('alpha', 'Alpha Tenant');
+        $em->persist($tenant);
+        $em->flush();
+        self::getContainer()->get(SeedTenantPrdRolesService::class)->seed($tenant);
+
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+
+        $marketingRole = self::getContainer()->get(RoleRepositoryInterface::class)->findByCode('marketing', $tenant);
+        \assert(null !== $marketingRole);
+        $marketing = new User($tenant, 'marketing@alpha.localhost', 'irrelevant', ['ROLE_USER']);
+        $marketing->addRole($marketingRole);
+        $em->persist($marketing);
+        $em->flush();
+
+        $type = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
+        $type->assignTenant($tenant);
+        $em->persist($type);
+        $object = new CatalogObject($type, 'WFL-GUARD-ACTING');
+        $object->assignTenant($tenant);
+        $em->persist($object);
+        $em->flush();
+
+        $workflow = self::getContainer()->get(Registry::class)->get($object, ObjectEditorialWorkflow::NAME);
+        $actingUser = self::getContainer()->get(ActingUserContext::class);
+
+        // Acting as marketing (worker path): submit allowed, publish blocked.
+        $actingUser->set($marketing->getId());
+        self::assertTrue($workflow->can($object, ObjectEditorialWorkflow::TRANSITION_SUBMIT_FOR_REVIEW));
+        self::assertFalse($workflow->can($object, ObjectEditorialWorkflow::TRANSITION_PUBLISH));
+
+        $blockers = [];
+        foreach ($workflow->buildTransitionBlockerList($object, ObjectEditorialWorkflow::TRANSITION_PUBLISH) as $blocker) {
+            $blockers[] = $blocker->getCode();
+        }
+        self::assertSame(['workflow.approve_reject'], $blockers, 'blocker must carry the missing permission code');
+
+        // No actor at all = trusted system path (CLI/fixtures) — allowed.
+        $actingUser->set(null);
+        self::assertTrue($workflow->can($object, ObjectEditorialWorkflow::TRANSITION_PUBLISH));
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -18847,7 +18847,7 @@
                     }
                 ],
                 "x-pim-source": "custom-route",
-                "x-cortex-permission": "products.edit"
+                "x-cortex-permission": "workflow.view"
             }
         },
         "/api/objects/{master_id}/generate-variants": {


### PR DESCRIPTION
**WFL-P1-01** (#2415, `[SEC]`) — pełna treść: [`Project Plan/feature-workflow-tickets.md`](https://github.com/malipie/PIM/blob/main/Project%20Plan/feature-workflow-tickets.md). Buduje na pakietach A (#2472) i B (#2473).

## Co

- **Doseed brakujących kodów PRD §3.8**: `workflow.edit_in_review`, `workflow.transition.unpublish`, `workflow.manage_definitions` (`PrdPermissionFixtures`) + dystrybucja per macierz ról (`PrdRoleTemplates`): Owner/Admin wszystkie trzy · Catalog Manager `edit_in_review` · Approver `edit_in_review` + `transition.unpublish`. Etykiety akcji w i18n pl/en (role builder).
- **`TransitionPermissionGuard`** na `workflow.object_editorial.guard` — mapa transition→permission jako DANE (ADR-0029 filar 4, lekcja Pimcore): `submit_for_review→products.edit` · `publish/approve/reject/archive/restore→workflow.approve_reject` · `unpublish→workflow.transition.unpublish`. Odmowa = `TransitionBlocker` z **kodem brakującej permission** → 409/discovery mówią użytkownikowi, czego mu brakuje.
- **`ActingUserContext`** — holder „czyimi uprawnieniami gate'ować" dla ścieżek bez tokena (Messenger worker bulka w P1-05 działa uprawnieniami inicjatora — model agenta z ADR-0024b). Brak aktora = zaufana ścieżka systemowa (CLI/fixtures); po HTTP nieosiągalne (endpointy wymagają auth).
- **Brama wejścia POST** przejść zluzowana do `workflow.view` — autorytetem autoryzacji per przejście jest guard wewnątrz `can()`/`apply()` (spójnie dla endpointu i legacy PATCH).

## Failing-first

Każdy przypadek DENY w `ObjectWorkflowGuardsApiTest` zwracał 200 na niestrzeżonej maszynie z M0 — macierz per rola (marketing nie publikuje; approver nie submituje — brak `products.edit`; catalog_manager nie unpublishuje; admin wszystko z draft) + kernel test `TransitionGuardActingUserTest` (ścieżka by-user-id + kody blockerów + allow-system).

## AC

- [x] Macierz PRD §3.8 pokryta testami (deny I allow); `GET …/workflow` pokazuje `enabled=false` + blocker code per rola
- [x] Odmowa przejścia → 409 z kodem brakującej permission (nie gołe 403)
- [x] Role builder pokazuje nowe kody (i18n pl/en); OpenAPI bez zmian tras

Bramki lokalnie (kontener na worktree): PHPStan max **No errors** · Deptrac `--no-cache` **0 errors** · cs-fixer czysto · testy workflow+guards **21/21 OK**.

Live smoke po merge (proof w #2415 przed zamknięciem): restricted user (invitation dev-token, role marketing) — submit 200, approve/publish 409 z kodem.

Refs #2415
