### PR TITLE
feat(catalog): validate SavedView config + per-ObjectType default + system protection (GRID-P4-01 + P4-03)

### DIFF
--- a/apps/api/src/Catalog/Application/SavedView/SavedViewConfigValidator.php
+++ b/apps/api/src/Catalog/Application/SavedView/SavedViewConfigValidator.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\SavedView;
+
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * GRID-P4-01 (#2394) — validates the structured `SavedView.config`
+ * envelope the grid persists (filters + columns + sort + density +
+ * variants mode + page size).
+ *
+ * `config` used to be an unvalidated JSONB blob ("operator
+ * responsibility"); once the grid round-trips columns/sort/density
+ * through it (GRID-P4-02), a malformed entry would break the list
+ * render for the whole view. This validator is the guard: unknown
+ * top-level keys and wrong value types fail with RFC 7807 Problem
+ * Details BEFORE the row is written.
+ *
+ * Backward compatible: every key is optional, so legacy configs
+ * (`{filters, variants_mode, page_size}`) validate unchanged. The
+ * canonical shape is documented in docs/api/jsonb-schemas.md.
+ */
+final class SavedViewConfigValidator
+{
+    private const array ALLOWED_KEYS = [
+        'filters',
+        'sort',
+        'columns',
+        'density',
+        'variants_mode',
+        'page_size',
+    ];
+
+    private const array ALLOWED_DENSITY = ['compact', 'normal'];
+    private const array ALLOWED_VARIANTS_MODE = ['tree', 'flat'];
+    private const array ALLOWED_SORT_DIR = ['asc', 'desc'];
+
+    /**
+     * @param array<string, mixed> $config
+     *
+     * @throws BadRequestHttpException on any unknown key or type mismatch
+     */
+    public function validate(array $config): void
+    {
+        foreach (array_keys($config) as $key) {
+            if (!\in_array($key, self::ALLOWED_KEYS, true)) {
+                throw new BadRequestHttpException(\sprintf('Unknown config key "%s".', $key));
+            }
+        }
+
+        if (\array_key_exists('filters', $config) && !\is_array($config['filters'])) {
+            throw new BadRequestHttpException('config.filters must be an object or array.');
+        }
+
+        if (\array_key_exists('sort', $config)) {
+            $this->validateSort($config['sort']);
+        }
+
+        if (\array_key_exists('columns', $config)) {
+            $this->validateColumns($config['columns']);
+        }
+
+        if (\array_key_exists('density', $config)
+            && !\in_array($config['density'], self::ALLOWED_DENSITY, true)) {
+            throw new BadRequestHttpException('config.density must be "compact" or "normal".');
+        }
+
+        if (\array_key_exists('variants_mode', $config)
+            && !\in_array($config['variants_mode'], self::ALLOWED_VARIANTS_MODE, true)) {
+            throw new BadRequestHttpException('config.variants_mode must be "tree" or "flat".');
+        }
+
+        if (\array_key_exists('page_size', $config)
+            && (!\is_int($config['page_size']) || $config['page_size'] < 1)) {
+            throw new BadRequestHttpException('config.page_size must be a positive integer.');
+        }
+    }
+
+    private function validateSort(mixed $sort): void
+    {
+        if (!\is_array($sort)) {
+            throw new BadRequestHttpException('config.sort must be an object.');
+        }
+        if (!isset($sort['key']) || !\is_string($sort['key']) || '' === $sort['key']) {
+            throw new BadRequestHttpException('config.sort.key must be a non-empty string.');
+        }
+        if (!isset($sort['dir']) || !\in_array($sort['dir'], self::ALLOWED_SORT_DIR, true)) {
+            throw new BadRequestHttpException('config.sort.dir must be "asc" or "desc".');
+        }
+    }
+
+    private function validateColumns(mixed $columns): void
+    {
+        if (!\is_array($columns)) {
+            throw new BadRequestHttpException('config.columns must be an array.');
+        }
+        foreach ($columns as $column) {
+            if (!\is_array($column) || !isset($column['key']) || !\is_string($column['key']) || '' === $column['key']) {
+                throw new BadRequestHttpException('Each config.columns entry needs a non-empty string "key".');
+            }
+            if (\array_key_exists('width', $column)
+                && (!\is_int($column['width']) || $column['width'] < 1)) {
+                throw new BadRequestHttpException('config.columns[].width must be a positive integer.');
+            }
+            if (\array_key_exists('hidden', $column) && !\is_bool($column['hidden'])) {
+                throw new BadRequestHttpException('config.columns[].hidden must be a boolean.');
+            }
+            if (\array_key_exists('pinned', $column) && !\is_bool($column['pinned'])) {
+                throw new BadRequestHttpException('config.columns[].pinned must be a boolean.');
+            }
+        }
+    }
+}

--- a/apps/api/src/Catalog/Presentation/Controller/SavedViewController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/SavedViewController.php
@@ -109,11 +109,7 @@ final class SavedViewController
         if (!\is_string($resource) || '' === $resource) {
             $resource = 'products';
         }
-        $config = $body['config'] ?? [];
-        if (!\is_array($config)) {
-            throw new BadRequestHttpException('config must be an object.');
-        }
-        /* @var array<string, mixed> $config */
+        $config = $this->asConfigArray($body['config'] ?? []);
         $this->configValidator->validate($config);
         $isDefault = (bool) ($body['is_default'] ?? false);
         $description = $body['description'] ?? null;
@@ -162,9 +158,8 @@ final class SavedViewController
         if (\array_key_exists('description', $body)) {
             $view->changeDescription(\is_string($body['description']) ? $body['description'] : null);
         }
-        if (\array_key_exists('config', $body) && \is_array($body['config'])) {
-            /** @var array<string, mixed> $cfg */
-            $cfg = $body['config'];
+        if (\array_key_exists('config', $body)) {
+            $cfg = $this->asConfigArray($body['config']);
             $this->configValidator->validate($cfg);
             $view->updateConfig($cfg);
         }
@@ -280,6 +275,27 @@ final class SavedViewController
         if ($view->isSystem()) {
             throw new AccessDeniedHttpException('System views cannot be modified.');
         }
+    }
+
+    /**
+     * JSON objects decode to string-keyed arrays, but PHPStan sees
+     * array<mixed, mixed>; this narrows (and rejects non-objects) so the
+     * validator and entity keep their array<string, mixed> contract
+     * without a fragile inline @var (cs-fixer downgrades those).
+     *
+     * @return array<string, mixed>
+     */
+    private function asConfigArray(mixed $config): array
+    {
+        if (!\is_array($config)) {
+            throw new BadRequestHttpException('config must be an object.');
+        }
+        $out = [];
+        foreach ($config as $key => $value) {
+            $out[(string) $key] = $value;
+        }
+
+        return $out;
     }
 
     private function resolveObjectType(mixed $objectTypeId): ?ObjectType

--- a/apps/api/src/Catalog/Presentation/Controller/SavedViewController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/SavedViewController.php
@@ -4,14 +4,19 @@ declare(strict_types=1);
 
 namespace App\Catalog\Presentation\Controller;
 
+use App\Catalog\Application\SavedView\SavedViewConfigValidator;
+use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\Entity\SavedView;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
 use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Identity\Contracts\Auth\CurrentUserProvider;
 use App\Shared\Application\TenantContext;
 use DateTimeInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
@@ -31,13 +36,15 @@ use Symfony\Component\Uid\Uuid;
  * any other view of the same `(tenant, resource)` is cleared first so
  * only one default exists per resource.
  *
- * **MVP scope reduction:** per-user owner scoping (the `user_id`
- * column on the entity) is wired through the schema but NOT enforced
- * at the controller layer in this slice. Owner-only writes + system
- * view immutability + Faza 1 ADR-013 permissions land together in
- * the follow-up that introduces the cross-bundle `CurrentUserProvider`
- * contract (Catalog cannot depend on the Identity entity directly per
- * Deptrac rules).
+ * GRID-P4-01 (#2394) — `config` is validated on write against the
+ * canonical grid envelope (unknown keys / wrong types → 400).
+ *
+ * GRID-P4-03 (#2396) — views are owned by `user_id` (resolved from
+ * `CurrentUserProvider`); `user_id IS NULL` marks a seeded SYSTEM view
+ * that PATCH / DELETE refuse with 403. The default flag is unique per
+ * `(tenant, object_type_id, user_id)` so two ObjectTypes keep
+ * independent defaults. Per-user list separation stays out of MVP
+ * (all tenant views are still listed).
  */
 final class SavedViewController
 {
@@ -46,6 +53,9 @@ final class SavedViewController
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly TenantContext $tenantContext,
+        private readonly SavedViewConfigValidator $configValidator,
+        private readonly CurrentUserProvider $currentUser,
+        private readonly ObjectTypeRepositoryInterface $objectTypes,
     ) {
     }
 
@@ -103,9 +113,11 @@ final class SavedViewController
         if (!\is_array($config)) {
             throw new BadRequestHttpException('config must be an object.');
         }
-        /** @var array<string, mixed> $config */
+        /* @var array<string, mixed> $config */
+        $this->configValidator->validate($config);
         $isDefault = (bool) ($body['is_default'] ?? false);
         $description = $body['description'] ?? null;
+        $objectType = $this->resolveObjectType($body['object_type_id'] ?? null);
 
         $slug = $this->generateUniqueSlug($name, $tenant->getId());
 
@@ -114,12 +126,16 @@ final class SavedViewController
             name: trim($name),
             resource: $resource,
             config: $config,
+            userId: $this->currentUser->userId(),
         );
+        if (null !== $objectType) {
+            $view->assignObjectType($objectType);
+        }
         if (\is_string($description)) {
             $view->changeDescription($description);
         }
         if ($isDefault) {
-            $this->clearOtherDefaults($tenant->getId(), $resource);
+            $this->clearOtherDefaults($tenant->getId(), $resource, $objectType, $view->getUserId());
             $view->markDefault(true);
         }
 
@@ -135,6 +151,7 @@ final class SavedViewController
     public function patch(string $id, Request $request): JsonResponse
     {
         $view = $this->mustFind($id);
+        $this->assertMutable($view);
 
         /** @var array<string, mixed> $body */
         $body = json_decode($request->getContent(), true) ?? [];
@@ -148,6 +165,7 @@ final class SavedViewController
         if (\array_key_exists('config', $body) && \is_array($body['config'])) {
             /** @var array<string, mixed> $cfg */
             $cfg = $body['config'];
+            $this->configValidator->validate($cfg);
             $view->updateConfig($cfg);
         }
         if (\array_key_exists('is_default', $body)) {
@@ -155,7 +173,13 @@ final class SavedViewController
             if ($isDefault) {
                 $tenant = $view->getTenant();
                 if (null !== $tenant) {
-                    $this->clearOtherDefaults($tenant->getId(), $view->getResource(), exceptId: $view->getId());
+                    $this->clearOtherDefaults(
+                        $tenant->getId(),
+                        $view->getResource(),
+                        $view->getObjectType(),
+                        $view->getUserId(),
+                        exceptId: $view->getId(),
+                    );
                 }
             }
             $view->markDefault($isDefault);
@@ -172,6 +196,7 @@ final class SavedViewController
     public function delete(string $id): Response
     {
         $view = $this->mustFind($id);
+        $this->assertMutable($view);
         $this->em->remove($view);
         $this->em->flush();
 
@@ -208,8 +233,13 @@ final class SavedViewController
         return trim($ascii, '-');
     }
 
-    private function clearOtherDefaults(Uuid $tenantId, string $resource, ?Uuid $exceptId = null): void
-    {
+    private function clearOtherDefaults(
+        Uuid $tenantId,
+        string $resource,
+        ?ObjectType $objectType,
+        ?Uuid $userId,
+        ?Uuid $exceptId = null,
+    ): void {
         $qb = $this->em->getRepository(SavedView::class)->createQueryBuilder('v')
             ->update()
             ->set('v.isDefault', ':false')
@@ -221,11 +251,51 @@ final class SavedViewController
             ->setParameter('tenant', $tenantId)
             ->setParameter('resource', $resource);
 
+        // GRID-P4-03 — scope the default per ObjectType and owner so two
+        // ObjectTypes (and two users) keep independent defaults.
+        if (null !== $objectType) {
+            $qb->andWhere('v.objectType = :ot')->setParameter('ot', $objectType->getId());
+        } else {
+            $qb->andWhere('v.objectType IS NULL');
+        }
+        if (null !== $userId) {
+            $qb->andWhere('v.userId = :user')->setParameter('user', $userId);
+        } else {
+            $qb->andWhere('v.userId IS NULL');
+        }
+
         if (null !== $exceptId) {
             $qb->andWhere('v.id != :except')->setParameter('except', $exceptId);
         }
 
         $qb->getQuery()->execute();
+    }
+
+    /**
+     * GRID-P4-03 — a seeded system view (`user_id IS NULL`) is a shared
+     * template; users cannot rename, reconfigure or delete it.
+     */
+    private function assertMutable(SavedView $view): void
+    {
+        if ($view->isSystem()) {
+            throw new AccessDeniedHttpException('System views cannot be modified.');
+        }
+    }
+
+    private function resolveObjectType(mixed $objectTypeId): ?ObjectType
+    {
+        if (null === $objectTypeId) {
+            return null;
+        }
+        if (!\is_string($objectTypeId) || !Uuid::isValid($objectTypeId)) {
+            throw new BadRequestHttpException('object_type_id must be a valid UUID.');
+        }
+        $objectType = $this->objectTypes->findById(Uuid::fromString($objectTypeId));
+        if (null === $objectType) {
+            throw new BadRequestHttpException(\sprintf('ObjectType "%s" was not found.', $objectTypeId));
+        }
+
+        return $objectType;
     }
 
     private function mustFind(string $id): SavedView
@@ -249,6 +319,7 @@ final class SavedViewController
             'name' => $view->getName(),
             'description' => $view->getDescription(),
             'resource' => $view->getResource(),
+            'object_type_id' => $view->getObjectType()?->getId()->toRfc4122(),
             'config' => $view->getConfig(),
             'is_default' => $view->isDefault(),
             'is_system' => $view->isSystem(),

--- a/apps/api/tests/Api/Catalog/SavedViewConfigApiTest.php
+++ b/apps/api/tests/Api/Catalog/SavedViewConfigApiTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\Entity\SavedView;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * GRID-P4-01/03 (#2394/#2396) — structured SavedView.config validation,
+ * per-ObjectType default independence, and system-view immutability.
+ */
+final class SavedViewConfigApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function acceptsStructuredConfigAndRejectsUnknownKeysAndTypes(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $ok = $client->request('POST', '/api/saved-views', [
+            'json' => [
+                'name' => 'Grid config '.bin2hex(random_bytes(3)),
+                'resource' => 'products',
+                'config' => [
+                    'filters' => ['brand' => 'Nike'],
+                    'sort' => ['key' => 'price', 'dir' => 'desc'],
+                    'columns' => [['key' => 'code'], ['key' => 'brand', 'width' => 200, 'hidden' => false]],
+                    'density' => 'compact',
+                    'variants_mode' => 'flat',
+                    'page_size' => 50,
+                ],
+            ],
+        ]);
+        self::assertSame(201, $ok->getStatusCode(), $ok->getContent(false));
+
+        $unknownKey = $client->request('POST', '/api/saved-views', [
+            'json' => [
+                'name' => 'Bad '.bin2hex(random_bytes(3)),
+                'config' => ['totally_unknown' => 1],
+            ],
+        ]);
+        self::assertSame(400, $unknownKey->getStatusCode());
+
+        $badSort = $client->request('POST', '/api/saved-views', [
+            'json' => [
+                'name' => 'Bad sort '.bin2hex(random_bytes(3)),
+                'config' => ['sort' => ['key' => 'price', 'dir' => 'sideways']],
+            ],
+        ]);
+        self::assertSame(400, $badSort->getStatusCode());
+
+        $badColumn = $client->request('POST', '/api/saved-views', [
+            'json' => [
+                'name' => 'Bad col '.bin2hex(random_bytes(3)),
+                'config' => ['columns' => [['width' => 100]]],
+            ],
+        ]);
+        self::assertSame(400, $badColumn->getStatusCode());
+    }
+
+    #[Test]
+    public function legacyConfigWithoutColumnsStillValidates(): void
+    {
+        $client = $this->authenticatedClient();
+
+        // The shape the FE shipped before GRID (filters + variants_mode +
+        // page_size, no columns/sort/density) must keep working.
+        $legacy = $client->request('POST', '/api/saved-views', [
+            'json' => [
+                'name' => 'Legacy '.bin2hex(random_bytes(3)),
+                'config' => ['filters' => ['status' => 'published'], 'variants_mode' => 'tree', 'page_size' => 20],
+            ],
+        ]);
+        self::assertSame(201, $legacy->getStatusCode(), $legacy->getContent(false));
+    }
+
+    #[Test]
+    public function defaultIsIndependentPerObjectType(): void
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $this->getContainer()->get(TenantContext::class)->set($tenant);
+        $repo = $this->getContainer()->get(ObjectTypeRepositoryInterface::class);
+        $product = $repo->findBuiltInByKind(ObjectKind::Product, $tenant);
+        $category = $repo->findBuiltInByKind(ObjectKind::Category, $tenant);
+        \assert(null !== $product && null !== $category);
+        $this->getContainer()->get(TenantContext::class)->clear();
+
+        $client = $this->authenticatedClient();
+
+        $productView = $client->request('POST', '/api/saved-views', [
+            'json' => [
+                'name' => 'Prod default '.bin2hex(random_bytes(3)),
+                'resource' => 'products',
+                'object_type_id' => $product->getId()->toRfc4122(),
+                'is_default' => true,
+                'config' => [],
+            ],
+        ])->toArray();
+
+        $categoryView = $client->request('POST', '/api/saved-views', [
+            'json' => [
+                'name' => 'Cat default '.bin2hex(random_bytes(3)),
+                'resource' => 'products',
+                'object_type_id' => $category->getId()->toRfc4122(),
+                'is_default' => true,
+                'config' => [],
+            ],
+        ])->toArray();
+
+        // Setting the category default must NOT clear the product default —
+        // they are scoped by object_type_id. Re-fetch via the list.
+        $byId = $this->indexViews($client->request('GET', '/api/saved-views?resource=products')->toArray());
+        $productId = $productView['id'];
+        $categoryId = $categoryView['id'];
+        self::assertIsString($productId);
+        self::assertIsString($categoryId);
+        self::assertTrue($byId[$productId]['is_default'] ?? null, 'product default survived');
+        self::assertTrue($byId[$categoryId]['is_default'] ?? null, 'category default set');
+        self::assertSame($product->getId()->toRfc4122(), $byId[$productId]['object_type_id'] ?? null);
+    }
+
+    /**
+     * @param array<mixed> $payload
+     *
+     * @return array<string, array<mixed>>
+     */
+    private function indexViews(array $payload): array
+    {
+        $views = $payload['views'] ?? [];
+        self::assertIsArray($views);
+        $byId = [];
+        foreach ($views as $view) {
+            if (\is_array($view) && \is_string($view['id'] ?? null)) {
+                $byId[$view['id']] = $view;
+            }
+        }
+
+        return $byId;
+    }
+
+    #[Test]
+    public function systemViewsCannotBeModifiedOrDeleted(): void
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $this->getContainer()->get(TenantContext::class)->set($tenant);
+
+        // Seed a system view (user_id IS NULL) directly.
+        $system = new SavedView(
+            slug: 'system-'.bin2hex(random_bytes(3)),
+            name: 'System Default',
+            resource: 'products',
+            config: [],
+            userId: null,
+        );
+        $system->assignTenant($tenant);
+        $em = $this->em();
+        $em->persist($system);
+        $em->flush();
+        $id = $system->getId()->toRfc4122();
+        $this->getContainer()->get(TenantContext::class)->clear();
+
+        $client = $this->authenticatedClient();
+
+        $patch = $client->request('PATCH', '/api/saved-views/'.$id, [
+            'json' => ['name' => 'hacked'],
+        ]);
+        self::assertSame(403, $patch->getStatusCode());
+
+        $delete = $client->request('DELETE', '/api/saved-views/'.$id);
+        self::assertSame(403, $delete->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Co (PR 5 wg strategii — bundel P4-01 + P4-03, oba BE)

### GRID-P4-01 — walidacja config (Closes #2394)
- `SavedViewConfigValidator`: kanoniczny kształt `{filters?, sort?:{key,dir}, columns?:[{key,width?,hidden?,pinned?}], density?, variants_mode?, page_size?}` walidowany na POST + PATCH.
- Nieznany klucz top-level / zły typ → **400 RFC 7807** przed zapisem. Każdy klucz opcjonalny → legacy `{filters, variants_mode, page_size}` waliduje się bez zmian.

### GRID-P4-03 — default per ObjectType + ochrona system views (Closes #2396)
- Widoki owner-scoped (`user_id` z `CurrentUserProvider`); **system view (`user_id IS NULL`) → PATCH/DELETE 403**.
- `is_default` unikalny per `(tenant, object_type_id, user_id)` → dwa ObjectType trzymają niezależne defaulty.
- `create()` przyjmuje `object_type_id` (walidacja UUID + istnienie); `serialize()` go eksponuje.

## Świadome odejścia
- Per-user list separation poza MVP — lista nadal zwraca wszystkie widoki tenanta. Widoki utworzone przed zmianą mają `user_id=null` → stają się szablonami systemowymi (legacy dev views).
- Seed widoku „Domyślny" per built-in ObjectType — follow-up (ten PR dostarcza mechanizm + ochronę).

## Bramki
- PHPStan max 0 (kontener), cs-fixer czysto, ApiTestCase `SavedViewConfigApiTest` (walidacja happy+400, legacy compat, default per-OT, system view 403).
- FE round-trip (P4-02) w osobnym PR (stackowany po tym + P5).

**Source of truth:** [Project Plan/feature-grid-tickets.md](https://github.com/malipie/PIM/blob/main/Project%20Plan/feature-grid-tickets.md)

Closes #2394
Closes #2396

🤖 Generated with [Claude Code](https://claude.com/claude-code)
