### PR TITLE
feat(admin): status control and workflow history on product detail (pakiet E)

### DIFF
--- a/apps/admin/e2e/wfl-p3-01-workflow-status-control.spec.ts
+++ b/apps/admin/e2e/wfl-p3-01-workflow-status-control.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@playwright/test';
+
+import { apiLogin, uniqueSku } from './helpers/auth';
+
+/**
+ * Pakiet E (WFL-P3-01 #2423 + WFL-P3-05 #2427) — the editorial state
+ * control on the product header: status pill mirrors the machine,
+ * transition buttons come from the guard-aware discovery endpoint,
+ * applying a transition with a comment moves the pill, and the history
+ * sheet lists the applied transitions with their comments.
+ */
+test('workflow control: submit -> approve loop with history on product detail', async ({
+  page,
+}) => {
+  await apiLogin(page);
+
+  // Fresh draft via the API the admin itself uses (cookie-authed context).
+  const typesResponse = await page.request.get('/api/object_types');
+  const types = (await typesResponse.json()) as {
+    'hydra:member'?: { id: string; kind: string }[];
+    member?: { id: string; kind: string }[];
+  };
+  const productType = (types['hydra:member'] ?? types.member ?? []).find(
+    (candidate) => candidate.kind === 'product',
+  );
+  if (productType === undefined) throw new Error('No product ObjectType seeded.');
+
+  const createResponse = await page.request.post('/api/objects', {
+    data: { code: uniqueSku('WFL-E2E'), objectTypeId: productType.id },
+    headers: { 'content-type': 'application/ld+json' },
+  });
+  expect(createResponse.status()).toBe(201);
+  const created = (await createResponse.json()) as { id: string };
+
+  await page.goto(`/products/${created.id}`);
+  const control = page.getByTestId('workflow-status-control');
+  await expect(control).toBeVisible();
+  await expect(control.getByText(/Szkic|Draft/).first()).toBeVisible();
+
+  // Submit for review with a comment.
+  await page.getByTestId('workflow-transition-submit_for_review').click();
+  await page.getByTestId('workflow-comment').fill('E2E: proszę o przegląd');
+  await page.getByTestId('workflow-confirm').click();
+  await expect(control.getByText(/W przeglądzie|In review/).first()).toBeVisible();
+
+  // Approve — admin holds workflow.approve_reject.
+  await page.getByTestId('workflow-transition-approve').click();
+  await page.getByTestId('workflow-confirm').click();
+  await expect(control.getByText(/Opublikowany|Published/).first()).toBeVisible();
+
+  // History sheet lists both transitions, newest first, with the comment.
+  await page.getByTestId('workflow-history-open').click();
+  const history = page.getByTestId('workflow-history-list');
+  await expect(history.getByText(/Zatwierdź|Approve/).first()).toBeVisible();
+  await expect(history.getByText('E2E: proszę o przegląd')).toBeVisible();
+
+  // Cleanup: back to draft so reruns start from a known place.
+  const cleanup = await page.request.post(
+    `/api/objects/${created.id}/workflow/transitions/unpublish`,
+  );
+  expect(cleanup.status()).toBe(200);
+});

--- a/apps/admin/e2e/wfl-p3-01-workflow-status-control.spec.ts
+++ b/apps/admin/e2e/wfl-p3-01-workflow-status-control.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { apiLogin, uniqueSku } from './helpers/auth';
+import { ADMIN_EMAIL, ADMIN_PASSWORD, apiLogin, uniqueSku } from './helpers/auth';
 
 /**
  * Pakiet E (WFL-P3-01 #2423 + WFL-P3-05 #2427) — the editorial state
@@ -12,10 +12,22 @@ import { apiLogin, uniqueSku } from './helpers/auth';
 test('workflow control: submit -> approve loop with history on product detail', async ({
   page,
 }) => {
+  // page.request carries only cookies; the API wants a Bearer — mint one
+  // explicitly for the setup/cleanup calls (same pattern as spec #1351).
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+  const bearer = { authorization: `Bearer ${token}` };
+
   await apiLogin(page);
 
-  // Fresh draft via the API the admin itself uses (cookie-authed context).
-  const typesResponse = await page.request.get('/api/object_types');
+  // Fresh draft via the API the admin itself uses.
+  const typesResponse = await page.request.get('/api/object_types?itemsPerPage=200', {
+    headers: { ...bearer, accept: 'application/ld+json' },
+  });
   const types = (await typesResponse.json()) as {
     'hydra:member'?: { id: string; kind: string }[];
     member?: { id: string; kind: string }[];
@@ -27,7 +39,7 @@ test('workflow control: submit -> approve loop with history on product detail', 
 
   const createResponse = await page.request.post('/api/objects', {
     data: { code: uniqueSku('WFL-E2E'), objectTypeId: productType.id },
-    headers: { 'content-type': 'application/ld+json' },
+    headers: { ...bearer, 'content-type': 'application/ld+json' },
   });
   expect(createResponse.status()).toBe(201);
   const created = (await createResponse.json()) as { id: string };
@@ -57,6 +69,7 @@ test('workflow control: submit -> approve loop with history on product detail', 
   // Cleanup: back to draft so reruns start from a known place.
   const cleanup = await page.request.post(
     `/api/objects/${created.id}/workflow/transitions/unpublish`,
+    { headers: bearer },
   );
   expect(cleanup.status()).toBe(200);
 });

--- a/apps/admin/src/features/catalog/products/components/product-detail-header.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-header.tsx
@@ -24,6 +24,7 @@ import type {
   ProductDetailMode,
   ProductLocale,
 } from './types';
+import { WorkflowStatusControl } from './workflow-status-control';
 
 /**
  * AUD-057 (#1608) — the product-detail sticky header (breadcrumb + action
@@ -295,6 +296,13 @@ export function ProductDetailHeader({
                     <span className="rounded-full bg-white px-2 py-1 text-[11px] font-medium text-zinc-700 soft-shadow">
                       {objectTypeName}
                     </span>
+                  </div>
+                ) : null}
+                {/* WFL-P3-01 (#2423) — editorial state chip + guard-aware
+                    transition buttons + history (self-fetching control). */}
+                {mode === 'edit' ? (
+                  <div className="mt-2.5">
+                    <WorkflowStatusControl objectId={id} />
                   </div>
                 ) : null}
               </>

--- a/apps/admin/src/features/catalog/products/components/workflow-history-sheet.tsx
+++ b/apps/admin/src/features/catalog/products/components/workflow-history-sheet.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
+import { fetchWorkflowLog, type WorkflowLogEntry } from '@/lib/workflow/api';
+
+/**
+ * Pakiet E (WFL-P3-05 #2427) — transition history timeline (Pimcore
+ * "notes & events" pattern): who moved the object between which places,
+ * with the reviewer comment and the auto-unpublish / bulk context
+ * badges. UUIDv7 cursor pages backwards ("pokaż starsze").
+ */
+export function WorkflowHistorySheet({
+  objectId,
+  open,
+  onOpenChange,
+}: {
+  objectId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { t, i18n } = useTranslation();
+  const [entries, setEntries] = useState<WorkflowLogEntry[]>([]);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    fetchWorkflowLog(objectId)
+      .then((page) => {
+        setEntries(page.items);
+        setCursor(page.next_cursor);
+      })
+      .catch(() => setEntries([]))
+      .finally(() => setLoading(false));
+  }, [open, objectId]);
+
+  const loadOlder = () => {
+    if (cursor === null) return;
+    setLoading(true);
+    fetchWorkflowLog(objectId, cursor)
+      .then((page) => {
+        setEntries((previous) => [...previous, ...page.items]);
+        setCursor(page.next_cursor);
+      })
+      .finally(() => setLoading(false));
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-96 overflow-y-auto">
+        <SheetTitle>
+          {t('workflow.history.title', { defaultValue: 'Historia workflow' })}
+        </SheetTitle>
+        <div className="mt-4 flex flex-col gap-3" data-testid="workflow-history-list">
+          {entries.length === 0 && !loading ? (
+            <p className="text-sm text-muted-foreground">
+              {t('workflow.history.empty', { defaultValue: 'Brak przejść.' })}
+            </p>
+          ) : (
+            entries.map((entry) => (
+              <HistoryRow key={entry.id} entry={entry} locale={i18n.language} />
+            ))
+          )}
+          {cursor !== null && (
+            <Button variant="outline" size="sm" onClick={loadOlder} disabled={loading}>
+              {t('workflow.history.older', { defaultValue: 'Pokaż starsze' })}
+            </Button>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function HistoryRow({ entry, locale }: { entry: WorkflowLogEntry; locale: string }) {
+  const { t } = useTranslation();
+  const autoUnpublish = entry.context?.auto_unpublish === true;
+  const bulk = entry.context?.bulk === true;
+
+  return (
+    <div className="rounded-md border border-border p-3">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-sm font-medium">
+          {t(`workflow.transition.${entry.transition}`, { defaultValue: entry.transition })}
+        </span>
+        <span className="text-xs text-muted-foreground">
+          {formatTime(entry.created_at, locale)}
+        </span>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {t(`workflow.place.${entry.from}`, { defaultValue: entry.from })}
+        {' → '}
+        {t(`workflow.place.${entry.to}`, { defaultValue: entry.to })}
+        {entry.actor_user_id === null &&
+          ` · ${t('workflow.history.system', { defaultValue: 'System' })}`}
+      </p>
+      {entry.comment !== null && <p className="mt-1 text-sm">{entry.comment}</p>}
+      {(autoUnpublish || bulk) && (
+        <div className="mt-1 flex gap-1">
+          {autoUnpublish && (
+            <span className="rounded bg-orange-50 px-1.5 py-0.5 text-[10px] font-medium text-orange-800">
+              {t('workflow.history.auto_unpublish', { defaultValue: 'auto-unpublish' })}
+            </span>
+          )}
+          {bulk && (
+            <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium text-zinc-600">
+              {t('workflow.history.bulk', { defaultValue: 'bulk' })}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatTime(value: string, locale: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(locale, { dateStyle: 'short', timeStyle: 'short' }).format(date);
+}

--- a/apps/admin/src/features/catalog/products/components/workflow-status-control.tsx
+++ b/apps/admin/src/features/catalog/products/components/workflow-status-control.tsx
@@ -1,0 +1,193 @@
+import { History } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { toast } from '@/components/ui/toast';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { StatusPill } from '@/components/ui-v2/status-pill';
+import {
+  applyWorkflowTransition,
+  fetchWorkflowState,
+  placePillVariant,
+  type WorkflowState,
+  type WorkflowTransitionOption,
+} from '@/lib/workflow/api';
+
+import { WorkflowHistorySheet } from './workflow-history-sheet';
+
+/**
+ * Pakiet E (WFL-P3-01 #2423) — editorial state control on the product
+ * header (Pimcore pattern: status chip + transition buttons). Buttons
+ * mirror the guard-aware discovery endpoint 1:1 — a blocked transition
+ * renders disabled with the blocker reasons in a tooltip (missing
+ * permission code / completeness gate with the missing attributes), so
+ * the FE never re-implements authorization. Reject requires a comment
+ * (PRD §3.8 review loop); every other transition takes an optional one.
+ */
+export function WorkflowStatusControl({ objectId }: { objectId: string }) {
+  const { t } = useTranslation();
+  const [state, setState] = useState<WorkflowState | null>(null);
+  const [pending, setPending] = useState<WorkflowTransitionOption | null>(null);
+  const [comment, setComment] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
+
+  const reload = useCallback(() => {
+    fetchWorkflowState(objectId)
+      .then(setState)
+      .catch(() => {
+        // Silent: users without workflow.view simply see no control.
+        setState(null);
+      });
+  }, [objectId]);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  if (state === null) {
+    return null;
+  }
+
+  const requiresComment = pending?.name === 'reject';
+
+  const confirm = () => {
+    if (pending === null) return;
+    if (requiresComment && comment.trim() === '') return;
+    setSubmitting(true);
+    applyWorkflowTransition(objectId, pending.name, comment.trim() || undefined)
+      .then((result) => {
+        toast.success(
+          t('workflow.toast.applied', {
+            defaultValue: 'Status zmieniony: {{place}}',
+            place: t(`workflow.place.${result.current_place}`, {
+              defaultValue: result.current_place,
+            }),
+          }),
+        );
+        setPending(null);
+        setComment('');
+        reload();
+      })
+      .catch((error: unknown) => {
+        toast.error(
+          error instanceof Error && error.message !== ''
+            ? error.message
+            : t('workflow.toast.failed', { defaultValue: 'Przejście nie powiodło się' }),
+        );
+      })
+      .finally(() => setSubmitting(false));
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2" data-testid="workflow-status-control">
+      <StatusPill
+        variant={placePillVariant(state.current_place)}
+        label={t(`workflow.place.${state.current_place}`, {
+          defaultValue: state.current_place,
+        })}
+      />
+      {state.transitions.map((transition) => {
+        const label = t(`workflow.transition.${transition.name}`, {
+          defaultValue: transition.name,
+        });
+        const button = (
+          <Button
+            key={transition.name}
+            variant="outline"
+            size="sm"
+            disabled={!transition.enabled || submitting}
+            onClick={() => {
+              setComment('');
+              setPending(transition);
+            }}
+            data-testid={`workflow-transition-${transition.name}`}
+          >
+            {label}
+          </Button>
+        );
+        if (transition.enabled) {
+          return button;
+        }
+        return (
+          <Tooltip key={transition.name}>
+            <TooltipTrigger asChild>
+              {/* span wrapper: disabled buttons swallow pointer events */}
+              <span>{button}</span>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">
+              {transition.blockers.map((blocker) => (
+                <p key={blocker.code} className="text-xs">
+                  {blocker.message}
+                </p>
+              ))}
+            </TooltipContent>
+          </Tooltip>
+        );
+      })}
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => setHistoryOpen(true)}
+        aria-label={t('workflow.history.open', { defaultValue: 'Historia workflow' })}
+        data-testid="workflow-history-open"
+      >
+        <History className="size-4" />
+      </Button>
+
+      <Dialog open={pending !== null} onOpenChange={(open) => !open && setPending(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {t(`workflow.transition.${pending?.name ?? ''}`, {
+                defaultValue: pending?.name ?? '',
+              })}
+            </DialogTitle>
+            <DialogDescription>
+              {requiresComment
+                ? t('workflow.dialog.comment_required', {
+                    defaultValue: 'Odrzucenie wymaga komentarza dla autora.',
+                  })
+                : t('workflow.dialog.comment_optional', {
+                    defaultValue: 'Możesz dodać komentarz (opcjonalnie).',
+                  })}
+            </DialogDescription>
+          </DialogHeader>
+          <Textarea
+            value={comment}
+            onChange={(event) => setComment(event.target.value)}
+            maxLength={2000}
+            placeholder={t('workflow.dialog.comment_placeholder', {
+              defaultValue: 'Komentarz…',
+            })}
+            data-testid="workflow-comment"
+          />
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setPending(null)} disabled={submitting}>
+              {t('common.cancel', { defaultValue: 'Anuluj' })}
+            </Button>
+            <Button
+              onClick={confirm}
+              disabled={submitting || (requiresComment && comment.trim() === '')}
+              data-testid="workflow-confirm"
+            >
+              {t('common.confirm', { defaultValue: 'Potwierdź' })}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <WorkflowHistorySheet objectId={objectId} open={historyOpen} onOpenChange={setHistoryOpen} />
+    </div>
+  );
+}

--- a/apps/admin/src/lib/workflow/api.ts
+++ b/apps/admin/src/lib/workflow/api.ts
@@ -1,0 +1,83 @@
+import { jsonFetch } from '@/lib/http';
+
+/**
+ * Pakiet E (WFL-P3-01/#2423 + WFL-P3-05/#2427) — typed client for the
+ * object_editorial workflow surface (WFL-P0-05). Discovery is the FE
+ * source of truth for which buttons render enabled: blockers carry the
+ * machine codes (missing permission / completeness_gate), so the UI
+ * never re-implements guard logic (ADR-0029).
+ */
+
+export interface WorkflowTransitionOption {
+  name: string;
+  to: string;
+  enabled: boolean;
+  blockers: { code: string; message: string }[];
+}
+
+export interface WorkflowState {
+  object_id: string;
+  workflow: string;
+  current_place: string;
+  transitions: WorkflowTransitionOption[];
+}
+
+export interface WorkflowLogEntry {
+  id: string;
+  transition: string;
+  from: string;
+  to: string;
+  actor_user_id: string | null;
+  comment: string | null;
+  context: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export interface WorkflowLogPage {
+  object_id: string;
+  items: WorkflowLogEntry[];
+  next_cursor: string | null;
+}
+
+export function fetchWorkflowState(objectId: string): Promise<WorkflowState> {
+  return jsonFetch<WorkflowState>(`/api/objects/${objectId}/workflow`);
+}
+
+export function applyWorkflowTransition(
+  objectId: string,
+  transition: string,
+  comment?: string,
+): Promise<{ object_id: string; applied: string; current_place: string }> {
+  return jsonFetch(`/api/objects/${objectId}/workflow/transitions/${transition}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(comment !== undefined && comment !== '' ? { comment } : {}),
+  });
+}
+
+export function fetchWorkflowLog(
+  objectId: string,
+  before?: string,
+  limit = 20,
+): Promise<WorkflowLogPage> {
+  const cursor = before !== undefined ? `&before=${before}` : '';
+  return jsonFetch<WorkflowLogPage>(
+    `/api/objects/${objectId}/workflow/transitions?limit=${limit}${cursor}`,
+  );
+}
+
+/** Editorial places -> StatusPill variants (ui-v2 status-maps palette). */
+export function placePillVariant(
+  place: string,
+): 'success' | 'warning' | 'queued' | 'cancelled' | 'running' {
+  switch (place) {
+    case 'published':
+      return 'success';
+    case 'review':
+      return 'warning';
+    case 'archived':
+      return 'cancelled';
+    default:
+      return 'queued';
+  }
+}

--- a/apps/admin/src/lib/workflow/api.ts
+++ b/apps/admin/src/lib/workflow/api.ts
@@ -50,8 +50,8 @@ export function applyWorkflowTransition(
 ): Promise<{ object_id: string; applied: string; current_place: string }> {
   return jsonFetch(`/api/objects/${objectId}/workflow/transitions/${transition}`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(comment !== undefined && comment !== '' ? { comment } : {}),
+    contentType: 'application/json',
+    body: comment !== undefined && comment !== '' ? { comment } : {},
   });
 }
 

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -4001,5 +4001,40 @@
       "voice_good": "GOOD example",
       "voice_bad": "BAD example"
     }
+  },
+  "workflow": {
+    "place": {
+      "draft": "Draft",
+      "review": "In review",
+      "published": "Published",
+      "archived": "Archived"
+    },
+    "transition": {
+      "submit_for_review": "Submit for review",
+      "publish": "Publish",
+      "approve": "Approve",
+      "reject": "Reject",
+      "unpublish": "Unpublish",
+      "archive": "Archive",
+      "restore": "Restore"
+    },
+    "dialog": {
+      "comment_required": "Rejecting requires a comment for the author.",
+      "comment_optional": "You can add a comment (optional).",
+      "comment_placeholder": "Comment…"
+    },
+    "toast": {
+      "applied": "Status changed: {{place}}",
+      "failed": "Transition failed"
+    },
+    "history": {
+      "title": "Workflow history",
+      "open": "Workflow history",
+      "empty": "No transitions.",
+      "older": "Show older",
+      "system": "System",
+      "auto_unpublish": "auto-unpublish",
+      "bulk": "bulk"
+    }
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -4021,5 +4021,40 @@
       "voice_good": "Przykład TAK",
       "voice_bad": "Przykład NIE"
     }
+  },
+  "workflow": {
+    "place": {
+      "draft": "Szkic",
+      "review": "W przeglądzie",
+      "published": "Opublikowany",
+      "archived": "Zarchiwizowany"
+    },
+    "transition": {
+      "submit_for_review": "Zgłoś do przeglądu",
+      "publish": "Opublikuj",
+      "approve": "Zatwierdź",
+      "reject": "Odrzuć",
+      "unpublish": "Cofnij publikację",
+      "archive": "Archiwizuj",
+      "restore": "Przywróć"
+    },
+    "dialog": {
+      "comment_required": "Odrzucenie wymaga komentarza dla autora.",
+      "comment_optional": "Możesz dodać komentarz (opcjonalnie).",
+      "comment_placeholder": "Komentarz…"
+    },
+    "toast": {
+      "applied": "Status zmieniony: {{place}}",
+      "failed": "Przejście nie powiodło się"
+    },
+    "history": {
+      "title": "Historia workflow",
+      "open": "Historia workflow",
+      "empty": "Brak przejść.",
+      "older": "Pokaż starsze",
+      "system": "System",
+      "auto_unpublish": "auto-unpublish",
+      "bulk": "bulk"
+    }
   }
 }

--- a/apps/api/config/packages/dev/framework.yaml
+++ b/apps/api/config/packages/dev/framework.yaml
@@ -8,9 +8,12 @@ framework:
         # this override only relaxes the limit when APP_ENV=dev so the
         # suite can grow without the limiter becoming the gate.
         # Bumped 50 → 200 after #867 surfaced settings-users-list flake.
+        # Bumped 200 → 400 after #2423: the suite crossed 200 logins per
+        # 15-minute window (223 tests, several mint an extra Bearer for
+        # page.request setup calls) and view-13 started 429-looping.
         auth_login:
             policy: 'fixed_window'
-            limit: 200
+            limit: 400
             interval: '15 minutes'
 
         # auth_refresh is the actual bottleneck on CI — every page reload


### PR DESCRIPTION
**Pakiet PR E** = WFL-P3-01 (#2423) + WFL-P3-05 (#2427) — jeden branch/PR/CI (§Pakiety PR backlogu).

## WFL-P3-01 — kontrolka stanu na karcie produktu

- `WorkflowStatusControl` w headerze product detail (wzorzec Pimcore): pill stanu (`StatusPill` z paletą per miejsce) + przyciski przejść **lustrzane 1:1 z guard-aware discovery** — zablokowane przejście renderuje się disabled z powodami blockerów w tooltipie (kod brakującej permission / gate completeness z listą braków), FE nie reimplementuje autoryzacji.
- Dialog przejścia z komentarzem (opcjonalny; **wymagany dla reject** — pętla review z PRD §3.8), toasty sukces/błąd, refetch stanu po akcji.

## WFL-P3-05 — timeline historii

- `WorkflowHistorySheet` (panel boczny, wzorzec „notes & events"): przejścia newest-first z aktorem/System, from→to, komentarzem recenzenta i badge'ami kontekstu `auto-unpublish`/`bulk`; kursor UUIDv7 „Pokaż starsze".
- Typed client `lib/workflow/api.ts` współdzielony z kolejką review (P3-02).

## Testy / bramki

Playwright spec `wfl-p3-01`: świeży draft przez API → submit z komentarzem → pill „W przeglądzie" → approve → „Opublikowany" → history sheet z oboma przejściami i komentarzem → cleanup unpublish. tsc/biome/vitest green; i18n pl/en.

Live smoke po merge (proof w #2423/#2427).

Refs #2423, Refs #2427
