### PR TITLE
feat(admin): add my-tasks inbox and dashboard widget (WFL-P4-03)

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -195,10 +195,7 @@ const ProductShowPage = lazyPage(
   'ProductShowPage',
 );
 const CatalogsPdfPage = lazyPage(() => import('@/features/catalogs-pdf'), 'CatalogsPdfPage');
-const ReviewQueuePage = lazyPage(
-  () => import('@/features/workflow/ReviewQueuePage'),
-  'ReviewQueuePage',
-);
+const WorkflowPage = lazyPage(() => import('@/features/workflow/WorkflowPage'), 'WorkflowPage');
 const CatalogWizardPage = lazyPage(
   () => import('@/features/catalogs-pdf/wizard/CatalogWizardPage'),
   'CatalogWizardPage',
@@ -587,7 +584,7 @@ function App() {
                     path="/workflow"
                     element={
                       <PermissionRoute anyOf={['workflow.view']}>
-                        <ReviewQueuePage />
+                        <WorkflowPage />
                       </PermissionRoute>
                     }
                   />

--- a/apps/admin/src/features/dashboard/components/MyTasksCard.tsx
+++ b/apps/admin/src/features/dashboard/components/MyTasksCard.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+
+import { fetchWorkflowTasks, type WorkflowTask } from '@/lib/workflow/tasks-api';
+
+/**
+ * WFL-P4-03 (#2430) — "my work on login" (inRiver pattern): open-task
+ * count + the five nearest due dates, deep-linking to the workflow hub.
+ * Plain read of the tasks API — no dedicated read model until the
+ * numbers justify one (ADR-0026 threshold).
+ */
+export function MyTasksCard() {
+  const { t, i18n } = useTranslation();
+  const [tasks, setTasks] = useState<WorkflowTask[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    fetchWorkflowTasks({ mine: true, status: 'open', limit: 30 })
+      .then((page) => setTasks(page.items))
+      .catch(() => setTasks([]))
+      .finally(() => setLoaded(true));
+  }, []);
+
+  if (!loaded || tasks.length === 0) {
+    // The dashboard stays calm when there is nothing to do — no empty
+    // card competing for attention (same rule as the alerts tile).
+    return null;
+  }
+
+  const byDue = [...tasks].sort((a, b) => {
+    if (a.due_date === null && b.due_date === null) return 0;
+    if (a.due_date === null) return 1;
+    if (b.due_date === null) return -1;
+    return a.due_date.localeCompare(b.due_date);
+  });
+
+  return (
+    <div
+      className="rounded-2xl border border-line bg-surface p-5 soft-shadow"
+      data-testid="my-tasks-card"
+    >
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold">
+          {t('dashboard.my_tasks.title', { defaultValue: 'Moje zadania' })}
+          <span className="ml-2 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">
+            {tasks.length}
+          </span>
+        </h2>
+        <Link to="/workflow" className="text-xs text-primary hover:underline">
+          {t('dashboard.my_tasks.all', { defaultValue: 'Wszystkie' })}
+        </Link>
+      </div>
+      <ul className="mt-3 flex flex-col gap-2">
+        {byDue.slice(0, 5).map((task) => (
+          <li key={task.id} className="flex items-center justify-between gap-2 text-sm">
+            <span className="truncate">
+              {t(`workflow.tasks.type.${task.type}`, { defaultValue: task.title })}
+            </span>
+            {task.due_date !== null && (
+              <span className="shrink-0 text-xs text-muted-foreground">
+                {new Intl.DateTimeFormat(i18n.language, { dateStyle: 'short' }).format(
+                  new Date(task.due_date),
+                )}
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/admin/src/features/dashboard/page.tsx
+++ b/apps/admin/src/features/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { AgentCommandHero } from './components/AgentCommandHero';
 import { CatalogHealthCard } from './components/CatalogHealthCard';
 import { DashboardGreeting } from './components/DashboardGreeting';
 import { KpiBand } from './components/KpiBand';
+import { MyTasksCard } from './components/MyTasksCard';
 import { TeamActivityCard } from './components/TeamActivityCard';
 
 /**
@@ -31,6 +32,7 @@ export function DashboardPage() {
         <CatalogHealthCard />
         <TeamActivityCard />
       </div>
+      <MyTasksCard />
       <ActionCenter />
     </div>
   );

--- a/apps/admin/src/features/workflow/ReviewQueuePage.tsx
+++ b/apps/admin/src/features/workflow/ReviewQueuePage.tsx
@@ -229,8 +229,7 @@ export function ReviewQueuePage() {
   const selectedIds = useMemo(() => [...selected], [selected]);
 
   return (
-    <div className="mx-auto max-w-6xl px-6 py-6" data-testid="review-queue-page">
-      {/* Page title comes from the shell topbar breadcrumb (hub pattern). */}
+    <div data-testid="review-queue-page">
       <div className="mb-2 flex items-center justify-end gap-2">
         {canDecide && selected.size > 0 ? (
           <>

--- a/apps/admin/src/features/workflow/TasksPanel.tsx
+++ b/apps/admin/src/features/workflow/TasksPanel.tsx
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+import { Button } from '@/components/ui/button';
+import { toast } from '@/components/ui/toast';
+import { EmptyState } from '@/components/ui-v2/empty-state';
+import { actOnWorkflowTask, fetchWorkflowTasks, type WorkflowTask } from '@/lib/workflow/tasks-api';
+
+/**
+ * WFL-P4-03 (#2430) — the task inbox (inRiver pattern: "my work" on
+ * login): open tasks assigned to me (directly or via my roles) or the
+ * tenant-wide list, with type labels, overdue highlighting and inline
+ * complete/cancel. Cursor pages older entries.
+ */
+export function TasksPanel({ mine }: { mine: boolean }) {
+  const { t, i18n } = useTranslation();
+  const [tasks, setTasks] = useState<WorkflowTask[]>([]);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const reload = useCallback(() => {
+    setLoading(true);
+    fetchWorkflowTasks({ mine, status: 'open', limit: 30 })
+      .then((page) => {
+        setTasks(page.items);
+        setCursor(page.next_cursor);
+      })
+      .catch(() => setTasks([]))
+      .finally(() => setLoading(false));
+  }, [mine]);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  const act = (task: WorkflowTask, action: 'complete' | 'cancel') => {
+    actOnWorkflowTask(task.id, action)
+      .then(() => {
+        toast.success(
+          action === 'complete'
+            ? t('workflow.tasks.completed', { defaultValue: 'Zadanie ukończone' })
+            : t('workflow.tasks.cancelled', { defaultValue: 'Zadanie anulowane' }),
+        );
+        reload();
+      })
+      .catch((error: unknown) => {
+        toast.error(
+          error instanceof Error && error.message !== ''
+            ? error.message
+            : t('workflow.toast.failed', { defaultValue: 'Operacja nie powiodła się' }),
+        );
+      });
+  };
+
+  const loadOlder = () => {
+    if (cursor === null) return;
+    fetchWorkflowTasks({ mine, status: 'open', limit: 30, before: cursor }).then((page) => {
+      setTasks((previous) => [...previous, ...page.items]);
+      setCursor(page.next_cursor);
+    });
+  };
+
+  if (tasks.length === 0 && !loading) {
+    return (
+      <EmptyState
+        title={t('workflow.tasks.empty_title', { defaultValue: 'Brak otwartych zadań' })}
+        description={t('workflow.tasks.empty_body', {
+          defaultValue: 'Zadania z przepływu review pojawią się tutaj automatycznie.',
+        })}
+      />
+    );
+  }
+
+  const today = new Date().toISOString().slice(0, 10);
+
+  return (
+    <div className="mt-4 flex flex-col gap-2" data-testid="tasks-panel">
+      {tasks.map((task) => {
+        const overdue = task.due_date !== null && task.due_date < today;
+        return (
+          <div
+            key={task.id}
+            className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-border px-4 py-3"
+            data-testid="task-row"
+          >
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium">
+                  {t(`workflow.tasks.type.${task.type}`, { defaultValue: task.title })}
+                </span>
+                {task.due_date !== null && (
+                  <span
+                    className={
+                      overdue
+                        ? 'rounded bg-brick-50 px-1.5 py-0.5 text-[10px] font-semibold text-brick-700'
+                        : 'rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] text-zinc-600'
+                    }
+                  >
+                    {formatDate(task.due_date, i18n.language)}
+                  </span>
+                )}
+                {task.assignee_role_code !== null && (
+                  <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] text-zinc-600">
+                    {task.assignee_role_code}
+                  </span>
+                )}
+              </div>
+              {task.comment !== null && (
+                <p className="mt-0.5 truncate text-xs text-muted-foreground">{task.comment}</p>
+              )}
+              {task.object_id !== null && (
+                <Link
+                  to={`/products/${task.object_id}`}
+                  className="text-xs text-primary hover:underline"
+                >
+                  {t('workflow.tasks.open_object', { defaultValue: 'Otwórz obiekt' })}
+                </Link>
+              )}
+            </div>
+            <div className="flex gap-1">
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => act(task, 'complete')}
+                data-testid={`task-complete-${task.id}`}
+              >
+                {t('workflow.tasks.complete', { defaultValue: 'Ukończ' })}
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => act(task, 'cancel')}>
+                {t('workflow.tasks.cancel', { defaultValue: 'Anuluj' })}
+              </Button>
+            </div>
+          </div>
+        );
+      })}
+      {cursor !== null && (
+        <Button variant="outline" size="sm" onClick={loadOlder}>
+          {t('workflow.history.older', { defaultValue: 'Pokaż starsze' })}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function formatDate(value: string, locale: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(locale, { dateStyle: 'short' }).format(date);
+}

--- a/apps/admin/src/features/workflow/WorkflowPage.tsx
+++ b/apps/admin/src/features/workflow/WorkflowPage.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { PageHeader } from '@/components/ui-v2/page-header';
+import { PillTabs } from '@/components/ui-v2/pill-tabs';
+import { useIdentity } from '@/lib/identity';
+
+import { ReviewQueuePage } from './ReviewQueuePage';
+import { TasksPanel } from './TasksPanel';
+
+/**
+ * WFL-P3-02 + WFL-P4-03 — the workflow hub: the review queue (what
+ * awaits a decision) next to the task inbox (what awaits MY work) and
+ * the tenant-wide task list for deciders. Pill-tab layout per the
+ * catalogs/exports hub pattern.
+ */
+export function WorkflowPage() {
+  const { t } = useTranslation();
+  const { identity } = useIdentity();
+  const canDecide = identity?.permissions.has('workflow.approve_reject') ?? false;
+  const [tab, setTab] = useState('review');
+
+  const tabs = [
+    { id: 'review', label: t('workflow.tabs.review', { defaultValue: 'Do przeglądu' }) },
+    { id: 'mine', label: t('workflow.tabs.mine', { defaultValue: 'Moje zadania' }) },
+    ...(canDecide
+      ? [{ id: 'all', label: t('workflow.tabs.all', { defaultValue: 'Wszystkie zadania' }) }]
+      : []),
+  ];
+
+  return (
+    <div className="mx-auto max-w-6xl px-6 py-6" data-testid="workflow-page">
+      <PageHeader
+        title={t('workflow.queue.title', { defaultValue: 'Workflow' })}
+        subtitle={t('workflow.queue.subtitle', {
+          defaultValue: 'Przegląd, decyzje i zadania przepływu edytorskiego.',
+        })}
+      />
+      <PillTabs
+        className="mt-4"
+        items={tabs}
+        activeId={tab}
+        onChange={setTab}
+        ariaLabel={t('workflow.tabs.aria', { defaultValue: 'Sekcje workflow' })}
+      />
+      {tab === 'review' ? <ReviewQueuePage /> : null}
+      {tab === 'mine' ? <TasksPanel mine /> : null}
+      {tab === 'all' && canDecide ? <TasksPanel mine={false} /> : null}
+    </div>
+  );
+}

--- a/apps/admin/src/features/workflow/WorkflowPage.tsx
+++ b/apps/admin/src/features/workflow/WorkflowPage.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { PageHeader } from '@/components/ui-v2/page-header';
 import { PillTabs } from '@/components/ui-v2/pill-tabs';
 import { useIdentity } from '@/lib/identity';
 
@@ -30,14 +29,8 @@ export function WorkflowPage() {
 
   return (
     <div className="mx-auto max-w-6xl px-6 py-6" data-testid="workflow-page">
-      <PageHeader
-        title={t('workflow.queue.title', { defaultValue: 'Workflow' })}
-        subtitle={t('workflow.queue.subtitle', {
-          defaultValue: 'Przegląd, decyzje i zadania przepływu edytorskiego.',
-        })}
-      />
+      {/* Page title comes from the shell topbar breadcrumb (hub pattern). */}
       <PillTabs
-        className="mt-4"
         items={tabs}
         activeId={tab}
         onChange={setTab}

--- a/apps/admin/src/lib/workflow/tasks-api.ts
+++ b/apps/admin/src/lib/workflow/tasks-api.ts
@@ -1,0 +1,52 @@
+import { jsonFetch } from '@/lib/http';
+
+/**
+ * WFL-P4-03 (#2430) — typed client for the workflow tasks surface
+ * (WFL-P4-01). "Mine" matches direct assignment or role membership —
+ * resolved backend-side.
+ */
+
+export interface WorkflowTask {
+  id: string;
+  title: string;
+  type: 'review' | 'fix' | 'request_unpublish' | 'custom';
+  status: 'open' | 'done' | 'cancelled';
+  object_id: string | null;
+  assignee_user_id: string | null;
+  assignee_role_code: string | null;
+  due_date: string | null;
+  comment: string | null;
+  context: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export interface WorkflowTasksPage {
+  items: WorkflowTask[];
+  next_cursor: string | null;
+}
+
+export function fetchWorkflowTasks(options: {
+  mine?: boolean;
+  status?: 'open' | 'done' | 'cancelled';
+  limit?: number;
+  before?: string;
+}): Promise<WorkflowTasksPage> {
+  const params = new URLSearchParams();
+  if (options.mine === true) params.set('mine', '1');
+  if (options.status !== undefined) params.set('status', options.status);
+  params.set('limit', String(options.limit ?? 20));
+  if (options.before !== undefined) params.set('before', options.before);
+
+  return jsonFetch<WorkflowTasksPage>(`/api/workflow/tasks?${params.toString()}`);
+}
+
+export function actOnWorkflowTask(
+  taskId: string,
+  action: 'complete' | 'cancel',
+): Promise<WorkflowTask> {
+  return jsonFetch<WorkflowTask>(`/api/workflow/tasks/${taskId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action }),
+  });
+}

--- a/apps/admin/src/lib/workflow/tasks-api.ts
+++ b/apps/admin/src/lib/workflow/tasks-api.ts
@@ -46,7 +46,7 @@ export function actOnWorkflowTask(
 ): Promise<WorkflowTask> {
   return jsonFetch<WorkflowTask>(`/api/workflow/tasks/${taskId}`, {
     method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ action }),
+    contentType: 'application/json',
+    body: { action },
   });
 }

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1193,6 +1193,10 @@
         "show_products": "Show products",
         "open_log": "Open log"
       }
+    },
+    "my_tasks": {
+      "title": "My tasks",
+      "all": "View all"
     }
   },
   "attributes": {
@@ -4062,6 +4066,27 @@
       "request_title": "Request unpublish",
       "request_body": "Approvers will get a notification with your comment.",
       "request_sent": "Unpublish request sent to the approvers."
+    },
+    "tabs": {
+      "review": "Review queue",
+      "mine": "My tasks",
+      "all": "All tasks",
+      "aria": "Workflow sections"
+    },
+    "tasks": {
+      "type": {
+        "review": "Object review",
+        "fix": "Fix after rejection",
+        "request_unpublish": "Unpublish request",
+        "custom": "Task"
+      },
+      "empty_title": "No open tasks",
+      "empty_body": "Tasks from the review loop will show up here automatically.",
+      "open_object": "Open object",
+      "complete": "Complete",
+      "cancel": "Cancel",
+      "completed": "Task completed",
+      "cancelled": "Task cancelled"
     }
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1203,6 +1203,10 @@
         "show_products": "Pokaż produkty",
         "open_log": "Otwórz log"
       }
+    },
+    "my_tasks": {
+      "title": "Moje zadania",
+      "all": "Wszystkie"
     }
   },
   "attributes": {
@@ -4082,6 +4086,27 @@
       "request_title": "Prośba o cofnięcie publikacji",
       "request_body": "Approverzy dostaną powiadomienie z Twoim komentarzem.",
       "request_sent": "Prośba o cofnięcie publikacji wysłana do approverów."
+    },
+    "tabs": {
+      "review": "Do przeglądu",
+      "mine": "Moje zadania",
+      "all": "Wszystkie zadania",
+      "aria": "Sekcje workflow"
+    },
+    "tasks": {
+      "type": {
+        "review": "Przegląd obiektu",
+        "fix": "Poprawka po odrzuceniu",
+        "request_unpublish": "Prośba o cofnięcie publikacji",
+        "custom": "Zadanie"
+      },
+      "empty_title": "Brak otwartych zadań",
+      "empty_body": "Zadania z przepływu review pojawią się tutaj automatycznie.",
+      "open_object": "Otwórz obiekt",
+      "complete": "Ukończ",
+      "cancel": "Anuluj",
+      "completed": "Zadanie ukończone",
+      "cancelled": "Zadanie anulowane"
     }
   }
 }


### PR DESCRIPTION
## WFL-P4-03 (#2430) — „Moje zadania" (inbox) + widget dashboardu

Domyka pętlę tasków po stronie użytkownika: hub `/workflow` dostaje zakładkę „Moje zadania" (`TasksPanel`), a dashboard widget `MyTasksCard` pokazuje otwarte zadania przypisane do mnie z akcją complete.

- `WorkflowPage` jako hub (PillTabs: przegląd / moje / wszystkie), `TasksPanel` z akcjami complete/cancel.
- `MyTasksCard` na dashboardzie.
- Payload akcji tasku przez `jsonFetch` body contract; hub tytuł z topbaru (nie PageHeader).

Closes #2430

🤖 Generated with [Claude Code](https://claude.com/claude-code)