### PR TITLE
feat(admin): add published edit lock with request-unpublish flow (WFL-P3-03)

### DIFF
--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -7,6 +7,9 @@ import { DetailNotFoundState } from '@/components/catalog/detail-not-found-state
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
 import { useContentRecipes } from '@/features/agent/hooks/use-content-recipes';
+import { useIdentity } from '@/lib/identity';
+import { fetchWorkflowState } from '@/lib/workflow/api';
+import { computeEditLock } from '@/lib/workflow/edit-lock';
 import { AskAiProposal } from './ask-ai-proposal';
 import { ProductDetailContent } from './product-detail-content';
 import { ProductDetailHeader } from './product-detail-header';
@@ -18,6 +21,7 @@ import type { ProductChannel, ProductDetailMode, ProductLocale } from './types';
 import { useAskAi } from './use-ask-ai';
 import { useProductDetailData } from './use-product-detail-data';
 import { useProductDetailForm } from './use-product-detail-form';
+import { WorkflowLockBanner } from './workflow-lock-banner';
 
 export interface ProductDetailPageProps {
   mode: ProductDetailMode;
@@ -103,6 +107,30 @@ export function ProductDetailPage({
   // read-only state anymore. "Zapisz zmiany" is always visible and a
   // "Zapisz i wróć do listy" action saves + returns to the list.
   const isEditing = true;
+
+  // WFL-P3-03 (#2425) — PRD §3.8 edit lock: banner + save gating derive
+  // from the workflow place and the caller's permissions. `null` place
+  // (state still loading / no workflow.view) means no lock UI.
+  const { identity } = useIdentity();
+  const [workflowPlace, setWorkflowPlace] = useState<string | null>(null);
+  useEffect(() => {
+    if (mode !== 'edit') return;
+    let cancelled = false;
+    fetchWorkflowState(id)
+      .then((state) => {
+        if (!cancelled) setWorkflowPlace(state.current_place);
+      })
+      .catch(() => {
+        if (!cancelled) setWorkflowPlace(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [mode, id]);
+  const editLock =
+    workflowPlace !== null && identity !== null
+      ? computeEditLock(workflowPlace, identity.permissions)
+      : null;
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<boolean>(false);
   // #2318 — "Anuluj" returns to the list without saving; if there are unsaved
   // edits it asks for confirmation first.
@@ -406,7 +434,14 @@ export function ProductDetailPage({
         channel={channel}
         locales={locales}
         channels={channels}
-        onSave={(returnToList) => void handleSave(returnToList)}
+        onSave={(returnToList) => {
+          // WFL-P3-03 — locked states never reach the backend 403; the
+          // banner explains, this guard absorbs a stray click.
+          if (editLock?.locked === true) {
+            return;
+          }
+          void handleSave(returnToList);
+        }}
         onCancel={() => {
           // #2318 — guard unsaved edits before leaving to the list.
           if (Object.keys(dirtyFields).length > 0) {
@@ -423,6 +458,11 @@ export function ProductDetailPage({
       />
 
       {/* Body */}
+      {editLock !== null && editLock.reason !== null ? (
+        <div className="px-7 pt-4">
+          <WorkflowLockBanner objectId={id} lock={editLock} />
+        </div>
+      ) : null}
       <div className="grid grid-cols-1 gap-5 px-7 py-6 lg:grid-cols-[minmax(0,1fr)_320px]">
         <div className="min-w-0 space-y-3">
           {/* AUD-071 (#1614) — lazy tab chunks (multimedia/categories/variants/

--- a/apps/admin/src/features/catalog/products/components/workflow-lock-banner.tsx
+++ b/apps/admin/src/features/catalog/products/components/workflow-lock-banner.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { toast } from '@/components/ui/toast';
+import { type EditLock, requestUnpublish } from '@/lib/workflow/edit-lock';
+
+/**
+ * WFL-P3-03 (#2425) — the PRD §3.8 lock UX: instead of a bare 403 the
+ * editor sees WHY the form is locked and WHAT they can do — request an
+ * unpublish (published, no rights), expect an auto-unpublish on save
+ * (transition.unpublish holders) or nothing (archived is read-only;
+ * restore lives on the workflow control next to the status pill).
+ */
+export function WorkflowLockBanner({ objectId, lock }: { objectId: string; lock: EditLock }) {
+  const { t } = useTranslation();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [comment, setComment] = useState('');
+  const [sending, setSending] = useState(false);
+
+  if (lock.reason === null) return null;
+
+  const send = () => {
+    setSending(true);
+    requestUnpublish(objectId, comment.trim() || undefined)
+      .then(() => {
+        toast.success(
+          t('workflow.lock.request_sent', {
+            defaultValue: 'Prośba o cofnięcie publikacji wysłana do approverów.',
+          }),
+        );
+        setDialogOpen(false);
+        setComment('');
+      })
+      .catch(() => {
+        toast.error(t('workflow.toast.failed', { defaultValue: 'Operacja nie powiodła się' }));
+      })
+      .finally(() => setSending(false));
+  };
+
+  const message = lock.autoUnpublishOnSave
+    ? t('workflow.lock.auto_unpublish', {
+        defaultValue: 'Produkt jest opublikowany — zapis automatycznie cofnie publikację (draft).',
+      })
+    : lock.reason === 'published'
+      ? t('workflow.lock.published', {
+          defaultValue:
+            'Produkt opublikowany — edycja wymaga cofnięcia publikacji przez Approvera.',
+        })
+      : lock.reason === 'review'
+        ? t('workflow.lock.review', {
+            defaultValue: 'Produkt w przeglądzie — edycja tylko dla recenzentów.',
+          })
+        : t('workflow.lock.archived', {
+            defaultValue: 'Produkt zarchiwizowany — tylko do odczytu (użyj „Przywróć").',
+          });
+
+  return (
+    <div
+      className={
+        lock.autoUnpublishOnSave
+          ? 'mb-4 flex flex-wrap items-center justify-between gap-2 rounded-lg border border-orange-200 bg-orange-50 px-4 py-3 text-sm text-orange-900'
+          : 'mb-4 flex flex-wrap items-center justify-between gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm text-zinc-800'
+      }
+      data-testid="workflow-lock-banner"
+      role="status"
+    >
+      <span>{message}</span>
+      {lock.canRequestUnpublish ? (
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => setDialogOpen(true)}
+          data-testid="request-unpublish"
+        >
+          {t('workflow.lock.request_button', { defaultValue: 'Poproś o cofnięcie publikacji' })}
+        </Button>
+      ) : null}
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {t('workflow.lock.request_title', { defaultValue: 'Prośba o cofnięcie publikacji' })}
+            </DialogTitle>
+            <DialogDescription>
+              {t('workflow.lock.request_body', {
+                defaultValue: 'Approverzy dostaną powiadomienie z Twoim komentarzem.',
+              })}
+            </DialogDescription>
+          </DialogHeader>
+          <Textarea
+            value={comment}
+            onChange={(event) => setComment(event.target.value)}
+            maxLength={2000}
+            data-testid="request-unpublish-comment"
+          />
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setDialogOpen(false)} disabled={sending}>
+              {t('common.cancel', { defaultValue: 'Anuluj' })}
+            </Button>
+            <Button onClick={send} disabled={sending} data-testid="request-unpublish-confirm">
+              {t('common.send', { defaultValue: 'Wyślij' })}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/admin/src/lib/workflow/__tests__/edit-lock.test.ts
+++ b/apps/admin/src/lib/workflow/__tests__/edit-lock.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeEditLock } from '../edit-lock';
+
+/**
+ * WFL-P3-03 (#2425) — the PRD §3.8 edit-lock matrix as a pure function.
+ */
+const perms = (...codes: string[]) => new Set(codes) as ReadonlySet<string>;
+
+describe('computeEditLock', () => {
+  it('draft is editable without any lock', () => {
+    expect(computeEditLock('draft', perms('products.edit'))).toMatchObject({
+      locked: false,
+      reason: null,
+    });
+  });
+
+  it('review locks plain editors and admits reviewers', () => {
+    expect(computeEditLock('review', perms('products.edit')).locked).toBe(true);
+    expect(computeEditLock('review', perms('workflow.edit_in_review')).locked).toBe(false);
+    expect(computeEditLock('review', perms('workflow.edit_any_state')).locked).toBe(false);
+  });
+
+  it('published: edit_any_state edits in place, unpublish holders auto-unpublish, others request', () => {
+    expect(computeEditLock('published', perms('workflow.edit_any_state'))).toMatchObject({
+      locked: false,
+      autoUnpublishOnSave: false,
+    });
+    expect(
+      computeEditLock('published', perms('products.edit', 'workflow.transition.unpublish')),
+    ).toMatchObject({ locked: false, autoUnpublishOnSave: true });
+    expect(computeEditLock('published', perms('products.edit'))).toMatchObject({
+      locked: true,
+      canRequestUnpublish: true,
+    });
+  });
+
+  it('archived is read-only for everyone', () => {
+    expect(
+      computeEditLock('archived', perms('workflow.edit_any_state', 'products.edit')).locked,
+    ).toBe(true);
+  });
+});

--- a/apps/admin/src/lib/workflow/edit-lock.ts
+++ b/apps/admin/src/lib/workflow/edit-lock.ts
@@ -82,7 +82,7 @@ export function requestUnpublish(
 ): Promise<{ object_id: string; requested: boolean }> {
   return jsonFetch(`/api/objects/${objectId}/workflow/request-unpublish`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(comment !== undefined && comment !== '' ? { comment } : {}),
+    contentType: 'application/json',
+    body: comment !== undefined && comment !== '' ? { comment } : {},
   });
 }

--- a/apps/admin/src/lib/workflow/edit-lock.ts
+++ b/apps/admin/src/lib/workflow/edit-lock.ts
@@ -1,0 +1,88 @@
+import { jsonFetch } from '@/lib/http';
+
+/**
+ * WFL-P3-03 (#2425) — PRD §3.8 edit-lock semantics as a pure function
+ * so the banner and the save gating share one source of truth (and the
+ * matrix is unit-testable without a DOM):
+ *
+ *   - draft      → editable with products.edit,
+ *   - review     → workflow.edit_in_review or workflow.edit_any_state,
+ *   - published  → edit_any_state edits in place; transition.unpublish
+ *                  edits WITH the auto-unpublish side effect (the
+ *                  backend applies it atomically, WFL-P1-03); anyone
+ *                  else is locked with "Request unpublish",
+ *   - archived   → read-only for everyone (restore is a transition).
+ */
+export type EditLockReason = 'review' | 'published' | 'archived' | null;
+
+export interface EditLock {
+  locked: boolean;
+  reason: EditLockReason;
+  /** Published + transition.unpublish: saving will auto-unpublish. */
+  autoUnpublishOnSave: boolean;
+  /** Published + locked: offer the request-unpublish flow. */
+  canRequestUnpublish: boolean;
+}
+
+export function computeEditLock(place: string, permissions: ReadonlySet<string>): EditLock {
+  const editAnywhere = permissions.has('workflow.edit_any_state');
+
+  switch (place) {
+    case 'review':
+      return {
+        locked: !(editAnywhere || permissions.has('workflow.edit_in_review')),
+        reason: 'review',
+        autoUnpublishOnSave: false,
+        canRequestUnpublish: false,
+      };
+    case 'published': {
+      if (editAnywhere) {
+        return {
+          locked: false,
+          reason: null,
+          autoUnpublishOnSave: false,
+          canRequestUnpublish: false,
+        };
+      }
+      if (permissions.has('workflow.transition.unpublish') && permissions.has('products.edit')) {
+        return {
+          locked: false,
+          reason: 'published',
+          autoUnpublishOnSave: true,
+          canRequestUnpublish: false,
+        };
+      }
+      return {
+        locked: true,
+        reason: 'published',
+        autoUnpublishOnSave: false,
+        canRequestUnpublish: true,
+      };
+    }
+    case 'archived':
+      return {
+        locked: true,
+        reason: 'archived',
+        autoUnpublishOnSave: false,
+        canRequestUnpublish: false,
+      };
+    default:
+      return {
+        locked: false,
+        reason: null,
+        autoUnpublishOnSave: false,
+        canRequestUnpublish: false,
+      };
+  }
+}
+
+export function requestUnpublish(
+  objectId: string,
+  comment?: string,
+): Promise<{ object_id: string; requested: boolean }> {
+  return jsonFetch(`/api/objects/${objectId}/workflow/request-unpublish`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(comment !== undefined && comment !== '' ? { comment } : {}),
+  });
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -55,7 +55,8 @@
       "workflow": {
         "submitted_for_review": "Submitted for review",
         "approved": "Your change was approved",
-        "rejected": "Your change was rejected"
+        "rejected": "Your change was rejected",
+        "unpublish_requested": "Unpublish requested"
       }
     }
   },
@@ -4046,6 +4047,16 @@
       "col_submitted": "Submitted",
       "select_all": "Select all",
       "decided": "Applied: {{count}} (skipped: {{locked}})"
+    },
+    "lock": {
+      "published": "Product is published — editing requires an unpublish by an Approver.",
+      "review": "Product is in review — editable by reviewers only.",
+      "archived": "Product is archived — read-only (use “Restore”).",
+      "auto_unpublish": "Product is published — saving will automatically unpublish it (draft).",
+      "request_button": "Request unpublish",
+      "request_title": "Request unpublish",
+      "request_body": "Approvers will get a notification with your comment.",
+      "request_sent": "Unpublish request sent to the approvers."
     }
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -55,7 +55,8 @@
       "workflow": {
         "submitted_for_review": "Zgłoszono do przeglądu",
         "approved": "Twoja zmiana zatwierdzona",
-        "rejected": "Twoja zmiana odrzucona"
+        "rejected": "Twoja zmiana odrzucona",
+        "unpublish_requested": "Prośba o cofnięcie publikacji"
       }
     }
   },
@@ -4066,6 +4067,16 @@
       "col_submitted": "Zgłoszono",
       "select_all": "Zaznacz wszystkie",
       "decided": "Zastosowano: {{count}} (pominięte: {{locked}})"
+    },
+    "lock": {
+      "published": "Produkt opublikowany — edycja wymaga cofnięcia publikacji przez Approvera.",
+      "review": "Produkt w przeglądzie — edycja tylko dla recenzentów.",
+      "archived": "Produkt zarchiwizowany — tylko do odczytu (użyj „Przywróć”).",
+      "auto_unpublish": "Produkt jest opublikowany — zapis automatycznie cofnie publikację (draft).",
+      "request_button": "Poproś o cofnięcie publikacji",
+      "request_title": "Prośba o cofnięcie publikacji",
+      "request_body": "Approverzy dostaną powiadomienie z Twoim komentarzem.",
+      "request_sent": "Prośba o cofnięcie publikacji wysłana do approverów."
     }
   }
 }

--- a/apps/api/src/Catalog/Contracts/Event/ObjectUnpublishRequested.php
+++ b/apps/api/src/Catalog/Contracts/Event/ObjectUnpublishRequested.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Event;
+
+use App\Shared\Application\TenantAwareMessage;
+use App\Shared\Domain\DomainEvent;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P3-03 (#2425) — an editor without unpublish rights asked the
+ * approvers to take a published object back to draft (PRD §3.8
+ * "Request unpublish" UX). Not a transition — the state is untouched;
+ * the fan-out notifies workflow.transition.unpublish grantees and
+ * WFL-P4-02 upgrades this to a task.
+ */
+final readonly class ObjectUnpublishRequested implements DomainEvent, TenantAwareMessage
+{
+    public function __construct(
+        public Uuid $objectId,
+        public Uuid $tenantId,
+        public ?Uuid $requesterId = null,
+        public ?string $comment = null,
+        public DateTimeImmutable $occurredOn = new DateTimeImmutable(),
+    ) {
+    }
+
+    public function occurredOn(): DateTimeImmutable
+    {
+        return $this->occurredOn;
+    }
+
+    public function eventName(): string
+    {
+        return 'catalog.object.unpublish_requested';
+    }
+
+    public function aggregateId(): string
+    {
+        return $this->objectId->toRfc4122();
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenantId;
+    }
+}

--- a/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
+++ b/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
@@ -15,6 +15,7 @@ use App\Catalog\Contracts\Event\ObjectRejected;
 use App\Catalog\Contracts\Event\ObjectRestored;
 use App\Catalog\Contracts\Event\ObjectSubmittedForReview;
 use App\Catalog\Contracts\Event\ObjectUnpublished;
+use App\Catalog\Contracts\Event\ObjectUnpublishRequested;
 use App\Catalog\Contracts\Workflow\EditorialWorkflowSubject;
 use App\Catalog\Domain\ObjectKind;
 use App\Shared\Application\Blameable;
@@ -384,6 +385,13 @@ class CatalogObject extends AggregateRoot implements TenantScoped, Blameable, Ed
     {
         if (null !== $this->tenant) {
             $this->recordThat(new ObjectUnpublished($this->id, $this->tenant->getId(), $autoUnpublish));
+        }
+    }
+
+    public function recordUnpublishRequested(?Uuid $requesterId, ?string $comment): void
+    {
+        if (null !== $this->tenant) {
+            $this->recordThat(new ObjectUnpublishRequested($this->id, $this->tenant->getId(), $requesterId, $comment));
         }
     }
 

--- a/apps/api/src/Catalog/Presentation/Controller/ObjectWorkflowController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ObjectWorkflowController.php
@@ -7,6 +7,7 @@ namespace App\Catalog\Presentation\Controller;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Identity\Contracts\Auth\CurrentUserProvider;
 use App\Workflow\Contracts\ObjectEditorialWorkflow;
 use App\Workflow\Contracts\TransitionLogEntry;
 use App\Workflow\Contracts\TransitionLogPort;
@@ -46,6 +47,7 @@ final class ObjectWorkflowController
     public function __construct(
         private readonly CatalogObjectRepositoryInterface $objects,
         private readonly TransitionLogPort $transitionLog,
+        private readonly CurrentUserProvider $currentUser,
         #[Target(ObjectEditorialWorkflow::NAME)]
         private readonly WorkflowInterface $objectEditorial,
     ) {
@@ -147,6 +149,34 @@ final class ObjectWorkflowController
             'next_cursor' => $hasMore && [] !== $entries
                 ? $entries[\count($entries) - 1]->id->toRfc4122()
                 : null,
+        ]);
+    }
+
+    #[Route(
+        path: '/api/objects/{id}/workflow/request-unpublish',
+        name: 'object_workflow_request_unpublish',
+        requirements: ['id' => self::UUID_REQUIREMENT],
+        methods: ['POST'],
+    )]
+    // WFL-P3-03 (#2425) — PRD §3.8 "Request unpublish": an editor who
+    // cannot unpublish asks the approvers to. No state change — a domain
+    // event fans out to workflow.transition.unpublish grantees (and
+    // becomes a task in WFL-P4-02).
+    #[RequiresPermission(module: 'products', action: 'edit')]
+    public function requestUnpublish(string $id, Request $request): JsonResponse
+    {
+        $object = $this->loadObject($id);
+        if (CatalogObject::STATUS_PUBLISHED !== $object->getStatus()) {
+            throw new ConflictHttpException('Only published objects can be requested for unpublish.');
+        }
+
+        $comment = $this->extractComment($request);
+        $object->recordUnpublishRequested($this->currentUser->userId(), $comment);
+        $this->objects->save($object);
+
+        return new JsonResponse([
+            'object_id' => $object->getId()->toRfc4122(),
+            'requested' => true,
         ]);
     }
 

--- a/apps/api/src/Notification/Infrastructure/Messenger/WorkflowNotificationFanOut.php
+++ b/apps/api/src/Notification/Infrastructure/Messenger/WorkflowNotificationFanOut.php
@@ -7,6 +7,7 @@ namespace App\Notification\Infrastructure\Messenger;
 use App\Catalog\Contracts\Event\ObjectApproved;
 use App\Catalog\Contracts\Event\ObjectRejected;
 use App\Catalog\Contracts\Event\ObjectSubmittedForReview;
+use App\Catalog\Contracts\Event\ObjectUnpublishRequested;
 use App\Identity\Contracts\Policy\PermissionGranteesInterface;
 use App\Notification\Contracts\NotifierPort;
 use App\Shared\Application\TenantContext;
@@ -33,6 +34,7 @@ final readonly class WorkflowNotificationFanOut
     public const string TYPE_SUBMITTED = 'workflow.submitted_for_review';
     public const string TYPE_APPROVED = 'workflow.approved';
     public const string TYPE_REJECTED = 'workflow.rejected';
+    public const string TYPE_UNPUBLISH_REQUESTED = 'workflow.unpublish_requested';
 
     public function __construct(
         private NotifierPort $notifier,
@@ -75,6 +77,28 @@ final readonly class WorkflowNotificationFanOut
     public function onRejected(ObjectRejected $event): void
     {
         $this->notifyAuthor($event->objectId, self::TYPE_REJECTED, $event->comment);
+    }
+
+    #[AsMessageHandler]
+    public function onUnpublishRequested(ObjectUnpublishRequested $event): void
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            return;
+        }
+
+        $recipients = [];
+        foreach ($this->grantees->userIdsWithPermission($tenant, 'workflow.transition.unpublish') as $userId) {
+            if (null !== $event->requesterId && $userId->equals($event->requesterId)) {
+                continue;
+            }
+            $recipients[] = $userId;
+        }
+
+        $this->notifier->notifyUsers($recipients, self::TYPE_UNPUBLISH_REQUESTED, [
+            'object_id' => $event->objectId->toRfc4122(),
+            'comment' => $event->comment,
+        ]);
     }
 
     private function notifyAuthor(Uuid $objectId, string $type, ?string $comment): void

--- a/apps/api/tests/Api/Catalog/NotificationsApiTest.php
+++ b/apps/api/tests/Api/Catalog/NotificationsApiTest.php
@@ -130,6 +130,48 @@ final class NotificationsApiTest extends CatalogApiTestCase
     }
 
     #[Test]
+    public function requestUnpublishNotifiesUnpublishGrantees(): void
+    {
+        // WFL-P3-03 (#2425) — the PRD §3.8 "Request unpublish" flow: an
+        // editor without unpublish rights pings the grantees; no state
+        // change happens and drafts are rejected with 409.
+        $this->createUserWithRole('marketing-u@demo.localhost', 'marketing');
+        $id = $this->seedProduct('WFL-N-REQ');
+
+        $marketing = $this->authenticatedClient('marketing-u@demo.localhost');
+        $draftAttempt = $marketing->request('POST', '/api/objects/'.$id.'/workflow/request-unpublish');
+        self::assertSame(409, $draftAttempt->getStatusCode(), 'draft cannot be requested for unpublish');
+
+        $admin = $this->authenticatedClient();
+        $publish = $admin->request('POST', '/api/objects/'.$id.'/workflow/transitions/publish');
+        self::assertSame(200, $publish->getStatusCode());
+        $this->drainAsyncTransport();
+        $admin->request('POST', '/api/notifications/read-all');
+
+        $request = $marketing->request('POST', '/api/objects/'.$id.'/workflow/request-unpublish', [
+            'json' => ['comment' => 'Muszę poprawić cenę'],
+        ]);
+        self::assertSame(200, $request->getStatusCode());
+        $this->drainAsyncTransport();
+
+        // Admin holds workflow.transition.unpublish -> notified with comment.
+        $body = $admin->request('GET', '/api/notifications?unread=1')->toArray();
+        self::assertSame(1, $body['unread_count']);
+        $items = $body['items'];
+        self::assertIsArray($items);
+        $first = $items[0];
+        self::assertIsArray($first);
+        self::assertSame('workflow.unpublish_requested', $first['type']);
+        $payload = $first['payload'];
+        self::assertIsArray($payload);
+        self::assertSame('Muszę poprawić cenę', $payload['comment']);
+
+        // Object state untouched.
+        $state = $admin->request('GET', '/api/objects/'.$id.'/workflow')->toArray();
+        self::assertSame('published', $state['current_place']);
+    }
+
+    #[Test]
     public function anonymousRequestsAreRejected(): void
     {
         $client = static::createClient();

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -18851,6 +18851,45 @@
                 "x-cortex-permission": "workflow.view"
             }
         },
+        "/api/objects/{id}/workflow/request-unpublish": {
+            "post": {
+                "operationId": "api_objects_id_workflow_request_unpublish_post",
+                "tags": [
+                    "objects"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api objects id workflow request unpublish",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "products.edit"
+            }
+        },
         "/api/objects/{id}/workflow/transitions": {
             "get": {
                 "operationId": "api_objects_id_workflow_transitions_get",


### PR DESCRIPTION
## WFL-P3-03 (#2425) — edit-lock na opublikowanych + request-unpublish

Treść obiektu w stanie `published`/`review` jest zablokowana dla użytkowników bez `products.edit_any_state`. FE pokazuje `workflow-lock-banner` z akcją „poproś o depublikację"; BE dodaje `POST /api/objects/{id}/workflow/request-unpublish` (rejestruje `ObjectUnpublishRequested`, 409 gdy obiekt nie jest published) + fan-out powiadomienia do grantees `workflow.transition.unpublish`.

- `computeEditLock` (pure, unit-tested) + banner na widoku produktu.
- Backend: event `ObjectUnpublishRequested`, endpoint request-unpublish, `WorkflowNotificationFanOut` rozszerzony.
- `jsonFetch` body contract (bez ręcznego `headers`).
- OpenAPI snapshot zregenerowany (nowa trasa request-unpublish).

Closes #2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)