### PR TITLE
fix(identity): add missing id PK to role_attribute_permissions (schema drift)

### DIFF
--- a/apps/api/migrations/Version20260711150000.php
+++ b/apps/api/migrations/Version20260711150000.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * #2491 — heal the role_attribute_permissions schema drift.
+ *
+ * Version20260518160000 created the table with a composite PK
+ * (role_id, attribute_id) and no `id` column; the later
+ * Version20260520090000 (#697) used CREATE TABLE IF NOT EXISTS with an
+ * `id UUID PRIMARY KEY`, which was a silent no-op on databases where the
+ * earlier migration had already created the table. The ORM mapping (and
+ * therefore the test databases, built from mappings) expects `id` — so
+ * every ORM read/write on the entity failed with 42703 on
+ * migration-built databases while CI stayed green.
+ *
+ * Converge migration-built schemas to the mapping shape: surrogate
+ * `id` PK, (role_id, attribute_id) kept unique. Defensive — a no-op on
+ * databases that already carry the column.
+ */
+final class Version20260711150000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add missing id PK column to role_attribute_permissions (drift vs ORM mapping)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name = 'role_attribute_permissions'
+                      AND column_name = 'id'
+                ) THEN
+                    ALTER TABLE role_attribute_permissions ADD COLUMN id UUID;
+                    UPDATE role_attribute_permissions SET id = gen_random_uuid() WHERE id IS NULL;
+                    ALTER TABLE role_attribute_permissions ALTER COLUMN id SET NOT NULL;
+                    ALTER TABLE role_attribute_permissions DROP CONSTRAINT role_attribute_permissions_pkey;
+                    ALTER TABLE role_attribute_permissions ADD PRIMARY KEY (id);
+                END IF;
+            END
+            $$;
+        SQL);
+
+        // The unique guarantee the composite PK used to provide. Both
+        // migration variants already create it, but keep the invariant
+        // explicit in case of hand-healed databases.
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX IF NOT EXISTS role_attribute_permissions_role_attr_uniq
+                ON role_attribute_permissions (role_id, attribute_id)
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE role_attribute_permissions DROP CONSTRAINT role_attribute_permissions_pkey');
+        $this->addSql('ALTER TABLE role_attribute_permissions DROP COLUMN id');
+        $this->addSql('ALTER TABLE role_attribute_permissions ADD PRIMARY KEY (role_id, attribute_id)');
+    }
+}


### PR DESCRIPTION
## Summary
Edytor roli w Settings → Roles kończył każdy zapis toastem „Operacja na roli nie powiodła się", a zakładka per-attribute grants nie ładowała się. `GET/PUT /api/roles/{id}/attribute-permissions` zwracały 500 (`SQLSTATE[42703] column r0_.id does not exist`) dla każdej roli.

Closes #2491

## Root cause
Schema drift: `Version20260518160000` utworzyła `role_attribute_permissions` z composite PK bez `id`; późniejsza `Version20260520090000` (#697, `CREATE TABLE IF NOT EXISTS ... id UUID PK`) była cichym no-opem. Mapping ORM wymaga `id` → każda hydracja/persist na bazie z migracji = 500. CI zielone, bo testowa DB budowana jest z mappingów (ma `id`).

## Backend changes
- Nowa migracja `Version20260711150000` — defensywna (guard na `information_schema.columns`): dodaje `id UUID` (backfill `gen_random_uuid()`), podmienia composite PK na `PK(id)`, utrzymuje unique `(role_id, attribute_id)`. No-op tam, gdzie `id` już jest (idempotentna).
- Bez zmian w encji/mappingu/endpointach — bug był wyłącznie w schemacie.

## Frontend changes
Brak — po fixie zapis roli wraca do toasta sukcesu.

## Quality gates
- php -l migracji czysty; PHPStan nie skanuje `migrations/` (bez zmian w src).
- Istniejący `RoleAttributePermissionsControllerTest` (6 case'ów, w tym happy path PUT→GET) pinuje kontrakt endpointu. Świadome odejście: NIE dodano nowego PHPUnit case'u — ta klasa buga (drift migracje↔mapping) jest niewykrywalna w PHPUnit, bo testowa DB powstaje z mappingów; kandydat na osobny CI gate „schema parity" (follow-up).
- CI: pełen pipeline na PR.

## Smoke test (wykonany na https://pim.localhost — migracja już uruchomiona na dev DB)
- `doctrine:migrations:migrate` → OK; `\d role_attribute_permissions` → `id uuid NOT NULL`, `PK(id)`, unique(role_id,attribute_id). Drugi bieg guardu → `NOTICE: no-op (id exists)`.
- `GET /api/roles/{approver}/attribute-permissions` → **200** (wcześniej 500).
- `PUT` z grantem `view` → **200**, GET pokazuje poziom, `PUT []` czyści → **200**.

## Świadome odejścia
- `role_attribute_group_permissions` (bliźniacza tabela, bez encji ORM) — nietknięta; pułapka odnotowana w lessons.
- CI gate schema-parity (migracje vs mapping) — follow-up, nie w tym PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
