### PR TITLE
feat(admin): add bulk status transitions from the product grid (WFL-P3-04)

### DIFF
--- a/apps/admin/src/components/catalog/bulk-actions-toolbar.tsx
+++ b/apps/admin/src/components/catalog/bulk-actions-toolbar.tsx
@@ -1,10 +1,20 @@
-import { CheckCircle2, Download, FolderTree, MinusCircle, Pencil, Trash2, X } from 'lucide-react';
+import {
+  CheckCircle2,
+  Download,
+  FolderTree,
+  GitBranch,
+  MinusCircle,
+  Pencil,
+  Trash2,
+  X,
+} from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
 import { MockBadge } from '@/components/ui/mock-badge';
 import { jsonFetch } from '@/lib/http';
+import { BulkChangeStatusDialog } from './bulk-change-status-dialog';
 
 import { BulkEditModal } from './bulk-edit-modal';
 
@@ -47,6 +57,7 @@ export function BulkActionsToolbar({
   const [isPending, setIsPending] = useState(false);
   const [lastJob, setLastJob] = useState<BulkEditJobResponse | null>(null);
   const [showEditModal, setShowEditModal] = useState(false);
+  const [showStatusModal, setShowStatusModal] = useState(false);
 
   if (ids.length === 0) return null;
 
@@ -150,6 +161,19 @@ export function BulkActionsToolbar({
           <MinusCircle className="size-4" />
           {t('products.bulk.disable', { defaultValue: 'Disable' })}
         </Button>
+        {/* WFL-P3-04 (#2426) — transitions per row through the state
+            machine (guards + gate evaluated backend-side). */}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => setShowStatusModal(true)}
+          disabled={isPending}
+          data-testid="bulk-change-status"
+        >
+          <GitBranch className="size-4" />
+          {t('products.bulk.change_status', { defaultValue: 'Zmień status' })}
+        </Button>
         {/* MOCK: bulk category change — wymaga rozszerzenia POST /api/products/bulk-edit
             o operation 'change_category' (#TBD). Patrz Project Plan/UI/Wdrozenie_grafiki/produkty-do-oprogramowania.md. */}
         <span className="inline-flex items-center gap-1.5">
@@ -211,6 +235,12 @@ export function BulkActionsToolbar({
         </Button>
       </div>
 
+      <BulkChangeStatusDialog
+        ids={ids}
+        open={showStatusModal}
+        onOpenChange={setShowStatusModal}
+        onApplied={onCleared}
+      />
       {showEditModal ? (
         <BulkEditModal
           productIds={ids}

--- a/apps/admin/src/components/catalog/bulk-change-status-dialog.tsx
+++ b/apps/admin/src/components/catalog/bulk-change-status-dialog.tsx
@@ -1,0 +1,157 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { toast } from '@/components/ui/toast';
+import { jsonFetch } from '@/lib/http';
+
+/**
+ * WFL-P3-04 (#2426) — bulk status change from the product grid: the
+ * segment-driven workflow idiom (filter -> select -> one transition).
+ * The transition list mirrors the object_editorial machine; the
+ * backend evaluates topology + RBAC guards + the completeness gate PER
+ * ROW (WFL-P1-05), so mixed selections partially apply and the result
+ * toast reports success/skipped/locked instead of failing the batch.
+ */
+const TRANSITIONS = [
+  'submit_for_review',
+  'publish',
+  'approve',
+  'reject',
+  'unpublish',
+  'archive',
+  'restore',
+] as const;
+
+interface BulkChangeStatusResult {
+  success_count: number;
+  skipped_count: number;
+  error_count: number;
+  locked_count?: number;
+}
+
+export function BulkChangeStatusDialog({
+  ids,
+  open,
+  onOpenChange,
+  onApplied,
+}: {
+  ids: string[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onApplied: () => void;
+}) {
+  const { t } = useTranslation();
+  const [transition, setTransition] = useState<(typeof TRANSITIONS)[number]>('submit_for_review');
+  const [comment, setComment] = useState('');
+  const [pending, setPending] = useState(false);
+
+  const requiresComment = transition === 'reject';
+
+  const apply = () => {
+    if (requiresComment && comment.trim() === '') return;
+    setPending(true);
+    jsonFetch<BulkChangeStatusResult>('/api/products/bulk-actions/change_status', {
+      method: 'POST',
+      body: {
+        target_ids: ids,
+        payload: {
+          transition,
+          ...(comment.trim() !== '' ? { comment: comment.trim() } : {}),
+        },
+      },
+    })
+      .then((result) => {
+        const skipped = result.skipped_count + (result.locked_count ?? 0) + result.error_count;
+        toast.success(
+          t('products.bulk.status_applied', {
+            defaultValue: 'Status zmieniony: {{count}} (pominięte: {{skipped}})',
+            count: result.success_count,
+            skipped,
+          }),
+        );
+        onOpenChange(false);
+        setComment('');
+        onApplied();
+      })
+      .catch((error: unknown) => {
+        toast.error(
+          error instanceof Error && error.message !== ''
+            ? error.message
+            : t('workflow.toast.failed', { defaultValue: 'Przejście nie powiodło się' }),
+        );
+      })
+      .finally(() => setPending(false));
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {t('products.bulk.change_status_title', {
+              defaultValue: 'Zmień status ({{count}})',
+              count: ids.length,
+            })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('products.bulk.change_status_body', {
+              defaultValue:
+                'Przejście stosowane per obiekt — wiersze zablokowane przez stan, uprawnienia lub gate kompletności zostaną pominięte i zaraportowane.',
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        <label className="text-sm font-medium" htmlFor="bulk-transition-select">
+          {t('products.bulk.transition_label', { defaultValue: 'Przejście' })}
+        </label>
+        <select
+          id="bulk-transition-select"
+          className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+          value={transition}
+          onChange={(event) => setTransition(event.target.value as (typeof TRANSITIONS)[number])}
+          data-testid="bulk-status-transition"
+        >
+          {TRANSITIONS.map((name) => (
+            <option key={name} value={name}>
+              {t(`workflow.transition.${name}`, { defaultValue: name })}
+            </option>
+          ))}
+        </select>
+        <Textarea
+          value={comment}
+          onChange={(event) => setComment(event.target.value)}
+          maxLength={2000}
+          placeholder={
+            requiresComment
+              ? t('workflow.dialog.comment_required', {
+                  defaultValue: 'Odrzucenie wymaga komentarza dla autora.',
+                })
+              : t('workflow.dialog.comment_placeholder', { defaultValue: 'Komentarz…' })
+          }
+          data-testid="bulk-status-comment"
+        />
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={pending}>
+            {t('common.cancel', { defaultValue: 'Anuluj' })}
+          </Button>
+          <Button
+            onClick={apply}
+            disabled={pending || (requiresComment && comment.trim() === '')}
+            data-testid="bulk-status-confirm"
+          >
+            {t('common.confirm', { defaultValue: 'Potwierdź' })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1798,7 +1798,12 @@
       "disable": "Disable",
       "delete": "Delete",
       "toggle_done": "Updated {{count}} products",
-      "toggle_partial": "Updated {{processed}}, errors: {{errors}}"
+      "toggle_partial": "Updated {{processed}}, errors: {{errors}}",
+      "change_status": "Change status",
+      "change_status_title": "Change status ({{count}})",
+      "change_status_body": "The transition applies per object — rows blocked by state, permissions or the completeness gate are skipped and reported.",
+      "transition_label": "Transition",
+      "status_applied": "Status changed: {{count}} (skipped: {{skipped}})"
     },
     "show": {
       "tabs_aria": "Product detail tabs",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1815,7 +1815,12 @@
       "disable": "Wyłącz",
       "delete": "Usuń",
       "toggle_done": "Zaktualizowano {{count}} produktów",
-      "toggle_partial": "Zaktualizowano {{processed}}, błędów: {{errors}}"
+      "toggle_partial": "Zaktualizowano {{processed}}, błędów: {{errors}}",
+      "change_status": "Zmień status",
+      "change_status_title": "Zmień status ({{count}})",
+      "change_status_body": "Przejście stosowane per obiekt — wiersze zablokowane przez stan, uprawnienia lub gate kompletności zostaną pominięte i zaraportowane.",
+      "transition_label": "Przejście",
+      "status_applied": "Status zmieniony: {{count}} (pominięte: {{skipped}})"
     },
     "show": {
       "tabs_aria": "Karty szczegółów produktu",


### PR DESCRIPTION
## WFL-P3-04 (#2426) — bulk zmiana statusu z grida produktów

Toolbar zaznaczenia w gridzie produktów dostaje akcję „zmień status": dialog wybiera przejście (submit/approve/reject/…) + opcjonalny komentarz, uderza w `POST /api/objects/bulk-actions/change_status` (maszyna stanów, per-row `can()`). Raport zwraca sukcesy/pominięte (zablokowane guardem).

- `bulk-actions-toolbar` + `bulk-change-status-dialog` (testids: `bulk-status-transition/comment/confirm`).
- Payload przez `jsonFetch` body contract.
- i18n pl/en.

Closes #2426

🤖 Generated with [Claude Code](https://claude.com/claude-code)