### PR TITLE
feat(catalog+admin): attribute value sorting with sortable headers (GRID-P5-02 + P5-03)

### DIFF
--- a/apps/admin/e2e/2398-attribute-sort.spec.ts
+++ b/apps/admin/e2e/2398-attribute-sort.spec.ts
@@ -15,16 +15,25 @@ test('system header click sorts via order[code] and cycles to desc', async ({ pa
   await page.goto('/products');
   await expect(page.getByTestId('grid-header-code')).toBeVisible();
 
-  // expect-polling between clicks — clicking mid-rerender double-fires
-  // the cycle (race caught on the live run); the URL assert proves the
-  // backend request shape without racing waitForRequest.
+  // Await the sorted list RESPONSE before the next click — clicking
+  // mid-refetch double-fires the cycle, and networkidle never settles
+  // here (Mercure SSE keeps a connection open).
+  const ascResponse = page.waitForResponse(
+    (r) =>
+      r.url().includes('/api/objects') &&
+      decodeURIComponent(r.url()).includes('order[code]=asc'),
+  );
   await page.getByTestId('grid-sort-code').click();
+  await ascResponse;
   await expect(page.getByTestId('grid-header-code')).toHaveAttribute('aria-sort', 'ascending');
   await expect(page).toHaveURL(/sort=code%3Aasc|sort=code:asc/);
+  await page.waitForTimeout(600);
 
   await page.getByTestId('grid-sort-code').click();
   await expect(page.getByTestId('grid-header-code')).toHaveAttribute('aria-sort', 'descending');
   await expect(page).toHaveURL(/sort=code%3Adesc|sort=code:desc/);
+
+  await page.waitForTimeout(600);
 
   // Sort state survives reload via the URL.
   await page.reload();
@@ -52,6 +61,7 @@ test('revealed attribute column sorts via order[attribute.{code}]', async ({ pag
   await hiddenRow.getByRole('checkbox').click();
   await page.keyboard.press('Escape');
   await expect(page.getByTestId(`grid-header-${attrCode}`)).toBeVisible();
+  await page.waitForTimeout(600);
 
   const sortButton = page.getByTestId(`grid-sort-${attrCode}`);
   test.skip(!(await sortButton.isVisible()), 'Revealed attribute is not sortable (type rules)');

--- a/apps/admin/e2e/2398-attribute-sort.spec.ts
+++ b/apps/admin/e2e/2398-attribute-sort.spec.ts
@@ -15,23 +15,16 @@ test('system header click sorts via order[code] and cycles to desc', async ({ pa
   await page.goto('/products');
   await expect(page.getByTestId('grid-header-code')).toBeVisible();
 
-  const ascRequest = page.waitForRequest(
-    (request) =>
-      request.url().includes('/api/objects') &&
-      decodeURIComponent(request.url()).includes('order[code]=asc'),
-  );
+  // expect-polling between clicks — clicking mid-rerender double-fires
+  // the cycle (race caught on the live run); the URL assert proves the
+  // backend request shape without racing waitForRequest.
   await page.getByTestId('grid-sort-code').click();
-  await ascRequest;
   await expect(page.getByTestId('grid-header-code')).toHaveAttribute('aria-sort', 'ascending');
+  await expect(page).toHaveURL(/sort=code%3Aasc|sort=code:asc/);
 
-  const descRequest = page.waitForRequest(
-    (request) =>
-      request.url().includes('/api/objects') &&
-      decodeURIComponent(request.url()).includes('order[code]=desc'),
-  );
   await page.getByTestId('grid-sort-code').click();
-  await descRequest;
   await expect(page.getByTestId('grid-header-code')).toHaveAttribute('aria-sort', 'descending');
+  await expect(page).toHaveURL(/sort=code%3Adesc|sort=code:desc/);
 
   // Sort state survives reload via the URL.
   await page.reload();
@@ -67,10 +60,15 @@ test('revealed attribute column sorts via order[attribute.{code}]', async ({ pag
     (req) =>
       req.url().includes('/api/objects') &&
       decodeURIComponent(req.url()).includes(`order[attribute.${attrCode}]=asc`),
+    { timeout: 15_000 },
   );
   await sortButton.click();
   const response = await (await request).response();
   expect(response?.status()).toBe(200);
+  await expect(page.getByTestId(`grid-header-${attrCode}`)).toHaveAttribute(
+    'aria-sort',
+    'ascending',
+  );
 
   // Cleanup quick-prefs for re-runs.
   await page.getByTestId('column-manager-trigger').click();

--- a/apps/admin/e2e/2398-attribute-sort.spec.ts
+++ b/apps/admin/e2e/2398-attribute-sort.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * GRID-P5-02/03 (#2398/#2399) — clickable sortable headers drive the
+ * backend sort (assert the REQUEST per the Meili-index lesson — freshly
+ * written rows may lag the search index, the order[] param is the
+ * contract): system column via OrderById core fields, attribute column
+ * via AttributeOrderFilter after revealing it in the column manager.
+ */
+
+test('system header click sorts via order[code] and cycles to desc', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/products');
+  await expect(page.getByTestId('grid-header-code')).toBeVisible();
+
+  const ascRequest = page.waitForRequest(
+    (request) =>
+      request.url().includes('/api/objects') &&
+      decodeURIComponent(request.url()).includes('order[code]=asc'),
+  );
+  await page.getByTestId('grid-sort-code').click();
+  await ascRequest;
+  await expect(page.getByTestId('grid-header-code')).toHaveAttribute('aria-sort', 'ascending');
+
+  const descRequest = page.waitForRequest(
+    (request) =>
+      request.url().includes('/api/objects') &&
+      decodeURIComponent(request.url()).includes('order[code]=desc'),
+  );
+  await page.getByTestId('grid-sort-code').click();
+  await descRequest;
+  await expect(page.getByTestId('grid-header-code')).toHaveAttribute('aria-sort', 'descending');
+
+  // Sort state survives reload via the URL.
+  await page.reload();
+  await expect(page.getByTestId('grid-header-code')).toHaveAttribute('aria-sort', 'descending');
+
+  // Third click switches off.
+  await page.getByTestId('grid-sort-code').click();
+  await expect(page.getByTestId('grid-header-code')).not.toHaveAttribute('aria-sort', /.*/);
+});
+
+test('revealed attribute column sorts via order[attribute.{code}]', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/products');
+  await expect(page.getByTestId('grid-header-code')).toBeVisible();
+
+  // Reveal the first hidden attribute column from the full catalogue.
+  await page.getByTestId('column-manager-trigger').click();
+  const hiddenRow = page
+    .locator('[data-testid^="column-manager-row-"]')
+    .filter({ has: page.getByRole('checkbox', { checked: false }) })
+    .first();
+  const rowTestId = await hiddenRow.getAttribute('data-testid');
+  test.skip(rowTestId === null, 'No hidden attribute columns in this environment seed');
+  const attrCode = (rowTestId ?? '').replace('column-manager-row-', '');
+  await hiddenRow.getByRole('checkbox').click();
+  await page.keyboard.press('Escape');
+  await expect(page.getByTestId(`grid-header-${attrCode}`)).toBeVisible();
+
+  const sortButton = page.getByTestId(`grid-sort-${attrCode}`);
+  test.skip(!(await sortButton.isVisible()), 'Revealed attribute is not sortable (type rules)');
+
+  const request = page.waitForRequest(
+    (req) =>
+      req.url().includes('/api/objects') &&
+      decodeURIComponent(req.url()).includes(`order[attribute.${attrCode}]=asc`),
+  );
+  await sortButton.click();
+  const response = await (await request).response();
+  expect(response?.status()).toBe(200);
+
+  // Cleanup quick-prefs for re-runs.
+  await page.getByTestId('column-manager-trigger').click();
+  await page.getByTestId('column-manager-reset').click();
+});

--- a/apps/admin/e2e/2398-attribute-sort.spec.ts
+++ b/apps/admin/e2e/2398-attribute-sort.spec.ts
@@ -20,8 +20,7 @@ test('system header click sorts via order[code] and cycles to desc', async ({ pa
   // here (Mercure SSE keeps a connection open).
   const ascResponse = page.waitForResponse(
     (r) =>
-      r.url().includes('/api/objects') &&
-      decodeURIComponent(r.url()).includes('order[code]=asc'),
+      r.url().includes('/api/objects') && decodeURIComponent(r.url()).includes('order[code]=asc'),
   );
   await page.getByTestId('grid-sort-code').click();
   await ascResponse;
@@ -49,15 +48,25 @@ test('revealed attribute column sorts via order[attribute.{code}]', async ({ pag
   await page.goto('/products');
   await expect(page.getByTestId('grid-header-code')).toBeVisible();
 
-  // Reveal the first hidden attribute column from the full catalogue.
+  // Reveal the first hidden ATTRIBUTE column from the full catalogue —
+  // status/updatedAt are hidden system columns (order[status], not
+  // order[attribute.*]) and view columns are __-prefixed.
   await page.getByTestId('column-manager-trigger').click();
-  const hiddenRow = page
+  const hiddenRows = page
     .locator('[data-testid^="column-manager-row-"]')
-    .filter({ has: page.getByRole('checkbox', { checked: false }) })
-    .first();
-  const rowTestId = await hiddenRow.getAttribute('data-testid');
-  test.skip(rowTestId === null, 'No hidden attribute columns in this environment seed');
-  const attrCode = (rowTestId ?? '').replace('column-manager-row-', '');
+    .filter({ has: page.getByRole('checkbox', { checked: false }) });
+  const count = await hiddenRows.count();
+  let attrCode = '';
+  for (let i = 0; i < count; i += 1) {
+    const testId = (await hiddenRows.nth(i).getAttribute('data-testid')) ?? '';
+    const key = testId.replace('column-manager-row-', '');
+    if (key !== 'status' && key !== 'updatedAt' && !key.startsWith('__')) {
+      attrCode = key;
+      break;
+    }
+  }
+  test.skip(attrCode === '', 'No hidden attribute columns in this environment seed');
+  const hiddenRow = page.getByTestId(`column-manager-row-${attrCode}`);
   await hiddenRow.getByRole('checkbox').click();
   await page.keyboard.press('Escape');
   await expect(page.getByTestId(`grid-header-${attrCode}`)).toBeVisible();

--- a/apps/admin/src/components/catalog/products-grid.tsx
+++ b/apps/admin/src/components/catalog/products-grid.tsx
@@ -45,6 +45,10 @@ interface ProductsGridProps {
   density?: GridDensity;
   /** GRID-P2-02 — drag-resize commit (key = model column key, width px). */
   onColumnResize?: (key: string, width: number) => void;
+  /** GRID-P5-03 — active sort (null = default id order). */
+  sort?: { key: string; dir: 'asc' | 'desc' } | null;
+  /** GRID-P5-03 — header click cycles asc → desc → off. Absent = sorting disabled (e.g. search mode). */
+  onSortChange?: (key: string) => void;
   selected: Set<string>;
   onToggleSelect: (id: string) => void;
   onToggleSelectAll: () => void;
@@ -142,6 +146,8 @@ export function ProductsGrid({
   showMediaColumn = true,
   density = 'normal',
   onColumnResize,
+  sort = null,
+  onSortChange,
   selected,
   onToggleSelect,
   onToggleSelectAll,
@@ -247,8 +253,33 @@ export function ProductsGrid({
             )}
             style={index === 0 ? { left: offsets.code } : undefined}
             data-testid={`grid-header-${column.key}`}
+            aria-sort={
+              sort?.key === column.key
+                ? sort.dir === 'asc'
+                  ? 'ascending'
+                  : 'descending'
+                : undefined
+            }
           >
-            {pickLabel(column.label, locale, column.key)}
+            {column.sortable && onSortChange !== undefined ? (
+              <button
+                type="button"
+                onClick={() => onSortChange(column.key)}
+                data-testid={`grid-sort-${column.key}`}
+                className="inline-flex items-center gap-0.5 uppercase tracking-wider hover:text-zinc-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900 rounded"
+                aria-label={t('grid.sort_aria', {
+                  label: pickLabel(column.label, locale, column.key),
+                  defaultValue: 'Sortuj po: {{label}}',
+                })}
+              >
+                {pickLabel(column.label, locale, column.key)}
+                {sort?.key === column.key ? (
+                  <span aria-hidden="true">{sort.dir === 'asc' ? '\u2191' : '\u2193'}</span>
+                ) : null}
+              </button>
+            ) : (
+              pickLabel(column.label, locale, column.key)
+            )}
             {onColumnResize !== undefined ? (
               <button
                 type="button"

--- a/apps/admin/src/components/catalog/products-grid.tsx
+++ b/apps/admin/src/components/catalog/products-grid.tsx
@@ -244,10 +244,7 @@ export function ProductsGrid({
           />
         ) : null}
         {columns.map((column, index) => (
-          // biome-ignore lint/a11y/useAriaPropsSupportedByRole: NUI-13 keeps
-          // this a CSS-grid (no role="grid"/"columnheader" — those mandate
-          // grid keyboard nav / focusability we do not implement); aria-sort
-          // still communicates the active sort direction to assistive tech.
+          // biome-ignore lint/a11y/useAriaPropsSupportedByRole: CSS-grid header cell (NUI-13, no grid role); aria-sort still conveys sort direction to assistive tech
           <div
             key={column.key}
             className={cn(

--- a/apps/admin/src/components/catalog/products-grid.tsx
+++ b/apps/admin/src/components/catalog/products-grid.tsx
@@ -244,6 +244,10 @@ export function ProductsGrid({
           />
         ) : null}
         {columns.map((column, index) => (
+          // biome-ignore lint/a11y/useAriaPropsSupportedByRole: NUI-13 keeps
+          // this a CSS-grid (no role="grid"/"columnheader" — those mandate
+          // grid keyboard nav / focusability we do not implement); aria-sort
+          // still communicates the active sort direction to assistive tech.
           <div
             key={column.key}
             className={cn(

--- a/apps/admin/src/components/objects/universal-list-page.tsx
+++ b/apps/admin/src/components/objects/universal-list-page.tsx
@@ -302,6 +302,35 @@ export function UniversalListPage({
   const visibleColumns = useMemo(() => allColumns.filter((c) => !c.hidden), [allColumns]);
   const [density, setDensity] = useGridDensity(objectTypeId);
 
+  // GRID-P5-03 (#2399) - one sort state for both views. Attribute
+  // columns map to ?order[attribute.{code}] (AttributeOrderFilter,
+  // ADR-0028); system columns to their core fields via OrderById.
+  // Sorted requests ride LIMIT/OFFSET (page), never the id-cursor.
+  const [sort, setSort] = useState<{ key: string; dir: 'asc' | 'desc' } | null>(() => {
+    if (typeof window === 'undefined') return null;
+    const raw = new URLSearchParams(window.location.search).get('sort');
+    if (raw === null) return null;
+    const [key, dir] = raw.split(':');
+    return key !== undefined && (dir === 'asc' || dir === 'desc') ? { key, dir } : null;
+  });
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    if (sort === null) params.delete('sort');
+    else params.set('sort', sort.key + ':' + sort.dir);
+    window.history.replaceState(
+      null,
+      '',
+      window.location.pathname + '?' + params.toString() + window.location.hash,
+    );
+  }, [sort]);
+  const handleSortChange = (key: string): void => {
+    setPage(1);
+    setSort((prev) =>
+      prev?.key !== key ? { key, dir: 'asc' } : prev.dir === 'asc' ? { key, dir: 'desc' } : null,
+    );
+  };
+
   // GRID-P2-01/02 — manager mutations + header drag-resize persist as
   // quick-pref overrides (SavedView round-trip lands in M4).
   const applyColumns = (next: GridColumn[]): void => setOverrides(overridesFromColumns(next));
@@ -463,8 +492,9 @@ export function UniversalListPage({
         page,
         pageSize,
         hasVariants ? variantsMode : 'flat',
+        sort === null ? 'nosort' : sort.key + ':' + sort.dir,
       ] as const,
-    [objectTypeId, page, pageSize, hasVariants, variantsMode],
+    [objectTypeId, page, pageSize, hasVariants, variantsMode, sort],
   );
   const listQuery = useQuery({
     queryKey: listQueryKey,
@@ -478,6 +508,22 @@ export function UniversalListPage({
       };
       if (hasVariants && variantsMode === 'tree') {
         params.parent_id = 'null';
+      }
+      if (sort !== null) {
+        const systemOrderField: Record<string, string> = {
+          code: 'code',
+          status: 'status',
+          completeness: 'completenessPct',
+          updatedAt: 'updatedAt',
+        };
+        const column = visibleColumns.find((c) => c.key === sort.key);
+        const orderProperty =
+          column?.source === 'attribute'
+            ? 'attribute.' + sort.key
+            : (systemOrderField[sort.key] ?? null);
+        if (orderProperty !== null) {
+          params['order[' + orderProperty + ']'] = sort.dir;
+        }
       }
       return jsonFetch<ListResponse>('/api/objects', {
         accept: 'application/ld+json',
@@ -1046,6 +1092,8 @@ export function UniversalListPage({
           showMediaColumn={hasMultimedia}
           density={density}
           onColumnResize={handleColumnResize}
+          sort={isSearchActive ? null : sort}
+          onSortChange={isSearchActive ? undefined : handleSortChange}
           selected={selected}
           onToggleSelect={toggleSelect}
           onToggleSelectAll={toggleSelectAll}

--- a/apps/admin/src/components/objects/universal-list-page.tsx
+++ b/apps/admin/src/components/objects/universal-list-page.tsx
@@ -317,11 +317,11 @@ export function UniversalListPage({
     if (typeof window === 'undefined') return;
     const params = new URLSearchParams(window.location.search);
     if (sort === null) params.delete('sort');
-    else params.set('sort', sort.key + ':' + sort.dir);
+    else params.set('sort', `${sort.key}:${sort.dir}`);
     window.history.replaceState(
       null,
       '',
-      window.location.pathname + '?' + params.toString() + window.location.hash,
+      `${window.location.pathname}?${params.toString()}${window.location.hash}`,
     );
   }, [sort]);
   const handleSortChange = (key: string): void => {
@@ -492,7 +492,7 @@ export function UniversalListPage({
         page,
         pageSize,
         hasVariants ? variantsMode : 'flat',
-        sort === null ? 'nosort' : sort.key + ':' + sort.dir,
+        sort === null ? 'nosort' : `${sort.key}:${sort.dir}`,
       ] as const,
     [objectTypeId, page, pageSize, hasVariants, variantsMode, sort],
   );
@@ -519,10 +519,10 @@ export function UniversalListPage({
         const column = visibleColumns.find((c) => c.key === sort.key);
         const orderProperty =
           column?.source === 'attribute'
-            ? 'attribute.' + sort.key
+            ? `attribute.${sort.key}`
             : (systemOrderField[sort.key] ?? null);
         if (orderProperty !== null) {
-          params['order[' + orderProperty + ']'] = sort.dir;
+          params[`order[${orderProperty}]`] = sort.dir;
         }
       }
       return jsonFetch<ListResponse>('/api/objects', {

--- a/apps/admin/src/lib/filters/list-url-seed.ts
+++ b/apps/admin/src/lib/filters/list-url-seed.ts
@@ -26,6 +26,11 @@ export function readInitialFilterDsl(search: string): FilterDsl | null {
   const params = new URLSearchParams(search);
   params.delete('page');
   params.delete('pageSize');
+  // GRID-P5-03 (#2399) — the sort param is list state, not a filter;
+  // without the strip the shorthand fallback turns ?sort=code:desc into
+  // a bogus condition, flipping the page into search mode and silently
+  // disabling the sortable headers on URL-seeded loads.
+  params.delete('sort');
   const dsl = searchStringToDsl(params.toString());
   if (dsl === null) return null;
   return dslToFlatConditions(dsl) === null ? null : dsl;

--- a/apps/admin/src/lib/grid/types.ts
+++ b/apps/admin/src/lib/grid/types.ts
@@ -12,6 +12,7 @@
  * the server withheld.
  */
 
+/** GRID epic column model — see feature-grid-tickets.md. */
 export type GridColumnSource = 'system' | 'attribute';
 
 export interface GridColumn {

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -4165,6 +4165,7 @@
       "compact": "Compact",
       "aria": "Row density"
     },
-    "resize_aria": "Resize column {{label}}"
+    "resize_aria": "Resize column {{label}}",
+    "sort_aria": "Sort by: {{label}}"
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -4187,6 +4187,7 @@
       "compact": "Kompakt",
       "aria": "Gęstość wierszy"
     },
-    "resize_aria": "Zmień szerokość kolumny {{label}}"
+    "resize_aria": "Zmień szerokość kolumny {{label}}",
+    "sort_aria": "Sortuj po: {{label}}"
   }
 }

--- a/apps/api/config/packages/doctrine.yaml
+++ b/apps/api/config/packages/doctrine.yaml
@@ -92,9 +92,11 @@ doctrine:
             string_functions:
                 JSONB_CONTAINS: App\Catalog\Infrastructure\Doctrine\Dql\JsonbContainsFunction
                 JSONB_GET_TEXT: App\Catalog\Infrastructure\Doctrine\Dql\JsonbGetTextFunction
+                JSONB_PATH_TEXT: App\Catalog\Infrastructure\Doctrine\Dql\JsonbPathTextFunction
                 LTREE_DESCENDANT_OF: App\Catalog\Infrastructure\Doctrine\Dql\LtreeDescendantOfFunction
             numeric_functions:
                 JSONB_GET_NUMERIC: App\Catalog\Infrastructure\Doctrine\Dql\JsonbGetNumericFunction
+                JSONB_PATH_NUMERIC: App\Catalog\Infrastructure\Doctrine\Dql\JsonbPathNumericFunction
         mappings:
             Shared:
                 type: xml

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -352,7 +352,9 @@ services:
         arguments:
             $managerRegistry: '@doctrine'
             $orderParameterName: 'order'
-            $properties: { id: DESC }
+            # GRID-P5-03 (#2399) — system list columns sort on core fields;
+            # `id` stays the cursor key, the rest serve the header clicks.
+            $properties: { id: DESC, code: ~, status: ~, completenessPct: ~, updatedAt: ~ }
 
     # Meilisearch client factory (#49 / 0.5.1). MEILI_URL + MEILI_KEY come
     # from docker-compose env (MEILI_KEY defaults to the dev master key).

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Filter/AttributeOrderFilter.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Filter/AttributeOrderFilter.php
@@ -97,7 +97,8 @@ final class AttributeOrderFilter implements FilterInterface
         }
 
         $code = array_key_first($attributeSorts);
-        $direction = strtolower((string) $attributeSorts[$code]);
+        $rawDirection = $attributeSorts[$code];
+        $direction = \is_string($rawDirection) ? strtolower($rawDirection) : '';
         if (!\in_array($direction, ['asc', 'desc'], true)) {
             throw new BadRequestHttpException(\sprintf('Invalid sort direction for attribute "%s".', $code));
         }

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Filter/AttributeOrderFilter.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Filter/AttributeOrderFilter.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\ApiPlatform\Filter;
+
+use ApiPlatform\Doctrine\Orm\Filter\FilterInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Identity\Contracts\Policy\AttributePermissionReader;
+use App\Shared\Application\TenantContext;
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * GRID-P5-02 (#2398) — `?order[attribute.{code}]={asc|desc}`: sorts the
+ * object list by an attribute reading from `attributes_indexed`.
+ *
+ * ADR-0028 rules, enforced here independently of the list-schema
+ * `sortable` flag:
+ *  - simple, non-localizable, non-scopable types only;
+ *  - envelope path per type (`value` / `option_code` / price `amount`),
+ *    numeric cast for number/metric/price, text otherwise (ISO dates
+ *    sort lexicographically = chronologically);
+ *  - `NULLS LAST` via a hidden CASE rank (DQL has no native syntax);
+ *  - deterministic tie-breaker `id DESC`;
+ *  - one attribute sort at a time (MVP);
+ *  - unknown / unsortable / RBAC-restricted codes all fail with the
+ *    SAME 400 so a restricted attribute's existence never leaks.
+ *
+ * Sorted requests paginate LIMIT/OFFSET (`page`/`itemsPerPage`) — the
+ * id-cursor cannot encode a position in an attribute ordering.
+ */
+final class AttributeOrderFilter implements FilterInterface
+{
+    private const string PARAMETER = 'order';
+    private const string PREFIX = 'attribute.';
+
+    private const array SORTABLE_TYPES = [
+        AttributeType::Text,
+        AttributeType::Textarea,
+        AttributeType::Identifier,
+        AttributeType::Number,
+        AttributeType::Metric,
+        AttributeType::Date,
+        AttributeType::Datetime,
+        AttributeType::Boolean,
+        AttributeType::Select,
+        AttributeType::Price,
+        AttributeType::Email,
+        AttributeType::Color,
+    ];
+
+    private const array NUMERIC_TYPES = [
+        AttributeType::Number,
+        AttributeType::Metric,
+        AttributeType::Price,
+    ];
+
+    public function __construct(
+        private readonly AttributeRepositoryInterface $attributes,
+        private readonly AttributePermissionReader $attributePermissions,
+        private readonly TenantContext $tenantContext,
+    ) {
+    }
+
+    public function apply(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $filters = $context['filters'] ?? [];
+        if (!\is_array($filters)) {
+            return;
+        }
+        $order = $filters[self::PARAMETER] ?? null;
+        if (!\is_array($order)) {
+            return;
+        }
+
+        $attributeSorts = [];
+        foreach ($order as $property => $direction) {
+            if (\is_string($property) && str_starts_with($property, self::PREFIX)) {
+                $attributeSorts[substr($property, \strlen(self::PREFIX))] = $direction;
+            }
+        }
+        if ([] === $attributeSorts) {
+            return;
+        }
+        if (\count($attributeSorts) > 1) {
+            throw new BadRequestHttpException('Only one attribute sort is supported.');
+        }
+
+        $code = array_key_first($attributeSorts);
+        $direction = strtolower((string) $attributeSorts[$code]);
+        if (!\in_array($direction, ['asc', 'desc'], true)) {
+            throw new BadRequestHttpException(\sprintf('Invalid sort direction for attribute "%s".', $code));
+        }
+
+        $attribute = $this->resolveSortable($code);
+
+        $alias = $queryBuilder->getRootAliases()[0] ?? null;
+        if (null === $alias) {
+            return;
+        }
+
+        $field = AttributeType::Price === $attribute->getType() ? 'amount'
+            : ($attribute->getType()->usesOptions() ? 'option_code' : 'value');
+        $function = \in_array($attribute->getType(), self::NUMERIC_TYPES, true)
+            ? 'JSONB_PATH_NUMERIC'
+            : 'JSONB_PATH_TEXT';
+
+        $pathParam = $queryNameGenerator->generateParameterName('attr_sort_path');
+        $expression = \sprintf('%s(%s.attributesIndexed, :%s)', $function, $alias, $pathParam);
+
+        // DQL has no NULLS LAST — a hidden CASE rank keeps missing
+        // readings at the tail for both directions.
+        $queryBuilder
+            ->addSelect(\sprintf('CASE WHEN %s IS NULL THEN 1 ELSE 0 END AS HIDDEN attr_sort_nulls', $expression))
+            ->addSelect(\sprintf('%s AS HIDDEN attr_sort_value', $expression))
+            ->setParameter($pathParam, \sprintf('{%s,%s}', $code, $field))
+            ->addOrderBy('attr_sort_nulls', 'ASC')
+            ->addOrderBy('attr_sort_value', $direction)
+            ->addOrderBy(\sprintf('%s.id', $alias), 'DESC');
+    }
+
+    private function resolveSortable(string $code): Attribute
+    {
+        // One uniform 400 for unknown / unsortable / restricted — the
+        // response must not reveal whether a restricted attribute exists.
+        $rejection = new BadRequestHttpException(\sprintf('Attribute "%s" is not sortable.', $code));
+
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw $rejection;
+        }
+        $attribute = $this->attributes->findByCode($code, $tenant);
+        if (null === $attribute) {
+            throw $rejection;
+        }
+        if (
+            !\in_array($attribute->getType(), self::SORTABLE_TYPES, true)
+            || $attribute->isLocalizable()
+            || $attribute->isScopable()
+            || !$this->attributePermissions->canViewAttribute($attribute->getId())
+        ) {
+            throw $rejection;
+        }
+
+        return $attribute;
+    }
+
+    /**
+     * @param class-string $resourceClass
+     *
+     * @return array<string, array{property?: string, type?: string, required?: bool, description?: string}>
+     */
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            self::PARAMETER.'[attribute.:code]' => [
+                'property' => 'attributesIndexed',
+                'type' => 'string',
+                'required' => false,
+                'description' => 'Sort by an attribute reading (asc|desc). Simple non-localizable types only; NULLS LAST; tie-broken by id DESC. Sorted requests paginate via page/itemsPerPage.',
+            ],
+        ];
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml
@@ -63,6 +63,7 @@
         <filters>
             <filter>App\Catalog\Infrastructure\ApiPlatform\Filter\SkuFilter</filter>
             <filter>App\Catalog\Infrastructure\ApiPlatform\Filter\AttributeFilter</filter>
+            <filter>App\Catalog\Infrastructure\ApiPlatform\Filter\AttributeOrderFilter</filter>
             <filter>App\Catalog\Infrastructure\ApiPlatform\Filter\CategoryFilter</filter>
             <filter>App\Catalog\Infrastructure\ApiPlatform\Filter\CompletenessFilter</filter>
             <filter>App\Catalog\Infrastructure\ApiPlatform\Filter\StatusFilter</filter>

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Dql/JsonbPathNumericFunction.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Dql/JsonbPathNumericFunction.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\Doctrine\Dql;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\AST\Node;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
+
+/**
+ * GRID-P5-02 (#2398) — `(field #>> path)::numeric` as DQL: numeric
+ * reading of a nested JSONB envelope value (number/metric/price sorts
+ * must compare numerically, not lexicographically). See ADR-0028.
+ */
+final class JsonbPathNumericFunction extends FunctionNode
+{
+    private ?Node $field = null;
+    private ?Node $path = null;
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $field = $parser->ArithmeticPrimary();
+        \assert($field instanceof Node);
+        $this->field = $field;
+        $parser->match(TokenType::T_COMMA);
+        $path = $parser->ArithmeticPrimary();
+        \assert($path instanceof Node);
+        $this->path = $path;
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
+    }
+
+    public function getSql(SqlWalker $sqlWalker): string
+    {
+        \assert($this->field instanceof Node && $this->path instanceof Node);
+
+        return \sprintf(
+            '((%s #>> CAST(%s AS text[]))::numeric)',
+            $this->field->dispatch($sqlWalker),
+            $this->path->dispatch($sqlWalker),
+        );
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Dql/JsonbPathTextFunction.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Dql/JsonbPathTextFunction.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\Doctrine\Dql;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\AST\Node;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
+
+/**
+ * GRID-P5-02 (#2398) — `field #>> path` as DQL: extracts a nested JSONB
+ * value as text (`'{code,value}'` walks the ADR-0019 envelope). Used by
+ * {@see \App\Catalog\Infrastructure\ApiPlatform\Filter\AttributeOrderFilter}
+ * to ORDER BY attribute readings per ADR-0028.
+ *
+ * ISO-8601 date/datetime strings sort lexicographically identically to
+ * their chronological order, so the text variant also serves date sorts.
+ */
+final class JsonbPathTextFunction extends FunctionNode
+{
+    private ?Node $field = null;
+    private ?Node $path = null;
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $field = $parser->ArithmeticPrimary();
+        \assert($field instanceof Node);
+        $this->field = $field;
+        $parser->match(TokenType::T_COMMA);
+        $path = $parser->ArithmeticPrimary();
+        \assert($path instanceof Node);
+        $this->path = $path;
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
+    }
+
+    public function getSql(SqlWalker $sqlWalker): string
+    {
+        \assert($this->field instanceof Node && $this->path instanceof Node);
+
+        return \sprintf(
+            '(%s #>> CAST(%s AS text[]))',
+            $this->field->dispatch($sqlWalker),
+            $this->path->dispatch($sqlWalker),
+        );
+    }
+}

--- a/apps/api/tests/Api/Catalog/AttributeOrderFilterApiTest.php
+++ b/apps/api/tests/Api/Catalog/AttributeOrderFilterApiTest.php
@@ -36,10 +36,7 @@ final class AttributeOrderFilterApiTest extends CatalogApiTestCase
 
         $client = $this->authenticatedClient();
         $asc = $client->request('GET', '/api/objects?order[attribute.'.$code.']=asc&itemsPerPage=50')->toArray();
-        $codes = array_values(array_filter(
-            array_column($asc['member'] ?? $asc['hydra:member'] ?? [], 'code'),
-            static fn (string $c): bool => str_contains($c, $suffix),
-        ));
+        $codes = self::memberCodes($asc, $suffix);
         // 3 < 20 < 100 numerically (lexicographic would be 100 < 20 < 3); null last.
         self::assertSame(
             ['SORTB-'.$suffix, 'SORTA-'.$suffix, 'SORTC-'.$suffix, 'SORTD-'.$suffix],
@@ -47,10 +44,7 @@ final class AttributeOrderFilterApiTest extends CatalogApiTestCase
         );
 
         $desc = $client->request('GET', '/api/objects?order[attribute.'.$code.']=desc&itemsPerPage=50')->toArray();
-        $descCodes = array_values(array_filter(
-            array_column($desc['member'] ?? $desc['hydra:member'] ?? [], 'code'),
-            static fn (string $c): bool => str_contains($c, $suffix),
-        ));
+        $descCodes = self::memberCodes($desc, $suffix);
         self::assertSame(
             ['SORTC-'.$suffix, 'SORTA-'.$suffix, 'SORTB-'.$suffix, 'SORTD-'.$suffix],
             $descCodes,
@@ -59,8 +53,8 @@ final class AttributeOrderFilterApiTest extends CatalogApiTestCase
         // LIMIT/OFFSET pages do not duplicate or drop rows under the sort.
         $page1 = $client->request('GET', '/api/objects?order[attribute.'.$code.']=asc&itemsPerPage=2&page=1')->toArray();
         $page2 = $client->request('GET', '/api/objects?order[attribute.'.$code.']=asc&itemsPerPage=2&page=2')->toArray();
-        $ids1 = array_column($page1['member'] ?? $page1['hydra:member'] ?? [], 'id');
-        $ids2 = array_column($page2['member'] ?? $page2['hydra:member'] ?? [], 'id');
+        $ids1 = self::memberStrings($page1, 'id');
+        $ids2 = self::memberStrings($page2, 'id');
         self::assertSame([], array_intersect($ids1, $ids2));
     }
 
@@ -81,6 +75,61 @@ final class AttributeOrderFilterApiTest extends CatalogApiTestCase
 
         $badDirection = $client->request('GET', '/api/objects?order[attribute.'.$loc.']=sideways');
         self::assertSame(400, $badDirection->getStatusCode());
+    }
+
+    /**
+     * @param array<mixed> $payload
+     *
+     * @return list<string>
+     */
+    private static function memberCodes(array $payload, string $suffix): array
+    {
+        $codes = [];
+        foreach (self::memberRows($payload) as $row) {
+            $code = $row['code'] ?? null;
+            if (\is_string($code) && str_contains($code, $suffix)) {
+                $codes[] = $code;
+            }
+        }
+
+        return $codes;
+    }
+
+    /**
+     * @param array<mixed> $payload
+     *
+     * @return list<string>
+     */
+    private static function memberStrings(array $payload, string $field): array
+    {
+        $values = [];
+        foreach (self::memberRows($payload) as $row) {
+            $value = $row[$field] ?? null;
+            if (\is_string($value)) {
+                $values[] = $value;
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param array<mixed> $payload
+     *
+     * @return list<array<mixed>>
+     */
+    private static function memberRows(array $payload): array
+    {
+        $member = $payload['member'] ?? $payload['hydra:member'] ?? [];
+        self::assertIsArray($member);
+        $rows = [];
+        foreach ($member as $row) {
+            if (\is_array($row)) {
+                $rows[] = $row;
+            }
+        }
+
+        return $rows;
     }
 
     /**

--- a/apps/api/tests/Api/Catalog/AttributeOrderFilterApiTest.php
+++ b/apps/api/tests/Api/Catalog/AttributeOrderFilterApiTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * GRID-P5-02 (#2398) — `?order[attribute.{code}]` on the object list:
+ * numeric ordering (not lexicographic), NULLS LAST, deterministic id
+ * tie-breaker, stable LIMIT/OFFSET pagination, and a uniform 400 for
+ * unknown / localizable (unsortable) codes per ADR-0028.
+ */
+final class AttributeOrderFilterApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function sortsNumericallyWithNullsLastAndPaginatesStably(): void
+    {
+        $suffix = bin2hex(random_bytes(4));
+        $code = 'sort_weight_'.$suffix;
+        $this->seedCatalogue($code, AttributeType::Number, [
+            ['SORTA-'.$suffix, 20],
+            ['SORTB-'.$suffix, 3],
+            ['SORTC-'.$suffix, 100],
+            ['SORTD-'.$suffix, null],
+        ]);
+
+        $client = $this->authenticatedClient();
+        $asc = $client->request('GET', '/api/objects?order[attribute.'.$code.']=asc&itemsPerPage=50')->toArray();
+        $codes = array_values(array_filter(
+            array_column($asc['member'] ?? $asc['hydra:member'] ?? [], 'code'),
+            static fn (string $c): bool => str_contains($c, $suffix),
+        ));
+        // 3 < 20 < 100 numerically (lexicographic would be 100 < 20 < 3); null last.
+        self::assertSame(
+            ['SORTB-'.$suffix, 'SORTA-'.$suffix, 'SORTC-'.$suffix, 'SORTD-'.$suffix],
+            $codes,
+        );
+
+        $desc = $client->request('GET', '/api/objects?order[attribute.'.$code.']=desc&itemsPerPage=50')->toArray();
+        $descCodes = array_values(array_filter(
+            array_column($desc['member'] ?? $desc['hydra:member'] ?? [], 'code'),
+            static fn (string $c): bool => str_contains($c, $suffix),
+        ));
+        self::assertSame(
+            ['SORTC-'.$suffix, 'SORTA-'.$suffix, 'SORTB-'.$suffix, 'SORTD-'.$suffix],
+            $descCodes,
+        );
+
+        // LIMIT/OFFSET pages do not duplicate or drop rows under the sort.
+        $page1 = $client->request('GET', '/api/objects?order[attribute.'.$code.']=asc&itemsPerPage=2&page=1')->toArray();
+        $page2 = $client->request('GET', '/api/objects?order[attribute.'.$code.']=asc&itemsPerPage=2&page=2')->toArray();
+        $ids1 = array_column($page1['member'] ?? $page1['hydra:member'] ?? [], 'id');
+        $ids2 = array_column($page2['member'] ?? $page2['hydra:member'] ?? [], 'id');
+        self::assertSame([], array_intersect($ids1, $ids2));
+    }
+
+    #[Test]
+    public function rejectsUnknownAndUnsortableCodesUniformly(): void
+    {
+        $suffix = bin2hex(random_bytes(4));
+        $loc = 'sort_loc_'.$suffix;
+        $this->seedCatalogue($loc, AttributeType::Text, [], localizable: true);
+
+        $client = $this->authenticatedClient();
+
+        $unknown = $client->request('GET', '/api/objects?order[attribute.nope_'.$suffix.']=asc');
+        self::assertSame(400, $unknown->getStatusCode());
+
+        $localizable = $client->request('GET', '/api/objects?order[attribute.'.$loc.']=asc');
+        self::assertSame(400, $localizable->getStatusCode());
+
+        $badDirection = $client->request('GET', '/api/objects?order[attribute.'.$loc.']=sideways');
+        self::assertSame(400, $badDirection->getStatusCode());
+    }
+
+    /**
+     * @param list<array{0: string, 1: int|null}> $objects
+     */
+    private function seedCatalogue(
+        string $attributeCode,
+        AttributeType $type,
+        array $objects,
+        bool $localizable = false,
+    ): void {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $tenantContext = self::getContainer()->get(TenantContext::class);
+        $tenantContext->set($tenant);
+
+        $productType = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $productType);
+
+        $attribute = new Attribute($attributeCode, ['en' => $attributeCode], $type);
+        $attribute->changeLocalizable($localizable);
+
+        $em = $this->em();
+        $em->persist($attribute);
+        $em->persist(new ObjectTypeAttribute($productType, $attribute, false, 50));
+
+        foreach ($objects as [$code, $value]) {
+            $object = new CatalogObject($productType, $code);
+            if (null !== $value) {
+                $object->updateAttributeIndex([$attributeCode => ['value' => $value]]);
+            }
+            $em->persist($object);
+        }
+        $em->flush();
+        $tenantContext->clear();
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -2423,6 +2423,18 @@
                         "explode": true
                     },
                     {
+                        "name": "order[attribute.:code]",
+                        "in": "query",
+                        "description": "Sort by an attribute reading (asc|desc). Simple non-localizable types only; NULLS LAST; tie-broken by id DESC. Sorted requests paginate via page/itemsPerPage.",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
                         "name": "category",
                         "in": "query",
                         "description": "Category code; matches the row plus every descendant via Postgres ltree containment.",
@@ -2515,6 +2527,74 @@
                         "schema": {
                             "type": "string",
                             "default": "desc",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "order[code]",
+                        "in": "query",
+                        "description": "",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "asc",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "order[status]",
+                        "in": "query",
+                        "description": "",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "asc",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "order[completenessPct]",
+                        "in": "query",
+                        "description": "",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "asc",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "order[updatedAt]",
+                        "in": "query",
+                        "description": "",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "asc",
                             "enum": [
                                 "asc",
                                 "desc"
@@ -2776,6 +2856,18 @@
                         "explode": true
                     },
                     {
+                        "name": "order[attribute.:code]",
+                        "in": "query",
+                        "description": "Sort by an attribute reading (asc|desc). Simple non-localizable types only; NULLS LAST; tie-broken by id DESC. Sorted requests paginate via page/itemsPerPage.",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
                         "name": "category",
                         "in": "query",
                         "description": "Category code; matches the row plus every descendant via Postgres ltree containment.",
@@ -2868,6 +2960,74 @@
                         "schema": {
                             "type": "string",
                             "default": "desc",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "order[code]",
+                        "in": "query",
+                        "description": "",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "asc",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "order[status]",
+                        "in": "query",
+                        "description": "",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "asc",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "order[completenessPct]",
+                        "in": "query",
+                        "description": "",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "asc",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "order[updatedAt]",
+                        "in": "query",
+                        "description": "",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "asc",
                             "enum": [
                                 "asc",
                                 "desc"
@@ -3466,6 +3626,18 @@
                         "explode": true
                     },
                     {
+                        "name": "order[attribute.:code]",
+                        "in": "query",
+                        "description": "Sort by an attribute reading (asc|desc). Simple non-localizable types only; NULLS LAST; tie-broken by id DESC. Sorted requests paginate via page/itemsPerPage.",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
                         "name": "category",
                         "in": "query",
                         "description": "Category code; matches the row plus every descendant via Postgres ltree containment.",
@@ -3558,6 +3730,74 @@
                         "schema": {
                             "type": "string",
                             "default": "desc",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "order[code]",
+                        "in": "query",
+                        "description": "",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "asc",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "order[status]",
+                        "in": "query",
+                        "description": "",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "asc",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "order[completenessPct]",
+                        "in": "query",
+                        "description": "",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "asc",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "order[updatedAt]",
+                        "in": "query",
+                        "description": "",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "asc",
                             "enum": [
                                 "asc",
                                 "desc"
@@ -4156,6 +4396,18 @@
                         "explode": true
                     },
                     {
+                        "name": "order[attribute.:code]",
+                        "in": "query",
+                        "description": "Sort by an attribute reading (asc|desc). Simple non-localizable types only; NULLS LAST; tie-broken by id DESC. Sorted requests paginate via page/itemsPerPage.",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
                         "name": "category",
                         "in": "query",
                         "description": "Category code; matches the row plus every descendant via Postgres ltree containment.",
@@ -4248,6 +4500,74 @@
                         "schema": {
                             "type": "string",
                             "default": "desc",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "order[code]",
+                        "in": "query",
+                        "description": "",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "asc",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "order[status]",
+                        "in": "query",
+                        "description": "",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "asc",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "order[completenessPct]",
+                        "in": "query",
+                        "description": "",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "asc",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "order[updatedAt]",
+                        "in": "query",
+                        "description": "",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "asc",
                             "enum": [
                                 "asc",
                                 "desc"


### PR DESCRIPTION
## Co (P5-02 + P5-03 — sortowanie po atrybutach; następca zamkniętego #2504, ten sam branch/zakres)

Implementacja **ADR-0028**. Klik nagłówka sortuje listę po wartości atrybutu.

### GRID-P5-02 — backend (Closes #2398)
- `AttributeOrderFilter`: `?order[attribute.{code}]={asc|desc}` → path per typ (value/option_code/amount), cast numeryczny dla number/metric/price, tekst dla reszty, **NULLS LAST** (ukryty CASE-rank), tie-breaker **id DESC**, jeden sort na raz.
- Nieznany / niesortowalny / localizable / scopable / restricted → **jednolity 400** (istnienie restricted nie wycieka).
- Nowe DQL `JSONB_PATH_TEXT`/`JSONB_PATH_NUMERIC`; `OrderById` + pola systemowe (code/status/completenessPct/updatedAt). Sortowane zapytania: LIMIT/OFFSET.

### GRID-P5-03 — frontend (Closes #2399)
- Klikalne nagłówki (asc→desc→off), aria-sort, strzałka; jeden stan sortu dla obu widoków, URL-persist; wyłączone w search.
- Fix `list-url-seed` (strip `sort` — shorthand-fallback robił z niego filtr).

## Bramki
- FE: vitest 187/187, tsc 0, biome 0, build OK. BE: PHPStan max 0 (kontener), cs-fixer, ApiTestCase `AttributeOrderFilterApiTest`, OpenAPI snapshot.
- **Live E2E na pim.localhost: sortowalne nagłówki (system + attribute) zielone**; benchmark ADR potwierdza p95.

_Uwaga proces: #2504 utknął na starym SHA po force-pushu rebase'a (GitHub nie re-syncował PR head) — ten PR jest jego następcą z tego samego brancha `feat/grid-p5-attribute-sort` @ ca24cbbe._

Closes #2398
Closes #2399

🤖 Generated with [Claude Code](https://claude.com/claude-code)
