### PR TITLE
feat(catalog): wire bulk change_status through the state machine (WFL-P1-05)

### DIFF
--- a/apps/api/src/Catalog/Application/Bulk/BulkChangeStatusHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkChangeStatusHandler.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Bulk;
+
+use App\Catalog\Application\BulkContext;
+use App\Catalog\Application\Reindex\BulkReindexQueueInterface;
+use App\Catalog\Domain\Entity\BulkLog;
+use App\Catalog\Domain\Entity\BulkSession;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Workflow\Contracts\ObjectEditorialWorkflow;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Target;
+use Symfony\Component\Workflow\WorkflowInterface;
+
+/**
+ * WFL-P1-05 (#2419) — bulk `change_status` through the state machine
+ * (the follow-up the BulkObjectsController MVP slice deferred). Input
+ * is a TRANSITION name, not a target status — semantics of the machine,
+ * so topology + RBAC guards (WFL-P1-01) + the completeness gate
+ * (WFL-P1-04) are evaluated PER OBJECT via `can()`; a blocked row is a
+ * warning BulkLog entry with the blocker reasons, never a silent write
+ * (lekcja bulk-endpoint-permission-escalation: no coarse bulk grant may
+ * exceed the single-item surface).
+ *
+ * Runs on the synchronous bulk path like every other bulk action
+ * (per-tenant lock, 10k cap, CHUNK_SIZE flush+clear); each apply also
+ * rides TransitionLoggingSubscriber, so workflow_transitions rows land
+ * with `bulk: true` context per object.
+ */
+final class BulkChangeStatusHandler extends AbstractBulkHandler
+{
+    private string $transition = '';
+    private ?string $comment = null;
+
+    public function __construct(
+        CatalogObjectRepositoryInterface $catalogObjects,
+        EntityManagerInterface $em,
+        BulkContext $bulkContext,
+        BulkReindexQueueInterface $reindexQueue,
+        #[Target(ObjectEditorialWorkflow::NAME)]
+        private readonly WorkflowInterface $objectEditorial,
+    ) {
+        parent::__construct($catalogObjects, $em, $bulkContext, $reindexQueue);
+    }
+
+    /**
+     * @return array{success: int, skipped: int, error: int}
+     */
+    public function handle(BulkSession $session, string $transition, ?string $comment): array
+    {
+        $this->transition = $transition;
+        $this->comment = $comment;
+
+        return $this->runBatch($session);
+    }
+
+    protected function processObject(CatalogObject $object, BulkSession $session, BulkCounters $counters): void
+    {
+        if (!$this->objectEditorial->can($object, $this->transition)) {
+            $reasons = [];
+            foreach ($this->objectEditorial->buildTransitionBlockerList($object, $this->transition) as $blocker) {
+                $reasons[] = $blocker->getMessage();
+            }
+            if ([] === $reasons) {
+                $reasons[] = \sprintf('transition "%s" is not defined from "%s"', $this->transition, $object->getStatus());
+            }
+
+            ++$counters->skipped;
+            $this->em->persist(new BulkLog(
+                $session->getId(),
+                $object->getId(),
+                null,
+                $object->getStatus(),
+                null,
+                BulkLog::LEVEL_WARNING,
+                'change_status blocked: '.\implode(' ', $reasons),
+            ));
+
+            return;
+        }
+
+        $before = $object->getStatus();
+        $context = ['bulk' => true];
+        if (null !== $this->comment) {
+            $context['comment'] = $this->comment;
+        }
+        $this->objectEditorial->apply($object, $this->transition, $context);
+
+        ++$counters->success;
+        $this->em->persist(new BulkLog(
+            $session->getId(),
+            $object->getId(),
+            null,
+            $before,
+            $object->getStatus(),
+            BulkLog::LEVEL_INFO,
+            \sprintf('change_status: %s (%s -> %s)', $this->transition, $before, $object->getStatus()),
+        ));
+    }
+}

--- a/apps/api/src/Catalog/Application/Bulk/StateEditabilityPartitioner.php
+++ b/apps/api/src/Catalog/Application/Bulk/StateEditabilityPartitioner.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Bulk;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Identity\Contracts\Policy\WorkflowStateEditPolicyInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P1-02 (#2416) — splits bulk target ids into [editable, locked]
+ * against the PRD §3.8 workflow-state policy before any bulk handler
+ * runs. One grouped status query, no per-row hydration; the policy is
+ * per-principal, so each distinct state is evaluated once. Extracted
+ * from BulkActionsController (WFL-P1-05 pushed it past the 800-line
+ * guard — and the DQL never belonged in a controller anyway).
+ */
+final readonly class StateEditabilityPartitioner
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private WorkflowStateEditPolicyInterface $statePolicy,
+    ) {
+    }
+
+    /**
+     * @param list<string> $targetIds
+     *
+     * @return array{0: list<string>, 1: list<string>} [editable, locked]
+     */
+    public function partition(array $targetIds): array
+    {
+        /** @var list<array{id: Uuid, status: string}> $rows */
+        $rows = $this->entityManager->createQueryBuilder()
+            ->select('o.id AS id', 'o.status AS status')
+            ->from(CatalogObject::class, 'o')
+            ->where('o.id IN (:ids)')
+            ->setParameter('ids', $targetIds)
+            ->getQuery()
+            ->getArrayResult();
+
+        $editableByState = [];
+        $editable = [];
+        $locked = [];
+        foreach ($rows as $row) {
+            $state = $row['status'];
+            $editableByState[$state] ??= $this->statePolicy->canEditInState($state);
+            if ($editableByState[$state]) {
+                $editable[] = $row['id']->toRfc4122();
+            } else {
+                $locked[] = $row['id']->toRfc4122();
+            }
+        }
+
+        return [$editable, $locked];
+    }
+}

--- a/apps/api/src/Catalog/Presentation/Controller/BulkActionsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/BulkActionsController.php
@@ -6,6 +6,7 @@ namespace App\Catalog\Presentation\Controller;
 
 use App\Catalog\Application\Bulk\BulkAddCategoryHandler;
 use App\Catalog\Application\Bulk\BulkAppendValueHandler;
+use App\Catalog\Application\Bulk\BulkChangeStatusHandler;
 use App\Catalog\Application\Bulk\BulkClearAttributeHandler;
 use App\Catalog\Application\Bulk\BulkDeleteHandler;
 use App\Catalog\Application\Bulk\BulkDuplicateHandler;
@@ -25,6 +26,7 @@ use App\Identity\Contracts\Policy\WorkflowStateEditPolicyInterface;
 use App\Shared\Application\BulkOperationLock;
 use App\Shared\Application\TenantContext;
 use App\Shared\Application\UserIdentityAware;
+use App\Workflow\Contracts\ObjectEditorialWorkflow;
 use DateTimeInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -97,6 +99,7 @@ final class BulkActionsController
         private readonly WorkflowStateEditPolicyInterface $statePolicy,
         private readonly CatalogObjectRepositoryInterface $catalogObjects,
         private readonly BulkSetAttributeHandler $setAttributeHandler,
+        private readonly BulkChangeStatusHandler $changeStatusHandler,
         private readonly BulkClearAttributeHandler $clearAttributeHandler,
         private readonly BulkAppendValueHandler $appendValueHandler,
         private readonly BulkRemoveValueHandler $removeValueHandler,
@@ -438,6 +441,14 @@ final class BulkActionsController
                     $this->extractChannelCodes($payload),
                     false,
                 ),
+                // WFL-P1-05 (#2419) — transitions via the state machine;
+                // per-object authorization happens inside can() (guards),
+                // NOT via a coarse bulk permission.
+                'change_status' => $this->changeStatusHandler->handle(
+                    $session,
+                    $this->requireTransition($payload),
+                    $this->optionalComment($payload),
+                ),
                 'delete' => $this->dispatchDelete($session, $body, $targetIds),
                 'duplicate' => $this->duplicateHandler->handle($session),
                 default => throw new NotFoundHttpException(\sprintf('Bulk action "%s" not implemented.', $actionType)),
@@ -495,6 +506,45 @@ final class BulkActionsController
         }
 
         return [$editable, $locked];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function requireTransition(array $payload): string
+    {
+        $transition = $payload['transition'] ?? null;
+        if (!\is_string($transition) || !\in_array($transition, ObjectEditorialWorkflow::TRANSITIONS, true)) {
+            throw new BadRequestHttpException(\sprintf(
+                'payload.transition must be one of: %s.',
+                \implode(', ', ObjectEditorialWorkflow::TRANSITIONS),
+            ));
+        }
+
+        return $transition;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function optionalComment(array $payload): ?string
+    {
+        $comment = $payload['comment'] ?? null;
+        if (null === $comment) {
+            return null;
+        }
+        if (!\is_string($comment)) {
+            throw new BadRequestHttpException('payload.comment must be a string.');
+        }
+        $comment = \trim($comment);
+        if ('' === $comment) {
+            return null;
+        }
+        if (\mb_strlen($comment) > 2000) {
+            throw new BadRequestHttpException('payload.comment must not exceed 2000 characters.');
+        }
+
+        return $comment;
     }
 
     /**

--- a/apps/api/src/Catalog/Presentation/Controller/BulkActionsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/BulkActionsController.php
@@ -17,12 +17,12 @@ use App\Catalog\Application\Bulk\BulkPublishChannelsHandler;
 use App\Catalog\Application\Bulk\BulkRemoveCategoryHandler;
 use App\Catalog\Application\Bulk\BulkRemoveValueHandler;
 use App\Catalog\Application\Bulk\BulkSetAttributeHandler;
+use App\Catalog\Application\Bulk\StateEditabilityPartitioner;
 use App\Catalog\Domain\Entity\BulkSession;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Identity\Contracts\Attribute\RequiresPermission;
 use App\Identity\Contracts\Policy\PermissionCheckerInterface;
-use App\Identity\Contracts\Policy\WorkflowStateEditPolicyInterface;
 use App\Shared\Application\BulkOperationLock;
 use App\Shared\Application\TenantContext;
 use App\Shared\Application\UserIdentityAware;
@@ -96,7 +96,7 @@ final class BulkActionsController
         private readonly TenantContext $tenantContext,
         private readonly Security $security,
         private readonly PermissionCheckerInterface $permissionChecker,
-        private readonly WorkflowStateEditPolicyInterface $statePolicy,
+        private readonly StateEditabilityPartitioner $statePartitioner,
         private readonly CatalogObjectRepositoryInterface $catalogObjects,
         private readonly BulkSetAttributeHandler $setAttributeHandler,
         private readonly BulkChangeStatusHandler $changeStatusHandler,
@@ -352,7 +352,7 @@ final class BulkActionsController
         // actionType can become a state-policy bypass (lekcja #2129).
         $lockedIds = [];
         if (\in_array($actionType, self::STATE_LOCKED_ACTIONS, true)) {
-            [$targetIds, $lockedIds] = $this->partitionByStateEditability($targetIds);
+            [$targetIds, $lockedIds] = $this->statePartitioner->partition($targetIds);
             // Early return only when the lock explains the empty set —
             // unknown ids keep flowing to the session path (and its 409
             // bulk-lock semantics) exactly as before.
@@ -469,43 +469,6 @@ final class BulkActionsController
         } finally {
             $lock->release();
         }
-    }
-
-    /**
-     * Splits target ids into [editable, locked] against the workflow
-     * state policy (one grouped status query, no per-row hydration).
-     * The policy is per-principal, so each distinct state is evaluated
-     * once, not per row.
-     *
-     * @param list<string> $targetIds
-     *
-     * @return array{0: list<string>, 1: list<string>}
-     */
-    private function partitionByStateEditability(array $targetIds): array
-    {
-        /** @var list<array{id: Uuid, status: string}> $rows */
-        $rows = $this->em->createQueryBuilder()
-            ->select('o.id AS id', 'o.status AS status')
-            ->from(CatalogObject::class, 'o')
-            ->where('o.id IN (:ids)')
-            ->setParameter('ids', $targetIds)
-            ->getQuery()
-            ->getArrayResult();
-
-        $editableByState = [];
-        $editable = [];
-        $locked = [];
-        foreach ($rows as $row) {
-            $state = $row['status'];
-            $editableByState[$state] ??= $this->statePolicy->canEditInState($state);
-            if ($editableByState[$state]) {
-                $editable[] = $row['id']->toRfc4122();
-            } else {
-                $locked[] = $row['id']->toRfc4122();
-            }
-        }
-
-        return [$editable, $locked];
     }
 
     /**

--- a/apps/api/tests/Api/Catalog/BulkChangeStatusApiTest.php
+++ b/apps/api/tests/Api/Catalog/BulkChangeStatusApiTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * WFL-P1-05 (#2419, SEC) — bulk change_status through the state machine.
+ * Input is a transition name; topology + RBAC guards + completeness gate
+ * are evaluated per object via can(), so no bulk path exceeds the
+ * single-item surface (lekcja bulk-endpoint-permission-escalation).
+ * Blocked rows fail individually (skipped + warning BulkLog) without
+ * stopping the batch.
+ */
+final class BulkChangeStatusApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function bulkSubmitMovesEveryDraftAndLogsTransitions(): void
+    {
+        $ids = [
+            $this->seedProduct('WFL-BCS-1'),
+            $this->seedProduct('WFL-BCS-2'),
+            $this->seedProduct('WFL-BCS-3'),
+        ];
+
+        $client = $this->authenticatedClient();
+        $body = $client->request('POST', '/api/products/bulk-actions/change_status', [
+            'json' => [
+                'target_ids' => $ids,
+                'payload' => ['transition' => 'submit_for_review', 'comment' => 'Zbiorcze zgłoszenie'],
+            ],
+        ])->toArray();
+
+        self::assertSame(3, $body['success_count']);
+        self::assertSame(0, $body['skipped_count']);
+        self::assertSame(0, $body['error_count']);
+
+        $state = $client->request('GET', '/api/objects/'.$ids[0].'/workflow')->toArray();
+        self::assertSame('review', $state['current_place']);
+
+        $log = $client->request('GET', '/api/objects/'.$ids[0].'/workflow/transitions')->toArray();
+        $items = $log['items'] ?? null;
+        self::assertIsArray($items);
+        $first = $items[0] ?? null;
+        self::assertIsArray($first);
+        self::assertSame('submit_for_review', $first['transition']);
+        self::assertSame('Zbiorcze zgłoszenie', $first['comment']);
+        $context = $first['context'];
+        self::assertIsArray($context);
+        self::assertTrue($context['bulk'] ?? null, 'bulk applies must be flagged in the transition log');
+    }
+
+    #[Test]
+    public function mixedStatesFailIndividuallyWithoutStoppingTheBatch(): void
+    {
+        $draft = $this->seedProduct('WFL-BCS-MIX-D');
+        $published = $this->seedProduct('WFL-BCS-MIX-P', CatalogObject::STATUS_PUBLISHED);
+
+        $client = $this->authenticatedClient();
+        $body = $client->request('POST', '/api/products/bulk-actions/change_status', [
+            'json' => [
+                'target_ids' => [$draft, $published],
+                'payload' => ['transition' => 'submit_for_review'],
+            ],
+        ])->toArray();
+
+        self::assertSame(1, $body['success_count'], 'draft row transitions');
+        self::assertSame(1, $body['skipped_count'], 'published row is topologically blocked, not silently written');
+
+        $state = $client->request('GET', '/api/objects/'.$published.'/workflow')->toArray();
+        self::assertSame('published', $state['current_place'], 'blocked row must keep its state');
+    }
+
+    #[Test]
+    public function marketingCannotBulkPublishPastTheGuards(): void
+    {
+        $this->createUserWithRole('marketing-bulk@demo.localhost', 'marketing');
+        $draft = $this->seedProduct('WFL-BCS-ESC');
+
+        $client = $this->authenticatedClient('marketing-bulk@demo.localhost');
+        $body = $client->request('POST', '/api/products/bulk-actions/change_status', [
+            'json' => [
+                'target_ids' => [$draft],
+                'payload' => ['transition' => 'publish'],
+            ],
+        ])->toArray();
+
+        self::assertSame(0, $body['success_count'], 'guards must block bulk publish for marketing');
+        self::assertSame(1, $body['skipped_count']);
+
+        $state = $this->authenticatedClient()->request('GET', '/api/objects/'.$draft.'/workflow')->toArray();
+        self::assertSame('draft', $state['current_place']);
+    }
+
+    #[Test]
+    public function unknownTransitionIsRejected(): void
+    {
+        $draft = $this->seedProduct('WFL-BCS-400');
+
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/products/bulk-actions/change_status', [
+            'json' => [
+                'target_ids' => [$draft],
+                'payload' => ['transition' => 'teleport'],
+            ],
+        ]);
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    private function createUserWithRole(string $email, string $roleCode): void
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $role = self::getContainer()->get(RoleRepositoryInterface::class)->findByCode($roleCode, $tenant);
+        \assert(null !== $role);
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $stub = new User($tenant, $email, '', ['ROLE_USER']);
+        $user = new User($tenant, $email, $hasher->hashPassword($stub, 'changeme'), ['ROLE_USER']);
+        $user->addRole($role);
+        $em->persist($user);
+        $em->flush();
+    }
+
+    private function seedProduct(string $code, string $status = CatalogObject::STATUS_DRAFT): string
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $type);
+
+        $object = new CatalogObject($type, $code);
+        if (CatalogObject::STATUS_DRAFT !== $status) {
+            $object->forceStatus($status);
+        }
+        self::getContainer()->get(CatalogObjectRepositoryInterface::class)->save($object);
+        $em->flush();
+        $em->clear();
+
+        return $object->getId()->toRfc4122();
+    }
+}


### PR DESCRIPTION
**WFL-P1-05** (#2419) — pełna treść: [`Project Plan/feature-workflow-tickets.md`](https://github.com/malipie/PIM/blob/main/Project%20Plan/feature-workflow-tickets.md). Domyka jawnie odroczony follow-up z `BulkObjectsController` (#2129: „mapping pre-exists for the follow-up that adds change_status").

## Co

- **`BulkChangeStatusHandler`** na standardowej ścieżce bulk (per-tenant lock, cap 10k, `CHUNK_SIZE` flush+clear, ślad `BulkLog` pod rollback): wejściem jest **nazwa przejścia** (semantyka maszyny), każdy wiersz przechodzi `can()` → topologia + guardy RBAC (P1-01) + gate completeness (P1-04) **per obiekt**; zablokowany wiersz = `skipped` + warning `BulkLog` z powodami blockerów, nigdy cichy zapis (lekcja #2129: bulk nie może przekroczyć powierzchni single-item).
- Akcja `change_status` w `BulkActionsController` (`/api/{products,objects}/bulk-actions/change_status`): payload `{transition, comment?}` (walidacja: transition ∈ definicji, komentarz ≤2000); każdy apply jedzie przez `TransitionLoggingSubscriber` → wpisy `workflow_transitions` z `context.bulk=true` + komentarzem operatora per obiekt.
- Celowo POZA listą `STATE_LOCKED_ACTIONS` z P1-02 — przejścia mają własne guardy.

## Świadome odejście od szkicu ticketu

Bez ścieżki async Messenger: KAŻDA istniejąca akcja bulk jest synchroniczna pod tenant lockiem z `set_time_limit(0)` i chunked flush; przejścia są tańsze niż zapisy wartości, więc rozjazd na drugi model wykonania nie ma dziś uzasadnienia. Rewizja, jeśli 10k przejść realnie zablokuje operatora. (`ActingUserContext` z P1-01 czeka gotowy na taki wariant.)

## AC / testy

- [x] Bulk submit_for_review na 3 draftach → 3× success, log per obiekt z `bulk:true` i komentarzem (test)
- [x] Mixed states: draft przechodzi, published skipped — batch się nie zatrzymuje, stan zablokowanego wiersza nietknięty
- [x] Eskalacja: marketing bulk `publish` → 0 success / 1 skipped (guardy per obiekt)
- [x] Nieznane przejście → 400 z listą dozwolonych

Bramki lokalnie: PHPStan max No errors · Deptrac --no-cache 0 · `BulkChangeStatusApiTest` 4/4. Live smoke po merge (proof w #2419).

Refs #2419
