### PR TITLE
feat(admin): add workflow review queue page (WFL-P3-02)

### DIFF
--- a/apps/admin/e2e/wfl-p3-02-review-queue.spec.ts
+++ b/apps/admin/e2e/wfl-p3-02-review-queue.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { apiLogin, uniqueSku } from './helpers/auth';
+import { ADMIN_EMAIL, ADMIN_PASSWORD, apiLogin, uniqueSku } from './helpers/auth';
 
 /**
  * WFL-P3-02 (#2424) — the review queue lists submitted objects with the
@@ -8,10 +8,22 @@ import { apiLogin, uniqueSku } from './helpers/auth';
  * sidebar Workflow entry routes to the page (comingSoon retired).
  */
 test('review queue lists a submitted object and approve clears it', async ({ page }) => {
+  // page.request carries only cookies; the API wants a Bearer — mint one
+  // explicitly for the setup/cleanup calls (same pattern as spec #1351).
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+  const bearer = { authorization: `Bearer ${token}` };
+
   await apiLogin(page);
 
   // Fresh draft submitted via the API with a distinctive comment.
-  const typesResponse = await page.request.get('/api/object_types');
+  const typesResponse = await page.request.get('/api/object_types?itemsPerPage=200', {
+    headers: { ...bearer, accept: 'application/ld+json' },
+  });
   const types = (await typesResponse.json()) as {
     'hydra:member'?: { id: string; kind: string }[];
     member?: { id: string; kind: string }[];
@@ -24,14 +36,14 @@ test('review queue lists a submitted object and approve clears it', async ({ pag
   const sku = uniqueSku('WFL-Q');
   const createResponse = await page.request.post('/api/objects', {
     data: { code: sku, objectTypeId: productType.id },
-    headers: { 'content-type': 'application/ld+json' },
+    headers: { ...bearer, 'content-type': 'application/ld+json' },
   });
   expect(createResponse.status()).toBe(201);
   const created = (await createResponse.json()) as { id: string };
 
   const submit = await page.request.post(
     `/api/objects/${created.id}/workflow/transitions/submit_for_review`,
-    { data: { comment: 'E2E kolejka: sprawdź mnie' } },
+    { data: { comment: 'E2E kolejka: sprawdź mnie' }, headers: bearer },
   );
   expect(submit.status()).toBe(200);
 
@@ -49,6 +61,7 @@ test('review queue lists a submitted object and approve clears it', async ({ pag
   // Cleanup: back to draft for rerun hygiene.
   const cleanup = await page.request.post(
     `/api/objects/${created.id}/workflow/transitions/unpublish`,
+    { headers: bearer },
   );
   expect(cleanup.status()).toBe(200);
 });

--- a/apps/admin/e2e/wfl-p3-02-review-queue.spec.ts
+++ b/apps/admin/e2e/wfl-p3-02-review-queue.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test';
+
+import { apiLogin, uniqueSku } from './helpers/auth';
+
+/**
+ * WFL-P3-02 (#2424) — the review queue lists submitted objects with the
+ * submitter's comment, and an inline approve empties the row. The
+ * sidebar Workflow entry routes to the page (comingSoon retired).
+ */
+test('review queue lists a submitted object and approve clears it', async ({ page }) => {
+  await apiLogin(page);
+
+  // Fresh draft submitted via the API with a distinctive comment.
+  const typesResponse = await page.request.get('/api/object_types');
+  const types = (await typesResponse.json()) as {
+    'hydra:member'?: { id: string; kind: string }[];
+    member?: { id: string; kind: string }[];
+  };
+  const productType = (types['hydra:member'] ?? types.member ?? []).find(
+    (candidate) => candidate.kind === 'product',
+  );
+  if (productType === undefined) throw new Error('No product ObjectType seeded.');
+
+  const sku = uniqueSku('WFL-Q');
+  const createResponse = await page.request.post('/api/objects', {
+    data: { code: sku, objectTypeId: productType.id },
+    headers: { 'content-type': 'application/ld+json' },
+  });
+  expect(createResponse.status()).toBe(201);
+  const created = (await createResponse.json()) as { id: string };
+
+  const submit = await page.request.post(
+    `/api/objects/${created.id}/workflow/transitions/submit_for_review`,
+    { data: { comment: 'E2E kolejka: sprawdź mnie' } },
+  );
+  expect(submit.status()).toBe(200);
+
+  await page.goto('/workflow');
+  await expect(page.getByTestId('review-queue-page')).toBeVisible();
+
+  const row = page.getByTestId('review-queue-row').filter({ hasText: sku });
+  await expect(row).toBeVisible();
+  await expect(row.getByText('E2E kolejka: sprawdź mnie')).toBeVisible();
+
+  await row.getByTestId(`queue-approve-${sku}`).click();
+  await page.getByTestId('queue-confirm').click();
+  await expect(row).toHaveCount(0);
+
+  // Cleanup: back to draft for rerun hygiene.
+  const cleanup = await page.request.post(
+    `/api/objects/${created.id}/workflow/transitions/unpublish`,
+  );
+  expect(cleanup.status()).toBe(200);
+});

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -195,6 +195,10 @@ const ProductShowPage = lazyPage(
   'ProductShowPage',
 );
 const CatalogsPdfPage = lazyPage(() => import('@/features/catalogs-pdf'), 'CatalogsPdfPage');
+const ReviewQueuePage = lazyPage(
+  () => import('@/features/workflow/ReviewQueuePage'),
+  'ReviewQueuePage',
+);
 const CatalogWizardPage = lazyPage(
   () => import('@/features/catalogs-pdf/wizard/CatalogWizardPage'),
   'CatalogWizardPage',
@@ -577,6 +581,16 @@ function App() {
                     deep-links here lands on Forbidden403Page instead of the
                     shell; per-action writes stay gated by their own BE checks
                     (integration.admin). Mirrors MENU_PERMISSIONS.catalogs_pdf. */}
+                  {/* WFL-P3-02 (#2424) — review queue; mirror of
+                      MENU_PERMISSIONS.workflow (workflow.view). */}
+                  <Route
+                    path="/workflow"
+                    element={
+                      <PermissionRoute anyOf={['workflow.view']}>
+                        <ReviewQueuePage />
+                      </PermissionRoute>
+                    }
+                  />
                   <Route
                     path="/catalogs-pdf"
                     element={

--- a/apps/admin/src/features/workflow/ReviewQueuePage.tsx
+++ b/apps/admin/src/features/workflow/ReviewQueuePage.tsx
@@ -14,7 +14,6 @@ import {
 import { Textarea } from '@/components/ui/textarea';
 import { toast } from '@/components/ui/toast';
 import { EmptyState } from '@/components/ui-v2/empty-state';
-import { PageHeader } from '@/components/ui-v2/page-header';
 import { jsonFetch } from '@/lib/http';
 import { useIdentity } from '@/lib/identity';
 import { ensureMercureAuthorization, mercureSubscribeUrl, mercureTenantTopic } from '@/lib/mercure';
@@ -180,25 +179,24 @@ export function ReviewQueuePage() {
     if (requiresComment && comment.trim() === '') return;
     setSubmitting(true);
 
+    const singleId = decision.ids.length === 1 ? decision.ids[0] : undefined;
     const run =
-      decision.ids.length === 1
-        ? applyWorkflowTransition(
-            decision.ids[0],
-            decision.transition,
-            comment.trim() || undefined,
-          ).then(() => ({ success: 1, locked: 0 }))
+      singleId !== undefined
+        ? applyWorkflowTransition(singleId, decision.transition, comment.trim() || undefined).then(
+            () => ({ success: 1, locked: 0 }),
+          )
         : jsonFetch<{ success_count: number; skipped_count: number; locked_count?: number }>(
             '/api/objects/bulk-actions/change_status',
             {
               method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
+              contentType: 'application/json',
+              body: {
                 target_ids: decision.ids,
                 payload: {
                   transition: decision.transition,
                   ...(comment.trim() !== '' ? { comment: comment.trim() } : {}),
                 },
-              }),
+              },
             },
           ).then((result) => ({
             success: result.success_count,
@@ -232,50 +230,42 @@ export function ReviewQueuePage() {
 
   return (
     <div className="mx-auto max-w-6xl px-6 py-6" data-testid="review-queue-page">
-      <PageHeader
-        title={t('workflow.queue.title', { defaultValue: 'Workflow — Do przeglądu' })}
-        subtitle={t('workflow.queue.subtitle', {
-          defaultValue: 'Obiekty czekające na decyzję (approve / reject).',
-        })}
-        actions={
-          <div className="flex items-center gap-2">
-            {canDecide && selected.size > 0 ? (
-              <>
-                <Button
-                  size="sm"
-                  onClick={() => {
-                    setComment('');
-                    setDecision({ transition: 'approve', ids: selectedIds });
-                  }}
-                  data-testid="queue-bulk-approve"
-                >
-                  {t('workflow.transition.approve', { defaultValue: 'Zatwierdź' })} ({selected.size}
-                  )
-                </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={() => {
-                    setComment('');
-                    setDecision({ transition: 'reject', ids: selectedIds });
-                  }}
-                  data-testid="queue-bulk-reject"
-                >
-                  {t('workflow.transition.reject', { defaultValue: 'Odrzuć' })} ({selected.size})
-                </Button>
-              </>
-            ) : null}
+      {/* Page title comes from the shell topbar breadcrumb (hub pattern). */}
+      <div className="mb-2 flex items-center justify-end gap-2">
+        {canDecide && selected.size > 0 ? (
+          <>
             <Button
-              variant="ghost"
-              size="icon"
-              onClick={reload}
-              aria-label={t('common.refresh', { defaultValue: 'Odśwież' })}
+              size="sm"
+              onClick={() => {
+                setComment('');
+                setDecision({ transition: 'approve', ids: selectedIds });
+              }}
+              data-testid="queue-bulk-approve"
             >
-              <RefreshCw className="size-4" />
+              {t('workflow.transition.approve', { defaultValue: 'Zatwierdź' })} ({selected.size})
             </Button>
-          </div>
-        }
-      />
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                setComment('');
+                setDecision({ transition: 'reject', ids: selectedIds });
+              }}
+              data-testid="queue-bulk-reject"
+            >
+              {t('workflow.transition.reject', { defaultValue: 'Odrzuć' })} ({selected.size})
+            </Button>
+          </>
+        ) : null}
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={reload}
+          aria-label={t('common.refresh', { defaultValue: 'Odśwież' })}
+        >
+          <RefreshCw className="size-4" />
+        </Button>
+      </div>
 
       {rows.length === 0 && !loading ? (
         <EmptyState

--- a/apps/admin/src/features/workflow/ReviewQueuePage.tsx
+++ b/apps/admin/src/features/workflow/ReviewQueuePage.tsx
@@ -1,0 +1,428 @@
+import { RefreshCw } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { toast } from '@/components/ui/toast';
+import { EmptyState } from '@/components/ui-v2/empty-state';
+import { PageHeader } from '@/components/ui-v2/page-header';
+import { jsonFetch } from '@/lib/http';
+import { useIdentity } from '@/lib/identity';
+import { ensureMercureAuthorization, mercureSubscribeUrl, mercureTenantTopic } from '@/lib/mercure';
+import {
+  applyWorkflowTransition,
+  fetchWorkflowLog,
+  type WorkflowLogEntry,
+} from '@/lib/workflow/api';
+
+/**
+ * WFL-P3-02 (#2424) — the review queue: every object waiting for a
+ * decision, with the submitter's comment and completeness, decidable
+ * inline (approve / reject with a mandatory comment) or in bulk via
+ * the state-machine bulk endpoint. This is the differentiator over
+ * Pimcore (which has no inbox — states are only visible via reports).
+ * The sidebar "Workflow" entry stops being comingSoon here.
+ *
+ * Live refresh: workflow transition events land on the tenant objects
+ * broadcast topic (WFL-P2-01) — any submit/approve/reject triggers a
+ * debounced refetch, so items appear/disappear without a reload.
+ */
+
+interface ReviewRow {
+  id: string;
+  code: string;
+  label: string;
+  completenessPct: number;
+  submitted: WorkflowLogEntry | null;
+}
+
+interface HydraObject {
+  id: string;
+  code?: string;
+  completenessPct?: number;
+  attributesIndexed?: Record<string, unknown>;
+  kind?: string;
+}
+
+const QUEUE_LIMIT = 50;
+
+function objectLabel(item: HydraObject, lang: string): string {
+  const name = item.attributesIndexed?.name;
+  if (typeof name === 'string' && name !== '') return name;
+  if (name !== null && typeof name === 'object') {
+    const map = name as Record<string, unknown>;
+    const localized = map[lang] ?? map.pl ?? map.en;
+    if (typeof localized === 'string' && localized !== '') return localized;
+  }
+  return item.code ?? item.id;
+}
+
+export function ReviewQueuePage() {
+  const { t, i18n } = useTranslation();
+  const { identity } = useIdentity();
+  const [rows, setRows] = useState<ReviewRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
+  const [decision, setDecision] = useState<{
+    transition: 'approve' | 'reject';
+    ids: string[];
+  } | null>(null);
+  const [comment, setComment] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const canDecide = identity?.permissions.has('workflow.approve_reject') ?? false;
+
+  const reload = useCallback(() => {
+    setLoading(true);
+    jsonFetch<{ 'hydra:member'?: HydraObject[]; member?: HydraObject[] }>(
+      `/api/objects?status=review&itemsPerPage=${QUEUE_LIMIT}`,
+    )
+      .then(async (body) => {
+        const members = body['hydra:member'] ?? body.member ?? [];
+        // The newest transition of an in-review object IS the submit
+        // (approve/reject would have moved it out) — one light log fetch
+        // per row carries author, comment and timestamp.
+        const enriched = await Promise.all(
+          members.map(async (item): Promise<ReviewRow> => {
+            const submitted = await fetchWorkflowLog(item.id, undefined, 1)
+              .then((page) => page.items[0] ?? null)
+              .catch(() => null);
+            return {
+              id: item.id,
+              code: item.code ?? item.id,
+              label: objectLabel(item, i18n.language),
+              completenessPct: item.completenessPct ?? 0,
+              submitted,
+            };
+          }),
+        );
+        setRows(enriched);
+        setSelected(new Set());
+      })
+      .catch(() => setRows([]))
+      .finally(() => setLoading(false));
+  }, [i18n.language]);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  // Live refetch on workflow events (debounced by a micro-timeout).
+  const tenantId = identity?.tenant?.id ?? null;
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof EventSource === 'undefined') return;
+    if (tenantId === null) return;
+
+    let source: EventSource | null = null;
+    let disposed = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    void ensureMercureAuthorization().then(() => {
+      if (disposed) return;
+      source = new EventSource(mercureSubscribeUrl(mercureTenantTopic(tenantId, 'objects')), {
+        withCredentials: true,
+      });
+      source.onmessage = (event: MessageEvent<string>) => {
+        try {
+          const parsed = JSON.parse(event.data) as { type?: string };
+          if (typeof parsed.type !== 'string') return;
+          if (
+            parsed.type.startsWith('object.submitted_for_review') ||
+            parsed.type.startsWith('object.approved') ||
+            parsed.type.startsWith('object.rejected') ||
+            parsed.type.startsWith('object.published')
+          ) {
+            if (timer !== null) clearTimeout(timer);
+            timer = setTimeout(reload, 400);
+          }
+        } catch {
+          // Ignore malformed frames.
+        }
+      };
+    });
+
+    return () => {
+      disposed = true;
+      if (timer !== null) clearTimeout(timer);
+      source?.close();
+    };
+  }, [tenantId, reload]);
+
+  const allSelected = rows.length > 0 && selected.size === rows.length;
+  const toggleAll = () => {
+    setSelected(allSelected ? new Set() : new Set(rows.map((row) => row.id)));
+  };
+  const toggleOne = (id: string) => {
+    setSelected((previous) => {
+      const next = new Set(previous);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const requiresComment = decision?.transition === 'reject';
+
+  const confirmDecision = () => {
+    if (decision === null) return;
+    if (requiresComment && comment.trim() === '') return;
+    setSubmitting(true);
+
+    const run =
+      decision.ids.length === 1
+        ? applyWorkflowTransition(
+            decision.ids[0],
+            decision.transition,
+            comment.trim() || undefined,
+          ).then(() => ({ success: 1, locked: 0 }))
+        : jsonFetch<{ success_count: number; skipped_count: number; locked_count?: number }>(
+            '/api/objects/bulk-actions/change_status',
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                target_ids: decision.ids,
+                payload: {
+                  transition: decision.transition,
+                  ...(comment.trim() !== '' ? { comment: comment.trim() } : {}),
+                },
+              }),
+            },
+          ).then((result) => ({
+            success: result.success_count,
+            locked: result.skipped_count + (result.locked_count ?? 0),
+          }));
+
+    run
+      .then(({ success, locked }) => {
+        toast.success(
+          t('workflow.queue.decided', {
+            defaultValue: 'Zastosowano: {{count}} (pominięte: {{locked}})',
+            count: success,
+            locked,
+          }),
+        );
+        setDecision(null);
+        setComment('');
+        reload();
+      })
+      .catch((error: unknown) => {
+        toast.error(
+          error instanceof Error && error.message !== ''
+            ? error.message
+            : t('workflow.toast.failed', { defaultValue: 'Przejście nie powiodło się' }),
+        );
+      })
+      .finally(() => setSubmitting(false));
+  };
+
+  const selectedIds = useMemo(() => [...selected], [selected]);
+
+  return (
+    <div className="mx-auto max-w-6xl px-6 py-6" data-testid="review-queue-page">
+      <PageHeader
+        title={t('workflow.queue.title', { defaultValue: 'Workflow — Do przeglądu' })}
+        subtitle={t('workflow.queue.subtitle', {
+          defaultValue: 'Obiekty czekające na decyzję (approve / reject).',
+        })}
+        actions={
+          <div className="flex items-center gap-2">
+            {canDecide && selected.size > 0 ? (
+              <>
+                <Button
+                  size="sm"
+                  onClick={() => {
+                    setComment('');
+                    setDecision({ transition: 'approve', ids: selectedIds });
+                  }}
+                  data-testid="queue-bulk-approve"
+                >
+                  {t('workflow.transition.approve', { defaultValue: 'Zatwierdź' })} ({selected.size}
+                  )
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => {
+                    setComment('');
+                    setDecision({ transition: 'reject', ids: selectedIds });
+                  }}
+                  data-testid="queue-bulk-reject"
+                >
+                  {t('workflow.transition.reject', { defaultValue: 'Odrzuć' })} ({selected.size})
+                </Button>
+              </>
+            ) : null}
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={reload}
+              aria-label={t('common.refresh', { defaultValue: 'Odśwież' })}
+            >
+              <RefreshCw className="size-4" />
+            </Button>
+          </div>
+        }
+      />
+
+      {rows.length === 0 && !loading ? (
+        <EmptyState
+          title={t('workflow.queue.empty_title', { defaultValue: 'Nic do przeglądu' })}
+          description={t('workflow.queue.empty_body', {
+            defaultValue: 'Zgłoszone obiekty pojawią się tutaj automatycznie.',
+          })}
+        />
+      ) : (
+        <div className="mt-4 overflow-x-auto rounded-lg border border-border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50 text-left text-xs text-muted-foreground">
+              <tr>
+                <th className="w-8 px-3 py-2">
+                  <input
+                    type="checkbox"
+                    checked={allSelected}
+                    onChange={toggleAll}
+                    aria-label={t('workflow.queue.select_all', {
+                      defaultValue: 'Zaznacz wszystkie',
+                    })}
+                  />
+                </th>
+                <th className="px-3 py-2">
+                  {t('workflow.queue.col_object', { defaultValue: 'Obiekt' })}
+                </th>
+                <th className="px-3 py-2">
+                  {t('workflow.queue.col_completeness', { defaultValue: 'Kompletność' })}
+                </th>
+                <th className="px-3 py-2">
+                  {t('workflow.queue.col_submitted', { defaultValue: 'Zgłoszono' })}
+                </th>
+                <th className="px-3 py-2" />
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.id} className="border-t border-border" data-testid="review-queue-row">
+                  <td className="px-3 py-2">
+                    <input
+                      type="checkbox"
+                      checked={selected.has(row.id)}
+                      onChange={() => toggleOne(row.id)}
+                      aria-label={row.label}
+                    />
+                  </td>
+                  <td className="px-3 py-2">
+                    <Link to={`/products/${row.id}`} className="font-medium hover:underline">
+                      {row.label}
+                    </Link>
+                    <div className="text-xs text-muted-foreground">{row.code}</div>
+                  </td>
+                  <td className="px-3 py-2">{row.completenessPct}%</td>
+                  <td className="px-3 py-2">
+                    {row.submitted !== null ? (
+                      <>
+                        <div className="text-xs text-muted-foreground">
+                          {formatTime(row.submitted.created_at, i18n.language)}
+                        </div>
+                        {row.submitted.comment !== null && (
+                          <div className="text-xs">{row.submitted.comment}</div>
+                        )}
+                      </>
+                    ) : (
+                      <span className="text-xs text-muted-foreground">—</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 text-right">
+                    {canDecide ? (
+                      <div className="flex justify-end gap-1">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => {
+                            setComment('');
+                            setDecision({ transition: 'approve', ids: [row.id] });
+                          }}
+                          data-testid={`queue-approve-${row.code}`}
+                        >
+                          {t('workflow.transition.approve', { defaultValue: 'Zatwierdź' })}
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => {
+                            setComment('');
+                            setDecision({ transition: 'reject', ids: [row.id] });
+                          }}
+                          data-testid={`queue-reject-${row.code}`}
+                        >
+                          {t('workflow.transition.reject', { defaultValue: 'Odrzuć' })}
+                        </Button>
+                      </div>
+                    ) : null}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <Dialog open={decision !== null} onOpenChange={(open) => !open && setDecision(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {decision?.transition === 'approve'
+                ? t('workflow.transition.approve', { defaultValue: 'Zatwierdź' })
+                : t('workflow.transition.reject', { defaultValue: 'Odrzuć' })}
+              {decision !== null && decision.ids.length > 1 ? ` (${decision.ids.length})` : ''}
+            </DialogTitle>
+            <DialogDescription>
+              {requiresComment
+                ? t('workflow.dialog.comment_required', {
+                    defaultValue: 'Odrzucenie wymaga komentarza dla autora.',
+                  })
+                : t('workflow.dialog.comment_optional', {
+                    defaultValue: 'Możesz dodać komentarz (opcjonalnie).',
+                  })}
+            </DialogDescription>
+          </DialogHeader>
+          <Textarea
+            value={comment}
+            onChange={(event) => setComment(event.target.value)}
+            maxLength={2000}
+            data-testid="queue-comment"
+          />
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setDecision(null)} disabled={submitting}>
+              {t('common.cancel', { defaultValue: 'Anuluj' })}
+            </Button>
+            <Button
+              onClick={confirmDecision}
+              disabled={submitting || (requiresComment && comment.trim() === '')}
+              data-testid="queue-confirm"
+            >
+              {t('common.confirm', { defaultValue: 'Potwierdź' })}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function formatTime(value: string, locale: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(locale, { dateStyle: 'short', timeStyle: 'short' }).format(date);
+}

--- a/apps/admin/src/layout/sidebar-nav.tsx
+++ b/apps/admin/src/layout/sidebar-nav.tsx
@@ -103,8 +103,8 @@ const FALLBACK_ITEMS: EffectiveMenuItem[] = [
     label: null,
     labelKey: 'nav.workflow',
     icon: 'Workflow',
-    route: null,
-    comingSoon: true,
+    route: '/workflow',
+    comingSoon: false,
     protected: false,
   },
   {

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -4035,6 +4035,17 @@
       "system": "System",
       "auto_unpublish": "auto-unpublish",
       "bulk": "bulk"
+    },
+    "queue": {
+      "title": "Workflow — Review queue",
+      "subtitle": "Objects waiting for a decision (approve / reject).",
+      "empty_title": "Nothing to review",
+      "empty_body": "Submitted objects will show up here automatically.",
+      "col_object": "Object",
+      "col_completeness": "Completeness",
+      "col_submitted": "Submitted",
+      "select_all": "Select all",
+      "decided": "Applied: {{count}} (skipped: {{locked}})"
     }
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -4055,6 +4055,17 @@
       "system": "System",
       "auto_unpublish": "auto-unpublish",
       "bulk": "bulk"
+    },
+    "queue": {
+      "title": "Workflow — Do przeglądu",
+      "subtitle": "Obiekty czekające na decyzję (approve / reject).",
+      "empty_title": "Nic do przeglądu",
+      "empty_body": "Zgłoszone obiekty pojawią się tutaj automatycznie.",
+      "col_object": "Obiekt",
+      "col_completeness": "Kompletność",
+      "col_submitted": "Zgłoszono",
+      "select_all": "Zaznacz wszystkie",
+      "decided": "Zastosowano: {{count}} (pominięte: {{locked}})"
     }
   }
 }

--- a/apps/api/src/Catalog/Domain/SystemMenuItemRegistry.php
+++ b/apps/api/src/Catalog/Domain/SystemMenuItemRegistry.php
@@ -65,10 +65,13 @@ final class SystemMenuItemRegistry
                 'protected' => false,
             ],
             'workflow' => [
-                'route' => null,
+                // WFL-P3-02 (#2424) — the review queue ships; the entry
+                // stops being a comingSoon placeholder. Menu visibility
+                // stays gated on workflow.view (menu-permissions.ts).
+                'route' => '/workflow',
                 'icon' => 'Workflow',
                 'labelKey' => 'nav.workflow',
-                'comingSoon' => true,
+                'comingSoon' => false,
                 'protected' => false,
             ],
             // Top-level „Integracje" hub — Imports MVP (0.13/UI-09) + sub-tab

--- a/apps/api/tests/Unit/Catalog/SystemMenuItemRegistryTest.php
+++ b/apps/api/tests/Unit/Catalog/SystemMenuItemRegistryTest.php
@@ -51,12 +51,15 @@ final class SystemMenuItemRegistryTest extends TestCase
     }
 
     #[Test]
-    public function workflowIsComingSoon(): void
+    public function workflowShipsAsARoutedEntry(): void
     {
+        // WFL-P3-02 (#2424) — the review queue ships, so the workflow
+        // entry stops being a comingSoon placeholder and routes to
+        // /workflow (still visibility-gated on workflow.view).
         $workflow = SystemMenuItemRegistry::get('workflow');
         self::assertNotNull($workflow);
-        self::assertTrue($workflow['comingSoon']);
-        self::assertNull($workflow['route']);
+        self::assertFalse($workflow['comingSoon']);
+        self::assertSame('/workflow', $workflow['route']);
     }
 
     #[Test]


### PR DESCRIPTION
## WFL-P3-02 (#2424) — kolejka przeglądu (review queue)

Domyka wyróżnik nad Pimcore (brak inboxa — stany widoczne tylko w raportach): dedykowana kolejka obiektów czekających na decyzję, z komentarzem submitu i kompletnością, decydowalna inline (approve/reject) lub bulk przez endpoint maszyny stanów. Wpis „Workflow" w sidebarze przestaje być comingSoon.

- Strona `/workflow` z zakładką „Do przeglądu" (`ReviewQueuePage`), live-refresh po zdarzeniach workflow (Mercure, WFL-P2-01).
- Tytuł strony z topbaru (wzorzec hubu), akcje bulk jako toolbar.
- Bulk change_status i pojedyncze przejścia przez kontrakt `jsonFetch` (bez ręcznego `headers`).
- E2E `wfl-p3-02-review-queue.spec.ts`: submit → pozycja w kolejce z komentarzem → approve czyści wiersz.

Closes #2424

🤖 Generated with [Claude Code](https://claude.com/claude-code)