### PR TITLE
feat(catalog): expose per-column editable flag in list-schema (GRID-P6-01)

### DIFF
--- a/apps/admin/src/hooks/use-list-schema.ts
+++ b/apps/admin/src/hooks/use-list-schema.ts
@@ -27,6 +27,8 @@ export interface ListSchemaColumn {
   label: Record<string, string>;
   position: number;
   sortable: boolean;
+  /** GRID-P6-01 — inline-editable in the Excel view (type + edit permission). */
+  editable?: boolean;
   system: boolean;
   /** GRID-P3-01 — full mode only: `show_in_list` default flag. */
   default?: boolean;

--- a/apps/admin/src/lib/grid/excel-columns.test.tsx
+++ b/apps/admin/src/lib/grid/excel-columns.test.tsx
@@ -18,6 +18,7 @@ function col(overrides: Partial<GridColumn>): GridColumn {
     type: 'text',
     label: { pl: 'Atrybut' },
     sortable: false,
+    editable: false,
     position: 0,
     hidden: false,
     ...overrides,

--- a/apps/admin/src/lib/grid/grid-attribute-cell.test.tsx
+++ b/apps/admin/src/lib/grid/grid-attribute-cell.test.tsx
@@ -17,6 +17,7 @@ function column(overrides: Partial<GridColumn>): GridColumn {
     type: 'text',
     label: { pl: 'Atrybut' },
     sortable: false,
+    editable: false,
     position: 0,
     hidden: false,
     ...overrides,

--- a/apps/admin/src/lib/grid/overrides.test.ts
+++ b/apps/admin/src/lib/grid/overrides.test.ts
@@ -19,6 +19,7 @@ function col(key: string, overrides: Partial<GridColumn> = {}): GridColumn {
     type: 'text',
     label: { pl: key },
     sortable: false,
+    editable: false,
     position: 0,
     hidden: false,
     ...overrides,

--- a/apps/admin/src/lib/grid/resolve-grid-columns.ts
+++ b/apps/admin/src/lib/grid/resolve-grid-columns.ts
@@ -22,6 +22,7 @@ export const FALLBACK_GRID_COLUMNS: GridColumn[] = [
     type: 'system_identifier',
     label: { pl: 'Kod', en: 'Code' },
     sortable: true,
+    editable: false,
     position: 0,
     hidden: false,
   },
@@ -31,6 +32,7 @@ export const FALLBACK_GRID_COLUMNS: GridColumn[] = [
     type: 'system_status',
     label: { pl: 'Status', en: 'Status' },
     sortable: true,
+    editable: false,
     position: 1,
     hidden: false,
   },
@@ -40,6 +42,7 @@ export const FALLBACK_GRID_COLUMNS: GridColumn[] = [
     type: 'system_completeness',
     label: { pl: 'Kompletność', en: 'Completeness' },
     sortable: true,
+    editable: false,
     position: 2,
     hidden: false,
   },
@@ -49,6 +52,7 @@ export const FALLBACK_GRID_COLUMNS: GridColumn[] = [
     type: 'system_date',
     label: { pl: 'Zmodyfikowano', en: 'Modified' },
     sortable: true,
+    editable: false,
     position: 3,
     hidden: false,
   },
@@ -92,6 +96,7 @@ export function resolveGridColumns(
       type: column.type,
       label: column.label ?? {},
       sortable: Boolean(column.sortable),
+      editable: column.editable === true,
       position: base.size,
       // GRID-P3-01 full-schema mode: non-default attributes (no
       // `show_in_list`) start hidden — the manager reveals them.
@@ -113,6 +118,7 @@ export function resolveGridColumns(
       type: seed.type,
       label: seed.label ?? {},
       sortable: Boolean(seed.sortable),
+      editable: false,
       position: 0, // re-numbered below
       hidden: false,
     };

--- a/apps/admin/src/lib/grid/types.ts
+++ b/apps/admin/src/lib/grid/types.ts
@@ -26,6 +26,8 @@ export interface GridColumn {
   /** Localized label map (`{pl: ..., en: ...}`) straight from the schema. */
   label: Record<string, string>;
   sortable: boolean;
+  /** GRID-P6-01 — inline-editable in the Excel view. */
+  editable: boolean;
   /** Resolved display order (0-based, contiguous). */
   position: number;
   hidden: boolean;

--- a/apps/api/src/Catalog/Application/Query/GetObjectTypeListSchema/GetObjectTypeListSchemaHandler.php
+++ b/apps/api/src/Catalog/Application/Query/GetObjectTypeListSchema/GetObjectTypeListSchemaHandler.php
@@ -130,7 +130,7 @@ final readonly class GetObjectTypeListSchemaHandler
      * @param list<ObjectTypeAttribute>                                                                   $listJunctions
      * @param array<string, array{id: string, code: string, label: array<string, string>, position: int}> $groupsByAttributeId
      *
-     * @return list<array{key: string, type: string, label: array<string, string>, position: int, sortable: bool, system: bool, default?: bool, group?: array{id: string, code: string, label: array<string, string>, position: int}|null}>
+     * @return list<array{key: string, type: string, label: array<string, string>, position: int, sortable: bool, editable: bool, system: bool, default?: bool, group?: array{id: string, code: string, label: array<string, string>, position: int}|null}>
      */
     private function buildColumns(array $listJunctions, bool $full = false, array $groupsByAttributeId = []): array
     {
@@ -142,6 +142,7 @@ final readonly class GetObjectTypeListSchemaHandler
                 'position' => 0,
                 'sortable' => true,
                 'system' => true,
+                'editable' => false,
             ],
             [
                 'key' => 'status',
@@ -150,6 +151,7 @@ final readonly class GetObjectTypeListSchemaHandler
                 'position' => 1,
                 'sortable' => true,
                 'system' => true,
+                'editable' => false,
             ],
             [
                 'key' => 'completeness',
@@ -158,6 +160,7 @@ final readonly class GetObjectTypeListSchemaHandler
                 'position' => 2,
                 'sortable' => true,
                 'system' => true,
+                'editable' => false,
             ],
             [
                 'key' => 'updatedAt',
@@ -166,6 +169,7 @@ final readonly class GetObjectTypeListSchemaHandler
                 'position' => 3,
                 'sortable' => true,
                 'system' => true,
+                'editable' => false,
             ],
         ];
 
@@ -181,6 +185,10 @@ final readonly class GetObjectTypeListSchemaHandler
                 // non-scopable types; enforced independently by the
                 // list endpoint in GRID-P5-02.
                 'sortable' => $this->isSortableAttribute($attribute),
+                // GRID-P6-01 (#2400) — inline-editable = user may edit
+                // (3-state RBAC) AND the type has an inline editor. Media /
+                // relation / multiselect stay read-only in the grid (MVP).
+                'editable' => $this->isEditableAttribute($attribute),
                 'system' => false,
             ];
             if ($full) {
@@ -213,6 +221,34 @@ final readonly class GetObjectTypeListSchemaHandler
         return \in_array($attribute->getType(), self::SORTABLE_TYPES, true)
             && !$attribute->isLocalizable()
             && !$attribute->isScopable();
+    }
+
+    /**
+     * GRID-P6-01 — types with a typed inline editor in the Excel view
+     * (GRID-P6-02). Media/relation/multiselect/wysiwyg edit through the
+     * detail page, not the grid, so they stay read-only here.
+     */
+    private const array INLINE_EDITABLE_TYPES = [
+        AttributeType::Text,
+        AttributeType::Textarea,
+        AttributeType::Identifier,
+        AttributeType::Number,
+        AttributeType::Metric,
+        AttributeType::Date,
+        AttributeType::Datetime,
+        AttributeType::Boolean,
+        AttributeType::Select,
+        AttributeType::Price,
+        AttributeType::Email,
+        AttributeType::Color,
+    ];
+
+    private function isEditableAttribute(Attribute $attribute): bool
+    {
+        return \in_array($attribute->getType(), self::INLINE_EDITABLE_TYPES, true)
+            && !$attribute->isLocalizable()
+            && !$attribute->isScopable()
+            && $this->attributePermissions->canEditAttribute($attribute->getId());
     }
 
     /**

--- a/apps/api/src/Catalog/Application/Query/GetObjectTypeListSchema/ObjectTypeListSchema.php
+++ b/apps/api/src/Catalog/Application/Query/GetObjectTypeListSchema/ObjectTypeListSchema.php
@@ -26,6 +26,7 @@ namespace App\Catalog\Application\Query\GetObjectTypeListSchema;
  *     label: array<string, string>,
  *     position: int,
  *     sortable: bool,
+ *     editable: bool,
  *     system: bool,
  *     default?: bool,
  *     group?: array{id: string, code: string, label: array<string, string>, position: int}|null

--- a/apps/api/tests/Unit/Catalog/Application/Query/GetObjectTypeListSchemaHandlerTest.php
+++ b/apps/api/tests/Unit/Catalog/Application/Query/GetObjectTypeListSchemaHandlerTest.php
@@ -97,6 +97,64 @@ final class GetObjectTypeListSchemaHandlerTest extends TestCase
     }
 
     #[Test]
+    public function editableFlagRespectsTypeAndEditPermission(): void
+    {
+        $objectType = $this->makeObjectType();
+        $text = $this->makeJunction($objectType, 'material', AttributeType::Text, showInList: true);
+        $media = $this->makeJunction($objectType, 'gallery', AttributeType::Asset, showInList: true);
+        $localizable = $this->makeJunction($objectType, 'name', AttributeType::Text, showInList: true);
+        $localizable->getAttribute()->changeLocalizable(true);
+
+        $handler = new GetObjectTypeListSchemaHandler(
+            $this->repositoryReturning($objectType),
+            $this->junctionRepositoryReturning([$text, $media, $localizable]),
+            $this->permissionsAllow(),
+            $this->groupResolver(),
+        );
+
+        $schema = $handler(new GetObjectTypeListSchemaQuery($objectType->getId()));
+        \assert(null !== $schema);
+        $byKey = [];
+        foreach ($schema->columns as $column) {
+            $byKey[$column['key']] = $column;
+        }
+
+        // Simple editable type + edit permission → editable.
+        self::assertTrue($byKey['material']['editable']);
+        // Media has no inline editor → not editable even with permission.
+        self::assertFalse($byKey['gallery']['editable']);
+        // Localizable needs the locale/channel context → not editable in MVP.
+        self::assertFalse($byKey['name']['editable']);
+        // System columns are never inline-editable through this flag.
+        self::assertFalse($byKey['code']['editable']);
+    }
+
+    #[Test]
+    public function editableFlagIsFalseWhenEditPermissionDenied(): void
+    {
+        $objectType = $this->makeObjectType();
+        $editable = $this->makeJunction($objectType, 'price', AttributeType::Price, showInList: true);
+        $viewOnlyId = $editable->getAttribute()->getId()->toRfc4122();
+
+        $handler = new GetObjectTypeListSchemaHandler(
+            $this->repositoryReturning($objectType),
+            $this->junctionRepositoryReturning([$editable]),
+            $this->permissionsViewOnly($viewOnlyId),
+            $this->groupResolver(),
+        );
+
+        $schema = $handler(new GetObjectTypeListSchemaQuery($objectType->getId()));
+        \assert(null !== $schema);
+        $byKey = [];
+        foreach ($schema->columns as $column) {
+            $byKey[$column['key']] = $column;
+        }
+        // Present (can view) but not editable (view-only).
+        self::assertArrayHasKey('price', $byKey);
+        self::assertFalse($byKey['price']['editable']);
+    }
+
+    #[Test]
     public function filterableAttributesAreOnlyTheFlaggedOnes(): void
     {
         $objectType = $this->makeObjectType();
@@ -221,6 +279,30 @@ final class GetObjectTypeListSchemaHandlerTest extends TestCase
             public function canViewAttribute(Uuid $attributeId): bool
             {
                 return $this->code !== $attributeId->toRfc4122();
+            }
+
+            public function canEditAttribute(Uuid $attributeId): bool
+            {
+                return $this->code !== $attributeId->toRfc4122();
+            }
+
+            public function isAttributePermissionEnforced(): bool
+            {
+                return true;
+            }
+        };
+    }
+
+    private function permissionsViewOnly(string $viewOnlyCode): AttributePermissionReader
+    {
+        return new class($viewOnlyCode) implements AttributePermissionReader {
+            public function __construct(private readonly string $code)
+            {
+            }
+
+            public function canViewAttribute(Uuid $attributeId): bool
+            {
+                return true;
             }
 
             public function canEditAttribute(Uuid $attributeId): bool


### PR DESCRIPTION
## Co (P6-01 — flaga editable w list-schema)

Każda kolumna atrybutowa w `GET /api/object_types/{id}/list-schema` niesie flagę **`editable`** = `canEditAttribute()` (3-state RBAC) **ORAZ** typ ma edytor inline. Media / relation / multiselect / wysiwyg / localizable / scopable → `false` (edycja przez detail page, nie grid). Kolumny systemowe → `false`.

FE: `ListSchemaColumn.editable` + `GridColumn.editable` przewleczone przez resolver (view seeds i fallback = false) — kontrakt gotowy pod typed editors (P6-02).

## Świadome odejście od strategii bundlowania
Strategia zakładała bundel **P6-01 + P6-02** (flaga + edytory). **Rozdzielam** — P6-02 (typed editors w Excel view: date/select/boolean + commit path atrybutów + walidacja + provenance + rollback) to duży, samodzielny kawałek zasługujący na własny PR + review. P6-01 to czysty, przetestowany kontrakt BE; flaga jest nieszkodliwa bez konsumenta (nie „martwy kod" łamiący cokolwiek). P6-02 jedzie jako następny dedykowany PR (#2401).

## Bramki
- PHPStan max 0 (kontener), cs-fixer czysto.
- Unit `GetObjectTypeListSchemaHandlerTest`: `editableFlagRespectsTypeAndEditPermission` (simple type+perm→true; media→false; localizable→false; system→false), `editableFlagIsFalseWhenEditPermissionDenied` (view-only → editable=false, present bo can-view).
- FE: vitest 187/187, tsc 0, biome 0, build OK.

**Source of truth:** [Project Plan/feature-grid-tickets.md](https://github.com/malipie/PIM/blob/main/Project%20Plan/feature-grid-tickets.md)

Closes #2400

🤖 Generated with [Claude Code](https://claude.com/claude-code)
