### PR TITLE
feat(workflow): widen my-tasks to approve_reject holders (#2495)

### DIFF
--- a/apps/api/src/Workflow/Contracts/ObjectEditorialWorkflow.php
+++ b/apps/api/src/Workflow/Contracts/ObjectEditorialWorkflow.php
@@ -18,6 +18,17 @@ final class ObjectEditorialWorkflow
 {
     public const string NAME = 'object_editorial';
 
+    /**
+     * Role that automation assigns review / request-unpublish tasks to
+     * (WFL-P4-02), and the virtual membership the "my tasks" audience
+     * grants to any holder of {@see self::PERMISSION_APPROVE_REJECT} so
+     * the task inbox matches the notification fan-out (#2495).
+     */
+    public const string REVIEWER_ROLE = 'approver';
+
+    /** Permission gating every reviewer transition (approve/reject/…). */
+    public const string PERMISSION_APPROVE_REJECT = 'workflow.approve_reject';
+
     public const string PLACE_DRAFT = 'draft';
     public const string PLACE_REVIEW = 'review';
     public const string PLACE_PUBLISHED = 'published';

--- a/apps/api/src/Workflow/Domain/Repository/WorkflowTaskRepositoryInterface.php
+++ b/apps/api/src/Workflow/Domain/Repository/WorkflowTaskRepositoryInterface.php
@@ -24,6 +24,12 @@ interface WorkflowTaskRepositoryInterface
     /**
      * Newest-first page (UUIDv7 cursor). `$mineUserId` matches direct
      * assignment OR membership in the assignee role (both role paths).
+     * `$mineExtraRoleCodes` widens that membership with virtual roles the
+     * caller is not a member of but is entitled to act as — e.g. the
+     * reviewer role for a `workflow.approve_reject` holder, so the task
+     * inbox matches the notification fan-out audience (#2495).
+     *
+     * @param list<string> $mineExtraRoleCodes
      *
      * @return list<WorkflowTask>
      */
@@ -34,6 +40,7 @@ interface WorkflowTaskRepositoryInterface
         ?Uuid $objectId = null,
         ?Uuid $mineUserId = null,
         ?DateTimeImmutable $dueBefore = null,
+        array $mineExtraRoleCodes = [],
     ): array;
 
     /**

--- a/apps/api/src/Workflow/Infrastructure/Doctrine/DoctrineWorkflowTaskRepository.php
+++ b/apps/api/src/Workflow/Infrastructure/Doctrine/DoctrineWorkflowTaskRepository.php
@@ -43,6 +43,7 @@ final readonly class DoctrineWorkflowTaskRepository implements WorkflowTaskRepos
         ?Uuid $objectId = null,
         ?Uuid $mineUserId = null,
         ?DateTimeImmutable $dueBefore = null,
+        array $mineExtraRoleCodes = [],
     ): array {
         $builder = $this->entityManager->createQueryBuilder()
             ->select('t')
@@ -64,7 +65,9 @@ final readonly class DoctrineWorkflowTaskRepository implements WorkflowTaskRepos
                 ->setParameter('dueBefore', $dueBefore);
         }
         if (null !== $mineUserId) {
-            $roleCodes = $this->roleCodesOf($mineUserId);
+            $roleCodes = array_values(array_unique(
+                [...$this->roleCodesOf($mineUserId), ...$mineExtraRoleCodes],
+            ));
             if ([] === $roleCodes) {
                 $builder->andWhere('t.assigneeUserId = :me')->setParameter('me', $mineUserId);
             } else {

--- a/apps/api/src/Workflow/Infrastructure/Messenger/WorkflowTaskAutomation.php
+++ b/apps/api/src/Workflow/Infrastructure/Messenger/WorkflowTaskAutomation.php
@@ -41,8 +41,6 @@ use Symfony\Component\Uid\Uuid;
  */
 final readonly class WorkflowTaskAutomation
 {
-    private const string REVIEWER_ROLE = 'approver';
-
     public function __construct(
         private WorkflowTaskRepositoryInterface $tasks,
         private TransitionLogPort $transitionLog,
@@ -61,7 +59,7 @@ final readonly class WorkflowTaskAutomation
             title: 'Review request',
             type: WorkflowTaskType::Review,
             objectId: $event->objectId,
-            assigneeRoleCode: self::REVIEWER_ROLE,
+            assigneeRoleCode: ObjectEditorialWorkflow::REVIEWER_ROLE,
             createdBy: $this->currentUser->userId(),
             comment: $event->comment,
             context: ['object_id' => $event->objectId->toRfc4122()],
@@ -118,7 +116,7 @@ final readonly class WorkflowTaskAutomation
             title: 'Unpublish request',
             type: WorkflowTaskType::RequestUnpublish,
             objectId: $event->objectId,
-            assigneeRoleCode: self::REVIEWER_ROLE,
+            assigneeRoleCode: ObjectEditorialWorkflow::REVIEWER_ROLE,
             createdBy: $event->requesterId,
             comment: $event->comment,
             context: ['object_id' => $event->objectId->toRfc4122()],

--- a/apps/api/src/Workflow/Presentation/Controller/WorkflowTasksController.php
+++ b/apps/api/src/Workflow/Presentation/Controller/WorkflowTasksController.php
@@ -7,6 +7,7 @@ namespace App\Workflow\Presentation\Controller;
 use App\Identity\Contracts\Attribute\RequiresPermission;
 use App\Identity\Contracts\Auth\CurrentUserProvider;
 use App\Identity\Contracts\Policy\PermissionCheckerInterface;
+use App\Workflow\Contracts\ObjectEditorialWorkflow;
 use App\Workflow\Contracts\WorkflowTaskStatus;
 use App\Workflow\Contracts\WorkflowTaskType;
 use App\Workflow\Domain\Entity\WorkflowTask;
@@ -90,7 +91,24 @@ final class WorkflowTasksController
 
         $mine = $request->query->getBoolean('mine') ? $this->requireUserId() : null;
 
-        $rows = $this->tasks->page($limit + 1, $before, $status, $objectId, $mine, $dueBefore);
+        // Review / request-unpublish tasks are assigned to the reviewer
+        // role; a caller who holds workflow.approve_reject can act on them
+        // even without being a member of that role, so widen "mine" to
+        // match the notification fan-out audience (#2495).
+        $mineExtraRoleCodes = null !== $mine
+            && $this->permissions->userHasPermission($mine, ObjectEditorialWorkflow::PERMISSION_APPROVE_REJECT)
+                ? [ObjectEditorialWorkflow::REVIEWER_ROLE]
+                : [];
+
+        $rows = $this->tasks->page(
+            $limit + 1,
+            $before,
+            $status,
+            $objectId,
+            $mine,
+            $dueBefore,
+            $mineExtraRoleCodes,
+        );
         $hasMore = \count($rows) > $limit;
         $rows = \array_slice($rows, 0, $limit);
 

--- a/apps/api/tests/Api/Catalog/WorkflowTasksApiTest.php
+++ b/apps/api/tests/Api/Catalog/WorkflowTasksApiTest.php
@@ -84,6 +84,38 @@ final class WorkflowTasksApiTest extends CatalogApiTestCase
     }
 
     #[Test]
+    public function mineSurfacesReviewTaskForApprovePermissionHolderWithoutRoleMembership(): void
+    {
+        // #2495 — the review task is assigned to the `approver` role, but
+        // the admin (super_admin, holds workflow.approve_reject) is not a
+        // member of it. Before the fix, "mine" matched only direct
+        // assignment or literal role membership, so the task inbox went
+        // empty for the very people the notification fan-out pinged.
+        $this->createUserWithRole('marketing-p@demo.localhost', 'marketing');
+        $id = $this->seedProduct('WFL-T-PERM');
+
+        $marketing = $this->authenticatedClient('marketing-p@demo.localhost');
+        $submit = $marketing->request('POST', '/api/objects/'.$id.'/workflow/transitions/submit_for_review');
+        self::assertSame(200, $submit->getStatusCode());
+        $this->drainAsyncTransport();
+
+        // Admin holds the permission but not the approver role → sees it now.
+        $admin = $this->authenticatedClient();
+        $mine = $admin->request('GET', '/api/workflow/tasks?mine=1&status=open&object_id='.$id)->toArray();
+        $items = $mine['items'];
+        self::assertIsArray($items);
+        $types = \array_column(\array_filter($items, 'is_array'), 'type');
+        self::assertContains('review', $types, 'approve_reject holder sees the role-assigned review task in mine');
+
+        // The submitter (marketing, no approve_reject, not approver) does not.
+        $notMine = $marketing->request('GET', '/api/workflow/tasks?mine=1&status=open&object_id='.$id)->toArray();
+        $notMineItems = $notMine['items'];
+        self::assertIsArray($notMineItems);
+        $notMineTypes = \array_column(\array_filter($notMineItems, 'is_array'), 'type');
+        self::assertNotContains('review', $notMineTypes, 'a non-approver without the permission never sees review tasks in mine');
+    }
+
+    #[Test]
     public function rejectOpensFixTaskForTheAuthorWithNotification(): void
     {
         $this->createUserWithRole('marketing-f@demo.localhost', 'marketing');


### PR DESCRIPTION
## Summary
„Moje zadania" na `/workflow` było puste dla admina mimo otwartych zadań review — operator zinterpretował to jako „nie da się wygenerować zadań". Zadania SIĘ generują; problem był w publiczności filtra `mine`.

Closes #2495

## Root cause
Zadania `review`/`request_unpublish` są przypisywane **roli `approver`**. `WorkflowTasksController` przy `mine=1` matchował tylko bezpośrednie przypisanie użytkownikowi LUB dosłowne członkostwo w roli. Admin (super_admin+tenant_owner, ma `workflow.approve_reject`, ale nie jest członkiem roli `approver`) → pusta skrzynka. Jednocześnie fan-out notyfikacji tego samego zdarzenia celuje w **grantees permissionu** `workflow.approve_reject` — dwie różne publiczności dla jednego zdarzenia.

## Backend changes
- `mine` poszerzone: gdy caller ma `workflow.approve_reject`, dokładane jest **wirtualne członkostwo roli `approver`** (`page()` dostaje argument `mineExtraRoleCodes`). Logika permissionu w kontrolerze (ma już `PermissionCheckerInterface`), repozytorium pozostaje czystym query.
- Jedno źródło prawdy: `REVIEWER_ROLE='approver'` + `PERMISSION_APPROVE_REJECT` przeniesione do `ObjectEditorialWorkflow` (Contracts); `WorkflowTaskAutomation` używa stałej zamiast prywatnego duplikatu.
- Bez migracji, bez zmiany tras (semantyka `mine` doprecyzowana w PHPDoc interfejsu).

## Frontend changes
Brak — „Moje zadania" i widget dashboardu używają `mine=1`, fix propaguje sam.

## Quality gates
- php -l wszystkich zmienionych plików czyste; PHPStan `src/Workflow` bez realnych błędów; deptrac 0 (PermissionCheckerInterface to Identity **Contracts** — dozwolony seam).
- Nowy `WorkflowTasksApiTest::mineSurfacesReviewTaskForApprovePermissionHolderWithoutRoleMembership`: admin (approve_reject, nie approver) widzi review task w mine; marketing (bez permissionu) nie. Istniejący test członkostwa roli (approver widzi task) nie regresuje.

## Smoke test (https://pim.localhost — dev stack bind-mountuje apps/api)
- `GET /api/workflow/tasks?mine=1&status=open` (admin) → **4× review (approver)** — wcześniej puste.
- To samo dla marketing → tylko `fix` (bezpośrednie przypisanie autorowi), **zero review** — izolacja zachowana.

## Świadome odejścia
- `request_unpublish` (też rola approver) pokryte tym samym mechanizmem — świadomie: publiczność = rola approver, nie per-type permission mapping (prostota).
- Osierocone open taski po usuniętym obiekcie — drobny data-hygiene follow-up, osobne issue (nice-to-have).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
