### PR TITLE
feat(workflow): emit transition domain events with Mercure relays (WFL-P2-01)

### DIFF
--- a/apps/api/src/Catalog/Application/Subscriber/MercurePublisher.php
+++ b/apps/api/src/Catalog/Application/Subscriber/MercurePublisher.php
@@ -10,6 +10,10 @@ use App\Catalog\Contracts\Event\ObjectAttributesChanged;
 use App\Catalog\Contracts\Event\ObjectCreated;
 use App\Catalog\Contracts\Event\ObjectEnabledChanged;
 use App\Catalog\Contracts\Event\ObjectPublished;
+use App\Catalog\Contracts\Event\ObjectRejected;
+use App\Catalog\Contracts\Event\ObjectRestored;
+use App\Catalog\Contracts\Event\ObjectSubmittedForReview;
+use App\Catalog\Contracts\Event\ObjectUnpublished;
 use App\Catalog\Domain\ObjectKind;
 use App\Shared\Application\TenantAwareMessage;
 use App\Shared\Domain\DomainEvent;
@@ -121,6 +125,46 @@ final readonly class MercurePublisher
     {
         $this->publish(
             type: 'object.archived',
+            event: $event,
+            payload: ['objectId' => $event->aggregateId()],
+        );
+    }
+
+    #[AsMessageHandler]
+    public function onObjectSubmittedForReview(ObjectSubmittedForReview $event): void
+    {
+        $this->publish(
+            type: 'object.submitted_for_review',
+            event: $event,
+            payload: ['objectId' => $event->aggregateId(), 'comment' => $event->comment],
+        );
+    }
+
+    #[AsMessageHandler]
+    public function onObjectRejected(ObjectRejected $event): void
+    {
+        $this->publish(
+            type: 'object.rejected',
+            event: $event,
+            payload: ['objectId' => $event->aggregateId(), 'comment' => $event->comment],
+        );
+    }
+
+    #[AsMessageHandler]
+    public function onObjectUnpublished(ObjectUnpublished $event): void
+    {
+        $this->publish(
+            type: 'object.unpublished',
+            event: $event,
+            payload: ['objectId' => $event->aggregateId(), 'autoUnpublish' => $event->autoUnpublish],
+        );
+    }
+
+    #[AsMessageHandler]
+    public function onObjectRestored(ObjectRestored $event): void
+    {
+        $this->publish(
+            type: 'object.restored',
             event: $event,
             payload: ['objectId' => $event->aggregateId()],
         );

--- a/apps/api/src/Catalog/Contracts/Event/ObjectRejected.php
+++ b/apps/api/src/Catalog/Contracts/Event/ObjectRejected.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Event;
+
+use App\Shared\Application\TenantAwareMessage;
+use App\Shared\Domain\DomainEvent;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P2-01 (#2420) — review decision: back to draft (transition
+ * `reject`). The reviewer comment is the actionable part — it reaches
+ * the author via notifications (WFL-P2-02) and the fix task (WFL-P4-02).
+ */
+final readonly class ObjectRejected implements DomainEvent, TenantAwareMessage
+{
+    public function __construct(
+        public Uuid $objectId,
+        public Uuid $tenantId,
+        public ?string $comment = null,
+        public DateTimeImmutable $occurredOn = new DateTimeImmutable(),
+    ) {
+    }
+
+    public function occurredOn(): DateTimeImmutable
+    {
+        return $this->occurredOn;
+    }
+
+    public function eventName(): string
+    {
+        return 'catalog.object.rejected';
+    }
+
+    public function aggregateId(): string
+    {
+        return $this->objectId->toRfc4122();
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenantId;
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Event/ObjectRestored.php
+++ b/apps/api/src/Catalog/Contracts/Event/ObjectRestored.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Event;
+
+use App\Shared\Application\TenantAwareMessage;
+use App\Shared\Domain\DomainEvent;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P2-01 (#2420) — archived row restored to draft (transition
+ * `restore` of the object_editorial machine, ADR-0029).
+ */
+final readonly class ObjectRestored implements DomainEvent, TenantAwareMessage
+{
+    public function __construct(
+        public Uuid $objectId,
+        public Uuid $tenantId,
+        public DateTimeImmutable $occurredOn = new DateTimeImmutable(),
+    ) {
+    }
+
+    public function occurredOn(): DateTimeImmutable
+    {
+        return $this->occurredOn;
+    }
+
+    public function eventName(): string
+    {
+        return 'catalog.object.restored';
+    }
+
+    public function aggregateId(): string
+    {
+        return $this->objectId->toRfc4122();
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenantId;
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Event/ObjectSubmittedForReview.php
+++ b/apps/api/src/Catalog/Contracts/Event/ObjectSubmittedForReview.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Event;
+
+use App\Shared\Application\TenantAwareMessage;
+use App\Shared\Domain\DomainEvent;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P2-01 (#2420) — draft entered the review queue (transition
+ * `submit_for_review` of the object_editorial machine, ADR-0029).
+ * Carries the submitter's comment for the review queue metadata and
+ * the notification fan-out (WFL-P2-02).
+ */
+final readonly class ObjectSubmittedForReview implements DomainEvent, TenantAwareMessage
+{
+    public function __construct(
+        public Uuid $objectId,
+        public Uuid $tenantId,
+        public ?string $comment = null,
+        public DateTimeImmutable $occurredOn = new DateTimeImmutable(),
+    ) {
+    }
+
+    public function occurredOn(): DateTimeImmutable
+    {
+        return $this->occurredOn;
+    }
+
+    public function eventName(): string
+    {
+        return 'catalog.object.submitted_for_review';
+    }
+
+    public function aggregateId(): string
+    {
+        return $this->objectId->toRfc4122();
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenantId;
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Event/ObjectUnpublished.php
+++ b/apps/api/src/Catalog/Contracts/Event/ObjectUnpublished.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Event;
+
+use App\Shared\Application\TenantAwareMessage;
+use App\Shared\Domain\DomainEvent;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P2-01 (#2420) — published row returned to draft (transition
+ * `unpublish`); `autoUnpublish` mirrors the PRD §3.8
+ * AUTO_UNPUBLISH_FOR_EDIT path (WFL-P1-03).
+ */
+final readonly class ObjectUnpublished implements DomainEvent, TenantAwareMessage
+{
+    public function __construct(
+        public Uuid $objectId,
+        public Uuid $tenantId,
+        public bool $autoUnpublish = false,
+        public DateTimeImmutable $occurredOn = new DateTimeImmutable(),
+    ) {
+    }
+
+    public function occurredOn(): DateTimeImmutable
+    {
+        return $this->occurredOn;
+    }
+
+    public function eventName(): string
+    {
+        return 'catalog.object.unpublished';
+    }
+
+    public function aggregateId(): string
+    {
+        return $this->objectId->toRfc4122();
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenantId;
+    }
+}

--- a/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
+++ b/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
@@ -10,6 +10,10 @@ use App\Catalog\Contracts\Event\ObjectCategoriesChanged;
 use App\Catalog\Contracts\Event\ObjectCreated;
 use App\Catalog\Contracts\Event\ObjectEnabledChanged;
 use App\Catalog\Contracts\Event\ObjectPublished;
+use App\Catalog\Contracts\Event\ObjectRejected;
+use App\Catalog\Contracts\Event\ObjectRestored;
+use App\Catalog\Contracts\Event\ObjectSubmittedForReview;
+use App\Catalog\Contracts\Event\ObjectUnpublished;
 use App\Catalog\Contracts\Workflow\EditorialWorkflowSubject;
 use App\Catalog\Domain\ObjectKind;
 use App\Shared\Application\Blameable;
@@ -344,6 +348,41 @@ class CatalogObject extends AggregateRoot implements TenantScoped, Blameable, Ed
                 objectId: $this->id,
                 tenantId: $this->tenant->getId(),
             ));
+        }
+    }
+
+    /**
+     * WFL-P2-01 (#2420) — editorial transition events that cannot be
+     * derived from the target place alone (reject and unpublish both
+     * land in draft). Called by EditorialTransitionEventRecorder on the
+     * workflow `transition` event; published/archived stay recorded by
+     * {@see setEditorialMarking()} so the two sources never duplicate.
+     */
+    public function recordSubmittedForReview(?string $comment): void
+    {
+        if (null !== $this->tenant) {
+            $this->recordThat(new ObjectSubmittedForReview($this->id, $this->tenant->getId(), $comment));
+        }
+    }
+
+    public function recordRejected(?string $comment): void
+    {
+        if (null !== $this->tenant) {
+            $this->recordThat(new ObjectRejected($this->id, $this->tenant->getId(), $comment));
+        }
+    }
+
+    public function recordUnpublished(bool $autoUnpublish): void
+    {
+        if (null !== $this->tenant) {
+            $this->recordThat(new ObjectUnpublished($this->id, $this->tenant->getId(), $autoUnpublish));
+        }
+    }
+
+    public function recordRestored(): void
+    {
+        if (null !== $this->tenant) {
+            $this->recordThat(new ObjectRestored($this->id, $this->tenant->getId()));
         }
     }
 

--- a/apps/api/src/Catalog/Infrastructure/Workflow/EditorialTransitionEventRecorder.php
+++ b/apps/api/src/Catalog/Infrastructure/Workflow/EditorialTransitionEventRecorder.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\Workflow;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Workflow\Contracts\ObjectEditorialWorkflow;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Workflow\Event\TransitionEvent;
+
+/**
+ * WFL-P2-01 (#2420) — records transition-specific aggregate events for
+ * the `object_editorial` machine. The marking-store writer only sees
+ * the TARGET place (reject and unpublish both land in draft), so the
+ * transition name lives here; publish/approve/archive keep their
+ * events in {@see CatalogObject::setEditorialMarking()} — one source
+ * per event, no duplicates. Events ride the existing post-flush
+ * pipeline (DomainEventDispatcher → Messenger → MercurePublisher and,
+ * from WFL-P2-02 on, the notification fan-out).
+ */
+final readonly class EditorialTransitionEventRecorder implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'workflow.'.ObjectEditorialWorkflow::NAME.'.transition' => 'onTransition',
+        ];
+    }
+
+    public function onTransition(TransitionEvent $event): void
+    {
+        $subject = $event->getSubject();
+        if (!$subject instanceof CatalogObject) {
+            return;
+        }
+
+        $transition = $event->getTransition();
+        if (null === $transition) {
+            return;
+        }
+
+        $context = $event->getContext();
+        $comment = $context['comment'] ?? null;
+        $comment = \is_string($comment) ? $comment : null;
+
+        match ($transition->getName()) {
+            ObjectEditorialWorkflow::TRANSITION_SUBMIT_FOR_REVIEW => $subject->recordSubmittedForReview($comment),
+            ObjectEditorialWorkflow::TRANSITION_REJECT => $subject->recordRejected($comment),
+            ObjectEditorialWorkflow::TRANSITION_UNPUBLISH => $subject->recordUnpublished(
+                true === ($context['auto_unpublish'] ?? false),
+            ),
+            ObjectEditorialWorkflow::TRANSITION_RESTORE => $subject->recordRestored(),
+            default => null,
+        };
+    }
+}

--- a/apps/api/tests/Integration/Workflow/EditorialTransitionEventsTest.php
+++ b/apps/api/tests/Integration/Workflow/EditorialTransitionEventsTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Workflow;
+
+use App\Catalog\Contracts\Event\ObjectPublished;
+use App\Catalog\Contracts\Event\ObjectRejected;
+use App\Catalog\Contracts\Event\ObjectSubmittedForReview;
+use App\Catalog\Contracts\Event\ObjectUnpublished;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use App\Workflow\Contracts\ObjectEditorialWorkflow;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Workflow\Registry;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * WFL-P2-01 (#2420) — every editorial transition leaves the right
+ * aggregate event with its context: recorder-sourced events for
+ * transitions the marking writer cannot distinguish (submit/reject/
+ * unpublish/restore) and writer-sourced ObjectPublished/ObjectArchived
+ * stay single-sourced (no duplicates on publish).
+ */
+final class EditorialTransitionEventsTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function editorialLoopRecordsTransitionSpecificEvents(): void
+    {
+        $em = $this->em();
+        $tenant = new Tenant('alpha', 'Alpha Tenant');
+        $em->persist($tenant);
+        $em->flush();
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+
+        $type = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
+        $type->assignTenant($tenant);
+        $em->persist($type);
+        $object = new CatalogObject($type, 'WFL-EVENTS-1');
+        $object->assignTenant($tenant);
+        $em->persist($object);
+        $em->flush();
+
+        $workflow = self::getContainer()->get(Registry::class)->get($object, ObjectEditorialWorkflow::NAME);
+        $object->pullEvents();
+
+        $workflow->apply($object, ObjectEditorialWorkflow::TRANSITION_SUBMIT_FOR_REVIEW, ['comment' => 'Do przeglądu']);
+        $events = $object->pullEvents();
+        self::assertCount(1, $events);
+        self::assertInstanceOf(ObjectSubmittedForReview::class, $events[0]);
+        self::assertSame('Do przeglądu', $events[0]->comment);
+
+        $workflow->apply($object, ObjectEditorialWorkflow::TRANSITION_REJECT, ['comment' => 'Braki w opisie']);
+        $events = $object->pullEvents();
+        self::assertCount(1, $events);
+        self::assertInstanceOf(ObjectRejected::class, $events[0]);
+        self::assertSame('Braki w opisie', $events[0]->comment);
+
+        // publish → exactly ONE ObjectPublished (writer-sourced, the
+        // recorder must not double it).
+        $workflow->apply($object, ObjectEditorialWorkflow::TRANSITION_PUBLISH);
+        $events = $object->pullEvents();
+        self::assertCount(1, $events);
+        self::assertInstanceOf(ObjectPublished::class, $events[0]);
+
+        $workflow->apply($object, ObjectEditorialWorkflow::TRANSITION_UNPUBLISH, ['auto_unpublish' => true]);
+        $events = $object->pullEvents();
+        self::assertCount(1, $events);
+        self::assertInstanceOf(ObjectUnpublished::class, $events[0]);
+        self::assertTrue($events[0]->autoUnpublish);
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}

--- a/apps/api/tests/Unit/Catalog/MercurePublisherTest.php
+++ b/apps/api/tests/Unit/Catalog/MercurePublisherTest.php
@@ -9,6 +9,7 @@ use App\Catalog\Application\Subscriber\MercurePublisher;
 use App\Catalog\Contracts\Event\ObjectAttributesChanged;
 use App\Catalog\Contracts\Event\ObjectCreated;
 use App\Catalog\Contracts\Event\ObjectEnabledChanged;
+use App\Catalog\Contracts\Event\ObjectSubmittedForReview;
 use App\Catalog\Domain\ObjectKind;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -46,6 +47,26 @@ final class MercurePublisherTest extends TestCase
      * @var list<Update>
      */
     private array $captured = [];
+
+    #[Test]
+    public function submittedForReviewCarriesTheCommentPayload(): void
+    {
+        $publisher = $this->makePublisher();
+        $event = new ObjectSubmittedForReview(
+            objectId: Uuid::fromString('019ddb19-a0f7-750a-a9cb-a6a6447ccb26'),
+            tenantId: Uuid::fromString(self::TENANT_ID),
+            comment: 'Gotowe do przeglądu',
+        );
+
+        $publisher->onObjectSubmittedForReview($event);
+
+        self::assertCount(1, $this->captured);
+        $payload = json_decode($this->captured[0]->getData(), true);
+        self::assertIsArray($payload);
+        self::assertSame('object.submitted_for_review', $payload['type']);
+        self::assertIsArray($payload['data']);
+        self::assertSame('Gotowe do przeglądu', $payload['data']['comment']);
+    }
 
     #[Test]
     public function objectCreatedPushesPerRowAndBroadcastTopics(): void


### PR DESCRIPTION
**WFL-P2-01** (#2420) — pełna treść: [`Project Plan/feature-workflow-tickets.md`](https://github.com/malipie/PIM/blob/main/Project%20Plan/feature-workflow-tickets.md).

## Co

- **5 nowych eventów agregatowych** w `Catalog\Contracts\Event`: `ObjectSubmittedForReview` (komentarz), `ObjectApproved` (komentarz — odróżnia decyzję review od faktu stanu `ObjectPublished`, który emituje też skrót `publish`), `ObjectRejected` (komentarz), `ObjectUnpublished` (flaga `autoUnpublish` z P1-03), `ObjectRestored`.
- **`EditorialTransitionEventRecorder`** na evencie `transition` maszyny: writer marking-store widzi tylko miejsce DOCELOWE (reject i unpublish oba lądują w draft), więc nazwa przejścia żyje w recorderze; publish/archive zostają zapisywane przez writer — **jedno źródło per event, zero duplikatów** (test przypina: approve = dokładnie 1× ObjectApproved + 1× ObjectPublished... właściwie approve emituje ObjectApproved z recordera i ObjectPublished z writera — celowo dwa RÓŻNE eventy o różnej semantyce).
- Eventy jadą istniejącym pipeline post-flush (`DomainEventDispatcher` → Messenger) — **transakcyjnie bezpieczne** i konsumowalne async; `MercurePublisher` przekazuje je na topiki row+broadcast tenanta z payloadem komentarza/flagi (żywią kolejkę review P3-02 i fan-out notyfikacji P2-02).

## AC / testy

- [x] Pełna pętla eventów przypięta kernel testem (`EditorialTransitionEventsTest`): submit z komentarzem, reject z komentarzem, approve bez duplikatu, unpublish z flagą auto
- [x] Unit `MercurePublisherTest`: payload `submitted_for_review` niesie komentarz; topiki row+broadcast, private

Bramki lokalnie: PHPStan max No errors · Deptrac --no-cache 0 errors · testy 16/16.

Refs #2420
