### PR TITLE
feat(admin): add grid column model and attribute cell renderers (GRID-P1-01 + P1-02)

### DIFF
--- a/apps/admin/src/lib/grid/cell-value.test.ts
+++ b/apps/admin/src/lib/grid/cell-value.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractGridCellValue } from './cell-value';
+
+/**
+ * GRID-P1-02 (#2386) — the extractor must map every canonical envelope
+ * (ADR-0019 / docs/api/jsonb-schemas.md) and never throw on garbage.
+ */
+
+describe('extractGridCellValue', () => {
+  it('maps canonical envelopes', () => {
+    expect(extractGridCellValue({ value: 'Nike' }, 'pl')).toEqual({ kind: 'text', value: 'Nike' });
+    expect(extractGridCellValue({ value: 42 }, 'pl')).toEqual({ kind: 'number', value: 42 });
+    expect(extractGridCellValue({ value: true }, 'pl')).toEqual({ kind: 'boolean', value: true });
+    expect(extractGridCellValue({ option_code: 'red' }, 'pl')).toEqual({
+      kind: 'options',
+      codes: ['red'],
+    });
+    expect(extractGridCellValue({ option_codes: ['red', 'blue'] }, 'pl')).toEqual({
+      kind: 'options',
+      codes: ['red', 'blue'],
+    });
+    expect(extractGridCellValue({ amount: 99.99, currency: 'PLN' }, 'pl')).toEqual({
+      kind: 'price',
+      amount: 99.99,
+      currency: 'PLN',
+    });
+    expect(extractGridCellValue({ amount: '12.50', currency: 'EUR' }, 'pl')).toEqual({
+      kind: 'price',
+      amount: 12.5,
+      currency: 'EUR',
+    });
+  });
+
+  it('resolves localizable/scopable maps for the UI locale with fallback', () => {
+    expect(extractGridCellValue({ pl: 'Nazwa', en: 'Name' }, 'pl')).toEqual({
+      kind: 'text',
+      value: 'Nazwa',
+    });
+    expect(extractGridCellValue({ en: 'Name' }, 'pl')).toEqual({ kind: 'text', value: 'Name' });
+    expect(extractGridCellValue({ value: { pl: 'Nazwa', en: 'Name' } }, 'en')).toEqual({
+      kind: 'text',
+      value: 'Name',
+    });
+    // channel-scoped numeric map — first non-empty wins when locale misses
+    expect(extractGridCellValue({ shopify: 10, allegro: 15 }, 'pl')).toEqual({
+      kind: 'number',
+      value: 10,
+    });
+  });
+
+  it('accepts already-unwrapped scalars (post-unwrapAttributesIndexed rows)', () => {
+    expect(extractGridCellValue('Nike', 'pl')).toEqual({ kind: 'text', value: 'Nike' });
+    expect(extractGridCellValue(7, 'pl')).toEqual({ kind: 'number', value: 7 });
+    expect(extractGridCellValue(false, 'pl')).toEqual({ kind: 'boolean', value: false });
+    expect(extractGridCellValue(['a', 'b'], 'pl')).toEqual({ kind: 'options', codes: ['a', 'b'] });
+  });
+
+  it('returns empty for null/undefined/blank and never throws on garbage', () => {
+    expect(extractGridCellValue(null, 'pl')).toEqual({ kind: 'empty' });
+    expect(extractGridCellValue(undefined, 'pl')).toEqual({ kind: 'empty' });
+    expect(extractGridCellValue('   ', 'pl')).toEqual({ kind: 'empty' });
+    expect(extractGridCellValue({ value: null }, 'pl')).toEqual({ kind: 'empty' });
+    expect(extractGridCellValue({ option_code: 7 }, 'pl')).toEqual({ kind: 'empty' });
+    // malformed writer (string instead of array) reads as one option
+    expect(extractGridCellValue({ option_codes: 'red' }, 'pl')).toEqual({
+      kind: 'options',
+      codes: ['red'],
+    });
+    expect(extractGridCellValue({ option_codes: 42 }, 'pl')).toEqual({ kind: 'empty' });
+    expect(extractGridCellValue({ amount: 'not-a-number' }, 'pl')).toEqual({ kind: 'empty' });
+    expect(extractGridCellValue(Number.NaN, 'pl')).toEqual({ kind: 'empty' });
+    expect(extractGridCellValue({ value: [Symbol('x')] } as unknown, 'pl')).toEqual({
+      kind: 'empty',
+    });
+    expect(extractGridCellValue(() => 'fn', 'pl')).toEqual({ kind: 'empty' });
+  });
+});

--- a/apps/admin/src/lib/grid/cell-value.ts
+++ b/apps/admin/src/lib/grid/cell-value.ts
@@ -1,0 +1,96 @@
+/**
+ * GRID-P1-02 (#2386) — pure extraction of a display value from one
+ * `attributesIndexed` entry. The envelope shapes are canonical (ADR-0019,
+ * docs/api/jsonb-schemas.md) but this reader must never throw on garbage:
+ * stale caches, half-migrated rows and already-unwrapped maps
+ * (`unwrapAttributesIndexed`) all flow through the same grids.
+ */
+
+export type GridCellValue =
+  | { kind: 'empty' }
+  | { kind: 'text'; value: string }
+  | { kind: 'number'; value: number }
+  | { kind: 'boolean'; value: boolean }
+  | { kind: 'options'; codes: string[] }
+  | { kind: 'price'; amount: number; currency: string };
+
+const EMPTY: GridCellValue = { kind: 'empty' };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function fromScalar(value: unknown): GridCellValue {
+  if (value === null || value === undefined) return EMPTY;
+  if (typeof value === 'boolean') return { kind: 'boolean', value };
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? { kind: 'number', value } : EMPTY;
+  }
+  if (typeof value === 'string') {
+    return value.trim().length === 0 ? EMPTY : { kind: 'text', value };
+  }
+  if (Array.isArray(value)) {
+    const codes = value.filter((item): item is string => typeof item === 'string');
+    return codes.length === 0 ? EMPTY : { kind: 'options', codes };
+  }
+  return EMPTY;
+}
+
+/**
+ * Picks a reading from a locale/channel map envelope
+ * (`{"pl": "...", "en": "..."}` / `{"shopify": 10}`): the current UI
+ * locale wins, then the first non-empty entry. The locale/channel
+ * context switcher is out of the GRID epic — this fallback is the
+ * documented MVP behaviour (backlog M1).
+ */
+function fromKeyedMap(map: Record<string, unknown>, locale: string): GridCellValue {
+  const direct = fromScalar(map[locale]);
+  if (direct.kind !== 'empty') return direct;
+  for (const entry of Object.values(map)) {
+    const candidate = fromScalar(entry);
+    if (candidate.kind !== 'empty') return candidate;
+  }
+  return EMPTY;
+}
+
+/**
+ * @param entry one value from `attributesIndexed[code]` — raw envelope or
+ *   an already-unwrapped scalar (both are in circulation).
+ * @param locale base UI locale (`i18n.language.split('-')[0]`).
+ */
+export function extractGridCellValue(entry: unknown, locale: string): GridCellValue {
+  if (!isRecord(entry)) return fromScalar(entry);
+
+  if ('value' in entry) {
+    const inner = entry.value;
+    // Localizable envelopes may nest the locale map under `value`.
+    if (isRecord(inner)) return fromKeyedMap(inner, locale);
+    return fromScalar(inner);
+  }
+  if ('option_code' in entry) {
+    const code = entry.option_code;
+    return typeof code === 'string' && code.length > 0 ? { kind: 'options', codes: [code] } : EMPTY;
+  }
+  if ('option_codes' in entry) {
+    const codes = entry.option_codes;
+    // Tolerant reading: a lone string (malformed writer) still shows as
+    // one option instead of silently dropping the value.
+    if (typeof codes === 'string' && codes.length > 0) return { kind: 'options', codes: [codes] };
+    if (Array.isArray(codes)) return fromScalar(codes);
+    return EMPTY;
+  }
+  if ('amount' in entry) {
+    const amount =
+      typeof entry.amount === 'number'
+        ? entry.amount
+        : typeof entry.amount === 'string'
+          ? Number(entry.amount)
+          : Number.NaN;
+    if (!Number.isFinite(amount)) return EMPTY;
+    const currency = typeof entry.currency === 'string' ? entry.currency : '';
+    return { kind: 'price', amount, currency };
+  }
+
+  // No canonical marker → localizable/scopable map keyed by locale/channel.
+  return fromKeyedMap(entry, locale);
+}

--- a/apps/admin/src/lib/grid/grid-attribute-cell.test.tsx
+++ b/apps/admin/src/lib/grid/grid-attribute-cell.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { GridAttributeCell, gridCellAlignment } from './grid-attribute-cell';
+import type { GridColumn } from './types';
+
+/**
+ * GRID-P1-02 (#2386) — every attribute type renders a readable cell
+ * (no `[object Object]`, option labels over codes, `—` for empty) and
+ * garbage input never crashes the row.
+ */
+
+function column(overrides: Partial<GridColumn>): GridColumn {
+  return {
+    key: 'attr',
+    source: 'attribute',
+    type: 'text',
+    label: { pl: 'Atrybut' },
+    sortable: false,
+    position: 0,
+    hidden: false,
+    ...overrides,
+  };
+}
+
+describe('GridAttributeCell', () => {
+  it('renders text with a full-value tooltip', () => {
+    render(
+      <GridAttributeCell
+        column={column({ type: 'text' })}
+        attributesIndexed={{ attr: { value: 'Nike Air' } }}
+      />,
+    );
+    expect(screen.getByTitle('Nike Air')).toHaveTextContent('Nike Air');
+  });
+
+  it('renders select option labels for the UI locale, falling back to the code', () => {
+    const { rerender } = render(
+      <GridAttributeCell
+        column={column({ key: 'color', type: 'select' })}
+        attributesIndexed={{ color: { option_code: 'red' } }}
+        optionLabels={{ color: { red: { pl: 'Czerwony', en: 'Red' } } }}
+      />,
+    );
+    expect(screen.getByText('Czerwony')).toBeInTheDocument();
+
+    rerender(
+      <GridAttributeCell
+        column={column({ key: 'color', type: 'select' })}
+        attributesIndexed={{ color: { option_code: 'unknown_code' } }}
+        optionLabels={{ color: {} }}
+      />,
+    );
+    expect(screen.getByText('unknown_code')).toBeInTheDocument();
+  });
+
+  it('renders multiselect chips with a +N overflow tooltip listing the rest', () => {
+    render(
+      <GridAttributeCell
+        column={column({ key: 'tags', type: 'multiselect' })}
+        attributesIndexed={{ tags: { option_codes: ['a', 'b', 'c', 'd', 'e'] } }}
+        optionLabels={{ tags: { d: { pl: 'Delta' }, e: { pl: 'Echo' } } }}
+      />,
+    );
+    expect(screen.getByText('a')).toBeInTheDocument();
+    expect(screen.getByText('+2')).toBeInTheDocument();
+    expect(screen.getByTitle('Delta, Echo')).toBeInTheDocument();
+    expect(screen.queryByText('d')).not.toBeInTheDocument();
+  });
+
+  it('formats price, number, boolean badge and date', () => {
+    const { rerender, container } = render(
+      <GridAttributeCell
+        column={column({ type: 'price' })}
+        attributesIndexed={{ attr: { amount: 99.99, currency: 'PLN' } }}
+      />,
+    );
+    expect(container.textContent).toContain('99,99');
+    expect(container.textContent).toContain('zł');
+
+    rerender(
+      <GridAttributeCell
+        column={column({ type: 'number' })}
+        attributesIndexed={{ attr: { value: 1234.5 } }}
+      />,
+    );
+    expect(container.textContent).toContain('1234,5');
+
+    rerender(
+      <GridAttributeCell
+        column={column({ type: 'boolean' })}
+        attributesIndexed={{ attr: { value: true } }}
+      />,
+    );
+    expect(screen.getByText('Tak')).toBeInTheDocument();
+
+    rerender(
+      <GridAttributeCell
+        column={column({ type: 'date' })}
+        attributesIndexed={{ attr: { value: '2026-07-09' } }}
+      />,
+    );
+    expect(container.textContent).toMatch(/2026/);
+    expect(container.textContent).not.toContain('[object Object]');
+  });
+
+  it('renders an em-dash for missing values and survives garbage envelopes', () => {
+    const { rerender, container } = render(
+      <GridAttributeCell column={column({ type: 'text' })} attributesIndexed={undefined} />,
+    );
+    expect(screen.getByText('—')).toBeInTheDocument();
+
+    rerender(
+      <GridAttributeCell
+        column={column({ type: 'select' })}
+        attributesIndexed={{ attr: { totally: { unexpected: ['shape'] } } }}
+      />,
+    );
+    expect(container.textContent).not.toContain('[object Object]');
+
+    rerender(
+      <GridAttributeCell
+        column={column({ type: 'unknown_future_type' })}
+        attributesIndexed={{ attr: { value: 'raw' } }}
+      />,
+    );
+    expect(screen.getByText('raw')).toBeInTheDocument();
+  });
+
+  it('renders a fixed-size asset placeholder without layout-shifting fetches', () => {
+    render(
+      <GridAttributeCell
+        column={column({ key: 'gallery', type: 'asset' })}
+        attributesIndexed={{ gallery: { option_codes: ['a1', 'a2'] } }}
+      />,
+    );
+    expect(screen.getByText('2 pliki')).toBeInTheDocument();
+  });
+});
+
+describe('gridCellAlignment', () => {
+  it('right-aligns numeric readings only', () => {
+    expect(gridCellAlignment({ type: 'number' })).toBe('right');
+    expect(gridCellAlignment({ type: 'price' })).toBe('right');
+    expect(gridCellAlignment({ type: 'metric' })).toBe('right');
+    expect(gridCellAlignment({ type: 'text' })).toBe('left');
+    expect(gridCellAlignment({ type: 'select' })).toBe('left');
+  });
+});

--- a/apps/admin/src/lib/grid/grid-attribute-cell.tsx
+++ b/apps/admin/src/lib/grid/grid-attribute-cell.tsx
@@ -1,0 +1,260 @@
+import { useQueries } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { jsonFetch } from '@/lib/http';
+
+import { extractGridCellValue } from './cell-value';
+import type { GridColumn } from './types';
+
+/**
+ * GRID-P1-02 (#2386) — per-attribute-type cell renderers for the list
+ * views. One shared component so the grid view (P1-03) and the Excel
+ * view (P1-04) display identical readings.
+ *
+ * Deliberately display-only: editing (typed editors) is GRID-P6-02, and
+ * relation/asset cells render what `attributesIndexed` already carries —
+ * no per-row fetches (backlog M1 "poza zakresem").
+ */
+
+const EM_DASH = '—';
+const MULTI_CHIP_LIMIT = 3;
+
+/** Column types whose cells right-align (numeric reading). */
+export function gridCellAlignment(column: Pick<GridColumn, 'type'>): 'left' | 'right' {
+  return column.type === 'number' || column.type === 'metric' || column.type === 'price'
+    ? 'right'
+    : 'left';
+}
+
+interface OptionRow {
+  code: string;
+  label: Record<string, string>;
+}
+
+type OptionLabelIndex = Record<string, Record<string, Record<string, string>>>;
+
+/**
+ * Batch-fetches option catalogues for the visible select/multiselect
+ * columns (`GET /api/attributes/{code}/options`, same queryKey family as
+ * the modeling values editor) and returns
+ * `attrCode → optionCode → label map`. Missing catalogues degrade to the
+ * raw option code in the cell.
+ */
+export function useAttributeOptionLabels(columns: GridColumn[]): OptionLabelIndex {
+  const selectCodes = useMemo(
+    () =>
+      columns
+        .filter(
+          (column) =>
+            column.source === 'attribute' &&
+            (column.type === 'select' || column.type === 'multiselect') &&
+            !column.hidden,
+        )
+        .map((column) => column.key)
+        .sort(),
+    [columns],
+  );
+
+  const results = useQueries({
+    queries: selectCodes.map((code) => ({
+      queryKey: ['attribute_options', code] as const,
+      staleTime: 5 * 60 * 1000,
+      queryFn: async () => {
+        const response = await jsonFetch<{ member?: OptionRow[]; 'hydra:member'?: OptionRow[] }>(
+          `/api/attributes/${code}/options`,
+          { accept: 'application/json' },
+        );
+        return response.member ?? response['hydra:member'] ?? [];
+      },
+    })),
+  });
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `results` is a new array each render; index by the stable data references instead.
+  return useMemo(() => {
+    const index: OptionLabelIndex = {};
+    selectCodes.forEach((code, i) => {
+      const rows = results[i]?.data;
+      if (!rows) return;
+      const byOption: Record<string, Record<string, string>> = {};
+      for (const row of rows) {
+        if (typeof row?.code === 'string') byOption[row.code] = row.label ?? {};
+      }
+      index[code] = byOption;
+    });
+    return index;
+  }, [selectCodes, ...results.map((result) => result.data)]);
+}
+
+function pickLabel(label: Record<string, string> | undefined, locale: string): string | undefined {
+  if (!label) return undefined;
+  return label[locale] ?? label.en ?? label.pl ?? Object.values(label)[0];
+}
+
+function OptionChips({
+  codes,
+  column,
+  optionLabels,
+  locale,
+}: {
+  codes: string[];
+  column: GridColumn;
+  optionLabels: OptionLabelIndex;
+  locale: string;
+}) {
+  const labelFor = (code: string): string =>
+    pickLabel(optionLabels[column.key]?.[code], locale) ?? code;
+
+  if (column.type !== 'multiselect' && codes.length === 1) {
+    return <span className="truncate">{labelFor(codes[0] ?? '')}</span>;
+  }
+  const shown = codes.slice(0, MULTI_CHIP_LIMIT);
+  const overflow = codes.length - shown.length;
+  return (
+    <span className="flex min-w-0 items-center gap-1">
+      {shown.map((code) => (
+        <span
+          key={code}
+          className="max-w-[9rem] truncate rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
+        >
+          {labelFor(code)}
+        </span>
+      ))}
+      {overflow > 0 ? (
+        <span
+          className="shrink-0 text-xs text-zinc-500"
+          title={codes
+            .slice(MULTI_CHIP_LIMIT)
+            .map((code) => labelFor(code))
+            .join(', ')}
+        >
+          {/* numeric symbol, deliberately not a translation key */}
+          {`+${overflow}`}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+/**
+ * Renders one attribute cell. `attributesIndexed` may be the raw API map
+ * or an already-unwrapped one — extraction tolerates both.
+ */
+export function GridAttributeCell({
+  column,
+  attributesIndexed,
+  optionLabels = {},
+}: {
+  column: GridColumn;
+  attributesIndexed: Record<string, unknown> | null | undefined;
+  optionLabels?: OptionLabelIndex;
+}) {
+  const { t, i18n } = useTranslation();
+  const locale = i18n.language.split('-')[0] ?? i18n.language;
+  const cell = extractGridCellValue(attributesIndexed?.[column.key], locale);
+
+  if (cell.kind === 'empty') {
+    return <span className="text-zinc-400">{EM_DASH}</span>;
+  }
+
+  switch (column.type) {
+    case 'number':
+    case 'metric': {
+      const numeric =
+        cell.kind === 'number'
+          ? cell.value
+          : cell.kind === 'text'
+            ? Number(cell.value)
+            : Number.NaN;
+      if (!Number.isFinite(numeric)) return <span className="truncate">{stringify(cell)}</span>;
+      return <span className="tabular-nums">{new Intl.NumberFormat(locale).format(numeric)}</span>;
+    }
+    case 'price': {
+      if (cell.kind !== 'price') return <span className="truncate">{stringify(cell)}</span>;
+      const formatted =
+        cell.currency.length === 3
+          ? new Intl.NumberFormat(locale, { style: 'currency', currency: cell.currency }).format(
+              cell.amount,
+            )
+          : `${new Intl.NumberFormat(locale, { minimumFractionDigits: 2 }).format(cell.amount)} ${cell.currency}`.trim();
+      return <span className="tabular-nums">{formatted}</span>;
+    }
+    case 'boolean': {
+      const truthy = cell.kind === 'boolean' ? cell.value : stringify(cell) === 'true';
+      return (
+        <span
+          className={
+            truthy
+              ? 'rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
+              : 'rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400'
+          }
+        >
+          {truthy
+            ? t('grid.cell.yes', { defaultValue: 'Tak' })
+            : t('grid.cell.no', { defaultValue: 'Nie' })}
+        </span>
+      );
+    }
+    case 'date':
+    case 'datetime': {
+      const raw = stringify(cell);
+      const parsed = new Date(raw);
+      if (Number.isNaN(parsed.getTime())) return <span className="truncate">{raw}</span>;
+      const formatted = new Intl.DateTimeFormat(locale, {
+        dateStyle: 'medium',
+        ...(column.type === 'datetime' ? { timeStyle: 'short' as const } : {}),
+      }).format(parsed);
+      return <span className="whitespace-nowrap">{formatted}</span>;
+    }
+    case 'select':
+    case 'multiselect': {
+      const codes = cell.kind === 'options' ? cell.codes : [stringify(cell)];
+      return (
+        <OptionChips codes={codes} column={column} optionLabels={optionLabels} locale={locale} />
+      );
+    }
+    case 'asset': {
+      // No per-row asset fetch in M1: a fixed-size placeholder keeps the
+      // layout stable; real thumbnails need the asset preview endpoint.
+      const raw = stringify(cell);
+      if (/^https?:\/\//.test(raw)) {
+        return (
+          <img src={raw} alt="" loading="lazy" className="h-8 w-8 shrink-0 rounded object-cover" />
+        );
+      }
+      const count = cell.kind === 'options' ? cell.codes.length : 1;
+      return (
+        <span className="inline-flex h-8 min-w-8 shrink-0 items-center justify-center rounded bg-zinc-100 px-1 text-xs text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+          {t('grid.cell.assets', { count, defaultValue: '{{count}} plik(i)' })}
+        </span>
+      );
+    }
+    default: {
+      // text / textarea / wysiwyg / identifier / email / color / relation
+      // and any future type: safe string with a full-value tooltip.
+      const raw = stringify(cell);
+      return (
+        <span className="truncate" title={raw}>
+          {raw}
+        </span>
+      );
+    }
+  }
+}
+
+function stringify(cell: ReturnType<typeof extractGridCellValue>): string {
+  switch (cell.kind) {
+    case 'empty':
+      return '';
+    case 'text':
+      return cell.value;
+    case 'number':
+      return String(cell.value);
+    case 'boolean':
+      return String(cell.value);
+    case 'options':
+      return cell.codes.join(', ');
+    case 'price':
+      return `${cell.amount} ${cell.currency}`.trim();
+  }
+}

--- a/apps/admin/src/lib/grid/resolve-grid-columns.test.ts
+++ b/apps/admin/src/lib/grid/resolve-grid-columns.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ListSchemaResponse } from '@/hooks/use-list-schema';
+
+import { FALLBACK_GRID_COLUMNS, resolveGridColumns } from './resolve-grid-columns';
+
+/**
+ * GRID-P1-01 (#2385) — merge matrix for the pure resolver: schema-only,
+ * overrides (hidden / reorder / width), RBAC-dropped override keys and
+ * the no-schema fallback.
+ */
+
+function schemaWith(columns: ListSchemaResponse['columns']): ListSchemaResponse {
+  return {
+    objectType: {
+      id: 'ot-1',
+      code: 'product',
+      kind: 'product',
+      label: { pl: 'Produkt' },
+      is_categorizable: true,
+      has_variants: true,
+      has_multimedia: true,
+      expose_to_main_menu: true,
+    },
+    columns,
+    filterableAttributes: [],
+    searchableAttributes: [],
+  };
+}
+
+const SCHEMA = schemaWith([
+  {
+    key: 'brand',
+    type: 'select',
+    label: { pl: 'Marka' },
+    position: 4,
+    sortable: true,
+    system: false,
+  },
+  {
+    key: 'code',
+    type: 'system_identifier',
+    label: { pl: 'Kod' },
+    position: 0,
+    sortable: true,
+    system: true,
+  },
+  {
+    key: 'status',
+    type: 'system_status',
+    label: { pl: 'Status' },
+    position: 1,
+    sortable: true,
+    system: true,
+  },
+]);
+
+describe('resolveGridColumns', () => {
+  it('orders schema columns by position and re-numbers contiguously', () => {
+    const columns = resolveGridColumns(SCHEMA);
+
+    expect(columns.map((column) => column.key)).toEqual(['code', 'status', 'brand']);
+    expect(columns.map((column) => column.position)).toEqual([0, 1, 2]);
+    expect(columns.every((column) => !column.hidden)).toBe(true);
+    expect(columns[2] ?? {}).toMatchObject({ source: 'attribute', type: 'select', sortable: true });
+    expect(columns[0]?.source).toBe('system');
+  });
+
+  it('applies override order, hidden and width; non-overridden columns follow schema order', () => {
+    const columns = resolveGridColumns(SCHEMA, [
+      { key: 'brand', width: 220 },
+      { key: 'code', hidden: true },
+    ]);
+
+    expect(columns.map((column) => column.key)).toEqual(['brand', 'code', 'status']);
+    expect(columns[0]?.width).toBe(220);
+    expect(columns[1]?.hidden).toBe(true);
+    expect(columns[2]?.hidden).toBe(false);
+  });
+
+  it('drops override keys absent from the schema (RBAC / deleted attribute)', () => {
+    const columns = resolveGridColumns(SCHEMA, [
+      { key: 'secret_margin', width: 300 },
+      { key: 'brand' },
+      { key: 'brand', hidden: true }, // duplicate entry — first one wins
+    ]);
+
+    expect(columns.map((column) => column.key)).toEqual(['brand', 'code', 'status']);
+    expect(columns.some((column) => column.key === 'secret_margin')).toBe(false);
+    expect(columns[0]?.hidden).toBe(false);
+  });
+
+  it('falls back to the system set when the schema is missing or empty', () => {
+    expect(resolveGridColumns(undefined)).toEqual(FALLBACK_GRID_COLUMNS);
+    expect(resolveGridColumns(null)).toEqual(FALLBACK_GRID_COLUMNS);
+    expect(resolveGridColumns(schemaWith([]), [{ key: 'code', hidden: true }])).toEqual(
+      FALLBACK_GRID_COLUMNS,
+    );
+  });
+
+  it('survives malformed schema entries without throwing', () => {
+    const malformed = schemaWith([
+      // @ts-expect-error deliberate garbage — resolver must not trust the wire
+      { key: 42, type: 'text', label: null, position: 0, sortable: true, system: false },
+      {
+        key: 'name',
+        type: 'text',
+        label: { pl: 'Nazwa' },
+        position: 1,
+        sortable: false,
+        system: false,
+      },
+    ]);
+
+    const columns = resolveGridColumns(malformed);
+    expect(columns.map((column) => column.key)).toEqual(['name']);
+  });
+});

--- a/apps/admin/src/lib/grid/resolve-grid-columns.ts
+++ b/apps/admin/src/lib/grid/resolve-grid-columns.ts
@@ -1,0 +1,116 @@
+import type { ListSchemaResponse } from '@/hooks/use-list-schema';
+
+import type { GridColumn, GridColumnOverride } from './types';
+
+/**
+ * GRID-P1-01 (#2385) — pure resolver: list-schema × user overrides →
+ * ordered `GridColumn[]`. Kept side-effect free so Vitest can cover the
+ * merge matrix without React or network.
+ */
+
+/**
+ * Minimal system set used when the schema is unavailable (fetch error /
+ * first paint before the query resolves). Mirrors the always-on system
+ * columns the backend emits (`GetObjectTypeListSchemaHandler`), so the
+ * views degrade to the pre-GRID column surface instead of rendering an
+ * empty table.
+ */
+export const FALLBACK_GRID_COLUMNS: GridColumn[] = [
+  {
+    key: 'code',
+    source: 'system',
+    type: 'system_identifier',
+    label: { pl: 'Kod', en: 'Code' },
+    sortable: true,
+    position: 0,
+    hidden: false,
+  },
+  {
+    key: 'status',
+    source: 'system',
+    type: 'system_status',
+    label: { pl: 'Status', en: 'Status' },
+    sortable: true,
+    position: 1,
+    hidden: false,
+  },
+  {
+    key: 'completeness',
+    source: 'system',
+    type: 'system_completeness',
+    label: { pl: 'Kompletność', en: 'Completeness' },
+    sortable: true,
+    position: 2,
+    hidden: false,
+  },
+  {
+    key: 'updatedAt',
+    source: 'system',
+    type: 'system_date',
+    label: { pl: 'Zmodyfikowano', en: 'Modified' },
+    sortable: true,
+    position: 3,
+    hidden: false,
+  },
+];
+
+/**
+ * Merges the server schema with user overrides.
+ *
+ * Rules:
+ * - No schema → {@link FALLBACK_GRID_COLUMNS} (overrides are ignored:
+ *   without the schema we cannot verify the keys are still permitted).
+ * - Override entries whose key is absent from the schema are DROPPED —
+ *   the schema is the RBAC-filtered allow-list (ULV-04b), localStorage
+ *   must never widen it.
+ * - Array order of `overrides` defines the leading column order;
+ *   schema columns without an override follow in schema `position`
+ *   order. `position` in the result is re-numbered to be contiguous.
+ * - `hidden` defaults to false — the schema only carries columns meant
+ *   to be shown (`system` + `show_in_list=true`).
+ */
+export function resolveGridColumns(
+  schema: ListSchemaResponse | undefined | null,
+  overrides: GridColumnOverride[] = [],
+): GridColumn[] {
+  const schemaColumns = schema?.columns;
+  if (!Array.isArray(schemaColumns) || schemaColumns.length === 0) {
+    return FALLBACK_GRID_COLUMNS;
+  }
+
+  const base = new Map<string, GridColumn>();
+  const sorted = [...schemaColumns].sort((a, b) => a.position - b.position);
+  for (const column of sorted) {
+    if (typeof column?.key !== 'string' || column.key.length === 0) continue;
+    base.set(column.key, {
+      key: column.key,
+      source: column.system ? 'system' : 'attribute',
+      type: column.type,
+      label: column.label ?? {},
+      sortable: Boolean(column.sortable),
+      position: base.size,
+      hidden: false,
+    });
+  }
+
+  const ordered: GridColumn[] = [];
+  const consumed = new Set<string>();
+  for (const override of overrides) {
+    const column = base.get(override.key);
+    // Unknown key = attribute removed from the ObjectType or newly
+    // RBAC-restricted since the pref was written — silently skip.
+    if (!column || consumed.has(override.key)) continue;
+    consumed.add(override.key);
+    ordered.push({
+      ...column,
+      hidden: override.hidden ?? false,
+      width: override.width,
+      pinned: override.pinned,
+    });
+  }
+  for (const column of base.values()) {
+    if (!consumed.has(column.key)) ordered.push(column);
+  }
+
+  return ordered.map((column, index) => ({ ...column, position: index }));
+}

--- a/apps/admin/src/lib/grid/types.ts
+++ b/apps/admin/src/lib/grid/types.ts
@@ -1,0 +1,50 @@
+/**
+ * GRID-P1-01 (#2385) — canonical column model for the universal object
+ * list views (grid + Excel). Resolved from the ULV-03 list-schema
+ * (`GET /api/object_types/{id}/list-schema`) merged with per-user
+ * overrides (localStorage quick-prefs today; SavedView.config in M4).
+ *
+ * The model is the single source both views consume (GRID-P1-03/04) and
+ * the column manager mutates (GRID-P2-01). RBAC is enforced upstream:
+ * the schema never contains `restricted` attribute columns (ULV-04b),
+ * and the resolver drops override entries whose key is absent from the
+ * schema, so a stale localStorage entry can never resurrect a column
+ * the server withheld.
+ */
+
+export type GridColumnSource = 'system' | 'attribute';
+
+export interface GridColumn {
+  /** Row/data key — system field name or attribute code. */
+  key: string;
+  source: GridColumnSource;
+  /**
+   * Backend list-schema type: `system_*` for system columns, otherwise
+   * the attribute type (`text`, `number`, `select`, `price`, ...).
+   */
+  type: string;
+  /** Localized label map (`{pl: ..., en: ...}`) straight from the schema. */
+  label: Record<string, string>;
+  sortable: boolean;
+  /** Resolved display order (0-based, contiguous). */
+  position: number;
+  hidden: boolean;
+  /** User-set width in px; undefined = per-type default (view decides). */
+  width?: number;
+  /** Reserved for GRID-P2-02 — only the identifier column pins in MVP. */
+  pinned?: boolean;
+}
+
+/**
+ * One user override entry. Array order = desired column order; columns
+ * without an entry keep schema order after the overridden ones. The
+ * shape deliberately matches the SavedView.config `columns` contract
+ * planned in GRID-P4-01 (`{key, width?, pinned?}` + `hidden` for the
+ * quick-pref layer).
+ */
+export interface GridColumnOverride {
+  key: string;
+  hidden?: boolean;
+  width?: number;
+  pinned?: boolean;
+}

--- a/apps/admin/src/lib/grid/use-grid-columns.ts
+++ b/apps/admin/src/lib/grid/use-grid-columns.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useListSchema } from '@/hooks/use-list-schema';
+
+import { resolveGridColumns } from './resolve-grid-columns';
+import type { GridColumn, GridColumnOverride } from './types';
+
+/**
+ * GRID-P1-01 (#2385) — single column model for both list views.
+ *
+ * Merges the ULV-03 list-schema with per-user quick-prefs persisted in
+ * localStorage (`pim.objectList.{objectTypeId}.columns`, same key family
+ * as viewMode/pageSize). The setters ship now so the column manager
+ * (GRID-P2-01) only has to call them; SavedView round-trip lands in M4
+ * with precedence SavedView > quick-prefs > schema default.
+ */
+
+function storageKey(objectTypeId: string): string {
+  return `pim.objectList.${objectTypeId}.columns`;
+}
+
+function readOverrides(objectTypeId: string): GridColumnOverride[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(storageKey(objectTypeId));
+    if (raw === null) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (entry): entry is GridColumnOverride =>
+        entry !== null &&
+        typeof entry === 'object' &&
+        typeof (entry as GridColumnOverride).key === 'string',
+    );
+  } catch {
+    // Corrupt JSON (manual edit, old shape) — fall back to schema defaults.
+    return [];
+  }
+}
+
+export interface UseGridColumnsResult {
+  /** Full resolved model (hidden columns included — the manager needs them). */
+  columns: GridColumn[];
+  /** Convenience: only the columns the views should render. */
+  visibleColumns: GridColumn[];
+  /** True while the schema query is loading or failed → fallback model. */
+  isFallback: boolean;
+  /** Replaces the override list (persists to localStorage). */
+  setOverrides: (next: GridColumnOverride[]) => void;
+  /** Clears quick-prefs → back to schema defaults. */
+  resetOverrides: () => void;
+}
+
+export function useGridColumns(objectTypeId: string | undefined): UseGridColumnsResult {
+  const schemaQuery = useListSchema(objectTypeId);
+  const [overrides, setOverridesState] = useState<GridColumnOverride[]>(() =>
+    objectTypeId !== undefined ? readOverrides(objectTypeId) : [],
+  );
+
+  // Re-read prefs when navigating between ObjectTypes — the hook instance
+  // survives route param changes inside the same list component.
+  useEffect(() => {
+    setOverridesState(objectTypeId !== undefined ? readOverrides(objectTypeId) : []);
+  }, [objectTypeId]);
+
+  const setOverrides = useCallback(
+    (next: GridColumnOverride[]) => {
+      setOverridesState(next);
+      if (typeof window === 'undefined' || objectTypeId === undefined) return;
+      try {
+        window.localStorage.setItem(storageKey(objectTypeId), JSON.stringify(next));
+      } catch {
+        // Quota/private mode — prefs stay in-memory for the session.
+      }
+    },
+    [objectTypeId],
+  );
+
+  const resetOverrides = useCallback(() => {
+    setOverridesState([]);
+    if (typeof window === 'undefined' || objectTypeId === undefined) return;
+    try {
+      window.localStorage.removeItem(storageKey(objectTypeId));
+    } catch {
+      // Best effort — same rationale as setOverrides.
+    }
+  }, [objectTypeId]);
+
+  const columns = useMemo(
+    () => resolveGridColumns(schemaQuery.data, overrides),
+    [schemaQuery.data, overrides],
+  );
+  const visibleColumns = useMemo(() => columns.filter((column) => !column.hidden), [columns]);
+
+  return {
+    columns,
+    visibleColumns,
+    isFallback: schemaQuery.data === undefined,
+    setOverrides,
+    resetOverrides,
+  };
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -4141,5 +4141,13 @@
       "completed": "Task completed",
       "cancelled": "Task cancelled"
     }
+  },
+  "grid": {
+    "cell": {
+      "yes": "Yes",
+      "no": "No",
+      "assets_one": "{{count}} file",
+      "assets_other": "{{count}} files"
+    }
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -4161,5 +4161,15 @@
       "completed": "Zadanie ukończone",
       "cancelled": "Zadanie anulowane"
     }
+  },
+  "grid": {
+    "cell": {
+      "yes": "Tak",
+      "no": "Nie",
+      "assets_one": "{{count}} plik",
+      "assets_few": "{{count}} pliki",
+      "assets_many": "{{count}} plików",
+      "assets_other": "{{count}} pliku"
+    }
   }
 }


### PR DESCRIPTION
## Co (PR 1 wg strategii PR epiku GRID — bundel P1-01 + P1-02)

**Lib-only, bez widocznej zmiany UI** — konsumpcja modelu w obu widokach to PR 2 (GRID-P1-03/04). Ships standalone lib, integration in follow-up.

### GRID-P1-01 — model kolumn (Closes #2385)
- `apps/admin/src/lib/grid/`: typ `GridColumn` + pure `resolveGridColumns(schema, overrides)` + hook `useGridColumns(objectTypeId)`.
- Overrides z localStorage (`pim.objectList.{id}.columns`); settery gotowe pod column manager (M2); kształt override'u zgodny z planowanym `SavedView.config.columns` (M4).
- **RBAC:** klucz override'u nieobecny w schema (restricted / usunięty atrybut) jest DROPOWANY — localStorage nigdy nie poszerza allow-listy serwera.
- Fallback przy braku schema = systemowy zestaw (code/status/completeness/updatedAt).

**AC P1-01:** ✅ Vitest schema-only / overrides (hidden+reorder+width) / fallback · ✅ model stabilny dla products i custom OT (pure fn niezależna od kind) · ✅ kolumna wycięta przez RBAC nigdy w modelu · ✅ zero zmian wizualnych.

### GRID-P1-02 — renderery komórek (Closes #2386)
- `extractGridCellValue` — typowana ekstrakcja z envelope `attributesIndexed` (ADR-0019: value / option_code(s) / price / mapy locale-channel), odporna na garbage i już-rozpakowane wiersze.
- `GridAttributeCell` — rendering per typ: select/multiselect z labelkami opcji (batch `GET /api/attributes/{code}/options`, cache 5 min, fallback kod), chipy z overflow \"+N\" (tooltip z resztą), price/number/date przez Intl, badge boolean (i18n `grid.cell.*`), asset = placeholder o stałym rozmiarze (bez per-row fetchy — zakres M1), puste → \"—\".
- Localizable/scopable: wartość dla locale UI + fallback pierwsza dostępna (kontekst locale/channel poza epikiem — decyzja operatora).

**AC P1-02:** ✅ każdy typ renderuje się czytelnie (test: brak \"[object Object]\") · ✅ labelki opcji w locale UI, fallback kod · ✅ odporność na null/garbage (Vitest) · ✅ media bez layout shift (stały rozmiar, lazy).

## Bramki (lokalnie)
- vitest **173/173** (16 nowych), tsc `-b --noEmit` 0 errors, biome 0 errors (2 pre-existing warningi w cudzych plikach), vite build OK, wszystkie pliki <500 linii.
- i18n: nowe klucze `grid.cell.*` w pl+en (pluralizacja PL one/few/many).

## Smoke
Brak — lib nieskonsumowany (zgodnie z SMOKE TEST RULE: *ships standalone lib, integration in follow-up*; smoke end-to-end w PR 2 przy P1-03/04).

**Source of truth:** [Project Plan/feature-grid-tickets.md](https://github.com/malipie/PIM/blob/main/Project%20Plan/feature-grid-tickets.md)

Closes #2385
Closes #2386

🤖 Generated with [Claude Code](https://claude.com/claude-code)