### PR TITLE
feat(admin): column manager, header resize, sticky identifier, density (GRID-P2-01+02+03)

### DIFF
--- a/apps/admin/e2e/2389-column-manager.spec.ts
+++ b/apps/admin/e2e/2389-column-manager.spec.ts
@@ -43,6 +43,7 @@ test('column manager: hide, reorder, reset — persisted per ObjectType', async 
   expect(headersAfter).not.toEqual(headersBefore);
 
   await page.reload();
+  await expect(page.getByTestId('grid-header-code')).toBeVisible();
   const headersReloaded = await page
     .locator('[data-testid^="grid-header-"]')
     .evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-testid')));

--- a/apps/admin/e2e/2389-column-manager.spec.ts
+++ b/apps/admin/e2e/2389-column-manager.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * GRID-P2-01/02/03 (#2389/#2390/#2391) — column manager, resize with a
+ * sticky identifier, and row density on /products:
+ *  - hide a column → gone from the grid → survives reload,
+ *  - reorder via the explicit a11y buttons → order persists,
+ *  - reset restores the default set,
+ *  - drag-resize a header → width persists after reload,
+ *  - density toggle shrinks rows and persists.
+ */
+
+test('column manager: hide, reorder, reset — persisted per ObjectType', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/products');
+  await expect(page.getByTestId('grid-header-completeness')).toBeVisible();
+
+  // Hide "Kompletność".
+  await page.getByTestId('column-manager-trigger').click();
+  await page.getByTestId('column-manager-row-completeness').getByRole('checkbox').click();
+  await page.keyboard.press('Escape');
+  await expect(page.getByTestId('grid-header-completeness')).toHaveCount(0);
+
+  await page.reload();
+  await expect(page.getByTestId('grid-header-code')).toBeVisible();
+  await expect(page.getByTestId('grid-header-completeness')).toHaveCount(0);
+
+  // Reorder: move "__categories" down one slot (a11y buttons — drag is
+  // covered by the same handler; buttons are deterministic in CI).
+  const headersBefore = await page
+    .locator('[data-testid^="grid-header-"]')
+    .evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-testid')));
+  await page.getByTestId('column-manager-trigger').click();
+  await page.getByTestId('column-manager-down-__categories').click();
+  await page.keyboard.press('Escape');
+  const headersAfter = await page
+    .locator('[data-testid^="grid-header-"]')
+    .evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-testid')));
+  expect(headersAfter).not.toEqual(headersBefore);
+
+  await page.reload();
+  const headersReloaded = await page
+    .locator('[data-testid^="grid-header-"]')
+    .evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-testid')));
+  expect(headersReloaded).toEqual(headersAfter);
+
+  // Reset → completeness is back, categories back in place.
+  await page.getByTestId('column-manager-trigger').click();
+  await page.getByTestId('column-manager-reset').click();
+  await page.keyboard.press('Escape');
+  await expect(page.getByTestId('grid-header-completeness')).toBeVisible();
+});
+
+test('header drag-resize persists and the identifier stays sticky', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/products');
+
+  const header = page.getByTestId('grid-header-__categories');
+  await expect(header).toBeVisible();
+  const before = (await header.boundingBox())?.width ?? 0;
+
+  const handle = page.getByTestId('grid-resize-__categories');
+  const box = await handle.boundingBox();
+  if (box === null) throw new Error('resize handle not visible');
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(box.x + 90, box.y + box.height / 2, { steps: 5 });
+  await page.mouse.up();
+
+  const after = (await header.boundingBox())?.width ?? 0;
+  expect(after).toBeGreaterThan(before + 40);
+
+  await page.reload();
+  const persisted = (await page.getByTestId('grid-header-__categories').boundingBox())?.width ?? 0;
+  expect(Math.abs(persisted - after)).toBeLessThan(4);
+
+  // Sticky identifier: scroll the list container right — SKU header keeps
+  // its viewport position.
+  const grid = page.getByTestId('products-grid');
+  await grid.evaluate((node) => {
+    node.scrollLeft = 400;
+  });
+  const codeBox = await page.getByTestId('grid-header-code').boundingBox();
+  const gridBox = await grid.boundingBox();
+  if (codeBox === null || gridBox === null) throw new Error('boxes unavailable');
+  expect(codeBox.x - gridBox.x).toBeLessThan(120); // pinned near the left edge
+
+  // Cleanup quick-prefs so the spec is re-runnable.
+  await page.getByTestId('column-manager-trigger').click();
+  await page.getByTestId('column-manager-reset').click();
+});
+
+test('density toggle shrinks rows and persists', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/products');
+
+  const firstRow = page.locator('[data-testid^="products-grid-row-"]').first();
+  await expect(firstRow).toBeVisible();
+  const normalHeight = (await firstRow.boundingBox())?.height ?? 0;
+
+  await page.getByTestId('density-compact').click();
+  const compactHeight = (await firstRow.boundingBox())?.height ?? 0;
+  expect(compactHeight).toBeLessThan(normalHeight * 0.8);
+
+  await page.reload();
+  await expect(page.getByTestId('density-compact')).toHaveAttribute('aria-selected', 'true');
+  const reloadedHeight =
+    (await page.locator('[data-testid^="products-grid-row-"]').first().boundingBox())?.height ?? 0;
+  expect(reloadedHeight).toBeLessThan(normalHeight * 0.8);
+
+  await page.getByTestId('density-normal').click();
+});

--- a/apps/admin/e2e/2389-column-manager.spec.ts
+++ b/apps/admin/e2e/2389-column-manager.spec.ts
@@ -27,13 +27,15 @@ test('column manager: hide, reorder, reset — persisted per ObjectType', async 
   await expect(page.getByTestId('grid-header-code')).toBeVisible();
   await expect(page.getByTestId('grid-header-completeness')).toHaveCount(0);
 
-  // Reorder: move "__categories" down one slot (a11y buttons — drag is
-  // covered by the same handler; buttons are deterministic in CI).
+  // Reorder: move "__sync" down one slot — its neighbour (__price) is
+  // visible, so the change is observable in the header row. (a11y
+  // buttons — drag is covered by the same handler; buttons are
+  // deterministic in CI.)
   const headersBefore = await page
     .locator('[data-testid^="grid-header-"]')
     .evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-testid')));
   await page.getByTestId('column-manager-trigger').click();
-  await page.getByTestId('column-manager-down-__categories').click();
+  await page.getByTestId('column-manager-down-__sync').click();
   await page.keyboard.press('Escape');
   const headersAfter = await page
     .locator('[data-testid^="grid-header-"]')

--- a/apps/admin/src/components/catalog/column-manager.tsx
+++ b/apps/admin/src/components/catalog/column-manager.tsx
@@ -1,0 +1,261 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { ChevronDown, ChevronUp, Columns3, GripVertical, Search } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { Sheet, SheetContent, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
+import { LOCKED_COLUMN_KEY, moveColumn, toggleColumnHidden } from '@/lib/grid/overrides';
+import type { GridColumn } from '@/lib/grid/types';
+import { cn } from '@/lib/utils';
+
+/**
+ * GRID-P2-01 (#2389) — the "Kolumny" manager for the universal list
+ * views. Operates on the FULL resolved model (hidden included): a
+ * checkbox toggles visibility, drag (pointer + dnd-kit keyboard sensor)
+ * or the explicit up/down buttons reorder, "Reset" clears quick-prefs.
+ *
+ * Same @dnd-kit sensor setup as the export wizard's ColumnPickerV2 —
+ * the two-pane picker itself is NOT extracted/reused: this surface is a
+ * single flat list and sharing internals would couple the export wizard
+ * to list-grid churn (deliberate deviation, documented in the PR).
+ */
+
+interface ColumnManagerProps {
+  columns: GridColumn[];
+  onChange: (next: GridColumn[]) => void;
+  onReset: () => void;
+  /** Locale used to pick display labels from the i18n maps. */
+  locale: string;
+}
+
+function pickLabel(label: Record<string, string>, locale: string, fallback: string): string {
+  return label[locale] ?? label.en ?? label.pl ?? Object.values(label)[0] ?? fallback;
+}
+
+export function ColumnManager({ columns, onChange, onReset, locale }: ColumnManagerProps) {
+  const { t } = useTranslation();
+  const [search, setSearch] = useState('');
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const query = search.trim().toLowerCase();
+  const filtered = useMemo(
+    () =>
+      query.length === 0
+        ? columns
+        : columns.filter(
+            (column) =>
+              pickLabel(column.label, locale, column.key).toLowerCase().includes(query) ||
+              column.key.toLowerCase().includes(query),
+          ),
+    [columns, query, locale],
+  );
+
+  const handleDragEnd = (event: DragEndEvent): void => {
+    const { active, over } = event;
+    if (over === null || active.id === over.id) return;
+    const from = columns.findIndex((column) => column.key === active.id);
+    const to = columns.findIndex((column) => column.key === over.id);
+    if (from === -1 || to === -1 || to === 0 || from === 0) return;
+    const next = [...columns];
+    const [moved] = next.splice(from, 1);
+    if (moved === undefined) return;
+    next.splice(to, 0, moved);
+    onChange(next.map((column, position) => ({ ...column, position })));
+  };
+
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button
+          variant="outline"
+          className="h-11 rounded-2xl px-4 text-[12.5px] font-medium"
+          data-testid="column-manager-trigger"
+        >
+          <Columns3 className="size-4" />
+          {t('grid.manager.trigger', { defaultValue: 'Kolumny' })}
+        </Button>
+      </SheetTrigger>
+      <SheetContent
+        side="right"
+        className="flex w-96 flex-col gap-0 p-0"
+        data-testid="column-manager-panel"
+      >
+        <div className="border-b border-zinc-100 p-4">
+          <SheetTitle className="text-sm font-semibold">
+            {t('grid.manager.title', { defaultValue: 'Zarządzaj kolumnami' })}
+          </SheetTitle>
+        </div>
+        <div className="border-b border-zinc-100 p-3">
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-zinc-400" />
+            <input
+              type="search"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder={t('grid.manager.search_placeholder', {
+                defaultValue: 'Szukaj kolumny…',
+              })}
+              aria-label={t('grid.manager.search_placeholder', {
+                defaultValue: 'Szukaj kolumny…',
+              })}
+              className="h-9 w-full rounded-lg border border-zinc-200 bg-white pl-8 pr-2 text-[12.5px] outline-none focus-visible:ring-2 focus-visible:ring-zinc-900"
+            />
+          </div>
+        </div>
+        <ul
+          className="min-h-0 flex-1 overflow-y-auto p-1.5"
+          aria-label={t('grid.manager.list_aria', { defaultValue: 'Kolumny listy' })}
+        >
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={filtered.map((column) => column.key)}
+              strategy={verticalListSortingStrategy}
+            >
+              {filtered.map((column) => (
+                <ColumnRow
+                  key={column.key}
+                  column={column}
+                  locale={locale}
+                  isFirst={columns[0]?.key === column.key}
+                  isLast={columns[columns.length - 1]?.key === column.key}
+                  onToggle={() => onChange(toggleColumnHidden(columns, column.key))}
+                  onMove={(delta) => onChange(moveColumn(columns, column.key, delta))}
+                />
+              ))}
+            </SortableContext>
+          </DndContext>
+        </ul>
+        <div className="border-t border-zinc-100 p-2">
+          <Button
+            variant="ghost"
+            className="h-8 w-full rounded-lg text-[12px] text-zinc-600"
+            onClick={onReset}
+            data-testid="column-manager-reset"
+          >
+            {t('grid.manager.reset', { defaultValue: 'Resetuj do domyślnych' })}
+          </Button>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function ColumnRow({
+  column,
+  locale,
+  isFirst,
+  isLast,
+  onToggle,
+  onMove,
+}: {
+  column: GridColumn;
+  locale: string;
+  isFirst: boolean;
+  isLast: boolean;
+  onToggle: () => void;
+  onMove: (delta: -1 | 1) => void;
+}) {
+  const { t } = useTranslation();
+  const locked = column.key === LOCKED_COLUMN_KEY;
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: column.key,
+    disabled: locked,
+  });
+  const label = pickLabel(column.label, locale, column.key);
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn(
+        'flex items-center gap-1.5 rounded-lg px-1.5 py-1 text-[12.5px]',
+        isDragging && 'z-10 bg-zinc-100 shadow-sm',
+      )}
+      data-testid={`column-manager-row-${column.key}`}
+    >
+      <button
+        type="button"
+        {...attributes}
+        {...listeners}
+        disabled={locked}
+        aria-label={t('grid.manager.drag_aria', {
+          label,
+          defaultValue: 'Przeciągnij, aby zmienić kolejność: {{label}}',
+        })}
+        className={cn(
+          'grid size-6 shrink-0 cursor-grab place-items-center rounded text-zinc-400 hover:text-zinc-600',
+          locked && 'invisible',
+        )}
+      >
+        <GripVertical className="size-3.5" />
+      </button>
+      <label className="flex min-w-0 flex-1 cursor-pointer items-center gap-2">
+        <input
+          type="checkbox"
+          checked={!column.hidden}
+          disabled={locked}
+          onChange={onToggle}
+          className="size-3.5 shrink-0 cursor-pointer accent-zinc-900 disabled:cursor-not-allowed"
+        />
+        <span className={cn('truncate', column.hidden && 'text-zinc-400')}>{label}</span>
+        {locked ? (
+          <span className="ml-auto shrink-0 text-[10px] uppercase tracking-wide text-zinc-400">
+            {t('grid.manager.locked', { defaultValue: 'stała' })}
+          </span>
+        ) : null}
+      </label>
+      <div className="flex shrink-0 items-center">
+        <button
+          type="button"
+          onClick={() => onMove(-1)}
+          disabled={locked || isFirst}
+          aria-label={t('grid.manager.move_up_aria', {
+            label,
+            defaultValue: 'Przesuń wyżej: {{label}}',
+          })}
+          className="grid size-6 place-items-center rounded text-zinc-400 hover:text-zinc-700 disabled:opacity-30"
+          data-testid={`column-manager-up-${column.key}`}
+        >
+          <ChevronUp className="size-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={() => onMove(1)}
+          disabled={locked || isLast}
+          aria-label={t('grid.manager.move_down_aria', {
+            label,
+            defaultValue: 'Przesuń niżej: {{label}}',
+          })}
+          className="grid size-6 place-items-center rounded text-zinc-400 hover:text-zinc-700 disabled:opacity-30"
+          data-testid={`column-manager-down-${column.key}`}
+        >
+          <ChevronDown className="size-3.5" />
+        </button>
+      </div>
+    </li>
+  );
+}

--- a/apps/admin/src/components/catalog/density-toggle.tsx
+++ b/apps/admin/src/components/catalog/density-toggle.tsx
@@ -1,0 +1,61 @@
+import { Rows2, Rows4 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import type { GridDensity } from '@/lib/grid/use-density';
+import { cn } from '@/lib/utils';
+
+/**
+ * GRID-P2-03 (#2391) — compact/normal row density for the list views.
+ * Same segmented-control shape as ViewModeToggle so the toolbar reads
+ * as one family of controls.
+ */
+export function DensityToggle({
+  density,
+  onChange,
+}: {
+  density: GridDensity;
+  onChange: (next: GridDensity) => void;
+}) {
+  const { t } = useTranslation();
+  const options: ReadonlyArray<{ value: GridDensity; label: string; Icon: typeof Rows2 }> = [
+    {
+      value: 'normal',
+      label: t('grid.density.normal', { defaultValue: 'Komfort' }),
+      Icon: Rows2,
+    },
+    {
+      value: 'compact',
+      label: t('grid.density.compact', { defaultValue: 'Kompakt' }),
+      Icon: Rows4,
+    },
+  ];
+
+  return (
+    <div
+      className="inline-flex h-11 items-center rounded-2xl bg-white p-1 shadow-sm"
+      role="tablist"
+      aria-label={t('grid.density.aria', { defaultValue: 'Gęstość wierszy' })}
+    >
+      {options.map(({ value, label, Icon }) => {
+        const active = density === value;
+        return (
+          <button
+            key={value}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            data-testid={`density-${value}`}
+            onClick={() => onChange(value)}
+            className={cn(
+              'inline-flex h-9 items-center gap-1.5 rounded-xl px-3 text-[12.5px] font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900',
+              active ? 'bg-zinc-900 text-white' : 'text-zinc-500 hover:text-zinc-700',
+            )}
+          >
+            <Icon className="size-3.5" />
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/admin/src/components/catalog/excel-like-grid.tsx
+++ b/apps/admin/src/components/catalog/excel-like-grid.tsx
@@ -15,6 +15,12 @@ export interface ExcelColumn<T extends Record<string, unknown>> {
    * projection under `key` alongside whatever this renders.
    */
   renderDisplay?: (row: T) => React.ReactNode;
+  /**
+   * GRID-P2-02 — the grid-model key this excel column maps back to
+   * (excel keys are row-field aliases like `sku` / `attr:{code}`);
+   * resize commits report this key so overrides land on the model.
+   */
+  modelKey?: string;
 }
 
 interface CellAddress {
@@ -66,10 +72,16 @@ export function ExcelLikeGrid<T extends Record<string, unknown>>({
   rows,
   columns,
   onCommit,
+  density = 'normal',
+  onColumnResize,
 }: {
   rows: T[];
   columns: ExcelColumn<T>[];
   onCommit: (rowIdx: number, colKey: string, value: unknown) => void;
+  /** GRID-P2-03 — compact rows for spreadsheet-style work. */
+  density?: 'normal' | 'compact';
+  /** GRID-P2-02 — resize commit keyed by the column's `modelKey`. */
+  onColumnResize?: (modelKey: string, width: number) => void;
 }) {
   const [active, setActive] = useState<CellAddress | null>(null);
   const [selectionEnd, setSelectionEnd] = useState<CellAddress | null>(null);
@@ -83,6 +95,16 @@ export function ExcelLikeGrid<T extends Record<string, unknown>>({
     [columns],
   );
 
+  // GRID-P2-02 — uncommitted drag widths (declared before the virtualizer:
+  // estimateSize closes over them).
+  const resizeRef = useRef<{
+    key: string;
+    modelKey: string;
+    startX: number;
+    startWidth: number;
+  } | null>(null);
+  const [liveWidths, setLiveWidths] = useState<Record<string, number>>({});
+
   // Horizontal column virtualizer. Estimates from each column's declared
   // width (falling back to DEFAULT_COLUMN_WIDTH) so spacer math matches the
   // real header/body widths. Overscan keeps a couple of columns mounted on
@@ -91,16 +113,40 @@ export function ExcelLikeGrid<T extends Record<string, unknown>>({
     horizontal: true,
     count: columns.length,
     getScrollElement: () => scrollRef.current,
-    estimateSize: (index) => columns[index]?.width ?? DEFAULT_COLUMN_WIDTH,
+    estimateSize: (index) => {
+      const col = columns[index];
+      if (col === undefined) return DEFAULT_COLUMN_WIDTH;
+      return liveWidths[col.key] ?? col.width ?? DEFAULT_COLUMN_WIDTH;
+    },
     overscan: 4,
   });
 
-  const virtualColumns = columnVirtualizer.getVirtualItems();
+  // biome-ignore lint/correctness/useExhaustiveDependencies: measure() is stable; re-run only when widths change.
+  useEffect(() => {
+    columnVirtualizer.measure();
+  }, [liveWidths]);
+
+  const windowColumns = columnVirtualizer.getVirtualItems();
+  // GRID-P2-02 — the identifier column (index 0) must stay mounted for
+  // position:sticky to hold while scrolled; prepend it when the window
+  // starts past it and shave its width off the lead spacer.
+  const firstWindowIndex = windowColumns[0]?.index ?? 0;
+  const pinnedWidth = columns[0]?.width ?? DEFAULT_COLUMN_WIDTH;
+  const virtualColumns =
+    firstWindowIndex > 0
+      ? [
+          { index: 0, start: 0, end: pinnedWidth } as (typeof windowColumns)[number],
+          ...windowColumns,
+        ]
+      : windowColumns;
   const totalWidth = columnVirtualizer.getTotalSize();
   // Width consumed by the off-screen columns before / after the window —
   // rendered as spacer cells so column alignment and horizontal scroll
   // extent stay identical to the non-virtualized table.
-  const leadWidth = virtualColumns.length > 0 ? (virtualColumns[0]?.start ?? 0) : 0;
+  const leadWidth =
+    windowColumns.length > 0
+      ? Math.max(0, (windowColumns[0]?.start ?? 0) - (firstWindowIndex > 0 ? pinnedWidth : 0))
+      : 0;
   const tailWidth =
     virtualColumns.length > 0
       ? Math.max(0, totalWidth - (virtualColumns[virtualColumns.length - 1]?.end ?? 0))
@@ -211,6 +257,8 @@ export function ExcelLikeGrid<T extends Record<string, unknown>>({
     [active, editing, selectionRect, columns, rows, colIndex, onCommit],
   );
 
+  const widthOf = (col: ExcelColumn<T>): number | undefined => liveWidths[col.key] ?? col.width;
+
   const renderCell = (row: T, rowIdx: number, colIdx: number) => {
     const col = columns[colIdx];
     if (col === undefined) return null;
@@ -228,10 +276,12 @@ export function ExcelLikeGrid<T extends Record<string, unknown>>({
       // biome-ignore lint/a11y/useKeyWithClickEvents: the parent <table> owns keyboard nav (handleKeyDown).
       <td
         key={col.key}
-        style={{ width: col.width }}
+        style={{ width: widthOf(col), ...(colIdx === 0 ? { left: 0 } : {}) }}
         onClick={(e) => handleCellClick(rowIdx, col.key, e.shiftKey)}
         onDoubleClick={() => handleCellDoubleClick(rowIdx, col.key)}
-        className={`relative border px-2 py-1 ${
+        className={`relative border px-2 ${density === 'compact' ? 'py-0.5 text-[12px]' : 'py-1'} ${
+          colIdx === 0 ? 'sticky z-10 bg-white' : ''
+        } ${
           isPrimary ? 'ring-2 ring-primary' : isActive ? 'bg-primary/10' : ''
         } ${col.readOnly === true ? 'bg-muted/40 text-muted-foreground' : 'cursor-cell'}`}
       >
@@ -277,10 +327,53 @@ export function ExcelLikeGrid<T extends Record<string, unknown>>({
               return (
                 <th
                   key={col.key}
-                  style={{ width: col.width }}
-                  className="border px-2 py-1 text-left font-medium"
+                  style={{ width: widthOf(col), ...(vc.index === 0 ? { left: 0 } : {}) }}
+                  className={`relative border px-2 text-left font-medium ${
+                    density === 'compact' ? 'py-0.5' : 'py-1'
+                  } ${vc.index === 0 ? 'sticky z-20 bg-muted' : ''}`}
                 >
                   {col.label}
+                  {onColumnResize !== undefined && col.modelKey !== undefined ? (
+                    <button
+                      type="button"
+                      aria-label={`Resize ${col.label}`}
+                      data-testid={`excel-resize-${col.modelKey}`}
+                      onPointerDown={(event) => {
+                        const th = (event.currentTarget as HTMLElement).parentElement;
+                        if (th === null || col.modelKey === undefined) return;
+                        resizeRef.current = {
+                          key: col.key,
+                          modelKey: col.modelKey,
+                          startX: event.clientX,
+                          startWidth: th.offsetWidth,
+                        };
+                        (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+                      }}
+                      onPointerMove={(event) => {
+                        const drag = resizeRef.current;
+                        if (drag === null) return;
+                        const width = Math.max(
+                          60,
+                          Math.min(640, drag.startWidth + event.clientX - drag.startX),
+                        );
+                        setLiveWidths((prev) =>
+                          prev[drag.key] === width ? prev : { ...prev, [drag.key]: width },
+                        );
+                      }}
+                      onPointerUp={() => {
+                        const drag = resizeRef.current;
+                        if (drag === null) return;
+                        resizeRef.current = null;
+                        setLiveWidths((prev) => {
+                          const width = prev[drag.key];
+                          if (width !== undefined) onColumnResize(drag.modelKey, width);
+                          const { [drag.key]: _done, ...rest } = prev;
+                          return rest;
+                        });
+                      }}
+                      className="absolute -right-1 top-0 z-10 h-full w-2 cursor-col-resize touch-none hover:bg-zinc-300/60"
+                    />
+                  ) : null}
                 </th>
               );
             })}

--- a/apps/admin/src/components/catalog/products-grid-row.tsx
+++ b/apps/admin/src/components/catalog/products-grid-row.tsx
@@ -34,6 +34,9 @@ interface RowViewProps {
   showMediaColumn: boolean;
   template: string;
   locale: string;
+  density: 'normal' | 'compact';
+  stickyCodeLeft: number;
+  stickyImgLeft: number;
   isSelected: boolean;
   onToggleSelect: (id: string) => void;
   isExpanded: boolean;
@@ -51,6 +54,9 @@ export function ProductsGridRowView({
   showMediaColumn,
   template,
   locale,
+  density,
+  stickyCodeLeft,
+  stickyImgLeft,
   isSelected,
   onToggleSelect,
   isExpanded,
@@ -66,7 +72,7 @@ export function ProductsGridRowView({
   const style: CSSProperties = { gridTemplateColumns: template };
 
   const identifierCell = (
-    <div className="px-3 py-2 font-mono text-[12px] flex items-center gap-1.5">
+    <div className="gcell px-3 py-2 font-mono text-[12px] flex items-center gap-1.5">
       {hasVariants ? (
         <button
           type="button"
@@ -107,7 +113,7 @@ export function ProductsGridRowView({
   );
 
   const nameCell = (
-    <div className="px-3 py-2.5 min-w-0 flex items-center gap-2">
+    <div className="gcell px-3 py-2.5 min-w-0 flex items-center gap-2">
       {variant ? (
         <span className="text-[13.5px] font-medium tracking-tight truncate text-left text-zinc-700">
           {row.name}
@@ -143,7 +149,7 @@ export function ProductsGridRowView({
         return nameCell;
       case '__categories':
         return (
-          <div className="px-3 py-2 flex items-center gap-1 flex-wrap">
+          <div className="gcell px-3 py-2 flex items-center gap-1 flex-wrap">
             {row.categories !== null && row.categories.length > 0 ? (
               <>
                 {row.categories.slice(0, 2).map((cat) => (
@@ -165,13 +171,13 @@ export function ProductsGridRowView({
         );
       case 'completeness':
         return (
-          <div className="px-3 py-2.5">
+          <div className="gcell px-3 py-2.5">
             <CompletenessBadge pct={row.completenessPct} />
           </div>
         );
       case '__sync':
         return (
-          <div className="px-3 py-2 flex items-center gap-2.5">
+          <div className="gcell px-3 py-2 flex items-center gap-2.5">
             <SyncAggregateIcon status={row.syncStatusAggregate} />
             <span
               className={cn('text-[10.5px] font-medium', SYNC_LABEL_TONE[row.syncStatusAggregate])}
@@ -184,7 +190,7 @@ export function ProductsGridRowView({
         );
       case '__price':
         return (
-          <div className="px-3 py-2 text-[13px] font-medium tabular-nums">
+          <div className="gcell px-3 py-2 text-[13px] font-medium tabular-nums">
             {row.price !== null ? (
               <>
                 {row.price.amount.toLocaleString(locale, { maximumFractionDigits: 2 })}
@@ -197,13 +203,13 @@ export function ProductsGridRowView({
         );
       case '__variant':
         return (
-          <div className="px-3 py-2 text-[11px] font-mono text-zinc-500">
+          <div className="gcell px-3 py-2 text-[11px] font-mono text-zinc-500">
             {row.variantAxis ?? '—'}
           </div>
         );
       case 'status':
         return (
-          <div className="px-3 py-2 text-[12px] text-zinc-600">
+          <div className="gcell px-3 py-2 text-[12px] text-zinc-600">
             {row.status !== null
               ? t(`products.status.${row.status}`, { defaultValue: row.status })
               : '—'}
@@ -211,7 +217,7 @@ export function ProductsGridRowView({
         );
       case 'updatedAt':
         return (
-          <div className="px-3 py-2 text-[12px] text-zinc-500 whitespace-nowrap">
+          <div className="gcell px-3 py-2 text-[12px] text-zinc-500 whitespace-nowrap">
             {formatDate(row.updatedAt, locale)}
           </div>
         );
@@ -219,7 +225,7 @@ export function ProductsGridRowView({
         return (
           <div
             className={cn(
-              'px-3 py-2 min-w-0 text-[12.5px] text-zinc-700 flex items-center',
+              'gcell px-3 py-2 min-w-0 text-[12.5px] text-zinc-700 flex items-center',
               gridCellAlignment(column) === 'right' && 'justify-end',
             )}
             data-testid={`grid-cell-${column.key}`}
@@ -238,12 +244,13 @@ export function ProductsGridRowView({
     <div
       data-testid={`products-grid-row-${row.sku}`}
       className={cn(
-        'group relative grid items-center text-[13px] border-b border-zinc-50 last:border-b-0 transition',
+        'group relative grid items-center text-[13px] border-b border-zinc-50 last:border-b-0 transition bg-white',
         isSelected ? 'bg-zinc-200/70' : variant ? 'bg-zinc-50/40' : 'hover:bg-zinc-50/60',
+        density === 'compact' && 'text-[12px] [&_.gcell]:py-1',
       )}
       style={style}
     >
-      <div className="px-3 py-2.5 pl-4">
+      <div className="gcell sticky left-0 z-10 bg-inherit px-3 py-2.5 pl-4">
         {variant ? (
           <span className="inline-block size-4" />
         ) : (
@@ -263,18 +270,29 @@ export function ProductsGridRowView({
       </div>
 
       {showMediaColumn ? (
-        <div className="px-3 py-2 flex items-center gap-1">
+        <div
+          className="gcell sticky z-10 bg-inherit px-3 py-2 flex items-center gap-1"
+          style={{ left: stickyImgLeft }}
+        >
           {variant ? <span className="ml-1 text-zinc-300">└</span> : null}
         </div>
       ) : null}
 
-      {columns.map((column) => (
-        <div key={column.key} className="contents">
+      {columns.map((column, index) => (
+        <div
+          key={column.key}
+          className={cn(
+            index === 0
+              ? 'sticky z-10 min-w-0 bg-inherit shadow-[inset_-1px_0_0_0_rgba(228,228,231,1)]'
+              : 'contents',
+          )}
+          style={index === 0 ? { left: stickyCodeLeft } : undefined}
+        >
           {dataCell(column)}
         </div>
       ))}
 
-      <div className="px-3 py-2 text-zinc-500 hover:text-zinc-900 opacity-0 group-hover:opacity-100 focus-within:opacity-100">
+      <div className="gcell px-3 py-2 text-zinc-500 hover:text-zinc-900 opacity-0 group-hover:opacity-100 focus-within:opacity-100">
         {variant ? null : <ProductRowActions productId={row.id} onChanged={onChangedRow} />}
       </div>
     </div>

--- a/apps/admin/src/components/catalog/products-grid-row.tsx
+++ b/apps/admin/src/components/catalog/products-grid-row.tsx
@@ -246,7 +246,7 @@ export function ProductsGridRowView({
       className={cn(
         'group relative grid items-center text-[13px] border-b border-zinc-50 last:border-b-0 transition bg-white',
         isSelected ? 'bg-zinc-200/70' : variant ? 'bg-zinc-50/40' : 'hover:bg-zinc-50/60',
-        density === 'compact' && 'text-[12px] [&_.gcell]:py-1',
+        density === 'compact' && 'text-[12px] [&_.gcell]:py-0.5',
       )}
       style={style}
     >

--- a/apps/admin/src/components/catalog/products-grid.tsx
+++ b/apps/admin/src/components/catalog/products-grid.tsx
@@ -1,8 +1,13 @@
-import type { CSSProperties } from 'react';
+import type { CSSProperties, PointerEvent as ReactPointerEvent } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { SyncAggregate } from '@/components/catalog/sync-aggregate-icon';
+import { extractGridCellValue, stringifyGridCellValue } from '@/lib/grid/cell-value';
+import { autoFitWidth, clampColumnWidth } from '@/lib/grid/overrides';
 import type { GridColumn } from '@/lib/grid/types';
+import type { GridDensity } from '@/lib/grid/use-density';
+import { cn } from '@/lib/utils';
 import { ProductsGridRowView } from './products-grid-row';
 
 export interface ProductsGridRow {
@@ -36,6 +41,10 @@ interface ProductsGridProps {
   optionLabels?: OptionLabelIndex;
   /** ObjectType capability — hides the thumbnail slot for media-less kinds. */
   showMediaColumn?: boolean;
+  /** GRID-P2-03 — compact shrinks row height ~30% for spreadsheet-style work. */
+  density?: GridDensity;
+  /** GRID-P2-02 — drag-resize commit (key = model column key, width px). */
+  onColumnResize?: (key: string, width: number) => void;
   selected: Set<string>;
   onToggleSelect: (id: string) => void;
   onToggleSelectAll: () => void;
@@ -95,12 +104,24 @@ function widthFor(column: GridColumn): string {
   return WIDTH_BY_KEY[column.key] ?? WIDTH_BY_TYPE[column.type] ?? '160px';
 }
 
-function gridTemplate(columns: GridColumn[], showMediaColumn: boolean): string {
+function gridTemplate(
+  columns: GridColumn[],
+  showMediaColumn: boolean,
+  liveWidths: Record<string, number>,
+): string {
   const parts = ['44px'];
   if (showMediaColumn) parts.push('52px');
-  for (const column of columns) parts.push(widthFor(column));
+  for (const column of columns) {
+    const live = liveWidths[column.key];
+    parts.push(live !== undefined ? `${live}px` : widthFor(column));
+  }
   parts.push('44px');
   return parts.join(' ');
+}
+
+/** Sticky offsets for the leading structural + identifier cells (px). */
+export function stickyOffsets(showMediaColumn: boolean): { img: number; code: number } {
+  return { img: 44, code: showMediaColumn ? 96 : 44 };
 }
 
 function pickLabel(label: Record<string, string>, locale: string, fallback: string): string {
@@ -119,6 +140,8 @@ export function ProductsGrid({
   columns,
   optionLabels = {},
   showMediaColumn = true,
+  density = 'normal',
+  onColumnResize,
   selected,
   onToggleSelect,
   onToggleSelectAll,
@@ -135,8 +158,51 @@ export function ProductsGrid({
   const masterIds = rows.filter((r) => r.parentId === null).map((r) => r.id);
   const allSelected = masterIds.length > 0 && masterIds.every((id) => selected.has(id));
 
-  const template = gridTemplate(columns, showMediaColumn);
+  // GRID-P2-02 — uncommitted drag widths live here so pointermove does not
+  // round-trip through localStorage/overrides on every frame.
+  const [liveWidths, setLiveWidths] = useState<Record<string, number>>({});
+  const dragRef = useRef<{ key: string; startX: number; startWidth: number } | null>(null);
+  const template = gridTemplate(columns, showMediaColumn, liveWidths);
   const headerStyle: CSSProperties = { gridTemplateColumns: template };
+  const offsets = stickyOffsets(showMediaColumn);
+  const compact = density === 'compact';
+
+  const autoFitSamples = useMemo(() => {
+    const byKey: Record<string, string[]> = {};
+    for (const column of columns) {
+      if (column.source !== 'attribute') continue;
+      byKey[column.key] = rows
+        .slice(0, 25)
+        .map((row) =>
+          stringifyGridCellValue(extractGridCellValue(row.attributesIndexed?.[column.key], locale)),
+        );
+    }
+    return byKey;
+  }, [columns, rows, locale]);
+
+  const startResize = (key: string, event: ReactPointerEvent<HTMLButtonElement>): void => {
+    const headerCell = (event.currentTarget as HTMLElement).parentElement;
+    if (headerCell === null) return;
+    dragRef.current = { key, startX: event.clientX, startWidth: headerCell.offsetWidth };
+    (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+  };
+  const moveResize = (event: ReactPointerEvent<HTMLButtonElement>): void => {
+    const drag = dragRef.current;
+    if (drag === null) return;
+    const width = clampColumnWidth(drag.startWidth + (event.clientX - drag.startX));
+    setLiveWidths((prev) => (prev[drag.key] === width ? prev : { ...prev, [drag.key]: width }));
+  };
+  const endResize = (): void => {
+    const drag = dragRef.current;
+    if (drag === null) return;
+    dragRef.current = null;
+    setLiveWidths((prev) => {
+      const width = prev[drag.key];
+      if (width !== undefined) onColumnResize?.(drag.key, width);
+      const { [drag.key]: _committed, ...rest } = prev;
+      return rest;
+    });
+  };
 
   return (
     // NUI-13 — no `role="grid"`: the ARIA grid pattern mandates grid keyboard
@@ -152,7 +218,9 @@ export function ProductsGrid({
         className="grid items-center text-[11px] uppercase tracking-wider text-zinc-500 font-semibold border-b border-zinc-100 bg-zinc-50/60"
         style={headerStyle}
       >
-        <div className="px-3 py-2.5 pl-4">
+        <div
+          className={cn('sticky left-0 z-20 bg-zinc-50 px-3 pl-4', compact ? 'py-1.5' : 'py-2.5')}
+        >
           <input
             type="checkbox"
             checked={allSelected}
@@ -163,13 +231,51 @@ export function ProductsGrid({
             className="size-4 cursor-pointer accent-zinc-900"
           />
         </div>
-        {showMediaColumn ? <div className="px-3 py-2.5" /> : null}
-        {columns.map((column) => (
-          <div key={column.key} className="px-3 py-2.5" data-testid={`grid-header-${column.key}`}>
+        {showMediaColumn ? (
+          <div
+            className={cn('sticky z-20 bg-zinc-50 px-3', compact ? 'py-1.5' : 'py-2.5')}
+            style={{ left: offsets.img }}
+          />
+        ) : null}
+        {columns.map((column, index) => (
+          <div
+            key={column.key}
+            className={cn(
+              'relative px-3',
+              compact ? 'py-1.5' : 'py-2.5',
+              index === 0 && 'sticky z-20 bg-zinc-50 shadow-[inset_-1px_0_0_0_rgba(228,228,231,1)]',
+            )}
+            style={index === 0 ? { left: offsets.code } : undefined}
+            data-testid={`grid-header-${column.key}`}
+          >
             {pickLabel(column.label, locale, column.key)}
+            {onColumnResize !== undefined ? (
+              <button
+                type="button"
+                aria-label={t('grid.resize_aria', {
+                  label: pickLabel(column.label, locale, column.key),
+                  defaultValue: 'Zmień szerokość kolumny {{label}}',
+                })}
+                data-testid={`grid-resize-${column.key}`}
+                onPointerDown={(event) => startResize(column.key, event)}
+                onPointerMove={moveResize}
+                onPointerUp={endResize}
+                onPointerCancel={endResize}
+                onDoubleClick={() =>
+                  onColumnResize(
+                    column.key,
+                    autoFitWidth(
+                      pickLabel(column.label, locale, column.key),
+                      autoFitSamples[column.key] ?? [],
+                    ),
+                  )
+                }
+                className="absolute -right-1 top-0 z-10 h-full w-2 cursor-col-resize touch-none hover:bg-zinc-300/60"
+              />
+            ) : null}
           </div>
         ))}
-        <div className="px-3 py-2.5" />
+        <div className={cn('px-3', compact ? 'py-1.5' : 'py-2.5')} />
       </div>
 
       {isLoading ? (
@@ -189,6 +295,9 @@ export function ProductsGrid({
               showMediaColumn={showMediaColumn}
               template={template}
               locale={locale}
+              density={density}
+              stickyCodeLeft={offsets.code}
+              stickyImgLeft={offsets.img}
               isSelected={!isVariant(row) && selected.has(row.id)}
               onToggleSelect={onToggleSelect}
               isExpanded={expandedMasters.has(row.id)}

--- a/apps/admin/src/components/objects/universal-list-page.tsx
+++ b/apps/admin/src/components/objects/universal-list-page.tsx
@@ -37,7 +37,9 @@ import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router';
 
 import { BulkBar } from '@/components/catalog/bulk-bar';
+import { ColumnManager } from '@/components/catalog/column-manager';
 import { DeletePresetDialog } from '@/components/catalog/delete-preset-dialog';
+import { DensityToggle } from '@/components/catalog/density-toggle';
 import { ExcelLikeGrid } from '@/components/catalog/excel-like-grid';
 import { FilterChipsBar } from '@/components/catalog/filter-chips-bar';
 import {
@@ -70,7 +72,9 @@ import { useFilterDslState } from '@/lib/filters/use-filter-dsl-state';
 import { type SmartFilterPreset, useSmartPresets } from '@/lib/filters/use-smart-presets';
 import { type ExcelObjectRow, toExcelColumns, toExcelRow } from '@/lib/grid/excel-columns';
 import { useAttributeOptionLabels } from '@/lib/grid/grid-attribute-cell';
-import type { GridColumnOverride, ViewColumnSeed } from '@/lib/grid/types';
+import { clampColumnWidth, overridesFromColumns, setColumnWidth } from '@/lib/grid/overrides';
+import type { GridColumn, GridColumnOverride, ViewColumnSeed } from '@/lib/grid/types';
+import { useGridDensity } from '@/lib/grid/use-density';
 import { useGridColumns } from '@/lib/grid/use-grid-columns';
 import { jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
@@ -273,13 +277,17 @@ export function UniversalListPage({
     return has('name') ? seeds.filter((seed) => seed.key !== '__name') : seeds;
   }, [schemaQuery.data, isCategorizable, isProduct, hasVariants]);
 
-  const { visibleColumns: modelColumns } = useGridColumns(objectTypeId, {
+  const {
+    columns: modelColumns,
+    setOverrides,
+    resetOverrides,
+  } = useGridColumns(objectTypeId, {
     viewColumns: gridViewColumns,
     defaultOverrides: DEFAULT_COLUMN_OVERRIDES,
   });
   // Visual parity: the schema labels the identifier column generically
   // ("Identyfikator"), but the products list has always shown "SKU".
-  const visibleColumns = useMemo(
+  const allColumns = useMemo(
     () =>
       isProduct
         ? modelColumns.map((column) =>
@@ -288,6 +296,15 @@ export function UniversalListPage({
         : modelColumns,
     [modelColumns, isProduct],
   );
+  const visibleColumns = useMemo(() => allColumns.filter((c) => !c.hidden), [allColumns]);
+  const [density, setDensity] = useGridDensity(objectTypeId);
+
+  // GRID-P2-01/02 — manager mutations + header drag-resize persist as
+  // quick-pref overrides (SavedView round-trip lands in M4).
+  const applyColumns = (next: GridColumn[]): void => setOverrides(overridesFromColumns(next));
+  const handleColumnResize = (key: string, width: number): void => {
+    applyColumns(setColumnWidth(allColumns, key, clampColumnWidth(width)));
+  };
   const optionLabels = useAttributeOptionLabels(visibleColumns);
   const excelColumns = useMemo(
     () => toExcelColumns(visibleColumns, uiLocale, optionLabels),
@@ -814,6 +831,13 @@ export function UniversalListPage({
 
         {hasVariants ? <VariantsToggle mode={variantsMode} onChange={setVariantsMode} /> : null}
 
+        <ColumnManager
+          columns={allColumns}
+          onChange={applyColumns}
+          onReset={resetOverrides}
+          locale={uiLocale}
+        />
+        <DensityToggle density={density} onChange={setDensity} />
         <ViewModeToggle mode={viewMode} onChange={handleViewModeChange} />
 
         <Button asChild className="h-11 rounded-2xl px-4">
@@ -1003,6 +1027,8 @@ export function UniversalListPage({
         <ExcelLikeGrid<ExcelObjectRow>
           rows={visible.map((row) => toExcelRow(row, visibleColumns, uiLocale, optionLabels))}
           columns={excelColumns}
+          density={density}
+          onColumnResize={handleColumnResize}
           onCommit={(rowIdx, colKey, value) => {
             const row = visible[rowIdx];
             if (row === undefined) return;
@@ -1015,6 +1041,8 @@ export function UniversalListPage({
           columns={visibleColumns}
           optionLabels={optionLabels}
           showMediaColumn={hasMultimedia}
+          density={density}
+          onColumnResize={handleColumnResize}
           selected={selected}
           onToggleSelect={toggleSelect}
           onToggleSelectAll={toggleSelectAll}

--- a/apps/admin/src/lib/grid/excel-columns.tsx
+++ b/apps/admin/src/lib/grid/excel-columns.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 
 import type { ExcelColumn } from '@/components/catalog/excel-like-grid';
 import type { ProductsGridRow } from '@/components/catalog/products-grid';
+import { SyncAggregateIcon } from '@/components/catalog/sync-aggregate-icon';
 
 import { extractGridCellValue, stringifyGridCellValue } from './cell-value';
 import { GridAttributeCell } from './grid-attribute-cell';
@@ -90,7 +91,17 @@ function systemExcelCell(column: GridColumn, locale: string): SystemExcelCell | 
         renderDisplay: (row) => (row.categories ?? []).join(', ') || '—',
       };
     case '__sync':
-      return { key: 'syncStatusAggregate', type: 'text', width: 110, readOnly: true };
+      return {
+        key: 'syncDisplay',
+        type: 'text',
+        width: 110,
+        readOnly: true,
+        renderDisplay: (row) => (
+          <span className="inline-flex items-center">
+            <SyncAggregateIcon status={row.syncStatusAggregate} />
+          </span>
+        ),
+      };
     case '__price':
       return {
         key: 'priceDisplay',
@@ -121,6 +132,7 @@ export function toExcelColumns(
     if (column.source === 'attribute' && !column.key.startsWith('__')) {
       out.push({
         key: `${EXCEL_ATTR_KEY_PREFIX}${column.key}`,
+        modelKey: column.key,
         label,
         type: 'text',
         width: column.width ?? EXCEL_WIDTH_BY_TYPE[column.type] ?? 170,
@@ -139,6 +151,7 @@ export function toExcelColumns(
     if (system === null) continue;
     out.push({
       key: system.key,
+      modelKey: column.key,
       label,
       type: system.type,
       width: column.width ?? system.width,
@@ -169,6 +182,7 @@ export function toExcelRow(
         : '',
     categoriesDisplay: (row.categories ?? []).join(', '),
     priceDisplay: row.price !== null ? `${row.price.amount} ${row.price.currency}` : '',
+    syncDisplay: row.syncStatusAggregate,
   };
   const attrs = (row as ExcelObjectRow).attributesIndexed as
     | Record<string, unknown>

--- a/apps/admin/src/lib/grid/overrides.test.ts
+++ b/apps/admin/src/lib/grid/overrides.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  autoFitWidth,
+  clampColumnWidth,
+  moveColumn,
+  overridesFromColumns,
+  setColumnWidth,
+  toggleColumnHidden,
+} from './overrides';
+import type { GridColumn } from './types';
+
+/** GRID-P2-01/02 (#2389/#2390) — manager state helpers. */
+
+function col(key: string, overrides: Partial<GridColumn> = {}): GridColumn {
+  return {
+    key,
+    source: 'attribute',
+    type: 'text',
+    label: { pl: key },
+    sortable: false,
+    position: 0,
+    hidden: false,
+    ...overrides,
+  };
+}
+
+const COLS = [col('code', { source: 'system' }), col('a'), col('b'), col('c')];
+
+describe('overridesFromColumns', () => {
+  it('emits minimal entries preserving order', () => {
+    const columns = [col('code'), col('a', { hidden: true }), col('b', { width: 200 })];
+    expect(overridesFromColumns(columns)).toEqual([
+      { key: 'code' },
+      { key: 'a', hidden: true },
+      { key: 'b', width: 200 },
+    ]);
+  });
+});
+
+describe('moveColumn', () => {
+  it('swaps with the neighbour and re-numbers positions', () => {
+    const next = moveColumn(COLS, 'b', -1);
+    expect(next.map((column) => column.key)).toEqual(['code', 'b', 'a', 'c']);
+    expect(next.map((column) => column.position)).toEqual([0, 1, 2, 3]);
+  });
+
+  it('never displaces the locked identifier from position 0', () => {
+    expect(moveColumn(COLS, 'a', -1)).toBe(COLS); // would land on code
+    expect(moveColumn(COLS, 'code', 1)).toBe(COLS);
+    expect(moveColumn(COLS, 'c', 1)).toBe(COLS); // out of range
+  });
+});
+
+describe('toggleColumnHidden / setColumnWidth', () => {
+  it('toggles visibility but refuses to hide the identifier', () => {
+    expect(toggleColumnHidden(COLS, 'a')[1]?.hidden).toBe(true);
+    expect(toggleColumnHidden(COLS, 'code')).toBe(COLS);
+  });
+
+  it('sets width on the targeted column only', () => {
+    const next = setColumnWidth(COLS, 'b', 240);
+    expect(next[2]?.width).toBe(240);
+    expect(next[1]?.width).toBeUndefined();
+  });
+});
+
+describe('clampColumnWidth / autoFitWidth', () => {
+  it('clamps to the usable range', () => {
+    expect(clampColumnWidth(10)).toBe(60);
+    expect(clampColumnWidth(9000)).toBe(640);
+    expect(clampColumnWidth(240.4)).toBe(240);
+  });
+
+  it('auto-fit grows with content and stays clamped', () => {
+    const narrow = autoFitWidth('Ab', ['x', 'yy']);
+    const wide = autoFitWidth('Label', ['some very long attribute value in a cell']);
+    expect(narrow).toBeLessThan(wide);
+    expect(wide).toBeLessThanOrEqual(640);
+    expect(narrow).toBeGreaterThanOrEqual(60);
+  });
+});

--- a/apps/admin/src/lib/grid/overrides.ts
+++ b/apps/admin/src/lib/grid/overrides.ts
@@ -1,0 +1,67 @@
+import type { GridColumn, GridColumnOverride } from './types';
+
+/**
+ * GRID-P2-01 (#2389) — serialises the manager's working state back into
+ * the override list `useGridColumns` persists. Every column gets an
+ * entry (array order == column order); `hidden`/`width`/`pinned` are
+ * emitted only when set so the JSON stays minimal and the resolver's
+ * defaults keep applying.
+ */
+export function overridesFromColumns(columns: GridColumn[]): GridColumnOverride[] {
+  return columns.map((column) => ({
+    key: column.key,
+    ...(column.hidden ? { hidden: true } : {}),
+    ...(column.width !== undefined ? { width: column.width } : {}),
+    ...(column.pinned !== undefined ? { pinned: column.pinned } : {}),
+  }));
+}
+
+/** Identifier column stays visible and first — the anchor of every row. */
+export const LOCKED_COLUMN_KEY = 'code';
+
+export function moveColumn(columns: GridColumn[], key: string, delta: -1 | 1): GridColumn[] {
+  const index = columns.findIndex((column) => column.key === key);
+  const target = index + delta;
+  if (index <= 0 && delta === -1) return columns;
+  if (index === -1 || target < 0 || target >= columns.length) return columns;
+  // Never displace the locked identifier from position 0.
+  if (columns[target]?.key === LOCKED_COLUMN_KEY || key === LOCKED_COLUMN_KEY) return columns;
+  const next = [...columns];
+  const [moved] = next.splice(index, 1);
+  if (moved === undefined) return columns;
+  next.splice(target, 0, moved);
+  return next.map((column, position) => ({ ...column, position }));
+}
+
+export function toggleColumnHidden(columns: GridColumn[], key: string): GridColumn[] {
+  if (key === LOCKED_COLUMN_KEY) return columns;
+  return columns.map((column) =>
+    column.key === key ? { ...column, hidden: !column.hidden } : column,
+  );
+}
+
+export function setColumnWidth(
+  columns: GridColumn[],
+  key: string,
+  width: number | undefined,
+): GridColumn[] {
+  return columns.map((column) => (column.key === key ? { ...column, width } : column));
+}
+
+/** Clamp for drag-resize — degenerate widths make cells unusable. */
+export const MIN_COLUMN_WIDTH = 60;
+export const MAX_COLUMN_WIDTH = 640;
+
+export function clampColumnWidth(width: number): number {
+  return Math.round(Math.min(MAX_COLUMN_WIDTH, Math.max(MIN_COLUMN_WIDTH, width)));
+}
+
+/**
+ * GRID-P2-02 — double-click auto-fit heuristic: approximate content
+ * width from the header label and a sample of cell strings (no canvas
+ * measurement — ballpark is enough for a convenience gesture).
+ */
+export function autoFitWidth(label: string, samples: string[]): number {
+  const longest = Math.max(label.length, ...samples.map((sample) => sample.length), 4);
+  return clampColumnWidth(longest * 7.5 + 32);
+}

--- a/apps/admin/src/lib/grid/use-density.ts
+++ b/apps/admin/src/lib/grid/use-density.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * GRID-P2-03 (#2391) — row density for the list views. Persisted per
+ * ObjectType next to the other quick-prefs
+ * (`pim.objectList.{id}.density`); the shape is ready for the
+ * SavedView.config round-trip in M4.
+ */
+export type GridDensity = 'normal' | 'compact';
+
+function storageKey(objectTypeId: string): string {
+  return `pim.objectList.${objectTypeId}.density`;
+}
+
+function read(objectTypeId: string | undefined): GridDensity {
+  if (typeof window === 'undefined' || objectTypeId === undefined) return 'normal';
+  return window.localStorage.getItem(storageKey(objectTypeId)) === 'compact' ? 'compact' : 'normal';
+}
+
+export function useGridDensity(
+  objectTypeId: string | undefined,
+): [GridDensity, (next: GridDensity) => void] {
+  const [density, setDensityState] = useState<GridDensity>(() => read(objectTypeId));
+
+  useEffect(() => {
+    setDensityState(read(objectTypeId));
+  }, [objectTypeId]);
+
+  const setDensity = useCallback(
+    (next: GridDensity) => {
+      setDensityState(next);
+      if (typeof window === 'undefined' || objectTypeId === undefined) return;
+      try {
+        window.localStorage.setItem(storageKey(objectTypeId), next);
+      } catch {
+        // Quota/private mode — session-only.
+      }
+    },
+    [objectTypeId],
+  );
+
+  return [density, setDensity];
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -4148,6 +4148,23 @@
       "no": "No",
       "assets_one": "{{count}} file",
       "assets_other": "{{count}} files"
-    }
+    },
+    "manager": {
+      "trigger": "Columns",
+      "title": "Manage columns",
+      "search_placeholder": "Search columns…",
+      "list_aria": "List columns",
+      "reset": "Reset to defaults",
+      "locked": "locked",
+      "drag_aria": "Drag to reorder: {{label}}",
+      "move_up_aria": "Move up: {{label}}",
+      "move_down_aria": "Move down: {{label}}"
+    },
+    "density": {
+      "normal": "Comfort",
+      "compact": "Compact",
+      "aria": "Row density"
+    },
+    "resize_aria": "Resize column {{label}}"
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -4170,6 +4170,23 @@
       "assets_few": "{{count}} pliki",
       "assets_many": "{{count}} plików",
       "assets_other": "{{count}} pliku"
-    }
+    },
+    "manager": {
+      "trigger": "Kolumny",
+      "title": "Zarządzaj kolumnami",
+      "search_placeholder": "Szukaj kolumny…",
+      "list_aria": "Kolumny listy",
+      "reset": "Resetuj do domyślnych",
+      "locked": "stała",
+      "drag_aria": "Przeciągnij, aby zmienić kolejność: {{label}}",
+      "move_up_aria": "Przesuń wyżej: {{label}}",
+      "move_down_aria": "Przesuń niżej: {{label}}"
+    },
+    "density": {
+      "normal": "Komfort",
+      "compact": "Kompakt",
+      "aria": "Gęstość wierszy"
+    },
+    "resize_aria": "Zmień szerokość kolumny {{label}}"
   }
 }


### PR DESCRIPTION
## Co (PR 3 wg strategii PR epiku GRID — bundel P2-01 + P2-02 + P2-03)

### GRID-P2-01 — column manager (Closes #2389)
- Przycisk **„Kolumny"** w toolbarze listy → sheet: checkbox show/hide, **drag-reorder** (@dnd-kit pointer + keyboard sensor) **+ jawne przyciski góra/dół** (a11y + deterministyczne E2E), search, „Resetuj do domyślnych".
- Operuje na pełnym modelu (ukryte kolumny widoczne na liście); identyfikator **locked** (zawsze widoczny, zawsze pierwszy — guard także w `moveColumn`).
- Zmiany natychmiast do localStorage (`overridesFromColumns`); oba widoki reagują live.
- **Świadome odejście:** NIE wydzielam prymitywów z `ColumnPickerV2` — inna powierzchnia (płaska lista vs two-pane), współdzielenie internals sprzęgłoby export wizard z churnem grida; kopiuję tylko setup sensorów dnd-kit. Export wizard nietknięty.

### GRID-P2-02 — resize + sticky identyfikator (Closes #2390)
- Drag-resize na krawędzi nagłówka w **obu widokach** (clamp 60–640 px, live width lokalnie — commit do overrides na pointerup), double-click = auto-fit (heurystyka z labelki + próbki 25 wierszy).
- Identyfikator sticky przy scrollu poziomym: CSS sticky (grid view: checkbox+miniatura+SKU z bg-inherit — podąża za hover/selected) oraz **pinning w wirtualizerze Excela** (kolumna 0 zawsze zamontowana + korekta lead-spacera — inaczej sticky odmontowywałby się przy przewinięciu).
- W Excelu resize commituje po `modelKey` (mapowanie klucz-excelowy → klucz modelu).

### GRID-P2-03 — density (Closes #2391)
- Toggle Komfort/Kompakt (segmented, jak ViewModeToggle), persist per ObjectType, działa w obu widokach; compact tnie wysokość wiersza >25%.

### Bonus (finding z live smoke M1)
Kolumna Kanały w Excelu renderuje ikonę agregatu sync zamiast surowego `gray`.

## Bramki
- Lokalnie: vitest **186/186** (7 nowych — helpery overrides), tsc 0, biome 0, build OK, max-lines guard na baseline.
- **Live E2E na pim.localhost (branch podpięty pod serwowane drzewo): 3/3 zielone** — `2389-column-manager.spec.ts` (hide→reload→hidden; reorder persist; reset; drag-resize persist + sticky przy scrollLeft=400; density −>25% + persist). Lokalny przebieg wyłapał przed CI: reorder za ukrytą kolumnę (niewidoczna zmiana) i za płytki compact.
- Spec `2387` lokalnie pada tylko na ENOTFOUND (page.request z Node bez /etc/hosts) — na CI zielony.

**Source of truth:** [Project Plan/feature-grid-tickets.md](https://github.com/malipie/PIM/blob/main/Project%20Plan/feature-grid-tickets.md)

Closes #2389
Closes #2390
Closes #2391

🤖 Generated with [Claude Code](https://claude.com/claude-code)