### PR TITLE
feat(identity): enforce workflow-state edit policy on write paths (pakiet C)

### DIFF
--- a/apps/api/src/Catalog/Application/Command/UpdateCatalogObject/UpdateCatalogObjectHandler.php
+++ b/apps/api/src/Catalog/Application/Command/UpdateCatalogObject/UpdateCatalogObjectHandler.php
@@ -8,10 +8,12 @@ use App\Catalog\Application\ObjectAttributesUpserter;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Channel\Contracts\ChannelResolverInterface;
+use App\Identity\Contracts\Policy\WorkflowStateEditPolicyInterface;
 use App\Shared\Domain\Tenant;
 use App\Workflow\Contracts\ObjectEditorialWorkflow;
 use Doctrine\ORM\OptimisticLockException;
 use Symfony\Component\DependencyInjection\Attribute\Target;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
@@ -27,6 +29,7 @@ final readonly class UpdateCatalogObjectHandler
         private ChannelResolverInterface $channels,
         #[Target(ObjectEditorialWorkflow::NAME)]
         private WorkflowInterface $objectEditorial,
+        private WorkflowStateEditPolicyInterface $statePolicy,
     ) {
     }
 
@@ -53,11 +56,41 @@ final readonly class UpdateCatalogObjectHandler
             ));
         }
 
-        if (null !== $command->enabled) {
-            $object->changeEnabled($command->enabled);
-        }
+        // Status transition first (guards enforce who may move the
+        // object); content edits below are then judged against the NEW
+        // state — "reject + fix in one PATCH" works for a reviewer.
         if (null !== $command->status && $command->status !== $object->getStatus()) {
             $this->applyStatusTransition($object, $command->status);
+        }
+
+        // WFL-P1-02/P1-03 (PRD §3.8) — the permission matrix says whether
+        // the caller may edit AT ALL; the workflow state says whether they
+        // may edit NOW. Published is editable in place only with
+        // workflow.edit_any_state; holders of workflow.transition.unpublish
+        // get the atomic auto-unpublish path; archived is read-only.
+        if ($this->hasContentEdits($command)) {
+            $state = $object->getStatus();
+            if (!$this->statePolicy->canEditInState($state)) {
+                if ($this->statePolicy->requiresAutoUnpublish($state)) {
+                    // Same flush as the edit below — transition + content
+                    // change land atomically; the transition-log row carries
+                    // the audit flag (PRD: AUTO_UNPUBLISH_FOR_EDIT).
+                    $this->objectEditorial->apply($object, ObjectEditorialWorkflow::TRANSITION_UNPUBLISH, [
+                        'auto_unpublish' => true,
+                        'special_flag' => 'AUTO_UNPUBLISH_FOR_EDIT',
+                    ]);
+                } else {
+                    throw new AccessDeniedHttpException(\sprintf(
+                        'workflow_state_locked: object is "%s" — content edits are blocked by the workflow state policy.%s',
+                        $state,
+                        CatalogObject::STATUS_PUBLISHED === $state ? ' request_unpublish_available' : '',
+                    ));
+                }
+            }
+        }
+
+        if (null !== $command->enabled) {
+            $object->changeEnabled($command->enabled);
         }
 
         if ($command->clearParent) {
@@ -117,6 +150,16 @@ final readonly class UpdateCatalogObjectHandler
                 channelId: $channelId,
             );
         }
+    }
+
+    private function hasContentEdits(UpdateCatalogObjectCommand $command): bool
+    {
+        return null !== $command->enabled
+            || $command->clearParent
+            || null !== $command->parentId
+            || $command->clearPath
+            || null !== $command->path
+            || (null !== $command->attributes && [] !== $command->attributes);
     }
 
     /**

--- a/apps/api/src/Catalog/Presentation/Controller/BulkActionsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/BulkActionsController.php
@@ -21,6 +21,7 @@ use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Identity\Contracts\Attribute\RequiresPermission;
 use App\Identity\Contracts\Policy\PermissionCheckerInterface;
+use App\Identity\Contracts\Policy\WorkflowStateEditPolicyInterface;
 use App\Shared\Application\BulkOperationLock;
 use App\Shared\Application\TenantContext;
 use App\Shared\Application\UserIdentityAware;
@@ -67,11 +68,33 @@ final class BulkActionsController
         'duplicate' => 'products.add',
     ];
 
+    /**
+     * WFL-P1-02 (#2416) — actions that edit entity CONTENT and therefore
+     * honour the PRD §3.8 workflow-state policy. Deliberately excluded:
+     * publish_channels/unpublish_channels (publication management, own
+     * permission), delete (products.delete governs it; archived rows are
+     * removable by design) and duplicate (creates a fresh draft).
+     *
+     * @var list<string>
+     */
+    private const array STATE_LOCKED_ACTIONS = [
+        'set_attribute',
+        'clear_attribute',
+        'append_value',
+        'remove_value',
+        'increment_numeric',
+        'multi_attribute_edit',
+        'add_category',
+        'remove_category',
+        'move_category',
+    ];
+
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly TenantContext $tenantContext,
         private readonly Security $security,
         private readonly PermissionCheckerInterface $permissionChecker,
+        private readonly WorkflowStateEditPolicyInterface $statePolicy,
         private readonly CatalogObjectRepositoryInterface $catalogObjects,
         private readonly BulkSetAttributeHandler $setAttributeHandler,
         private readonly BulkClearAttributeHandler $clearAttributeHandler,
@@ -320,6 +343,29 @@ final class BulkActionsController
             throw new BadRequestHttpException('target_ids exceeds 10000 hard cap.');
         }
 
+        // WFL-P1-02 (#2416) — workflow-state gate per object BEFORE any
+        // handler runs: rows in review/published/archived that the caller
+        // may not edit NOW are dropped here and reported, so no bulk
+        // actionType can become a state-policy bypass (lekcja #2129).
+        $lockedIds = [];
+        if (\in_array($actionType, self::STATE_LOCKED_ACTIONS, true)) {
+            [$targetIds, $lockedIds] = $this->partitionByStateEditability($targetIds);
+            // Early return only when the lock explains the empty set —
+            // unknown ids keep flowing to the session path (and its 409
+            // bulk-lock semantics) exactly as before.
+            if ([] === $targetIds && [] !== $lockedIds) {
+                return new JsonResponse([
+                    'action' => $actionType,
+                    'target_count' => 0,
+                    'success_count' => 0,
+                    'skipped_count' => 0,
+                    'error_count' => 0,
+                    'locked_count' => \count($lockedIds),
+                    'locked_ids' => \array_slice($lockedIds, 0, 100),
+                ], 200);
+            }
+        }
+
         // IMP2-2.9 (#1485) — every bulk write path shares the per-tenant lock with
         // imports / bulk-edit. A collision is a 409 (RFC 7807); released in finally
         // so an exception mid-batch never leaks the lock.
@@ -404,12 +450,51 @@ final class BulkActionsController
                 'success_count' => $result['success'],
                 'skipped_count' => $result['skipped'],
                 'error_count' => $result['error'],
+                'locked_count' => \count($lockedIds),
+                'locked_ids' => \array_slice($lockedIds, 0, 100),
                 'rollback_available_until' => $session->getRollbackAvailableUntil()?->format(DateTimeInterface::ATOM),
                 'completed_at' => $session->getCompletedAt()?->format(DateTimeInterface::ATOM),
             ]);
         } finally {
             $lock->release();
         }
+    }
+
+    /**
+     * Splits target ids into [editable, locked] against the workflow
+     * state policy (one grouped status query, no per-row hydration).
+     * The policy is per-principal, so each distinct state is evaluated
+     * once, not per row.
+     *
+     * @param list<string> $targetIds
+     *
+     * @return array{0: list<string>, 1: list<string>}
+     */
+    private function partitionByStateEditability(array $targetIds): array
+    {
+        /** @var list<array{id: Uuid, status: string}> $rows */
+        $rows = $this->em->createQueryBuilder()
+            ->select('o.id AS id', 'o.status AS status')
+            ->from(CatalogObject::class, 'o')
+            ->where('o.id IN (:ids)')
+            ->setParameter('ids', $targetIds)
+            ->getQuery()
+            ->getArrayResult();
+
+        $editableByState = [];
+        $editable = [];
+        $locked = [];
+        foreach ($rows as $row) {
+            $state = $row['status'];
+            $editableByState[$state] ??= $this->statePolicy->canEditInState($state);
+            if ($editableByState[$state]) {
+                $editable[] = $row['id']->toRfc4122();
+            } else {
+                $locked[] = $row['id']->toRfc4122();
+            }
+        }
+
+        return [$editable, $locked];
     }
 
     /**

--- a/apps/api/src/Catalog/Presentation/Controller/BulkEditController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/BulkEditController.php
@@ -9,6 +9,7 @@ use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Identity\Contracts\Policy\WorkflowStateEditPolicyInterface;
 use App\Shared\Application\BulkOperationLock;
 use App\Shared\Application\TenantContext;
 use DateTimeInterface;
@@ -16,6 +17,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -49,6 +51,7 @@ final class BulkEditController
 
     public function __construct(
         private readonly CatalogObjectRepositoryInterface $objects,
+        private readonly WorkflowStateEditPolicyInterface $statePolicy,
         private readonly TenantContext $tenantContext,
         private readonly EntityManagerInterface $em,
         private readonly BulkOperationLock $bulkLock,
@@ -130,6 +133,19 @@ final class BulkEditController
                     $object = $this->objects->findById($uuid);
                     if (!$object instanceof CatalogObject || ObjectKind::Product !== $object->getKind()) {
                         throw new NotFoundHttpException(\sprintf('Product %s not found.', $rawId));
+                    }
+
+                    // WFL-P1-02 (#2416) — PRD §3.8 state gate per row; the
+                    // catch below records it as a per-id error, so locked
+                    // rows are reported instead of silently written. No
+                    // auto-unpublish on bulk paths by design (a mass
+                    // unpublish-for-edit would be a surprising side effect).
+                    $state = $object->getStatus();
+                    if (!$this->statePolicy->canEditInState($state)) {
+                        throw new AccessDeniedHttpException(\sprintf(
+                            'workflow_state_locked: object is "%s" — content edits are blocked by the workflow state policy.',
+                            $state,
+                        ));
                     }
 
                     $this->applyOperation($operation, $object, $payload);

--- a/apps/api/src/Identity/Application/Policy/ContractsWorkflowStateEditPolicy.php
+++ b/apps/api/src/Identity/Application/Policy/ContractsWorkflowStateEditPolicy.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application\Policy;
+
+use App\Identity\Contracts\Policy\WorkflowStateEditPolicyInterface;
+use App\Identity\Domain\Entity\User;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * WFL-P1-02 (#2416) — token-resolving adapter over
+ * {@see WorkflowStatePolicy} (RBAC-P3-011, dormant until now). Missing
+ * or non-domain principal = trusted system path (import/CLI/fixtures)
+ * — allowed by design (ADR-0029 pillar 8); every HTTP write endpoint
+ * authenticates first, so anonymous requests never reach this branch.
+ */
+final readonly class ContractsWorkflowStateEditPolicy implements WorkflowStateEditPolicyInterface
+{
+    public function __construct(
+        private Security $security,
+        private WorkflowStatePolicy $policy,
+    ) {
+    }
+
+    public function canEditInState(string $state): bool
+    {
+        if ('' === $state) {
+            return false;
+        }
+
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            return true;
+        }
+
+        return $this->policy->canEditInState($user, $state);
+    }
+
+    public function requiresAutoUnpublish(string $state): bool
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            return false;
+        }
+
+        return $this->policy->requiresAutoUnpublish($user, $state);
+    }
+}

--- a/apps/api/src/Identity/Application/Policy/WorkflowStatePolicy.php
+++ b/apps/api/src/Identity/Application/Policy/WorkflowStatePolicy.php
@@ -45,6 +45,7 @@ use App\Identity\Domain\Entity\User;
 final readonly class WorkflowStatePolicy
 {
     public const string STATE_DRAFT = 'draft';
+    public const string STATE_REVIEW = 'review';
     public const string STATE_PUBLISHED = 'published';
     public const string STATE_ARCHIVED = 'archived';
 
@@ -61,6 +62,11 @@ final readonly class WorkflowStatePolicy
 
         return match ($state) {
             self::STATE_DRAFT => $permissions->has('products.edit'),
+            // WFL-P1-02 (#2416) — the review place shipped with the
+            // object_editorial state machine (ADR-0029); editable only
+            // for reviewers (edit_in_review) or the edit-anywhere grant.
+            self::STATE_REVIEW => $permissions->has('workflow.edit_in_review')
+                || $permissions->has('workflow.edit_any_state'),
             self::STATE_PUBLISHED => $permissions->has('workflow.edit_any_state'),
             self::STATE_ARCHIVED => false,
             default => false,

--- a/apps/api/src/Identity/Contracts/Policy/WorkflowStateEditPolicyInterface.php
+++ b/apps/api/src/Identity/Contracts/Policy/WorkflowStateEditPolicyInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Contracts\Policy;
+
+/**
+ * WFL-P1-02 (#2416) — cross-context seam for the PRD §3.8 workflow-state
+ * edit policy: "the matrix says whether you may edit AT ALL, the state
+ * says whether you may edit NOW". Catalog write paths (PATCH handler,
+ * bulk actions, bulk edit) consult it before touching a row; the
+ * Identity adapter resolves the current principal from the security
+ * token — same current-token shape as {@see AttributePermissionReader}.
+ *
+ * Both methods treat a missing principal as a trusted system path
+ * (import/CLI/fixtures write regardless of editorial state, ADR-0029
+ * pillar 8); HTTP callers always carry a user because every write
+ * endpoint requires authentication.
+ */
+interface WorkflowStateEditPolicyInterface
+{
+    /**
+     * May the current principal edit entity CONTENT while the entity
+     * sits in `$state`? (draft -> products.edit · review ->
+     * workflow.edit_in_review · published -> workflow.edit_any_state ·
+     * archived -> nobody.)
+     */
+    public function canEditInState(string $state): bool;
+
+    /**
+     * PRD §3.8 auto-unpublish: the current principal cannot edit
+     * published in place (no edit_any_state) but holds
+     * `workflow.transition.unpublish` — the write path may atomically
+     * apply `unpublish` and proceed with the edit in one request
+     * (audited via the transition-log context flag).
+     */
+    public function requiresAutoUnpublish(string $state): bool;
+}

--- a/apps/api/src/Identity/Infrastructure/Security/ProductVoter.php
+++ b/apps/api/src/Identity/Infrastructure/Security/ProductVoter.php
@@ -41,6 +41,15 @@ final class ProductVoter extends AbstractPrdVoter
             'view' => 'products.view',
             'add' => 'products.add',
             'edit' => 'products.edit',
+            // WFL-P1-02 (#2416) — alias for the API Platform Patch
+            // operation attribute (`is_granted('UPDATE', object)`). The
+            // PRD §3.2 matrix always intended products.edit to gate
+            // product edits, but this voter only spoke lowercase verbs,
+            // so PRD-only principals (marketing, catalog_manager) were
+            // denied by default and the §3.8 state policy was dead code
+            // on the PATCH surface. Remaining uppercase aliases
+            // (READ/CREATE/DELETE) are audited in WFL-P6-01.
+            'UPDATE' => 'products.edit',
             'delete' => 'products.delete',
             'bulk_operations' => 'products.bulk_operations',
             'approve_pending_changes' => 'products.approve_pending_changes',

--- a/apps/api/tests/Api/Catalog/BulkOperationLockConflictApiTest.php
+++ b/apps/api/tests/Api/Catalog/BulkOperationLockConflictApiTest.php
@@ -148,7 +148,8 @@ final class BulkOperationLockConflictApiTest extends CatalogApiTestCase
         $em = $this->createStub(EntityManagerInterface::class);
         $em->method('flush')->willThrowException(new RuntimeException('flush exploded mid-batch'));
 
-        $controller = new BulkEditController($objects, $tenantContext, $em, $bulkLock);
+        $statePolicy = self::getContainer()->get(\App\Identity\Contracts\Policy\WorkflowStateEditPolicyInterface::class);
+        $controller = new BulkEditController($objects, $statePolicy, $tenantContext, $em, $bulkLock);
 
         $request = new Request(
             content: json_encode([

--- a/apps/api/tests/Api/Catalog/ObjectWorkflowGuardsApiTest.php
+++ b/apps/api/tests/Api/Catalog/ObjectWorkflowGuardsApiTest.php
@@ -113,18 +113,8 @@ final class ObjectWorkflowGuardsApiTest extends CatalogApiTestCase
         self::assertResponseIsSuccessful();
     }
 
-    /**
-     * Layering note: the legacy PATCH surface is gated by
-     * `is_granted('UPDATE', object)` (CatalogObjectVoter, legacy
-     * `object.write`) BEFORE the workflow guard can run — a marketing
-     * user is stopped at 403 and never reaches the state machine. That
-     * is defence in depth, not a bypass: guard parity for the PATCH
-     * path itself is pinned by the acting-user kernel test in
-     * tests/Integration/Workflow (getEnabledTransitions honours guards
-     * for whoever DOES pass the endpoint gate).
-     */
     #[Test]
-    public function patchStatusSurfaceIsGatedBeforeTheGuards(): void
+    public function patchStatusSurfaceHonoursTheSameGuards(): void
     {
         $this->createUserWithRole('marketing3@demo.localhost', 'marketing');
         $id = $this->seedProduct('WFL-G-PATCH');
@@ -134,7 +124,13 @@ final class ObjectWorkflowGuardsApiTest extends CatalogApiTestCase
             'headers' => ['content-type' => 'application/merge-patch+json'],
             'json' => ['status' => CatalogObject::STATUS_PUBLISHED],
         ]);
-        self::assertResponseStatusCodeSame(403, 'endpoint RBAC fires before the workflow guard');
+        self::assertResponseStatusCodeSame(409, 'no guard-enabled transition reaches published for marketing');
+
+        $client->request('PATCH', '/api/products/'.$id, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['status' => CatalogObject::STATUS_REVIEW],
+        ]);
+        self::assertResponseIsSuccessful();
     }
 
     /**

--- a/apps/api/tests/Api/Catalog/ObjectWorkflowStateEditApiTest.php
+++ b/apps/api/tests/Api/Catalog/ObjectWorkflowStateEditApiTest.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Identity\Domain\Entity\Role;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\PermissionRepositoryInterface;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Pakiet C = WFL-P1-02 (#2416) + WFL-P1-03 (#2417), SEC failing-first —
+ * PRD §3.8 workflow-state edit policy on every human write path: PATCH
+ * (fields + attributes), bulk actions and bulk edit. Published locks
+ * content edits unless edit_any_state; review needs edit_in_review;
+ * archived is read-only for everyone; holders of transition.unpublish
+ * (without edit_any_state) get the atomic auto-unpublish-for-edit.
+ */
+final class ObjectWorkflowStateEditApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function publishedLocksContentEditsWithoutEditAnyState(): void
+    {
+        $this->createUserWithRole('cm-state@demo.localhost', 'catalog_manager');
+        $id = $this->seedProduct('WFL-SE-PUB', CatalogObject::STATUS_PUBLISHED);
+
+        $client = $this->authenticatedClient('cm-state@demo.localhost');
+        $response = $client->request('PATCH', '/api/products/'.$id, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['attributes' => ['name' => ['pl' => 'Podmiana']]],
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+        $body = $response->getContent(false);
+        self::assertStringContainsString('workflow_state_locked', $body);
+        self::assertStringContainsString('request_unpublish_available', $body);
+    }
+
+    #[Test]
+    public function editAnyStateEditsPublishedInPlace(): void
+    {
+        $id = $this->seedProduct('WFL-SE-ANY', CatalogObject::STATUS_PUBLISHED);
+
+        $client = $this->authenticatedClient();
+        $client->request('PATCH', '/api/products/'.$id, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['attributes' => ['name' => ['pl' => 'Edycja w miejscu']]],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        $body = $client->request('GET', '/api/products/'.$id)->toArray();
+        self::assertSame(CatalogObject::STATUS_PUBLISHED, $body['status'], 'edit_any_state edits WITHOUT leaving published');
+    }
+
+    #[Test]
+    public function reviewIsEditableWithEditInReview(): void
+    {
+        $this->createUserWithRole('cm-review@demo.localhost', 'catalog_manager');
+        $id = $this->seedProduct('WFL-SE-REVIEW', CatalogObject::STATUS_REVIEW);
+
+        $client = $this->authenticatedClient('cm-review@demo.localhost');
+        $client->request('PATCH', '/api/products/'.$id, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['attributes' => ['name' => ['pl' => 'Poprawka w review']]],
+        ]);
+
+        self::assertResponseIsSuccessful();
+    }
+
+    #[Test]
+    public function archivedIsReadOnlyEvenForEditAnyState(): void
+    {
+        $id = $this->seedProduct('WFL-SE-ARCH', CatalogObject::STATUS_ARCHIVED);
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('PATCH', '/api/products/'.$id, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['enabled' => false],
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+        self::assertStringContainsString('workflow_state_locked', $response->getContent(false));
+        self::assertStringNotContainsString('request_unpublish_available', $response->getContent(false));
+    }
+
+    #[Test]
+    public function autoUnpublishForEditIsAtomicAndAudited(): void
+    {
+        // WFL-P1-03 — custom role shaped exactly for the PRD §3.8
+        // auto-unpublish window: broad edit + transition.unpublish,
+        // WITHOUT edit_any_state. No seeded role sits in this window
+        // (owner/admin edit in place), but the role builder can mint one.
+        $this->createCustomRoleUser('unpublisher@demo.localhost', 'unpublisher', [
+            'products.view', 'products.edit', 'object.view', 'object.edit', 'workflow.view',
+            'workflow.transition.unpublish',
+        ]);
+        $id = $this->seedProduct('WFL-SE-AUTO', CatalogObject::STATUS_PUBLISHED);
+
+        $client = $this->authenticatedClient('unpublisher@demo.localhost');
+        $client->request('PATCH', '/api/products/'.$id, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['attributes' => ['name' => ['pl' => 'Edycja po auto-unpublish']]],
+        ]);
+        self::assertResponseIsSuccessful();
+
+        // Read state via the workflow endpoint (workflow.view) — the
+        // custom role deliberately has no legacy READ grant and the
+        // uppercase READ voter alias is a WFL-P6-01 audit item.
+        $body = $client->request('GET', '/api/objects/'.$id.'/workflow')->toArray();
+        self::assertSame(CatalogObject::STATUS_DRAFT, $body['current_place'], 'auto-unpublish must land the object in draft');
+
+        $log = $client->request('GET', '/api/objects/'.$id.'/workflow/transitions')->toArray();
+        $items = $log['items'] ?? null;
+        self::assertIsArray($items);
+        self::assertNotEmpty($items);
+        $latest = $items[0];
+        self::assertIsArray($latest);
+        self::assertSame('unpublish', $latest['transition']);
+        $context = $latest['context'];
+        self::assertIsArray($context);
+        self::assertTrue($context['auto_unpublish'] ?? null, 'transition log must carry the audit flag');
+        self::assertSame('AUTO_UNPUBLISH_FOR_EDIT', $context['special_flag'] ?? null);
+    }
+
+    #[Test]
+    public function bulkActionsSkipLockedRowsAndReportThem(): void
+    {
+        $this->createUserWithRole('cm-bulk@demo.localhost', 'catalog_manager');
+        $draft = $this->seedProduct('WFL-SE-BULK-D');
+        $published = $this->seedProduct('WFL-SE-BULK-P', CatalogObject::STATUS_PUBLISHED);
+
+        $client = $this->authenticatedClient('cm-bulk@demo.localhost');
+        $body = $client->request('POST', '/api/products/bulk-actions/set_attribute', [
+            'json' => [
+                'target_ids' => [$draft, $published],
+                'payload' => ['attr' => 'name', 'value' => ['pl' => 'Bulk po stanie']],
+            ],
+        ])->toArray();
+
+        self::assertSame(1, $body['locked_count'], 'published row must be dropped for catalog_manager');
+        self::assertSame([$published], $body['locked_ids']);
+        self::assertSame(1, $body['success_count']);
+    }
+
+    #[Test]
+    public function bulkEditReportsLockedRowsAsPerIdErrors(): void
+    {
+        $this->createUserWithRole('cm-bulkedit@demo.localhost', 'catalog_manager');
+        $published = $this->seedProduct('WFL-SE-BE-P', CatalogObject::STATUS_PUBLISHED);
+
+        $client = $this->authenticatedClient('cm-bulkedit@demo.localhost');
+        $body = $client->request('POST', '/api/products/bulk-edit', [
+            'json' => [
+                'operation' => 'toggle_enabled',
+                'product_ids' => [$published],
+                'payload' => ['enabled' => false],
+            ],
+        ])->toArray();
+
+        self::assertSame(0, $body['processed']);
+        self::assertSame(1, $body['errors_count']);
+        $firstErrors = $body['first_errors'];
+        self::assertIsArray($firstErrors);
+        self::assertStringContainsString('workflow_state_locked', \json_encode($firstErrors, JSON_THROW_ON_ERROR));
+    }
+
+    private function createUserWithRole(string $email, string $roleCode): void
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $role = self::getContainer()->get(RoleRepositoryInterface::class)->findByCode($roleCode, $tenant);
+        \assert(null !== $role);
+        $this->persistUser($email, $tenant, $role);
+    }
+
+    /**
+     * @param list<string> $permissionCodes
+     */
+    private function createCustomRoleUser(string $email, string $roleCode, array $permissionCodes): void
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $role = new Role(code: $roleCode, name: \ucfirst($roleCode), tenant: $tenant);
+        $permissions = self::getContainer()->get(PermissionRepositoryInterface::class);
+        foreach ($permissionCodes as $code) {
+            $permission = $permissions->findByCode($code);
+            \assert(null !== $permission, \sprintf('permission "%s" must be seeded', $code));
+            $role->getPermissions()->add($permission);
+        }
+        $em->persist($role);
+        $this->persistUser($email, $tenant, $role);
+    }
+
+    private function persistUser(string $email, Tenant $tenant, Role $role): void
+    {
+        $em = $this->em();
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $stub = new User($tenant, $email, '', ['ROLE_USER']);
+        $user = new User($tenant, $email, $hasher->hashPassword($stub, 'changeme'), ['ROLE_USER']);
+        $user->addRole($role);
+        $em->persist($user);
+        $em->flush();
+    }
+
+    private function seedProduct(string $code, string $status = CatalogObject::STATUS_DRAFT): string
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $type);
+
+        $object = new CatalogObject($type, $code);
+        if (CatalogObject::STATUS_DRAFT !== $status) {
+            $object->forceStatus($status);
+        }
+        self::getContainer()->get(CatalogObjectRepositoryInterface::class)->save($object);
+        $em->flush();
+        $em->clear();
+
+        return $object->getId()->toRfc4122();
+    }
+}

--- a/apps/api/tests/Unit/Identity/Application/Policy/WorkflowStatePolicyTest.php
+++ b/apps/api/tests/Unit/Identity/Application/Policy/WorkflowStatePolicyTest.php
@@ -110,8 +110,37 @@ final class WorkflowStatePolicyTest extends TestCase
             'workflow.edit_any_state',
         ]));
 
-        // PHPStan @param non-empty-string — call with a literal to satisfy.
-        self::assertFalse($policy->canEditInState($this->user(), 'review'));
+        // 'review' graduated to a real state (WFL-P1-02) — use a literal
+        // that stays outside the machine to keep the default-deny pinned.
+        self::assertFalse($policy->canEditInState($this->user(), 'limbo'));
+    }
+
+    #[Test]
+    public function reviewIsEditableForReviewersAndEditAnywhere(): void
+    {
+        $reviewer = new WorkflowStatePolicy($this->resolverWith([
+            'products.edit',
+            'workflow.edit_in_review',
+        ]));
+        self::assertTrue($reviewer->canEditInState($this->user(), WorkflowStatePolicy::STATE_REVIEW));
+
+        $editAnywhere = new WorkflowStatePolicy($this->resolverWith([
+            'workflow.edit_any_state',
+        ]));
+        self::assertTrue($editAnywhere->canEditInState($this->user(), WorkflowStatePolicy::STATE_REVIEW));
+    }
+
+    #[Test]
+    public function reviewLocksOutPlainEditors(): void
+    {
+        // WFL-P1-02 (#2416) — marketing edits drafts but not rows waiting
+        // for a decision (PRD §3.8 macierz: edit-in-review = ✗).
+        $policy = new WorkflowStatePolicy($this->resolverWith([
+            'products.edit',
+        ]));
+
+        self::assertTrue($policy->canEditInState($this->user(), WorkflowStatePolicy::STATE_DRAFT));
+        self::assertFalse($policy->canEditInState($this->user(), WorkflowStatePolicy::STATE_REVIEW));
     }
 
     private function user(): User


### PR DESCRIPTION
**Pakiet PR C** = WFL-P1-02 (#2416, `[SEC]`) + WFL-P1-03 (#2417) — jeden branch/PR/CI zgodnie z §Pakiety PR backlogu ([`Project Plan/feature-workflow-tickets.md`](https://github.com/malipie/PIM/blob/main/Project%20Plan/feature-workflow-tickets.md)). Buduje na #2474 (guardy).

## WFL-P1-02 — polityka stanów na ścieżkach zapisu (obudzenie uśpionej warstwy)

Sedno PRD §3.8: *macierz mówi czy w ogóle może edytować, stan mówi czy może TERAZ*. `WorkflowStatePolicy` (RBAC-P3-011, dotąd 0 call sites) dostaje stan `review` (`edit_in_review` lub `edit_any_state`) i wchodzi do gry przez seam `WorkflowStateEditPolicyInterface` (adapter tokenowy; brak principala = zaufana ścieżka systemowa — import/CLI, ADR-0029 filar 8):

- **PATCH (handler)**: najpierw przejście statusu (guardy), potem edycje treści oceniane wobec (nowego) stanu — „reject + poprawka jednym PATCHem" działa dla reviewera. Zablokowane → **403** `workflow_state_locked` (+ `request_unpublish_available` na published — kontrakt dla P3-03).
- **Bulk actions**: partycja targetów po stanie PRZED handlerami (9 akcji treściowych; celowo poza gate'em: publish/unpublish_channels, delete, duplicate) — zablokowane wiersze raportowane jako `locked_count`/`locked_ids`, nigdy pisane po cichu.
- **Bulk edit**: gate per wiersz przez istniejący `recordError` (raport per id).
- **`ProductVoter`: alias `UPDATE → products.edit`** — voter PRD mówił tylko małymi literami, a operacja Patch głosuje `UPDATE`; principals PRD-only (marketing/catalog_manager) odbijali się 403 zanim polityka stanów mogła zadziałać — martwy kod §3.8 na powierzchni PATCH. Alias przywraca intencję macierzy §3.2; pozostałe aliasy (READ/CREATE/DELETE) = audyt w WFL-P6-01.

## WFL-P1-03 — atomowy auto-unpublish-for-edit

Posiadacz `workflow.transition.unpublish` **bez** `edit_any_state` edytujący published: jeden request = `apply('unpublish')` + edycja w tym samym flushu (transakcyjnie); wpis `workflow_transitions` niesie `auto_unpublish: true` + `special_flag: AUTO_UNPUBLISH_FOR_EDIT` (PRD §3.8, default z open-question potwierdzony: auto-transition). Żadna seedowana rola nie siedzi w tym oknie (Owner/Admin edytują w miejscu) — ścieżka istnieje dla custom ról z buildera; test tworzy taką rolę.

## Failing-first / testy

`ObjectWorkflowStateEditApiTest` (7): published lock z kodami · edit-in-place dla `edit_any_state` (status NIE schodzi z published) · review z `edit_in_review` · archived read-only nawet dla admina · auto-unpublish atomowy z audit flagą (odczyt stanu przez endpoint workflow) · bulk actions `locked_ids` · bulk edit per-id error. Macierz unit `WorkflowStatePolicyTest` + review cases; guard-parity PATCH test przywrócony do 409.

Bramki lokalnie: PHPStan max No errors · Deptrac --no-cache 0 errors · suita workflow 73/73.

Live smoke po merge (proof w #2416/#2417). Świadome decyzje: bulk bez auto-unpublish (masowe unpublish-for-edit = zaskakujący side effect); import/integration bypass (ADR-0029).

Refs #2416, Refs #2417
