### PR TITLE
feat(workflow): add completeness gate on publish transitions (WFL-P1-04)

### DIFF
--- a/apps/api/migrations/Version20260711100000.php
+++ b/apps/api/migrations/Version20260711100000.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * WFL-P1-04 (#2418) — per-ObjectType completeness gate on publishing
+ * transitions (ADR-0029 pillar 6). NULL = gate off (the benchmark
+ * default: no PIM hard-blocks publication out of the box). Shape:
+ * `{enabled, min_completeness_pct, scope: global|per_channel,
+ * channels?}` — authoritative contract in docs/api/jsonb-schemas.md §6.
+ */
+final class Version20260711100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'WFL-P1-04: object_types.workflow_publish_gate JSONB (completeness gate config)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE object_types ADD workflow_publish_gate JSONB DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE object_types DROP workflow_publish_gate');
+    }
+}

--- a/apps/api/src/Catalog/Application/ObjectTypeService.php
+++ b/apps/api/src/Catalog/Application/ObjectTypeService.php
@@ -121,6 +121,7 @@ final readonly class ObjectTypeService
      * @param list<string>|null               $allowedParentTypeIds
      * @param array<string, mixed>|null       $completenessRules
      * @param list<array<string, mixed>>|null $validationRules      DP-07 (#2037, ADR-0025) cross-field rules
+     * @param array<string, mixed>|null       $workflowPublishGate  WFL-P1-04 (#2418) completeness gate; applied only when $updateWorkflowPublishGate
      */
     public function update(
         ObjectType $objectType,
@@ -136,6 +137,8 @@ final readonly class ObjectTypeService
         ?bool $exposeToMainMenu = null,
         ?bool $isCategorizable = null,
         ?bool $hasMultimedia = null,
+        bool $updateWorkflowPublishGate = false,
+        ?array $workflowPublishGate = null,
     ): ObjectType {
         $isBuiltIn = $objectType->isBuiltIn();
 
@@ -181,6 +184,13 @@ final readonly class ObjectTypeService
                 throw BuiltInObjectTypeException::fieldLocked($objectType, 'completenessRules');
             }
             $objectType->updateCompletenessRules($completenessRules);
+        }
+        if ($updateWorkflowPublishGate) {
+            // WFL-P1-04 (#2418) — like validationRules, the gate constrains
+            // OPERATIONS (publishing), not the entity model, so it stays
+            // editable on built-in ObjectTypes; merge-patch semantics: the
+            // controller sets the flag when the key is present, null clears.
+            $objectType->setWorkflowPublishGate($workflowPublishGate);
         }
         if (null !== $validationRules) {
             // DP-07 (#2037, ADR-0025) — deliberately editable on built-in

--- a/apps/api/src/Catalog/Domain/Entity/ObjectType.php
+++ b/apps/api/src/Catalog/Domain/Entity/ObjectType.php
@@ -8,6 +8,7 @@ use App\Catalog\Domain\ObjectKind;
 use App\Shared\Application\TenantScoped;
 use App\Shared\Domain\Tenant;
 use DateTimeImmutable;
+use InvalidArgumentException;
 use LogicException;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -74,6 +75,17 @@ class ObjectType implements TenantScoped
      * @var list<array<string, mixed>>
      */
     private array $validationRules = [];
+
+    /**
+     * WFL-P1-04 (#2418) — completeness gate on publish/approve
+     * transitions (ADR-0029 pillar 6). NULL = gate off (default).
+     * Shape (docs/api/jsonb-schemas.md §6): {enabled: bool,
+     * min_completeness_pct: int 0-100, scope: 'global'|'per_channel',
+     * channels?: list<string>}.
+     *
+     * @var array<string, mixed>|null
+     */
+    private ?array $workflowPublishGate = null;
     private ?Attribute $labelAttribute = null;
     private ?Attribute $imageAttribute = null;
 
@@ -314,6 +326,56 @@ class ObjectType implements TenantScoped
     public function updateValidationRules(array $rules): void
     {
         $this->validationRules = $rules;
+        $this->touch();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getWorkflowPublishGate(): ?array
+    {
+        return $this->workflowPublishGate;
+    }
+
+    /**
+     * @param array<string, mixed>|null $gate
+     *
+     * @throws InvalidArgumentException on a malformed gate payload
+     */
+    public function setWorkflowPublishGate(?array $gate): void
+    {
+        if (null !== $gate) {
+            if (!\is_bool($gate['enabled'] ?? null)) {
+                throw new InvalidArgumentException('workflowPublishGate.enabled must be a boolean.');
+            }
+            $minPct = $gate['min_completeness_pct'] ?? null;
+            if (!\is_int($minPct) || $minPct < 0 || $minPct > 100) {
+                throw new InvalidArgumentException('workflowPublishGate.min_completeness_pct must be an integer 0-100.');
+            }
+            $scope = $gate['scope'] ?? 'global';
+            if (!\in_array($scope, ['global', 'per_channel'], true)) {
+                throw new InvalidArgumentException('workflowPublishGate.scope must be "global" or "per_channel".');
+            }
+            if ('per_channel' === $scope) {
+                $channels = $gate['channels'] ?? null;
+                if (!\is_array($channels) || [] === $channels) {
+                    throw new InvalidArgumentException('workflowPublishGate.channels must be a non-empty list for per_channel scope.');
+                }
+                foreach ($channels as $channel) {
+                    if (!\is_string($channel) || '' === \trim($channel)) {
+                        throw new InvalidArgumentException('workflowPublishGate.channels entries must be non-empty strings.');
+                    }
+                }
+            }
+            $known = ['enabled', 'min_completeness_pct', 'scope', 'channels'];
+            foreach (\array_keys($gate) as $key) {
+                if (!\in_array($key, $known, true)) {
+                    throw new InvalidArgumentException(\sprintf('workflowPublishGate: unknown key "%s".', $key));
+                }
+            }
+        }
+
+        $this->workflowPublishGate = $gate;
         $this->touch();
     }
 

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectType.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectType.orm.xml
@@ -55,6 +55,11 @@
                 <option name="default">{}</option>
             </options>
         </field>
+        <field name="workflowPublishGate" type="json" column="workflow_publish_gate" nullable="true">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
         <field name="validationRules" type="json" column="validation_rules">
             <options>
                 <option name="jsonb">true</option>

--- a/apps/api/src/Catalog/Infrastructure/Workflow/CompletenessGateGuard.php
+++ b/apps/api/src/Catalog/Infrastructure/Workflow/CompletenessGateGuard.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\Workflow;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Workflow\Contracts\ObjectEditorialWorkflow;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Workflow\Event\GuardEvent;
+use Symfony\Component\Workflow\TransitionBlocker;
+
+/**
+ * WFL-P1-04 (#2418) — completeness gate on publishing transitions
+ * (ADR-0029 pillar 6, benchmark: Ergonode conditions / Akeneo entry
+ * criteria / Salsify readiness). Reads the per-ObjectType config
+ * (`workflow_publish_gate`, default OFF) against the denormalised
+ * completeness read model (`objects.completeness` + `completeness_pct`,
+ * docs/api/jsonb-schemas.md §3) — no recomputation on the hot path.
+ *
+ * Lives in Catalog (not the Workflow BC): the gate needs the entity's
+ * completeness payload and its ObjectType config, which the
+ * EditorialWorkflowSubject seam deliberately does not expose.
+ */
+final readonly class CompletenessGateGuard implements EventSubscriberInterface
+{
+    public const string BLOCKER_CODE = 'completeness_gate';
+
+    /**
+     * @var list<string>
+     */
+    private const array GATED_TRANSITIONS = [
+        ObjectEditorialWorkflow::TRANSITION_PUBLISH,
+        ObjectEditorialWorkflow::TRANSITION_APPROVE,
+    ];
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'workflow.'.ObjectEditorialWorkflow::NAME.'.guard' => 'onGuard',
+        ];
+    }
+
+    public function onGuard(GuardEvent $event): void
+    {
+        if (!\in_array($event->getTransition()->getName(), self::GATED_TRANSITIONS, true)) {
+            return;
+        }
+
+        $subject = $event->getSubject();
+        if (!$subject instanceof CatalogObject) {
+            return;
+        }
+
+        $gate = $subject->getObjectType()->getWorkflowPublishGate();
+        if (null === $gate || true !== ($gate['enabled'] ?? false)) {
+            return;
+        }
+
+        $minPct = \is_int($gate['min_completeness_pct'] ?? null) ? $gate['min_completeness_pct'] : 100;
+        $scope = \is_string($gate['scope'] ?? null) ? $gate['scope'] : 'global';
+
+        $failures = [];
+        if ('per_channel' === $scope) {
+            $channels = \is_array($gate['channels'] ?? null) ? $gate['channels'] : [];
+            $perChannel = $subject->getCompleteness()['per_channel'] ?? [];
+            $perChannel = \is_array($perChannel) ? $perChannel : [];
+            foreach ($channels as $channel) {
+                if (!\is_string($channel)) {
+                    continue;
+                }
+                // Contract §3: per_channel is optional — a channel with no
+                // computed pct falls back to the global mirror.
+                $pct = $perChannel[$channel] ?? $subject->getCompletenessPct();
+                $pct = \is_int($pct) ? $pct : 0;
+                if ($pct < $minPct) {
+                    $failures[] = \sprintf('%s: %d%%', $channel, $pct);
+                }
+            }
+        } elseif ($subject->getCompletenessPct() < $minPct) {
+            $failures[] = \sprintf('global: %d%%', $subject->getCompletenessPct());
+        }
+
+        if ([] === $failures) {
+            return;
+        }
+
+        $missing = $this->missingRequiredCodes($subject);
+
+        $event->addTransitionBlocker(new TransitionBlocker(
+            \sprintf(
+                'Completeness below the publish gate (min %d%%): %s.%s',
+                $minPct,
+                \implode(', ', $failures),
+                [] === $missing ? '' : ' Missing required: '.\implode(', ', $missing).'.',
+            ),
+            self::BLOCKER_CODE,
+        ));
+    }
+
+    /**
+     * Required attribute codes (ObjectType.completeness_rules.required)
+     * that have no non-empty value in the denormalised attribute index —
+     * the actionable part of the 409 for the FE tooltip (WFL-P3-01).
+     *
+     * @return list<string>
+     */
+    private function missingRequiredCodes(CatalogObject $subject): array
+    {
+        $rules = $subject->getObjectType()->getCompletenessRules();
+        $required = \is_array($rules['required'] ?? null) ? $rules['required'] : [];
+        $indexed = $subject->getAttributesIndexed();
+
+        $missing = [];
+        foreach ($required as $code) {
+            if (!\is_string($code)) {
+                continue;
+            }
+            $value = $indexed[$code] ?? null;
+            if (null === $value || '' === $value || [] === $value) {
+                $missing[] = $code;
+            }
+        }
+
+        return $missing;
+    }
+}

--- a/apps/api/src/Catalog/Presentation/Controller/UpdateObjectTypeController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/UpdateObjectTypeController.php
@@ -76,6 +76,8 @@ final class UpdateObjectTypeController
                 exposeToMainMenu: $this->boolOrNull($body['exposeToMainMenu'] ?? null),
                 isCategorizable: $this->boolOrNull($body['isCategorizable'] ?? null),
                 hasMultimedia: $this->boolOrNull($body['hasMultimedia'] ?? null),
+                updateWorkflowPublishGate: \array_key_exists('workflowPublishGate', $body),
+                workflowPublishGate: $this->gateOrNull($body['workflowPublishGate'] ?? null),
             );
         } catch (BuiltInObjectTypeException $e) {
             throw new HttpException(Response::HTTP_FORBIDDEN, $e->getMessage(), $e);
@@ -97,11 +99,38 @@ final class UpdateObjectTypeController
             'allowedParentTypeIds' => $objectType->getAllowedParentTypeIds(),
             'completenessRules' => $objectType->getCompletenessRules(),
             'validationRules' => $objectType->getValidationRules(),
+            'workflowPublishGate' => $objectType->getWorkflowPublishGate(),
             'exposeToMainMenu' => $objectType->isExposedToMainMenu(),
             'isCategorizable' => $objectType->isCategorizable(),
             'hasMultimedia' => $objectType->hasMultimedia(),
             'schemaVersion' => $objectType->getSchemaVersion(),
         ]);
+    }
+
+    /**
+     * Shape is validated in {@see \App\Catalog\Domain\Entity\ObjectType::setWorkflowPublishGate()}
+     * (thrown InvalidArgumentException surfaces as 422 via the catch above)
+     * — here only the JSON type is asserted.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function gateOrNull(mixed $raw): ?array
+    {
+        if (null === $raw) {
+            return null;
+        }
+        if (!\is_array($raw)) {
+            throw new BadRequestHttpException('workflowPublishGate must be an object or null.');
+        }
+        $clean = [];
+        foreach ($raw as $key => $value) {
+            if (!\is_string($key)) {
+                throw new BadRequestHttpException('workflowPublishGate keys must be strings.');
+            }
+            $clean[$key] = $value;
+        }
+
+        return $clean;
     }
 
     /**

--- a/apps/api/tests/Api/Catalog/ObjectWorkflowCompletenessGateApiTest.php
+++ b/apps/api/tests/Api/Catalog/ObjectWorkflowCompletenessGateApiTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * WFL-P1-04 (#2418) — completeness gate on publish/approve (ADR-0029
+ * pillar 6). Default OFF (no behaviour change); ON blocks below the
+ * threshold with the `completeness_gate` blocker and an actionable list
+ * of missing required attributes; per_channel scope reads the §3
+ * contract with a global fallback for channels without a computed pct.
+ */
+final class ObjectWorkflowCompletenessGateApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function gateOffPublishesRegardlessOfCompleteness(): void
+    {
+        $id = $this->seedProduct('WFL-CG-OFF', completenessPct: 0);
+
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/objects/'.$id.'/workflow/transitions/publish');
+        self::assertResponseIsSuccessful();
+    }
+
+    #[Test]
+    public function gateBlocksBelowThresholdWithMissingAttributes(): void
+    {
+        $this->configureGate(['enabled' => true, 'min_completeness_pct' => 80]);
+        $this->setRequired(['ean']);
+        $id = $this->seedProduct('WFL-CG-BLOCK', completenessPct: 40);
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/objects/'.$id.'/workflow/transitions/publish');
+        self::assertResponseStatusCodeSame(409);
+        $detail = $response->getContent(false);
+        self::assertStringContainsString('min 80%', $detail);
+        self::assertStringContainsString('ean', $detail, '409 must list the missing required attribute');
+
+        // Discovery mirrors the blocker with its machine code.
+        $body = $client->request('GET', '/api/objects/'.$id.'/workflow')->toArray();
+        $publish = null;
+        $transitions = $body['transitions'] ?? [];
+        self::assertIsArray($transitions);
+        foreach ($transitions as $transition) {
+            self::assertIsArray($transition);
+            if ('publish' === $transition['name']) {
+                $publish = $transition;
+            }
+        }
+        self::assertNotNull($publish);
+        self::assertFalse($publish['enabled']);
+        $blockers = $publish['blockers'];
+        self::assertIsArray($blockers);
+        $first = $blockers[0] ?? null;
+        self::assertIsArray($first);
+        self::assertSame('completeness_gate', $first['code'] ?? null);
+    }
+
+    #[Test]
+    public function gatePassesAtThresholdAndGatesApproveToo(): void
+    {
+        $this->configureGate(['enabled' => true, 'min_completeness_pct' => 80]);
+        $ok = $this->seedProduct('WFL-CG-OK', completenessPct: 80);
+        $inReview = $this->seedProduct('WFL-CG-REVIEW', completenessPct: 10, status: CatalogObject::STATUS_REVIEW);
+
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/objects/'.$ok.'/workflow/transitions/publish');
+        self::assertResponseIsSuccessful();
+
+        $client->request('POST', '/api/objects/'.$inReview.'/workflow/transitions/approve');
+        self::assertResponseStatusCodeSame(409, 'approve is a publishing transition and honours the gate');
+    }
+
+    #[Test]
+    public function perChannelScopeReadsChannelPctWithGlobalFallback(): void
+    {
+        $this->configureGate([
+            'enabled' => true,
+            'min_completeness_pct' => 80,
+            'scope' => 'per_channel',
+            'channels' => ['web'],
+        ]);
+        $low = $this->seedProduct('WFL-CG-CH-LOW', completenessPct: 95, perChannel: ['web' => 50]);
+        $high = $this->seedProduct('WFL-CG-CH-HIGH', completenessPct: 10, perChannel: ['web' => 90]);
+        $fallback = $this->seedProduct('WFL-CG-CH-FB', completenessPct: 85, perChannel: []);
+
+        $client = $this->authenticatedClient();
+
+        $client->request('POST', '/api/objects/'.$low.'/workflow/transitions/publish');
+        self::assertResponseStatusCodeSame(409, 'web=50 < 80 even though global is 95');
+
+        $client->request('POST', '/api/objects/'.$high.'/workflow/transitions/publish');
+        self::assertResponseIsSuccessful();
+
+        $client->request('POST', '/api/objects/'.$fallback.'/workflow/transitions/publish');
+        self::assertResponseIsSuccessful();
+    }
+
+    #[Test]
+    public function malformedGateConfigIsRejectedWith422(): void
+    {
+        $client = $this->authenticatedClient();
+        $typeId = $this->objectTypeIdFor(ObjectKind::Product);
+
+        $client->request('PATCH', '/api/object_types/'.$typeId, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['workflowPublishGate' => ['enabled' => true, 'min_completeness_pct' => 250]],
+        ]);
+        self::assertResponseStatusCodeSame(422);
+
+        $body = $client->request('PATCH', '/api/object_types/'.$typeId, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['workflowPublishGate' => ['enabled' => true, 'min_completeness_pct' => 90]],
+        ])->toArray();
+        self::assertResponseIsSuccessful();
+        $gate = $body['workflowPublishGate'];
+        self::assertIsArray($gate);
+        self::assertSame(90, $gate['min_completeness_pct'] ?? null);
+
+        $body = $client->request('PATCH', '/api/object_types/'.$typeId, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['workflowPublishGate' => null],
+        ])->toArray();
+        self::assertResponseIsSuccessful();
+        self::assertNull($body['workflowPublishGate'], 'null clears the gate');
+    }
+
+    /**
+     * @param array<string, mixed> $gate
+     */
+    private function configureGate(array $gate): void
+    {
+        $em = $this->em();
+        $type = $this->productType();
+        $type->setWorkflowPublishGate($gate);
+        $em->flush();
+    }
+
+    /**
+     * @param list<string> $required
+     */
+    private function setRequired(array $required): void
+    {
+        $em = $this->em();
+        $type = $this->productType();
+        $type->updateCompletenessRules(['required' => $required]);
+        $em->flush();
+    }
+
+    /**
+     * @param array<string, int> $perChannel
+     */
+    private function seedProduct(
+        string $code,
+        int $completenessPct,
+        array $perChannel = [],
+        string $status = CatalogObject::STATUS_DRAFT,
+    ): string {
+        $em = $this->em();
+        $object = new CatalogObject($this->productType(), $code);
+        if (CatalogObject::STATUS_DRAFT !== $status) {
+            $object->forceStatus($status);
+        }
+        self::getContainer()->get(CatalogObjectRepositoryInterface::class)->save($object);
+        $em->flush();
+
+        // The sync rebuild listener recomputes completeness on flush, so
+        // the fixture value is pinned with raw SQL AFTER the flush (same
+        // pattern as the DASH attributes_indexed lesson).
+        $completeness = ['global' => $completenessPct];
+        if ([] !== $perChannel) {
+            $completeness['per_channel'] = $perChannel;
+        }
+        $em->getConnection()->executeStatement(
+            'UPDATE objects SET completeness = :c, completeness_pct = :pct WHERE id = :id',
+            ['c' => \json_encode($completeness, JSON_THROW_ON_ERROR), 'pct' => $completenessPct, 'id' => $object->getId()->toRfc4122()],
+        );
+        $em->clear();
+
+        return $object->getId()->toRfc4122();
+    }
+
+    private function productType(): \App\Catalog\Domain\Entity\ObjectType
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $type);
+
+        return $type;
+    }
+}

--- a/docs/api/jsonb-schemas.md
+++ b/docs/api/jsonb-schemas.md
@@ -354,3 +354,33 @@ Legacy odstępstwa (select `{"value": code}` z admina, osie wariantów
 `{"value": x}` z GenerateVariants, price `{"value": n}` bez waluty) migruje
 jednorazowo #1464; do tego czasu readery mogą mieć tolerancyjny fallback,
 po migracji fallbacki znikają.
+
+## 7. `object_types.workflow_publish_gate` — gate completeness na publikacji (WFL-P1-04, ADR-0029)
+
+**Tabela**: `object_types.workflow_publish_gate JSONB NULLABLE` · **NULL = gate wyłączony (default)**.
+
+```json
+{
+  "$id": "pim:jsonb:workflow-publish-gate",
+  "type": ["object", "null"],
+  "required": ["enabled", "min_completeness_pct"],
+  "properties": {
+    "enabled": { "type": "boolean" },
+    "min_completeness_pct": { "type": "integer", "minimum": 0, "maximum": 100 },
+    "scope": { "enum": ["global", "per_channel"], "default": "global" },
+    "channels": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1,
+      "description": "Wymagane (niepuste) gdy scope=per_channel — kody kanałów sprawdzane przeciw completeness.per_channel."
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+### Reguły
+
+- Egzekwowany przez guard na przejściach `publish` i `approve` maszyny `object_editorial` (`CompletenessGateGuard`); odmowa = `TransitionBlocker` code `completeness_gate` + lista brakujących wymaganych atrybutów (409 / discovery).
+- `scope=global` czyta mirror `objects.completeness_pct`; `scope=per_channel` czyta `completeness.per_channel[channel]` z fallbackiem do global, gdy kanał nie ma policzonego pct (kontrakt §3: pole opcjonalne).
+- Shape walidowany na write-edge (`ObjectType::setWorkflowPublishGate()` → 422 przez `PATCH /api/object_types/{id}`).


### PR DESCRIPTION
**WFL-P1-04** (#2418) — pełna treść: [`Project Plan/feature-workflow-tickets.md`](https://github.com/malipie/PIM/blob/main/Project%20Plan/feature-workflow-tickets.md). Buduje na pakiecie C (#2475).

## Co

- **`object_types.workflow_publish_gate` JSONB** (migracja + mapping + walidowany setter na encji; NULL = gate wyłączony — benchmarkowy default: żaden PIM nie hard-blokuje publikacji out-of-the-box). Shape: `{enabled, min_completeness_pct 0-100, scope: global|per_channel, channels[]}` — kontrakt w `docs/api/jsonb-schemas.md` §7.
- **`CompletenessGateGuard`** na przejściach `publish` i `approve`: czyta zdenormalizowany read-model (`completeness_pct` / `completeness.per_channel` z fallbackiem do global gdy kanał bez policzonego pct — kontrakt §3); blocker code **`completeness_gate`** niesie próg, failujące scope'y i **listę brakujących wymaganych atrybutów** (required z `completeness_rules` minus niepuste wpisy `attributes_indexed`) → 409 i discovery mówią użytkownikowi CO uzupełnić (kontrakt tooltipa P3-01).
- Konfiguracja przez istniejący `PATCH /api/object_types/{id}` (edytowalne też na built-in — gate ogranicza OPERACJE, nie model; jak validationRules z ADR-0025); zły shape → 422 z konkretnym polem; `null` czyści.
- Guard żyje w **Catalog** (potrzebuje completeness + configu ObjectType, których seam `EditorialWorkflowSubject` celowo nie eksponuje).

## AC

- [x] Gate OFF (default) → regresja przejść bez zmian (test)
- [x] Gate ON global: poniżej progu 409 z listą braków (`ean`), na progu przechodzi; **approve też gate'owany**
- [x] Scope per_channel czyta `per_channel[ch]`, fallback global (3 przypadki testowe)
- [x] `docs/api/jsonb-schemas.md` §7 + walidacja shape na write-edge (422/echo/clear)

Bramki lokalnie: PHPStan max No errors · Deptrac --no-cache 0 · `ObjectWorkflowCompletenessGateApiTest` 5/5 + regresja 23/23. Snapshot OpenAPI bez driftu (zweryfikowane regen).

Live smoke po merge (proof w #2418).

Refs #2418
