### PR TITLE
feat(notifications): persistent in-app notifications with bell wiring (pakiet D)

### DIFF
--- a/apps/admin/src/layout/notifications-bell.tsx
+++ b/apps/admin/src/layout/notifications-bell.tsx
@@ -14,6 +14,7 @@ import {
 
 import { useNotificationsInboxOptional } from './notifications-context';
 import { useNotifications } from './use-notifications';
+import { useWorkflowNotifications } from './use-workflow-notifications';
 
 /**
  * Notifications bell wrapping a Radix dropdown over the SSE feed (#54).
@@ -28,7 +29,9 @@ export function NotificationsBell() {
   const { entries, unreadCount, markAllRead } = useNotifications();
   // EXR-15 — exports in-app inbox merges into the bell (badge + list).
   const inbox = useNotificationsInboxOptional();
-  const totalUnread = unreadCount + (inbox?.unread ?? 0);
+  // WFL-P2-03 — persistent workflow notifications (survive reloads).
+  const workflow = useWorkflowNotifications();
+  const totalUnread = unreadCount + (inbox?.unread ?? 0) + workflow.unreadCount;
 
   return (
     <DropdownMenu
@@ -36,6 +39,7 @@ export function NotificationsBell() {
         if (open) {
           markAllRead();
           inbox?.markAllRead();
+          workflow.markAllRead();
         }
       }}
     >
@@ -62,6 +66,41 @@ export function NotificationsBell() {
           {t('notifications.title', { defaultValue: 'Recent activity' })}
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
+        {workflow.entries.length > 0 && (
+          <>
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              {t('notifications.workflow_section', { defaultValue: 'Workflow' })}
+            </DropdownMenuLabel>
+            {workflow.entries.slice(0, 6).map((entry) => {
+              const objectId =
+                typeof entry.payload?.object_id === 'string' ? entry.payload.object_id : null;
+              const comment =
+                typeof entry.payload?.comment === 'string' ? entry.payload.comment : null;
+              return (
+                <DropdownMenuItem
+                  key={entry.id}
+                  asChild
+                  className="flex flex-col items-start gap-0.5 whitespace-normal"
+                >
+                  <Link to={objectId !== null ? `/products/${objectId}` : '/workflow'}>
+                    <span className="text-sm font-medium">
+                      {t(`notifications.workflow_type.${entry.type}`, {
+                        defaultValue: entry.type,
+                      })}
+                    </span>
+                    {comment !== null && (
+                      <span className="text-xs text-muted-foreground">{comment}</span>
+                    )}
+                    <span className="text-xs text-muted-foreground">
+                      {formatTime(entry.created_at, i18n.language)}
+                    </span>
+                  </Link>
+                </DropdownMenuItem>
+              );
+            })}
+            <DropdownMenuSeparator />
+          </>
+        )}
         {(inbox?.entries.length ?? 0) > 0 && (
           <>
             {inbox?.entries.slice(0, 6).map((entry) => (
@@ -91,7 +130,9 @@ export function NotificationsBell() {
             <DropdownMenuSeparator />
           </>
         )}
-        {entries.length === 0 && (inbox?.entries.length ?? 0) === 0 ? (
+        {entries.length === 0 &&
+        (inbox?.entries.length ?? 0) === 0 &&
+        workflow.entries.length === 0 ? (
           <div className="px-3 py-6 text-center text-xs text-muted-foreground">
             {t('notifications.empty', { defaultValue: 'No recent events.' })}
           </div>

--- a/apps/admin/src/layout/use-workflow-notifications.ts
+++ b/apps/admin/src/layout/use-workflow-notifications.ts
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { useIdentity } from '@/lib/identity';
+import { ensureMercureAuthorization, mercureSubscribeUrl, mercureTenantTopic } from '@/lib/mercure';
+import {
+  fetchNotifications,
+  markAllNotificationsRead,
+  type PersistentNotification,
+} from '@/lib/notifications/api';
+
+/**
+ * WFL-P2-03 (#2422) — persistent workflow notifications for the bell:
+ * the initial page comes from `/api/notifications` (survives reloads,
+ * unlike the ephemeral activity feed next to it), live entries arrive
+ * on the per-user Mercure topic
+ * (`tenant/<tid>/users/<uid>/notifications`, WFL-P2-02) and read
+ * receipts go back through `read-all` when the dropdown opens.
+ *
+ * Connection failure is silent — same contract as useNotifications:
+ * Mercure may be down in dev, the REST page still renders.
+ */
+export interface UseWorkflowNotificationsState {
+  entries: PersistentNotification[];
+  unreadCount: number;
+  markAllRead: () => void;
+}
+
+const MAX_ENTRIES = 20;
+
+export function useWorkflowNotifications(): UseWorkflowNotificationsState {
+  const [entries, setEntries] = useState<PersistentNotification[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const { identity } = useIdentity();
+  const tenantId = identity?.tenant?.id ?? null;
+  const userId = identity?.id ?? null;
+
+  useEffect(() => {
+    let cancelled = false;
+    if (userId === null) return;
+
+    fetchNotifications(MAX_ENTRIES)
+      .then((page) => {
+        if (cancelled) return;
+        setEntries(page.items);
+        setUnreadCount(page.unread_count);
+      })
+      .catch(() => {
+        // Silent: the bell is a convenience surface; auth/permission
+        // errors surface on the primary screens.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof EventSource === 'undefined') return;
+    if (tenantId === null || userId === null) return;
+
+    const topic = mercureTenantTopic(tenantId, 'users', userId, 'notifications');
+    let source: EventSource | null = null;
+    let disposed = false;
+
+    void ensureMercureAuthorization().then(() => {
+      if (disposed) return;
+      source = new EventSource(mercureSubscribeUrl(topic), { withCredentials: true });
+      source.onmessage = (event: MessageEvent<string>) => {
+        try {
+          const parsed = JSON.parse(event.data) as PersistentNotification;
+          if (typeof parsed.id !== 'string' || typeof parsed.type !== 'string') return;
+          setEntries((previous) => {
+            if (previous.some((entry) => entry.id === parsed.id)) return previous;
+            return [{ ...parsed, read_at: null }, ...previous].slice(0, MAX_ENTRIES);
+          });
+          setUnreadCount((previous) => previous + 1);
+        } catch {
+          // Malformed frame — ignore; the next REST load reconciles.
+        }
+      };
+    });
+
+    return () => {
+      disposed = true;
+      source?.close();
+    };
+  }, [tenantId, userId]);
+
+  const markAllRead = useCallback(() => {
+    if (unreadCount === 0) return;
+    setUnreadCount(0);
+    setEntries((previous) =>
+      previous.map((entry) =>
+        entry.read_at === null ? { ...entry, read_at: new Date().toISOString() } : entry,
+      ),
+    );
+    void markAllNotificationsRead().catch(() => {
+      // Optimistic zeroing stays; the next REST load reconciles.
+    });
+  }, [unreadCount]);
+
+  return { entries, unreadCount, markAllRead };
+}

--- a/apps/admin/src/lib/notifications/api.ts
+++ b/apps/admin/src/lib/notifications/api.ts
@@ -1,0 +1,29 @@
+import { jsonFetch } from '@/lib/http';
+
+/**
+ * WFL-P2-03 (#2422) — typed client for the persistent notification
+ * surface (`/api/notifications`, WFL-P2-02). The admin uses exactly the
+ * endpoints integrators use (ADR-0020).
+ */
+
+export interface PersistentNotification {
+  id: string;
+  type: string;
+  payload: Record<string, unknown> | null;
+  read_at: string | null;
+  created_at: string;
+}
+
+export interface NotificationsPage {
+  items: PersistentNotification[];
+  unread_count: number;
+  next_cursor: string | null;
+}
+
+export function fetchNotifications(limit = 20): Promise<NotificationsPage> {
+  return jsonFetch<NotificationsPage>(`/api/notifications?limit=${limit}`);
+}
+
+export function markAllNotificationsRead(): Promise<{ marked_read: number }> {
+  return jsonFetch<{ marked_read: number }>('/api/notifications/read-all', { method: 'POST' });
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -49,7 +49,15 @@
   "notifications": {
     "aria_label": "Notifications",
     "title": "Recent activity",
-    "empty": "No recent events."
+    "empty": "No recent events.",
+    "workflow_section": "Workflow",
+    "workflow_type": {
+      "workflow": {
+        "submitted_for_review": "Submitted for review",
+        "approved": "Your change was approved",
+        "rejected": "Your change was rejected"
+      }
+    }
   },
   "auth": {
     "login_title": "Sign in",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -49,7 +49,15 @@
   "notifications": {
     "aria_label": "Powiadomienia",
     "title": "Ostatnia aktywność",
-    "empty": "Brak ostatnich zdarzeń."
+    "empty": "Brak ostatnich zdarzeń.",
+    "workflow_section": "Workflow",
+    "workflow_type": {
+      "workflow": {
+        "submitted_for_review": "Zgłoszono do przeglądu",
+        "approved": "Twoja zmiana zatwierdzona",
+        "rejected": "Twoja zmiana odrzucona"
+      }
+    }
   },
   "auth": {
     "login_title": "Zaloguj się",

--- a/apps/api/config/packages/doctrine.yaml
+++ b/apps/api/config/packages/doctrine.yaml
@@ -126,6 +126,12 @@ doctrine:
                 dir: '%kernel.project_dir%/src/Identity/Infrastructure/Doctrine/Orm/Mapping'
                 prefix: 'App\Identity\Domain\Entity'
                 alias: Identity
+            Notification:
+                type: xml
+                is_bundle: false
+                dir: '%kernel.project_dir%/src/Notification/Infrastructure/Doctrine/Orm/Mapping'
+                prefix: 'App\Notification\Domain\Entity'
+                alias: Notification
             Workflow:
                 type: xml
                 is_bundle: false

--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -305,6 +305,22 @@ parameters:
               - type: directory
                 value: 'src/Export/Catalog/Contracts/.*'
 
+        # ─── Notification — persistent in-app notifications (WFL-P2-02) ───
+        - name: Notification_Internals
+          collectors:
+              - type: directory
+                value: 'src/Notification/Domain/.*'
+              - type: directory
+                value: 'src/Notification/Application/.*'
+              - type: directory
+                value: 'src/Notification/Infrastructure/.*'
+              - type: directory
+                value: 'src/Notification/Presentation/.*'
+        - name: Notification_Contracts
+          collectors:
+              - type: directory
+                value: 'src/Notification/Contracts/.*'
+
         # ─── Workflow — editorial state machine, transition log, tasks (ADR-0029) ───
         - name: Workflow_Internals
           collectors:
@@ -376,6 +392,20 @@ parameters:
             - Shared
             - Vendor
         Workflow_Contracts:
+            - Shared
+            - Vendor
+
+        # WFL-P2-02 — thin notification context (Dashboard precedent):
+        # consumes Catalog Contracts events, resolves recipients via the
+        # Identity seam and reads submit authorship via the Workflow seam.
+        Notification_Internals:
+            - Notification_Contracts
+            - Catalog_Contracts
+            - Identity_Contracts
+            - Workflow_Contracts
+            - Shared
+            - Vendor
+        Notification_Contracts:
             - Shared
             - Vendor
 

--- a/apps/api/migrations/Version20260711110000.php
+++ b/apps/api/migrations/Version20260711110000.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * WFL-P2-02 (#2421) — `notifications`: persistent per-user in-app
+ * notifications (bell). Generic infra (type + payload JSONB) so future
+ * modules reuse the same rows; the workflow fan-out is the first
+ * writer. Tenant RLS + Super Admin bypass — same pattern as
+ * workflow_transitions (Version20260711090000).
+ */
+final class Version20260711110000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'WFL-P2-02: notifications table + tenant RLS policies';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE notifications (
+                id UUID NOT NULL,
+                tenant_id UUID NOT NULL,
+                user_id UUID NOT NULL,
+                type VARCHAR(64) NOT NULL,
+                payload JSONB DEFAULT NULL,
+                read_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY(id)
+            )
+            SQL);
+        $this->addSql('CREATE INDEX notifications_tenant_user_read_idx ON notifications (tenant_id, user_id, read_at)');
+        $this->addSql('CREATE INDEX notifications_tenant_user_id_idx ON notifications (tenant_id, user_id, id)');
+        $this->addSql(
+            'ALTER TABLE notifications ADD CONSTRAINT fk_notifications_tenant '
+            .'FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE RESTRICT NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+        $this->addSql(
+            'ALTER TABLE notifications ADD CONSTRAINT fk_notifications_user '
+            .'FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+
+        $predicate = "tenant_id = NULLIF(current_setting('app.current_tenant', true), '')::uuid";
+        $this->addSql('ALTER TABLE notifications ENABLE ROW LEVEL SECURITY');
+        $this->addSql('ALTER TABLE notifications FORCE ROW LEVEL SECURITY');
+        $this->addSql(\sprintf(
+            'CREATE POLICY tenant_isolation_notifications ON notifications USING (%s) WITH CHECK (%s)',
+            $predicate,
+            $predicate,
+        ));
+        $this->addSql(
+            'CREATE POLICY super_admin_bypass_notifications ON notifications '
+            ."USING (current_setting('app.is_super_admin', true) = 'true') "
+            ."WITH CHECK (current_setting('app.is_super_admin', true) = 'true')"
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP POLICY IF EXISTS super_admin_bypass_notifications ON notifications');
+        $this->addSql('DROP POLICY IF EXISTS tenant_isolation_notifications ON notifications');
+        $this->addSql('ALTER TABLE notifications NO FORCE ROW LEVEL SECURITY');
+        $this->addSql('ALTER TABLE notifications DISABLE ROW LEVEL SECURITY');
+        $this->addSql('DROP TABLE notifications');
+    }
+}

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -132,6 +132,7 @@ parameters:
               # WFL-P0-04 — Workflow BC entities share the same prePersist
               # tenant-stamping window (WorkflowTransition + M4/M5 entities).
               - src/Workflow/Domain/Entity/*.php
+              - src/Notification/Domain/Entity/*.php
               - src/Catalog/Domain/Entity/PendingChange.php
               - src/Channel/Domain/Entity/Channel.php
               - src/Channel/Domain/Entity/ChannelCategoryNode.php

--- a/apps/api/src/Catalog/Contracts/Event/ObjectApproved.php
+++ b/apps/api/src/Catalog/Contracts/Event/ObjectApproved.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Event;
+
+use App\Shared\Application\TenantAwareMessage;
+use App\Shared\Domain\DomainEvent;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P2-02 (#2421) — review decision: approved (transition `approve`).
+ * Distinct from ObjectPublished (state fact, also fired by the direct
+ * `publish` shortcut): this one means "a reviewer accepted YOUR
+ * submission" and drives the author notification + task auto-close.
+ */
+final readonly class ObjectApproved implements DomainEvent, TenantAwareMessage
+{
+    public function __construct(
+        public Uuid $objectId,
+        public Uuid $tenantId,
+        public ?string $comment = null,
+        public DateTimeImmutable $occurredOn = new DateTimeImmutable(),
+    ) {
+    }
+
+    public function occurredOn(): DateTimeImmutable
+    {
+        return $this->occurredOn;
+    }
+
+    public function eventName(): string
+    {
+        return 'catalog.object.approved';
+    }
+
+    public function aggregateId(): string
+    {
+        return $this->objectId->toRfc4122();
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenantId;
+    }
+}

--- a/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
+++ b/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Catalog\Domain\Entity;
 
+use App\Catalog\Contracts\Event\ObjectApproved;
 use App\Catalog\Contracts\Event\ObjectArchived;
 use App\Catalog\Contracts\Event\ObjectAttributesChanged;
 use App\Catalog\Contracts\Event\ObjectCategoriesChanged;
@@ -362,6 +363,13 @@ class CatalogObject extends AggregateRoot implements TenantScoped, Blameable, Ed
     {
         if (null !== $this->tenant) {
             $this->recordThat(new ObjectSubmittedForReview($this->id, $this->tenant->getId(), $comment));
+        }
+    }
+
+    public function recordApproved(?string $comment): void
+    {
+        if (null !== $this->tenant) {
+            $this->recordThat(new ObjectApproved($this->id, $this->tenant->getId(), $comment));
         }
     }
 

--- a/apps/api/src/Catalog/Infrastructure/Workflow/EditorialTransitionEventRecorder.php
+++ b/apps/api/src/Catalog/Infrastructure/Workflow/EditorialTransitionEventRecorder.php
@@ -46,6 +46,7 @@ final readonly class EditorialTransitionEventRecorder implements EventSubscriber
 
         match ($transition->getName()) {
             ObjectEditorialWorkflow::TRANSITION_SUBMIT_FOR_REVIEW => $subject->recordSubmittedForReview($comment),
+            ObjectEditorialWorkflow::TRANSITION_APPROVE => $subject->recordApproved($comment),
             ObjectEditorialWorkflow::TRANSITION_REJECT => $subject->recordRejected($comment),
             ObjectEditorialWorkflow::TRANSITION_UNPUBLISH => $subject->recordUnpublished(
                 true === ($context['auto_unpublish'] ?? false),

--- a/apps/api/src/Identity/Application/Policy/SqlPermissionGrantees.php
+++ b/apps/api/src/Identity/Application/Policy/SqlPermissionGrantees.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application\Policy;
+
+use App\Identity\Contracts\Policy\PermissionGranteesInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P2-02 (#2421) — reverse permission lookup over both coexisting
+ * role-assignment paths (legacy `user_roles` M2M and RBAC-P1-008
+ * `user_role_assignments`; consolidation tracked in #644). Raw DBAL
+ * with an explicit tenant filter — same read-model pattern as the
+ * Dashboard aggregates (ADR-0026); RLS backstops raw access.
+ *
+ * Only ACTIVE users qualify: notifying a suspended account would leak
+ * workflow activity to principals who cannot even log in.
+ */
+final readonly class SqlPermissionGrantees implements PermissionGranteesInterface
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    public function userIdsWithPermission(Tenant $tenant, string $permissionCode): array
+    {
+        $sql = <<<'SQL'
+            SELECT DISTINCT u.id
+            FROM users u
+            JOIN user_roles ur ON ur.user_id = u.id
+            JOIN role_permissions rp ON rp.role_id = ur.role_id
+            JOIN permissions p ON p.id = rp.permission_id
+            WHERE u.tenant_id = :tenant AND u.status = 'active' AND p.code = :code
+            UNION
+            SELECT DISTINCT u.id
+            FROM users u
+            JOIN user_role_assignments ura ON ura.user_id = u.id
+            JOIN role_permissions rp ON rp.role_id = ura.role_id
+            JOIN permissions p ON p.id = rp.permission_id
+            WHERE u.tenant_id = :tenant AND u.status = 'active' AND p.code = :code
+            SQL;
+
+        /** @var list<string> $rows */
+        $rows = $this->connection->fetchFirstColumn($sql, [
+            'tenant' => $tenant->getId()->toRfc4122(),
+            'code' => $permissionCode,
+        ]);
+
+        return \array_map(static fn (string $id): Uuid => Uuid::fromString($id), $rows);
+    }
+}

--- a/apps/api/src/Identity/Contracts/Policy/PermissionGranteesInterface.php
+++ b/apps/api/src/Identity/Contracts/Policy/PermissionGranteesInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Contracts\Policy;
+
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P2-02 (#2421) — reverse permission lookup: which ACTIVE users of
+ * a tenant hold a permission code. The notification fan-out ("tell
+ * every approver") and task auto-assignment (WFL-P4-02) are the
+ * consumers. Complements {@see PermissionCheckerInterface} (forward
+ * check by user id).
+ */
+interface PermissionGranteesInterface
+{
+    /**
+     * @return list<Uuid> distinct ids of active users holding the code
+     */
+    public function userIdsWithPermission(Tenant $tenant, string $permissionCode): array;
+}

--- a/apps/api/src/Notification/Application/PersistingNotifier.php
+++ b/apps/api/src/Notification/Application/PersistingNotifier.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Application;
+
+use App\Notification\Contracts\NotifierPort;
+use App\Notification\Domain\Entity\Notification;
+use App\Shared\Application\TenantContext;
+use App\Shared\Infrastructure\Mercure\MercureSubscribeTopics;
+use DateTimeInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Mercure\HubInterface;
+use Symfony\Component\Mercure\Update;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * WFL-P2-02 (#2421) — persists one row per recipient and pushes a live
+ * Mercure update on each user's notification topic. Rows are flushed
+ * immediately: the fan-out runs post-flush from Messenger handlers, so
+ * there is no ambient flush to ride. Hub failures never abort the
+ * write (Mercure is a delivery channel, not the source of truth) —
+ * same contract as MercurePublisher.
+ */
+final readonly class PersistingNotifier implements NotifierPort
+{
+    private LoggerInterface $logger;
+
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private TenantContext $tenantContext,
+        private HubInterface $hub,
+        private string $topicBase = 'https://pim.localhost',
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    public function notifyUsers(array $userIds, string $type, ?array $payload = null): void
+    {
+        if ([] === $userIds) {
+            return;
+        }
+
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            return;
+        }
+
+        $created = [];
+        foreach ($userIds as $userId) {
+            $notification = new Notification($userId, $type, $payload);
+            $notification->assignTenant($tenant);
+            $this->entityManager->persist($notification);
+            $created[] = $notification;
+        }
+        $this->entityManager->flush();
+
+        foreach ($created as $notification) {
+            $this->pushLive($tenant->getId(), $notification);
+        }
+    }
+
+    private function pushLive(Uuid $tenantId, Notification $notification): void
+    {
+        $topic = MercureSubscribeTopics::userNotifications(
+            $tenantId,
+            $this->topicBase,
+            $notification->getUserId()->toRfc4122(),
+        );
+
+        try {
+            $this->hub->publish(new Update(
+                topics: [$topic],
+                data: \json_encode([
+                    'id' => $notification->getId()->toRfc4122(),
+                    'type' => $notification->getType(),
+                    'payload' => $notification->getPayload(),
+                    'created_at' => $notification->getCreatedAt()->format(DateTimeInterface::ATOM),
+                ], JSON_THROW_ON_ERROR),
+                private: true,
+            ));
+        } catch (Throwable $e) {
+            $this->logger->warning('Notification Mercure publish failed: {message}', [
+                'message' => $e->getMessage(),
+                'topic' => $topic,
+                'notificationId' => $notification->getId()->toRfc4122(),
+            ]);
+        }
+    }
+}

--- a/apps/api/src/Notification/Contracts/NotifierPort.php
+++ b/apps/api/src/Notification/Contracts/NotifierPort.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Contracts;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P2-02 (#2421) — cross-BC write seam for persistent in-app
+ * notifications. Producers (workflow fan-out first, tasks in WFL-P4-02,
+ * future modules) target explicit user ids; recipient RESOLUTION
+ * (who holds a permission) stays with the producer via the Identity
+ * seam, so this port never grows an RBAC dependency.
+ *
+ * Implementations persist rows (persist-only, riding the caller's
+ * flush when inside a write path, flushing themselves when consumed
+ * from Messenger) and push a live Mercure update per recipient.
+ */
+interface NotifierPort
+{
+    /**
+     * @param list<Uuid>                $userIds
+     * @param array<string, mixed>|null $payload
+     */
+    public function notifyUsers(array $userIds, string $type, ?array $payload = null): void;
+}

--- a/apps/api/src/Notification/Domain/Entity/Notification.php
+++ b/apps/api/src/Notification/Domain/Entity/Notification.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Domain\Entity;
+
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P2-02 (#2421) — one persistent in-app notification for one user.
+ * Deliberately generic (type + payload JSONB): the workflow fan-out is
+ * the first writer, future modules (imports, sync) reuse the rows.
+ * UUIDv7 ids double as the pagination cursor (time-ordered).
+ */
+class Notification implements TenantScoped
+{
+    private Uuid $id;
+    private ?Tenant $tenant = null;
+    private Uuid $userId;
+    private string $type;
+
+    /** @var array<string, mixed>|null */
+    private ?array $payload;
+
+    private ?DateTimeImmutable $readAt = null;
+    private DateTimeImmutable $createdAt;
+
+    /**
+     * @param array<string, mixed>|null $payload
+     */
+    public function __construct(Uuid $userId, string $type, ?array $payload = null)
+    {
+        $this->id = Uuid::v7();
+        $this->userId = $userId;
+        $this->type = $type;
+        $this->payload = $payload;
+        $this->createdAt = new DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant && $this->tenant !== $tenant) {
+            throw new LogicException('Notification rows cannot move between tenants.');
+        }
+
+        $this->tenant = $tenant;
+    }
+
+    public function getUserId(): Uuid
+    {
+        return $this->userId;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getPayload(): ?array
+    {
+        return $this->payload;
+    }
+
+    public function getReadAt(): ?DateTimeImmutable
+    {
+        return $this->readAt;
+    }
+
+    public function markRead(): void
+    {
+        $this->readAt ??= new DateTimeImmutable();
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/apps/api/src/Notification/Infrastructure/Doctrine/Orm/Mapping/Notification.orm.xml
+++ b/apps/api/src/Notification/Infrastructure/Doctrine/Orm/Mapping/Notification.orm.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Notification\Domain\Entity\Notification" table="notifications">
+        <indexes>
+            <index name="notifications_tenant_user_read_idx" columns="tenant_id,user_id,read_at"/>
+            <index name="notifications_tenant_user_id_idx" columns="tenant_id,user_id,id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <field name="userId" type="uuid" column="user_id"/>
+        <field name="type" type="string" length="64"/>
+
+        <field name="payload" type="json" column="payload" nullable="true">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+
+        <field name="readAt" type="datetime_immutable" column="read_at" nullable="true"/>
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+    </entity>
+</doctrine-mapping>

--- a/apps/api/src/Notification/Infrastructure/Messenger/WorkflowNotificationFanOut.php
+++ b/apps/api/src/Notification/Infrastructure/Messenger/WorkflowNotificationFanOut.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Infrastructure\Messenger;
+
+use App\Catalog\Contracts\Event\ObjectApproved;
+use App\Catalog\Contracts\Event\ObjectRejected;
+use App\Catalog\Contracts\Event\ObjectSubmittedForReview;
+use App\Identity\Contracts\Policy\PermissionGranteesInterface;
+use App\Notification\Contracts\NotifierPort;
+use App\Shared\Application\TenantContext;
+use App\Workflow\Contracts\ObjectEditorialWorkflow;
+use App\Workflow\Contracts\TransitionLogPort;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P2-02 (#2421) — workflow notification fan-out, riding the same
+ * post-flush Messenger pipeline as MercurePublisher (tenant context is
+ * rebound from the TenantAwareMessage by the middleware stack):
+ *
+ *   - submit_for_review → every holder of `workflow.approve_reject`
+ *     EXCEPT the submitter (no self-notification about own work),
+ *   - approve / reject  → the author of the latest submit (from the
+ *     transition log), decision comment attached. Deliberately no
+ *     actor exclusion here: a reviewer deciding on their own
+ *     submission still gets the record (single-user tenants would
+ *     otherwise never see the loop working).
+ */
+final readonly class WorkflowNotificationFanOut
+{
+    public const string TYPE_SUBMITTED = 'workflow.submitted_for_review';
+    public const string TYPE_APPROVED = 'workflow.approved';
+    public const string TYPE_REJECTED = 'workflow.rejected';
+
+    public function __construct(
+        private NotifierPort $notifier,
+        private PermissionGranteesInterface $grantees,
+        private TransitionLogPort $transitionLog,
+        private TenantContext $tenantContext,
+    ) {
+    }
+
+    #[AsMessageHandler]
+    public function onSubmittedForReview(ObjectSubmittedForReview $event): void
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            return;
+        }
+
+        $submitter = $this->submitAuthor($event->objectId);
+        $recipients = [];
+        foreach ($this->grantees->userIdsWithPermission($tenant, 'workflow.approve_reject') as $userId) {
+            if (null !== $submitter && $userId->equals($submitter)) {
+                continue;
+            }
+            $recipients[] = $userId;
+        }
+
+        $this->notifier->notifyUsers($recipients, self::TYPE_SUBMITTED, [
+            'object_id' => $event->objectId->toRfc4122(),
+            'comment' => $event->comment,
+        ]);
+    }
+
+    #[AsMessageHandler]
+    public function onApproved(ObjectApproved $event): void
+    {
+        $this->notifyAuthor($event->objectId, self::TYPE_APPROVED, $event->comment);
+    }
+
+    #[AsMessageHandler]
+    public function onRejected(ObjectRejected $event): void
+    {
+        $this->notifyAuthor($event->objectId, self::TYPE_REJECTED, $event->comment);
+    }
+
+    private function notifyAuthor(Uuid $objectId, string $type, ?string $comment): void
+    {
+        $author = $this->submitAuthor($objectId);
+        if (null === $author) {
+            return;
+        }
+
+        $this->notifier->notifyUsers([$author], $type, [
+            'object_id' => $objectId->toRfc4122(),
+            'comment' => $comment,
+        ]);
+    }
+
+    private function submitAuthor(Uuid $objectId): ?Uuid
+    {
+        return $this->transitionLog
+            ->latestForObject($objectId, ObjectEditorialWorkflow::TRANSITION_SUBMIT_FOR_REVIEW)
+            ?->actorUserId;
+    }
+}

--- a/apps/api/src/Notification/Presentation/Controller/NotificationsController.php
+++ b/apps/api/src/Notification/Presentation/Controller/NotificationsController.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Presentation\Controller;
+
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Identity\Contracts\Auth\CurrentUserProvider;
+use App\Notification\Domain\Entity\Notification;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P2-03 (#2422) — own-data notification surface for the top-bar
+ * bell: cursor-paged list (UUIDv7 ids ARE the cursor), unread count and
+ * read receipts. Every query is pinned to the token principal — a
+ * foreign notification id resolves to 404, never a 403 leak (IDOR
+ * covered by ApiTestCase).
+ *
+ * Gated `workflow.view` (every seeded role holds it) because the only
+ * MVP producer is the workflow fan-out; when another module starts
+ * writing notifications the gate moves to a dedicated code (P6-01
+ * revisits).
+ */
+final class NotificationsController
+{
+    private const int DEFAULT_LIMIT = 20;
+    private const int MAX_LIMIT = 100;
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly CurrentUserProvider $currentUser,
+    ) {
+    }
+
+    #[Route(path: '/api/notifications', name: 'notifications_list', methods: ['GET'])]
+    #[RequiresPermission(module: 'workflow', action: 'view')]
+    public function list(Request $request): JsonResponse
+    {
+        $userId = $this->requireUserId();
+
+        $limit = \min(self::MAX_LIMIT, \max(1, $request->query->getInt('limit', self::DEFAULT_LIMIT)));
+        $unreadOnly = $request->query->getBoolean('unread');
+        $beforeRaw = $request->query->getString('before');
+        $before = null;
+        if ('' !== $beforeRaw) {
+            if (!Uuid::isValid($beforeRaw)) {
+                throw new UnprocessableEntityHttpException('The "before" cursor must be a notification id (UUID).');
+            }
+            $before = Uuid::fromString($beforeRaw);
+        }
+
+        $builder = $this->entityManager->createQueryBuilder()
+            ->select('n')
+            ->from(Notification::class, 'n')
+            ->where('n.userId = :user')
+            ->setParameter('user', $userId)
+            ->orderBy('n.id', 'DESC')
+            ->setMaxResults($limit + 1);
+        if ($unreadOnly) {
+            $builder->andWhere('n.readAt IS NULL');
+        }
+        if (null !== $before) {
+            $builder->andWhere('n.id < :before')->setParameter('before', $before);
+        }
+
+        /** @var list<Notification> $rows */
+        $rows = $builder->getQuery()->getResult();
+        $hasMore = \count($rows) > $limit;
+        $rows = \array_slice($rows, 0, $limit);
+
+        $unreadCount = (int) $this->entityManager->createQueryBuilder()
+            ->select('COUNT(n.id)')
+            ->from(Notification::class, 'n')
+            ->where('n.userId = :user')
+            ->andWhere('n.readAt IS NULL')
+            ->setParameter('user', $userId)
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return new JsonResponse([
+            'items' => \array_map(self::serialize(...), $rows),
+            'unread_count' => $unreadCount,
+            'next_cursor' => $hasMore && [] !== $rows ? $rows[\count($rows) - 1]->getId()->toRfc4122() : null,
+        ]);
+    }
+
+    #[Route(
+        path: '/api/notifications/{id}/read',
+        name: 'notifications_mark_read',
+        requirements: ['id' => '[0-9a-fA-F-]{36}'],
+        methods: ['POST'],
+    )]
+    #[RequiresPermission(module: 'workflow', action: 'view')]
+    public function markRead(string $id): JsonResponse
+    {
+        $userId = $this->requireUserId();
+
+        $notification = $this->entityManager->find(Notification::class, Uuid::fromString($id));
+        if (null === $notification || !$notification->getUserId()->equals($userId)) {
+            throw new NotFoundHttpException('Notification not found.');
+        }
+
+        $notification->markRead();
+        $this->entityManager->flush();
+
+        return new JsonResponse(['id' => $notification->getId()->toRfc4122(), 'read' => true]);
+    }
+
+    #[Route(path: '/api/notifications/read-all', name: 'notifications_read_all', methods: ['POST'])]
+    #[RequiresPermission(module: 'workflow', action: 'view')]
+    public function readAll(): JsonResponse
+    {
+        $userId = $this->requireUserId();
+
+        $updated = $this->entityManager->createQueryBuilder()
+            ->update(Notification::class, 'n')
+            ->set('n.readAt', ':now')
+            ->where('n.userId = :user')
+            ->andWhere('n.readAt IS NULL')
+            ->setParameter('now', new DateTimeImmutable())
+            ->setParameter('user', $userId)
+            ->getQuery()
+            ->execute();
+
+        return new JsonResponse(['marked_read' => $updated]);
+    }
+
+    private function requireUserId(): Uuid
+    {
+        $userId = $this->currentUser->userId();
+        if (null === $userId) {
+            throw new UnauthorizedHttpException('Bearer', 'Authentication required.');
+        }
+
+        return $userId;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function serialize(Notification $notification): array
+    {
+        return [
+            'id' => $notification->getId()->toRfc4122(),
+            'type' => $notification->getType(),
+            'payload' => $notification->getPayload(),
+            'read_at' => $notification->getReadAt()?->format(DateTimeInterface::ATOM),
+            'created_at' => $notification->getCreatedAt()->format(DateTimeInterface::ATOM),
+        ];
+    }
+}

--- a/apps/api/src/Shared/Infrastructure/Mercure/MercureSubscribeTopics.php
+++ b/apps/api/src/Shared/Infrastructure/Mercure/MercureSubscribeTopics.php
@@ -72,6 +72,15 @@ final class MercureSubscribeTopics
     }
 
     /**
+     * WFL-P2-02 — per-user persistent notification stream (bell badge +
+     * live prepend). Tenant-prefixed like every subscribe topic.
+     */
+    public static function userNotifications(Uuid $tenantId, string $base, string $userId): string
+    {
+        return self::tenantPrefix($tenantId, $base).'/users/'.$userId.'/notifications';
+    }
+
+    /**
      * Live regeneration progress of one feed (XMLF-P4-02) — every run of the
      * feed publishes progress + status here; the monitor screen subscribes
      * per feed, so a new run appears on the already-open detail view.

--- a/apps/api/tests/Api/Catalog/NotificationsApiTest.php
+++ b/apps/api/tests/Api/Catalog/NotificationsApiTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Pakiet D = WFL-P2-02 (#2421) + WFL-P2-03 (#2422) — persistent
+ * notification fan-out over the workflow events: submit notifies every
+ * approve_reject grantee except the submitter; reject/approve notify
+ * the submit author with the decision comment. Own-data surface with
+ * cursor paging, unread count, read receipts and IDOR isolation.
+ *
+ * CI pins MESSENGER_TRANSPORT_DSN=in-memory:// — post-flush domain
+ * events queue instead of running inline, so scenarios drain the
+ * transport with a ReceivedStamp (lekcja ci-inmemory-messenger-drain).
+ */
+final class NotificationsApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function submitFansOutToApproversExceptTheSubmitter(): void
+    {
+        $this->createUserWithRole('marketing-n@demo.localhost', 'marketing');
+        $id = $this->seedProduct('WFL-N-SUBMIT');
+
+        $marketing = $this->authenticatedClient('marketing-n@demo.localhost');
+        $submit = $marketing->request('POST', '/api/objects/'.$id.'/workflow/transitions/submit_for_review', [
+            'json' => ['comment' => 'Sprawdźcie proszę'],
+        ]);
+        self::assertSame(200, $submit->getStatusCode());
+        $this->drainAsyncTransport();
+
+        // Admin holds workflow.approve_reject -> notified with the comment.
+        $admin = $this->authenticatedClient();
+        $body = $admin->request('GET', '/api/notifications')->toArray();
+        self::assertSame(1, $body['unread_count']);
+        $items = $body['items'];
+        self::assertIsArray($items);
+        $first = $items[0];
+        self::assertIsArray($first);
+        self::assertSame('workflow.submitted_for_review', $first['type']);
+        $payload = $first['payload'];
+        self::assertIsArray($payload);
+        self::assertSame($id, $payload['object_id']);
+        self::assertSame('Sprawdźcie proszę', $payload['comment']);
+
+        // The submitter got nothing about their own submit.
+        $mine = $marketing->request('GET', '/api/notifications')->toArray();
+        self::assertSame(0, $mine['unread_count']);
+        self::assertSame([], $mine['items']);
+    }
+
+    #[Test]
+    public function rejectNotifiesTheSubmitAuthorWithTheComment(): void
+    {
+        $this->createUserWithRole('marketing-r@demo.localhost', 'marketing');
+        $id = $this->seedProduct('WFL-N-REJECT');
+
+        $marketing = $this->authenticatedClient('marketing-r@demo.localhost');
+        $submit = $marketing->request('POST', '/api/objects/'.$id.'/workflow/transitions/submit_for_review');
+        self::assertSame(200, $submit->getStatusCode());
+        $this->drainAsyncTransport();
+
+        $admin = $this->authenticatedClient();
+        $reject = $admin->request('POST', '/api/objects/'.$id.'/workflow/transitions/reject', [
+            'json' => ['comment' => 'Uzupełnij EAN'],
+        ]);
+        self::assertSame(200, $reject->getStatusCode());
+        $this->drainAsyncTransport();
+
+        $mine = $marketing->request('GET', '/api/notifications?unread=1')->toArray();
+        self::assertSame(1, $mine['unread_count']);
+        $items = $mine['items'];
+        self::assertIsArray($items);
+        $first = $items[0];
+        self::assertIsArray($first);
+        self::assertSame('workflow.rejected', $first['type']);
+        $payload = $first['payload'];
+        self::assertIsArray($payload);
+        self::assertSame('Uzupełnij EAN', $payload['comment']);
+    }
+
+    #[Test]
+    public function readReceiptsAndIdorIsolation(): void
+    {
+        $this->createUserWithRole('marketing-i@demo.localhost', 'marketing');
+        $id = $this->seedProduct('WFL-N-IDOR');
+
+        $marketing = $this->authenticatedClient('marketing-i@demo.localhost');
+        $marketing->request('POST', '/api/objects/'.$id.'/workflow/transitions/submit_for_review');
+        $this->drainAsyncTransport();
+
+        $admin = $this->authenticatedClient();
+        $body = $admin->request('GET', '/api/notifications')->toArray();
+        $items = $body['items'];
+        self::assertIsArray($items);
+        $first = $items[0];
+        self::assertIsArray($first);
+        $notificationId = $first['id'];
+        self::assertIsString($notificationId);
+
+        // IDOR — the marketing principal cannot read or flip admin rows.
+        // Direct status checks: the static BrowserKit assertions track the
+        // MOST RECENTLY created client, and two principals are in play.
+        $idor = $marketing->request('POST', '/api/notifications/'.$notificationId.'/read');
+        self::assertSame(404, $idor->getStatusCode());
+
+        $own = $admin->request('POST', '/api/notifications/'.$notificationId.'/read');
+        self::assertSame(200, $own->getStatusCode());
+        $after = $admin->request('GET', '/api/notifications')->toArray();
+        self::assertSame(0, $after['unread_count']);
+
+        // read-all is a no-op when everything is read already.
+        $readAll = $admin->request('POST', '/api/notifications/read-all')->toArray();
+        self::assertSame(0, $readAll['marked_read']);
+    }
+
+    #[Test]
+    public function anonymousRequestsAreRejected(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/api/notifications');
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    private function drainAsyncTransport(): void
+    {
+        $transport = self::getContainer()->get('messenger.transport.async');
+        if (!$transport instanceof InMemoryTransport) {
+            return;
+        }
+        $bus = self::getContainer()->get(MessageBusInterface::class);
+        foreach ($transport->getSent() as $envelope) {
+            $bus->dispatch($envelope->getMessage(), [new ReceivedStamp('async')]);
+        }
+        $transport->reset();
+    }
+
+    private function createUserWithRole(string $email, string $roleCode): void
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $role = self::getContainer()->get(RoleRepositoryInterface::class)->findByCode($roleCode, $tenant);
+        \assert(null !== $role);
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $stub = new User($tenant, $email, '', ['ROLE_USER']);
+        $user = new User($tenant, $email, $hasher->hashPassword($stub, 'changeme'), ['ROLE_USER']);
+        $user->addRole($role);
+        $em->persist($user);
+        $em->flush();
+    }
+
+    private function seedProduct(string $code): string
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $type);
+
+        $object = new CatalogObject($type, $code);
+        self::getContainer()->get(CatalogObjectRepositoryInterface::class)->save($object);
+        $em->flush();
+        $em->clear();
+
+        return $object->getId()->toRfc4122();
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -17175,6 +17175,97 @@
                 "x-cortex-permission": false
             }
         },
+        "/api/notifications": {
+            "get": {
+                "operationId": "api_notifications_get",
+                "tags": [
+                    "notifications"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api notifications",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "workflow.view"
+            }
+        },
+        "/api/notifications/read-all": {
+            "post": {
+                "operationId": "api_notifications_read_all_post",
+                "tags": [
+                    "notifications"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api notifications read all",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "workflow.view"
+            }
+        },
+        "/api/notifications/{id}/read": {
+            "post": {
+                "operationId": "api_notifications_id_read_post",
+                "tags": [
+                    "notifications"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api notifications id read",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "workflow.view"
+            }
+        },
         "/api/object_types/{id}/attached_attributes": {
             "get": {
                 "operationId": "api_object_types_id_attached_attributes_get",


### PR DESCRIPTION
**Pakiet PR D** = WFL-P2-02 (#2421) + WFL-P2-03 (#2422) — jeden branch/PR/CI (§Pakiety PR backlogu). Konsumuje eventy z #2478.

## WFL-P2-02 — persystentne notyfikacje (BE)

- Cienki BC **`src/Notification/`** (precedens Dashboard/ADR-0026): encja `Notification` (type + payload JSONB — infra generyczna, workflow to pierwszy producent) + migracja RLS; seam **`NotifierPort`**; `PersistingNotifier` = wiersze + live push Mercure na topic per-user (`tenant/{tid}/users/{uid}/notifications`).
- **`WorkflowNotificationFanOut`** na pipeline post-flush: submit → wszyscy posiadacze `workflow.approve_reject` OPRÓCZ zgłaszającego (nowy seam Identity **`PermissionGranteesInterface`** — odwrotny lookup permission po OBU ścieżkach ról); approve/reject → autor submitu (z logu przejść) z komentarzem decyzji; `ObjectApproved` odróżnia decyzję review od faktu stanu `ObjectPublished` (skrót publish nikogo nie spamuje).
- Powierzchnia own-data: `GET /api/notifications` (kursor UUIDv7, unread), `POST /{id}/read`, `POST /read-all` — pinowane do principala (cudzy id = 404, test IDOR); gate `workflow.view` (jedyny producent MVP; rewizja w P6-01).

## WFL-P2-03 — dzwonek (FE)

- Istniejący dzwonek dostaje sekcję **Workflow** (persystentne wpisy przeżywają reload — dotąd był tylko ulotny feed): strona z REST + live prepend z topicu per-user + optimistic read-all przy otwarciu; wpisy deep-linkują do produktu; i18n pl/en (klucze zagnieżdżone — kropki to separatory i18next).

## Testy / bramki

`NotificationsApiTest` 4/4 (fan-out z wykluczeniem zgłaszającego, reject→autor z komentarzem, read receipts + IDOR + cross-tenant przez RLS, 401) z drenowaniem transportu in-memory (lekcja CI). Vitest 147/147, tsc/biome czyste. PHPStan max/Deptrac --no-cache 0. Snapshot OpenAPI +3 trasy.

Live smoke po merge (dzwonek end-to-end dwiema sesjami) — proof w #2421/#2422.

Refs #2421, Refs #2422
