### PR TITLE
feat(workflow): add tasks entity, API and transition automation (pakiet F)

### DIFF
--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -389,6 +389,9 @@ parameters:
             - Workflow_Contracts
             - Catalog_Contracts
             - Identity_Contracts
+            # WFL-P4-02 — task automation emits task_assigned notifications
+            # through the Notification seam.
+            - Notification_Contracts
             - Shared
             - Vendor
         Workflow_Contracts:

--- a/apps/api/migrations/Version20260711120000.php
+++ b/apps/api/migrations/Version20260711120000.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * WFL-P4-01 (#2428) — `workflow_tasks`: assignable work items of the
+ * editorial loop (review / fix / request_unpublish / custom). Work
+ * reaches PEOPLE (inRiver/Akeneo pattern) instead of waiting for
+ * someone to browse states. `object_id` is a bare UUID (ADR-0015);
+ * tenant RLS + Super Admin bypass like every WFL table.
+ */
+final class Version20260711120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'WFL-P4-01: workflow_tasks table + tenant RLS policies';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE workflow_tasks (
+                id UUID NOT NULL,
+                tenant_id UUID NOT NULL,
+                object_id UUID DEFAULT NULL,
+                title VARCHAR(255) NOT NULL,
+                type VARCHAR(32) NOT NULL,
+                assignee_user_id UUID DEFAULT NULL,
+                assignee_role_code VARCHAR(64) DEFAULT NULL,
+                due_date DATE DEFAULT NULL,
+                status VARCHAR(16) DEFAULT 'open' NOT NULL,
+                created_by UUID DEFAULT NULL,
+                resolved_by UUID DEFAULT NULL,
+                resolved_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+                comment TEXT DEFAULT NULL,
+                context JSONB DEFAULT NULL,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY(id)
+            )
+            SQL);
+        $this->addSql('CREATE INDEX workflow_tasks_tenant_status_due_idx ON workflow_tasks (tenant_id, status, due_date)');
+        $this->addSql('CREATE INDEX workflow_tasks_tenant_assignee_idx ON workflow_tasks (tenant_id, assignee_user_id)');
+        $this->addSql('CREATE INDEX workflow_tasks_tenant_object_idx ON workflow_tasks (tenant_id, object_id)');
+        $this->addSql(
+            'ALTER TABLE workflow_tasks ADD CONSTRAINT fk_workflow_tasks_tenant '
+            .'FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE RESTRICT NOT DEFERRABLE INITIALLY IMMEDIATE'
+        );
+
+        $predicate = "tenant_id = NULLIF(current_setting('app.current_tenant', true), '')::uuid";
+        $this->addSql('ALTER TABLE workflow_tasks ENABLE ROW LEVEL SECURITY');
+        $this->addSql('ALTER TABLE workflow_tasks FORCE ROW LEVEL SECURITY');
+        $this->addSql(\sprintf(
+            'CREATE POLICY tenant_isolation_workflow_tasks ON workflow_tasks USING (%s) WITH CHECK (%s)',
+            $predicate,
+            $predicate,
+        ));
+        $this->addSql(
+            'CREATE POLICY super_admin_bypass_workflow_tasks ON workflow_tasks '
+            ."USING (current_setting('app.is_super_admin', true) = 'true') "
+            ."WITH CHECK (current_setting('app.is_super_admin', true) = 'true')"
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP POLICY IF EXISTS super_admin_bypass_workflow_tasks ON workflow_tasks');
+        $this->addSql('DROP POLICY IF EXISTS tenant_isolation_workflow_tasks ON workflow_tasks');
+        $this->addSql('ALTER TABLE workflow_tasks NO FORCE ROW LEVEL SECURITY');
+        $this->addSql('ALTER TABLE workflow_tasks DISABLE ROW LEVEL SECURITY');
+        $this->addSql('DROP TABLE workflow_tasks');
+    }
+}

--- a/apps/api/src/Workflow/Contracts/WorkflowTaskStatus.php
+++ b/apps/api/src/Workflow/Contracts/WorkflowTaskStatus.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Workflow\Contracts;
+
+/**
+ * WFL-P4-01 (#2428) — task lifecycle. Open tasks are the inbox; done
+ * carries resolved_by/resolved_at; cancelled closes without an outcome.
+ */
+enum WorkflowTaskStatus: string
+{
+    case Open = 'open';
+    case Done = 'done';
+    case Cancelled = 'cancelled';
+
+    public function isTerminal(): bool
+    {
+        return self::Open !== $this;
+    }
+}

--- a/apps/api/src/Workflow/Contracts/WorkflowTaskType.php
+++ b/apps/api/src/Workflow/Contracts/WorkflowTaskType.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Workflow\Contracts;
+
+/**
+ * WFL-P4-01 (#2428) — task categories of the editorial loop. `custom`
+ * covers operator-created todos; the other three are written by the
+ * transition automation (WFL-P4-02).
+ */
+enum WorkflowTaskType: string
+{
+    case Review = 'review';
+    case Fix = 'fix';
+    case RequestUnpublish = 'request_unpublish';
+    case Custom = 'custom';
+}

--- a/apps/api/src/Workflow/Domain/Entity/WorkflowTask.php
+++ b/apps/api/src/Workflow/Domain/Entity/WorkflowTask.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Workflow\Domain\Entity;
+
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\Tenant;
+use App\Workflow\Contracts\WorkflowTaskStatus;
+use App\Workflow\Contracts\WorkflowTaskType;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P4-01 (#2428) — one assignable work item of the editorial loop.
+ * PRD §3.7: tasks are collaborative — visible to everyone with the
+ * permission, assigned to a USER or a ROLE (one of the two). No
+ * ownership semantics beyond assignment.
+ */
+class WorkflowTask implements TenantScoped
+{
+    private Uuid $id;
+    private ?Tenant $tenant = null;
+    private ?Uuid $objectId;
+    private string $title;
+    private WorkflowTaskType $type;
+    private ?Uuid $assigneeUserId;
+    private ?string $assigneeRoleCode;
+    private ?DateTimeImmutable $dueDate;
+    private WorkflowTaskStatus $status = WorkflowTaskStatus::Open;
+    private ?Uuid $createdBy;
+    private ?Uuid $resolvedBy = null;
+    private ?DateTimeImmutable $resolvedAt = null;
+    private ?string $comment;
+
+    /** @var array<string, mixed>|null */
+    private ?array $context;
+
+    private DateTimeImmutable $createdAt;
+
+    /**
+     * @param array<string, mixed>|null $context
+     */
+    public function __construct(
+        string $title,
+        WorkflowTaskType $type,
+        ?Uuid $objectId = null,
+        ?Uuid $assigneeUserId = null,
+        ?string $assigneeRoleCode = null,
+        ?DateTimeImmutable $dueDate = null,
+        ?Uuid $createdBy = null,
+        ?string $comment = null,
+        ?array $context = null,
+    ) {
+        if (null !== $assigneeUserId && null !== $assigneeRoleCode) {
+            throw new LogicException('A task is assigned to a user OR a role, not both.');
+        }
+
+        $this->id = Uuid::v7();
+        $this->title = $title;
+        $this->type = $type;
+        $this->objectId = $objectId;
+        $this->assigneeUserId = $assigneeUserId;
+        $this->assigneeRoleCode = $assigneeRoleCode;
+        $this->dueDate = $dueDate;
+        $this->createdBy = $createdBy;
+        $this->comment = $comment;
+        $this->context = $context;
+        $this->createdAt = new DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant && $this->tenant !== $tenant) {
+            throw new LogicException('WorkflowTask rows cannot move between tenants.');
+        }
+
+        $this->tenant = $tenant;
+    }
+
+    public function getObjectId(): ?Uuid
+    {
+        return $this->objectId;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getType(): WorkflowTaskType
+    {
+        return $this->type;
+    }
+
+    public function getAssigneeUserId(): ?Uuid
+    {
+        return $this->assigneeUserId;
+    }
+
+    public function getAssigneeRoleCode(): ?string
+    {
+        return $this->assigneeRoleCode;
+    }
+
+    public function reassign(?Uuid $userId, ?string $roleCode): void
+    {
+        if (null !== $userId && null !== $roleCode) {
+            throw new LogicException('A task is assigned to a user OR a role, not both.');
+        }
+        $this->assertOpen();
+        $this->assigneeUserId = $userId;
+        $this->assigneeRoleCode = $roleCode;
+    }
+
+    public function getDueDate(): ?DateTimeImmutable
+    {
+        return $this->dueDate;
+    }
+
+    public function getStatus(): WorkflowTaskStatus
+    {
+        return $this->status;
+    }
+
+    public function complete(?Uuid $resolvedBy): void
+    {
+        $this->assertOpen();
+        $this->status = WorkflowTaskStatus::Done;
+        $this->resolvedBy = $resolvedBy;
+        $this->resolvedAt = new DateTimeImmutable();
+    }
+
+    public function cancel(?Uuid $resolvedBy): void
+    {
+        $this->assertOpen();
+        $this->status = WorkflowTaskStatus::Cancelled;
+        $this->resolvedBy = $resolvedBy;
+        $this->resolvedAt = new DateTimeImmutable();
+    }
+
+    public function getCreatedBy(): ?Uuid
+    {
+        return $this->createdBy;
+    }
+
+    public function getResolvedBy(): ?Uuid
+    {
+        return $this->resolvedBy;
+    }
+
+    public function getResolvedAt(): ?DateTimeImmutable
+    {
+        return $this->resolvedAt;
+    }
+
+    public function getComment(): ?string
+    {
+        return $this->comment;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getContext(): ?array
+    {
+        return $this->context;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    private function assertOpen(): void
+    {
+        if ($this->status->isTerminal()) {
+            throw new LogicException(\sprintf('Task "%s" is already %s.', $this->id->toRfc4122(), $this->status->value));
+        }
+    }
+}

--- a/apps/api/src/Workflow/Domain/Repository/WorkflowTaskRepositoryInterface.php
+++ b/apps/api/src/Workflow/Domain/Repository/WorkflowTaskRepositoryInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Workflow\Domain\Repository;
+
+use App\Workflow\Contracts\WorkflowTaskStatus;
+use App\Workflow\Contracts\WorkflowTaskType;
+use App\Workflow\Domain\Entity\WorkflowTask;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P4-01 (#2428) — task persistence. `save()` flushes immediately:
+ * the automation writes from post-flush Messenger handlers where no
+ * ambient flush follows.
+ */
+interface WorkflowTaskRepositoryInterface
+{
+    public function save(WorkflowTask $task): void;
+
+    public function find(Uuid $id): ?WorkflowTask;
+
+    /**
+     * Newest-first page (UUIDv7 cursor). `$mineUserId` matches direct
+     * assignment OR membership in the assignee role (both role paths).
+     *
+     * @return list<WorkflowTask>
+     */
+    public function page(
+        int $limit,
+        ?Uuid $before = null,
+        ?WorkflowTaskStatus $status = null,
+        ?Uuid $objectId = null,
+        ?Uuid $mineUserId = null,
+        ?DateTimeImmutable $dueBefore = null,
+    ): array;
+
+    /**
+     * @return list<WorkflowTask> every OPEN task of the type for the object
+     */
+    public function openTasksFor(Uuid $objectId, WorkflowTaskType $type): array;
+}

--- a/apps/api/src/Workflow/Infrastructure/Doctrine/DoctrineWorkflowTaskRepository.php
+++ b/apps/api/src/Workflow/Infrastructure/Doctrine/DoctrineWorkflowTaskRepository.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Workflow\Infrastructure\Doctrine;
+
+use App\Workflow\Contracts\WorkflowTaskStatus;
+use App\Workflow\Contracts\WorkflowTaskType;
+use App\Workflow\Domain\Entity\WorkflowTask;
+use App\Workflow\Domain\Repository\WorkflowTaskRepositoryInterface;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P4-01 (#2428) — Doctrine adapter. "Mine" resolves the caller's
+ * role codes with raw DBAL over BOTH coexisting assignment paths
+ * (legacy `user_roles` + RBAC `user_role_assignments`, consolidation
+ * #644) — referencing Identity entities in DQL would leak
+ * Identity_Internals into this BC (deptrac).
+ */
+final readonly class DoctrineWorkflowTaskRepository implements WorkflowTaskRepositoryInterface
+{
+    public function __construct(private EntityManagerInterface $entityManager)
+    {
+    }
+
+    public function save(WorkflowTask $task): void
+    {
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+    }
+
+    public function find(Uuid $id): ?WorkflowTask
+    {
+        return $this->entityManager->find(WorkflowTask::class, $id);
+    }
+
+    public function page(
+        int $limit,
+        ?Uuid $before = null,
+        ?WorkflowTaskStatus $status = null,
+        ?Uuid $objectId = null,
+        ?Uuid $mineUserId = null,
+        ?DateTimeImmutable $dueBefore = null,
+    ): array {
+        $builder = $this->entityManager->createQueryBuilder()
+            ->select('t')
+            ->from(WorkflowTask::class, 't')
+            ->orderBy('t.id', 'DESC')
+            ->setMaxResults($limit);
+
+        if (null !== $before) {
+            $builder->andWhere('t.id < :before')->setParameter('before', $before);
+        }
+        if (null !== $status) {
+            $builder->andWhere('t.status = :status')->setParameter('status', $status);
+        }
+        if (null !== $objectId) {
+            $builder->andWhere('t.objectId = :objectId')->setParameter('objectId', $objectId);
+        }
+        if (null !== $dueBefore) {
+            $builder->andWhere('t.dueDate IS NOT NULL AND t.dueDate <= :dueBefore')
+                ->setParameter('dueBefore', $dueBefore);
+        }
+        if (null !== $mineUserId) {
+            $roleCodes = $this->roleCodesOf($mineUserId);
+            if ([] === $roleCodes) {
+                $builder->andWhere('t.assigneeUserId = :me')->setParameter('me', $mineUserId);
+            } else {
+                $builder->andWhere('t.assigneeUserId = :me OR t.assigneeRoleCode IN (:roles)')
+                    ->setParameter('me', $mineUserId)
+                    ->setParameter('roles', $roleCodes);
+            }
+        }
+
+        /** @var list<WorkflowTask> $rows */
+        $rows = $builder->getQuery()->getResult();
+
+        return $rows;
+    }
+
+    public function openTasksFor(Uuid $objectId, WorkflowTaskType $type): array
+    {
+        /** @var list<WorkflowTask> $rows */
+        $rows = $this->entityManager->createQueryBuilder()
+            ->select('t')
+            ->from(WorkflowTask::class, 't')
+            ->where('t.objectId = :objectId')
+            ->andWhere('t.type = :type')
+            ->andWhere('t.status = :open')
+            ->setParameter('objectId', $objectId)
+            ->setParameter('type', $type)
+            ->setParameter('open', WorkflowTaskStatus::Open)
+            ->getQuery()
+            ->getResult();
+
+        return $rows;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function roleCodesOf(Uuid $userId): array
+    {
+        $sql = <<<'SQL'
+            SELECT DISTINCT r.code FROM roles r
+            JOIN user_roles ur ON ur.role_id = r.id AND ur.user_id = :user
+            UNION
+            SELECT DISTINCT r.code FROM roles r
+            JOIN user_role_assignments ura ON ura.role_id = r.id AND ura.user_id = :user
+            SQL;
+
+        /** @var list<string> $codes */
+        $codes = $this->entityManager->getConnection()
+            ->fetchFirstColumn($sql, ['user' => $userId->toRfc4122()]);
+
+        return $codes;
+    }
+}

--- a/apps/api/src/Workflow/Infrastructure/Doctrine/Orm/Mapping/WorkflowTask.orm.xml
+++ b/apps/api/src/Workflow/Infrastructure/Doctrine/Orm/Mapping/WorkflowTask.orm.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Workflow\Domain\Entity\WorkflowTask" table="workflow_tasks">
+        <indexes>
+            <index name="workflow_tasks_tenant_status_due_idx" columns="tenant_id,status,due_date"/>
+            <index name="workflow_tasks_tenant_assignee_idx" columns="tenant_id,assignee_user_id"/>
+            <index name="workflow_tasks_tenant_object_idx" columns="tenant_id,object_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <field name="objectId" type="uuid" column="object_id" nullable="true"/>
+        <field name="title" type="string" length="255"/>
+        <field name="type" type="string" length="32" enum-type="App\Workflow\Contracts\WorkflowTaskType"/>
+        <field name="assigneeUserId" type="uuid" column="assignee_user_id" nullable="true"/>
+        <field name="assigneeRoleCode" type="string" length="64" column="assignee_role_code" nullable="true"/>
+        <field name="dueDate" type="date_immutable" column="due_date" nullable="true"/>
+        <field name="status" type="string" length="16" enum-type="App\Workflow\Contracts\WorkflowTaskStatus">
+            <options>
+                <option name="default">open</option>
+            </options>
+        </field>
+        <field name="createdBy" type="uuid" column="created_by" nullable="true"/>
+        <field name="resolvedBy" type="uuid" column="resolved_by" nullable="true"/>
+        <field name="resolvedAt" type="datetime_immutable" column="resolved_at" nullable="true"/>
+        <field name="comment" type="text" nullable="true"/>
+
+        <field name="context" type="json" column="context" nullable="true">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+    </entity>
+</doctrine-mapping>

--- a/apps/api/src/Workflow/Infrastructure/Messenger/WorkflowTaskAutomation.php
+++ b/apps/api/src/Workflow/Infrastructure/Messenger/WorkflowTaskAutomation.php
@@ -10,7 +10,6 @@ use App\Catalog\Contracts\Event\ObjectSubmittedForReview;
 use App\Catalog\Contracts\Event\ObjectUnpublished;
 use App\Catalog\Contracts\Event\ObjectUnpublishRequested;
 use App\Identity\Contracts\Auth\CurrentUserProvider;
-use App\Notification\Contracts\NotifierPort;
 use App\Workflow\Contracts\ObjectEditorialWorkflow;
 use App\Workflow\Contracts\TransitionLogPort;
 use App\Workflow\Contracts\WorkflowTaskType;
@@ -28,16 +27,17 @@ use Symfony\Component\Uid\Uuid;
  *   - approve / reject      → close open review tasks (resolved by the
  *                             decision maker); reject additionally
  *                             opens a `fix` task for the submit author
- *                             with the reviewer comment (+ a
- *                             task_assigned notification),
+ *                             with the reviewer comment,
  *   - unpublish             → close open request_unpublish tasks,
  *   - unpublish requested   → open `request_unpublish` task for the
  *                             approver role.
  *
  * Idempotent: an object never carries two OPEN tasks of one type
- * (a re-submit reuses the existing review task). Role-assigned tasks
- * skip the extra notification — the P2-02 fan-out already pinged the
- * same audience about the underlying event.
+ * (a re-submit reuses the existing review task). Tasks never send
+ * their own notification — the P2-02 fan-out already pinged the same
+ * audience about the underlying event (the fix task's author IS the
+ * `workflow.rejected` recipient), and the task itself lands in the
+ * assignee's inbox (WFL-P4-03).
  */
 final readonly class WorkflowTaskAutomation
 {
@@ -46,7 +46,6 @@ final readonly class WorkflowTaskAutomation
     public function __construct(
         private WorkflowTaskRepositoryInterface $tasks,
         private TransitionLogPort $transitionLog,
-        private NotifierPort $notifier,
         private CurrentUserProvider $currentUser,
     ) {
     }
@@ -100,12 +99,6 @@ final readonly class WorkflowTaskAutomation
             comment: $event->comment,
             context: ['object_id' => $event->objectId->toRfc4122()],
         ));
-
-        $this->notifier->notifyUsers([$author], 'workflow.task_assigned', [
-            'object_id' => $event->objectId->toRfc4122(),
-            'task_type' => WorkflowTaskType::Fix->value,
-            'comment' => $event->comment,
-        ]);
     }
 
     #[AsMessageHandler]

--- a/apps/api/src/Workflow/Infrastructure/Messenger/WorkflowTaskAutomation.php
+++ b/apps/api/src/Workflow/Infrastructure/Messenger/WorkflowTaskAutomation.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Workflow\Infrastructure\Messenger;
+
+use App\Catalog\Contracts\Event\ObjectApproved;
+use App\Catalog\Contracts\Event\ObjectRejected;
+use App\Catalog\Contracts\Event\ObjectSubmittedForReview;
+use App\Catalog\Contracts\Event\ObjectUnpublished;
+use App\Catalog\Contracts\Event\ObjectUnpublishRequested;
+use App\Identity\Contracts\Auth\CurrentUserProvider;
+use App\Notification\Contracts\NotifierPort;
+use App\Workflow\Contracts\ObjectEditorialWorkflow;
+use App\Workflow\Contracts\TransitionLogPort;
+use App\Workflow\Contracts\WorkflowTaskType;
+use App\Workflow\Domain\Entity\WorkflowTask;
+use App\Workflow\Domain\Repository\WorkflowTaskRepositoryInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P4-02 (#2429) — the task loop nobody has to run by hand
+ * (Akeneo/inRiver pattern: a workflow step IS a task):
+ *
+ *   - submit_for_review     → open `review` task for the canonical
+ *                             reviewer role (PRD persona `approver`),
+ *   - approve / reject      → close open review tasks (resolved by the
+ *                             decision maker); reject additionally
+ *                             opens a `fix` task for the submit author
+ *                             with the reviewer comment (+ a
+ *                             task_assigned notification),
+ *   - unpublish             → close open request_unpublish tasks,
+ *   - unpublish requested   → open `request_unpublish` task for the
+ *                             approver role.
+ *
+ * Idempotent: an object never carries two OPEN tasks of one type
+ * (a re-submit reuses the existing review task). Role-assigned tasks
+ * skip the extra notification — the P2-02 fan-out already pinged the
+ * same audience about the underlying event.
+ */
+final readonly class WorkflowTaskAutomation
+{
+    private const string REVIEWER_ROLE = 'approver';
+
+    public function __construct(
+        private WorkflowTaskRepositoryInterface $tasks,
+        private TransitionLogPort $transitionLog,
+        private NotifierPort $notifier,
+        private CurrentUserProvider $currentUser,
+    ) {
+    }
+
+    #[AsMessageHandler]
+    public function onSubmittedForReview(ObjectSubmittedForReview $event): void
+    {
+        if ([] !== $this->tasks->openTasksFor($event->objectId, WorkflowTaskType::Review)) {
+            return;
+        }
+
+        $this->tasks->save(new WorkflowTask(
+            title: 'Review request',
+            type: WorkflowTaskType::Review,
+            objectId: $event->objectId,
+            assigneeRoleCode: self::REVIEWER_ROLE,
+            createdBy: $this->currentUser->userId(),
+            comment: $event->comment,
+            context: ['object_id' => $event->objectId->toRfc4122()],
+        ));
+    }
+
+    #[AsMessageHandler]
+    public function onApproved(ObjectApproved $event): void
+    {
+        $this->closeOpen($event->objectId, WorkflowTaskType::Review);
+    }
+
+    #[AsMessageHandler]
+    public function onRejected(ObjectRejected $event): void
+    {
+        $this->closeOpen($event->objectId, WorkflowTaskType::Review);
+
+        $author = $this->transitionLog
+            ->latestForObject($event->objectId, ObjectEditorialWorkflow::TRANSITION_SUBMIT_FOR_REVIEW)
+            ?->actorUserId;
+        if (null === $author) {
+            return;
+        }
+
+        if ([] !== $this->tasks->openTasksFor($event->objectId, WorkflowTaskType::Fix)) {
+            return;
+        }
+
+        $this->tasks->save(new WorkflowTask(
+            title: 'Fix after rejection',
+            type: WorkflowTaskType::Fix,
+            objectId: $event->objectId,
+            assigneeUserId: $author,
+            createdBy: $this->currentUser->userId(),
+            comment: $event->comment,
+            context: ['object_id' => $event->objectId->toRfc4122()],
+        ));
+
+        $this->notifier->notifyUsers([$author], 'workflow.task_assigned', [
+            'object_id' => $event->objectId->toRfc4122(),
+            'task_type' => WorkflowTaskType::Fix->value,
+            'comment' => $event->comment,
+        ]);
+    }
+
+    #[AsMessageHandler]
+    public function onUnpublished(ObjectUnpublished $event): void
+    {
+        $this->closeOpen($event->objectId, WorkflowTaskType::RequestUnpublish);
+    }
+
+    #[AsMessageHandler]
+    public function onUnpublishRequested(ObjectUnpublishRequested $event): void
+    {
+        if ([] !== $this->tasks->openTasksFor($event->objectId, WorkflowTaskType::RequestUnpublish)) {
+            return;
+        }
+
+        $this->tasks->save(new WorkflowTask(
+            title: 'Unpublish request',
+            type: WorkflowTaskType::RequestUnpublish,
+            objectId: $event->objectId,
+            assigneeRoleCode: self::REVIEWER_ROLE,
+            createdBy: $event->requesterId,
+            comment: $event->comment,
+            context: ['object_id' => $event->objectId->toRfc4122()],
+        ));
+    }
+
+    private function closeOpen(Uuid $objectId, WorkflowTaskType $type): void
+    {
+        foreach ($this->tasks->openTasksFor($objectId, $type) as $task) {
+            $task->complete($this->currentUser->userId());
+            $this->tasks->save($task);
+        }
+    }
+}

--- a/apps/api/src/Workflow/Presentation/Controller/WorkflowTasksController.php
+++ b/apps/api/src/Workflow/Presentation/Controller/WorkflowTasksController.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Workflow\Presentation\Controller;
+
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Identity\Contracts\Auth\CurrentUserProvider;
+use App\Identity\Contracts\Policy\PermissionCheckerInterface;
+use App\Workflow\Contracts\WorkflowTaskStatus;
+use App\Workflow\Contracts\WorkflowTaskType;
+use App\Workflow\Domain\Entity\WorkflowTask;
+use App\Workflow\Domain\Repository\WorkflowTaskRepositoryInterface;
+use App\Workflow\Infrastructure\Doctrine\DoctrineWorkflowTaskRepository;
+use DateTimeImmutable;
+use DateTimeInterface;
+use LogicException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL-P4-01 (#2428) — workflow tasks surface: cursor-paged list with
+ * mine/status/object/due filters, manual creation and the
+ * complete/cancel/reassign actions. Tasks are collaborative (PRD
+ * §3.7): everyone with workflow.view reads them; resolving needs to be
+ * the assignee (direct or via role membership) or a
+ * workflow.approve_reject holder.
+ */
+final class WorkflowTasksController
+{
+    private const string UUID_REQUIREMENT = '[0-9a-fA-F-]{36}';
+    private const int DEFAULT_LIMIT = 20;
+    private const int MAX_LIMIT = 100;
+
+    public function __construct(
+        private readonly WorkflowTaskRepositoryInterface $tasks,
+        private readonly DoctrineWorkflowTaskRepository $taskQueries,
+        private readonly CurrentUserProvider $currentUser,
+        private readonly PermissionCheckerInterface $permissions,
+    ) {
+    }
+
+    #[Route(path: '/api/workflow/tasks', name: 'workflow_tasks_list', methods: ['GET'])]
+    #[RequiresPermission(module: 'workflow', action: 'view')]
+    public function list(Request $request): JsonResponse
+    {
+        $limit = \min(self::MAX_LIMIT, \max(1, $request->query->getInt('limit', self::DEFAULT_LIMIT)));
+
+        $before = null;
+        $beforeRaw = $request->query->getString('before');
+        if ('' !== $beforeRaw) {
+            if (!Uuid::isValid($beforeRaw)) {
+                throw new BadRequestHttpException('The "before" cursor must be a task id (UUID).');
+            }
+            $before = Uuid::fromString($beforeRaw);
+        }
+
+        $status = null;
+        $statusRaw = $request->query->getString('status');
+        if ('' !== $statusRaw) {
+            $status = WorkflowTaskStatus::tryFrom($statusRaw)
+                ?? throw new BadRequestHttpException('Unknown task status filter.');
+        }
+
+        $objectId = null;
+        $objectRaw = $request->query->getString('object_id');
+        if ('' !== $objectRaw) {
+            if (!Uuid::isValid($objectRaw)) {
+                throw new BadRequestHttpException('object_id must be a UUID.');
+            }
+            $objectId = Uuid::fromString($objectRaw);
+        }
+
+        $dueBefore = null;
+        $dueRaw = $request->query->getString('due_before');
+        if ('' !== $dueRaw) {
+            $parsedDue = DateTimeImmutable::createFromFormat('Y-m-d', $dueRaw);
+            if (false === $parsedDue) {
+                throw new BadRequestHttpException('due_before must be YYYY-MM-DD.');
+            }
+            $dueBefore = $parsedDue;
+        }
+
+        $mine = $request->query->getBoolean('mine') ? $this->requireUserId() : null;
+
+        $rows = $this->tasks->page($limit + 1, $before, $status, $objectId, $mine, $dueBefore);
+        $hasMore = \count($rows) > $limit;
+        $rows = \array_slice($rows, 0, $limit);
+
+        return new JsonResponse([
+            'items' => \array_map(self::serialize(...), $rows),
+            'next_cursor' => $hasMore && [] !== $rows ? $rows[\count($rows) - 1]->getId()->toRfc4122() : null,
+        ]);
+    }
+
+    #[Route(path: '/api/workflow/tasks', name: 'workflow_tasks_create', methods: ['POST'])]
+    #[RequiresPermission(module: 'products', action: 'edit')]
+    public function create(Request $request): JsonResponse
+    {
+        /** @var array<string, mixed> $body */
+        $body = \json_decode($request->getContent(), true) ?? [];
+
+        $title = $body['title'] ?? null;
+        if (!\is_string($title) || '' === \trim($title) || \mb_strlen($title) > 255) {
+            throw new BadRequestHttpException('title is required (max 255 chars).');
+        }
+
+        $assigneeUserId = null;
+        if (\is_string($body['assignee_user_id'] ?? null) && Uuid::isValid($body['assignee_user_id'])) {
+            $assigneeUserId = Uuid::fromString($body['assignee_user_id']);
+        }
+        $assigneeRoleCode = \is_string($body['assignee_role_code'] ?? null) ? $body['assignee_role_code'] : null;
+        if (null !== $assigneeUserId && null !== $assigneeRoleCode) {
+            throw new BadRequestHttpException('Assign a user OR a role, not both.');
+        }
+
+        $objectId = null;
+        if (\is_string($body['object_id'] ?? null) && Uuid::isValid($body['object_id'])) {
+            $objectId = Uuid::fromString($body['object_id']);
+        }
+
+        $dueDate = null;
+        if (\is_string($body['due_date'] ?? null)) {
+            $parsedDate = DateTimeImmutable::createFromFormat('Y-m-d', $body['due_date']);
+            if (false === $parsedDate) {
+                throw new BadRequestHttpException('due_date must be YYYY-MM-DD.');
+            }
+            $dueDate = $parsedDate;
+        }
+
+        $comment = \is_string($body['comment'] ?? null) ? \trim($body['comment']) : null;
+
+        $task = new WorkflowTask(
+            title: \trim($title),
+            type: WorkflowTaskType::Custom,
+            objectId: $objectId,
+            assigneeUserId: $assigneeUserId,
+            assigneeRoleCode: $assigneeRoleCode,
+            dueDate: $dueDate,
+            createdBy: $this->currentUser->userId(),
+            comment: '' !== $comment ? $comment : null,
+        );
+        $this->tasks->save($task);
+
+        return new JsonResponse(self::serialize($task), 201);
+    }
+
+    #[Route(
+        path: '/api/workflow/tasks/{id}',
+        name: 'workflow_tasks_update',
+        requirements: ['id' => self::UUID_REQUIREMENT],
+        methods: ['PATCH'],
+    )]
+    #[RequiresPermission(module: 'workflow', action: 'view')]
+    public function update(string $id, Request $request): JsonResponse
+    {
+        $task = $this->tasks->find(Uuid::fromString($id));
+        if (null === $task) {
+            throw new NotFoundHttpException('Task not found.');
+        }
+
+        /** @var array<string, mixed> $body */
+        $body = \json_decode($request->getContent(), true) ?? [];
+        $action = $body['action'] ?? null;
+        if (!\in_array($action, ['complete', 'cancel', 'reassign'], true)) {
+            throw new BadRequestHttpException('action must be complete, cancel or reassign.');
+        }
+
+        $userId = $this->requireUserId();
+        if (!$this->mayResolve($task, $userId)) {
+            throw new AccessDeniedHttpException(
+                'Only the assignee or a workflow.approve_reject holder may act on this task.',
+            );
+        }
+
+        try {
+            match ($action) {
+                'complete' => $task->complete($userId),
+                'cancel' => $task->cancel($userId),
+                'reassign' => $this->applyReassign($task, $body),
+            };
+        } catch (LogicException $exception) {
+            throw new ConflictHttpException($exception->getMessage(), $exception);
+        }
+
+        $this->tasks->save($task);
+
+        return new JsonResponse(self::serialize($task));
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    private function applyReassign(WorkflowTask $task, array $body): void
+    {
+        $userId = null;
+        if (\is_string($body['assignee_user_id'] ?? null) && Uuid::isValid($body['assignee_user_id'])) {
+            $userId = Uuid::fromString($body['assignee_user_id']);
+        }
+        $roleCode = \is_string($body['assignee_role_code'] ?? null) ? $body['assignee_role_code'] : null;
+
+        $task->reassign($userId, $roleCode);
+    }
+
+    private function mayResolve(WorkflowTask $task, Uuid $userId): bool
+    {
+        if ($this->permissions->userHasPermission($userId, 'workflow.approve_reject')) {
+            return true;
+        }
+        if (null !== $task->getAssigneeUserId() && $task->getAssigneeUserId()->equals($userId)) {
+            return true;
+        }
+        $roleCode = $task->getAssigneeRoleCode();
+        if (null !== $roleCode) {
+            return \in_array($roleCode, $this->taskQueries->roleCodesOf($userId), true);
+        }
+
+        return false;
+    }
+
+    private function requireUserId(): Uuid
+    {
+        return $this->currentUser->userId()
+            ?? throw new UnauthorizedHttpException('Bearer', 'Authentication required.');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function serialize(WorkflowTask $task): array
+    {
+        return [
+            'id' => $task->getId()->toRfc4122(),
+            'title' => $task->getTitle(),
+            'type' => $task->getType()->value,
+            'status' => $task->getStatus()->value,
+            'object_id' => $task->getObjectId()?->toRfc4122(),
+            'assignee_user_id' => $task->getAssigneeUserId()?->toRfc4122(),
+            'assignee_role_code' => $task->getAssigneeRoleCode(),
+            'due_date' => $task->getDueDate()?->format('Y-m-d'),
+            'comment' => $task->getComment(),
+            'context' => $task->getContext(),
+            'created_by' => $task->getCreatedBy()?->toRfc4122(),
+            'resolved_by' => $task->getResolvedBy()?->toRfc4122(),
+            'resolved_at' => $task->getResolvedAt()?->format(DateTimeInterface::ATOM),
+            'created_at' => $task->getCreatedAt()->format(DateTimeInterface::ATOM),
+        ];
+    }
+}

--- a/apps/api/tests/Api/Catalog/WorkflowTasksApiTest.php
+++ b/apps/api/tests/Api/Catalog/WorkflowTasksApiTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Pakiet F = WFL-P4-01 (#2428) + WFL-P4-02 (#2429) — the task loop:
+ * submit opens a role-assigned review task (idempotent), reject closes
+ * it and opens a fix task for the submit author (with the reviewer
+ * comment + notification), approve closes review tasks; unpublish
+ * requests open/close request_unpublish tasks. Manual CRUD +
+ * complete/cancel/reassign with assignee-or-approver authorization.
+ */
+final class WorkflowTasksApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function submitOpensReviewTaskIdempotentlyAndDecisionClosesIt(): void
+    {
+        $this->createUserWithRole('marketing-t@demo.localhost', 'marketing');
+        $this->createUserWithRole('approver-t@demo.localhost', 'approver');
+        $id = $this->seedProduct('WFL-T-LOOP');
+
+        $marketing = $this->authenticatedClient('marketing-t@demo.localhost');
+        $submit = $marketing->request('POST', '/api/objects/'.$id.'/workflow/transitions/submit_for_review', [
+            'json' => ['comment' => 'Do zadania'],
+        ]);
+        self::assertSame(200, $submit->getStatusCode());
+        $this->drainAsyncTransport();
+
+        // The approver sees the review task via mine (role membership).
+        $approver = $this->authenticatedClient('approver-t@demo.localhost');
+        $mine = $approver->request('GET', '/api/workflow/tasks?mine=1&status=open')->toArray();
+        $items = $mine['items'];
+        self::assertIsArray($items);
+        self::assertCount(1, $items);
+        $task = $items[0];
+        self::assertIsArray($task);
+        self::assertSame('review', $task['type']);
+        self::assertSame('approver', $task['assignee_role_code']);
+        self::assertSame('Do zadania', $task['comment']);
+
+        // Re-submit does not duplicate the open task.
+        $reject = $approver->request('POST', '/api/objects/'.$id.'/workflow/transitions/reject', [
+            'json' => ['comment' => 'Popraw opis'],
+        ]);
+        self::assertSame(200, $reject->getStatusCode());
+        $this->drainAsyncTransport();
+
+        $resubmit = $marketing->request('POST', '/api/objects/'.$id.'/workflow/transitions/submit_for_review');
+        self::assertSame(200, $resubmit->getStatusCode());
+        $this->drainAsyncTransport();
+
+        $open = $approver->request('GET', '/api/workflow/tasks?status=open&object_id='.$id)->toArray();
+        $openItems = $open['items'];
+        self::assertIsArray($openItems);
+        $types = \array_column(\array_filter($openItems, 'is_array'), 'type');
+        self::assertEqualsCanonicalizing(['review', 'fix'], $types, 'reject closed the first review task, opened fix; resubmit opened a fresh review');
+
+        // Approve closes the open review task.
+        $approve = $approver->request('POST', '/api/objects/'.$id.'/workflow/transitions/approve');
+        self::assertSame(200, $approve->getStatusCode());
+        $this->drainAsyncTransport();
+
+        $after = $approver->request('GET', '/api/workflow/tasks?status=open&object_id='.$id)->toArray();
+        $afterItems = $after['items'];
+        self::assertIsArray($afterItems);
+        $afterTypes = \array_column(\array_filter($afterItems, 'is_array'), 'type');
+        self::assertSame(['fix'], $afterTypes, 'only the author fix task stays open');
+    }
+
+    #[Test]
+    public function rejectOpensFixTaskForTheAuthorWithNotification(): void
+    {
+        $this->createUserWithRole('marketing-f@demo.localhost', 'marketing');
+        $id = $this->seedProduct('WFL-T-FIX');
+
+        $marketing = $this->authenticatedClient('marketing-f@demo.localhost');
+        $marketing->request('POST', '/api/objects/'.$id.'/workflow/transitions/submit_for_review');
+        $this->drainAsyncTransport();
+
+        $admin = $this->authenticatedClient();
+        $admin->request('POST', '/api/objects/'.$id.'/workflow/transitions/reject', [
+            'json' => ['comment' => 'Brak EAN'],
+        ]);
+        $this->drainAsyncTransport();
+
+        $mine = $marketing->request('GET', '/api/workflow/tasks?mine=1&status=open')->toArray();
+        $items = $mine['items'];
+        self::assertIsArray($items);
+        self::assertCount(1, $items);
+        $task = $items[0];
+        self::assertIsArray($task);
+        self::assertSame('fix', $task['type']);
+        self::assertSame('Brak EAN', $task['comment']);
+
+        // The author may complete their own task; a foreign marketing
+        // user may not (assignee-or-approver rule).
+        $taskId = $task['id'];
+        self::assertIsString($taskId);
+
+        $this->createUserWithRole('marketing-f2@demo.localhost', 'marketing');
+        $stranger = $this->authenticatedClient('marketing-f2@demo.localhost');
+        $denied = $stranger->request('PATCH', '/api/workflow/tasks/'.$taskId, [
+            'json' => ['action' => 'complete'],
+        ]);
+        self::assertSame(403, $denied->getStatusCode());
+
+        $done = $marketing->request('PATCH', '/api/workflow/tasks/'.$taskId, [
+            'json' => ['action' => 'complete'],
+        ]);
+        self::assertSame(200, $done->getStatusCode());
+
+        $again = $marketing->request('PATCH', '/api/workflow/tasks/'.$taskId, [
+            'json' => ['action' => 'complete'],
+        ]);
+        self::assertSame(409, $again->getStatusCode(), 'terminal tasks conflict on repeat actions');
+    }
+
+    #[Test]
+    public function manualTaskCrudWithDueDateAndReassign(): void
+    {
+        $id = $this->seedProduct('WFL-T-MANUAL');
+
+        $admin = $this->authenticatedClient();
+        $created = $admin->request('POST', '/api/workflow/tasks', [
+            'json' => [
+                'title' => 'Uzupełnij zdjęcia',
+                'object_id' => $id,
+                'assignee_role_code' => 'marketing',
+                'due_date' => '2026-08-01',
+            ],
+        ])->toArray();
+        self::assertSame('custom', $created['type']);
+        self::assertSame('2026-08-01', $created['due_date']);
+
+        $taskId = $created['id'];
+        self::assertIsString($taskId);
+
+        $reassigned = $admin->request('PATCH', '/api/workflow/tasks/'.$taskId, [
+            'json' => ['action' => 'reassign', 'assignee_role_code' => 'approver'],
+        ])->toArray();
+        self::assertSame('approver', $reassigned['assignee_role_code']);
+
+        $due = $admin->request('GET', '/api/workflow/tasks?due_before=2026-08-02&status=open')->toArray();
+        $dueItems = $due['items'];
+        self::assertIsArray($dueItems);
+        self::assertNotEmpty($dueItems);
+
+        $cancelled = $admin->request('PATCH', '/api/workflow/tasks/'.$taskId, [
+            'json' => ['action' => 'cancel'],
+        ])->toArray();
+        self::assertSame('cancelled', $cancelled['status']);
+    }
+
+    private function drainAsyncTransport(): void
+    {
+        $transport = self::getContainer()->get('messenger.transport.async');
+        if (!$transport instanceof InMemoryTransport) {
+            return;
+        }
+        $bus = self::getContainer()->get(MessageBusInterface::class);
+        foreach ($transport->getSent() as $envelope) {
+            $bus->dispatch($envelope->getMessage(), [new ReceivedStamp('async')]);
+        }
+        $transport->reset();
+    }
+
+    private function createUserWithRole(string $email, string $roleCode): void
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $role = self::getContainer()->get(RoleRepositoryInterface::class)->findByCode($roleCode, $tenant);
+        \assert(null !== $role);
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $stub = new User($tenant, $email, '', ['ROLE_USER']);
+        $user = new User($tenant, $email, $hasher->hashPassword($stub, 'changeme'), ['ROLE_USER']);
+        $user->addRole($role);
+        $em->persist($user);
+        $em->flush();
+    }
+
+    private function seedProduct(string $code): string
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $type);
+
+        $object = new CatalogObject($type, $code);
+        self::getContainer()->get(CatalogObjectRepositoryInterface::class)->save($object);
+        $em->flush();
+        $em->clear();
+
+        return $object->getId()->toRfc4122();
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -21693,6 +21693,95 @@
                 "x-cortex-permission": "user.admin"
             }
         },
+        "/api/workflow/tasks": {
+            "get": {
+                "operationId": "api_workflow_tasks_get",
+                "tags": [
+                    "workflow"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api workflow tasks",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "workflow.view"
+            },
+            "post": {
+                "operationId": "api_workflow_tasks_post",
+                "tags": [
+                    "workflow"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api workflow tasks",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "products.edit"
+            }
+        },
+        "/api/workflow/tasks/{id}": {
+            "patch": {
+                "operationId": "api_workflow_tasks_id_patch",
+                "tags": [
+                    "workflow"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api workflow tasks id",
+                "description": "Custom controller route.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "workflow.view"
+            }
+        },
         "/api/workspaces/current": {
             "get": {
                 "operationId": "api_workspaces_current_get",


### PR DESCRIPTION
## Pakiet F — WFL-P4-01 (#2428) + WFL-P4-02 (#2429): zadania workflow + automatyka przejść

Jedno źródło zadań edytorskich. Pętla „krok workflow = zadanie" (wzorzec Akeneo/inRiver):

**WFL-P4-01 — encja + API tasków:**
- Encja `WorkflowTask` (user-XOR-role assignment) + migracja `workflow_transitions`→`workflow_tasks` (RLS FORCE + super_admin bypass), enumy `WorkflowTaskType`/`WorkflowTaskStatus`.
- `GET /api/workflow/tasks` (mine/status/object_id/due, kursor) · `POST` custom · `PATCH` complete/cancel/reassign (gated assignee-or-approver).

**WFL-P4-02 — automatyka:**
- `submit_for_review`→task review (rola approver, idempotentnie) · `reject`→zamknięcie review + task fix dla autora z komentarzem · `approve`→zamknięcie review · `request-unpublish`→task request_unpublish.
- Taski NIE wysyłają własnego powiadomienia (fan-out zdarzenia już powiadomił tę samą publiczność — unika dubla).

OpenAPI snapshot zregenerowany (trasy tasków). ApiTestCase + automatyka pokryte.

Closes #2428
Closes #2429

🤖 Generated with [Claude Code](https://claude.com/claude-code)