### PR TITLE
feat(admin): typed inline editors for attribute columns in Excel view (GRID-P6-02)

### DIFF
--- a/apps/admin/e2e/2401-inline-attribute-edit.spec.ts
+++ b/apps/admin/e2e/2401-inline-attribute-edit.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin, uniqueSku } from './helpers/auth';
+
+/**
+ * GRID-P6-02 (#2401) — typed inline editors for attribute columns in the
+ * Excel view. Seeds a custom ObjectType with an editable text attribute,
+ * reveals it as a column, edits the cell in Excel view, and asserts the
+ * PATCH persists (value survives reload).
+ */
+
+test('edits an attribute value inline in the Excel view and persists it', async ({ page }) => {
+  test.setTimeout(120_000);
+  await loginAsAdmin(page);
+
+  const refresh = await page.request.post('/api/auth/refresh');
+  expect(refresh.status()).toBe(200);
+  const token = ((await refresh.json()) as { token: string }).token;
+  const bearer = { Authorization: `Bearer ${token}` };
+  const json = { ...bearer, accept: 'application/ld+json', 'content-type': 'application/json' };
+
+  const stamp = uniqueSku('edit')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '_');
+  const otCode = `edit_ot_${stamp}`;
+  const groupCode = `edit_grp_${stamp}`;
+  const attrCode = `edit_note_${stamp}`;
+  const attrLabel = `Notatka ${stamp}`;
+
+  const ot = await page.request.post('/api/object_types', {
+    data: { code: otCode, label: { pl: `Edytowalne ${stamp}`, en: `Editable ${stamp}` } },
+    headers: json,
+  });
+  expect(ot.status(), await ot.text()).toBe(201);
+  const objectTypeId = ((await ot.json()) as { id: string }).id;
+
+  const group = await page.request.post('/api/attribute_groups', {
+    data: { code: groupCode, label: { pl: 'Podstawowe', en: 'Basics' } },
+    headers: json,
+  });
+  expect(group.status()).toBe(201);
+  const groupId = ((await group.json()) as { id: string }).id;
+
+  const attr = await page.request.post('/api/attributes', {
+    data: {
+      code: attrCode,
+      type: 'text',
+      label: { pl: attrLabel, en: attrLabel },
+      required: false,
+    },
+    headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/ld+json' },
+  });
+  expect(attr.status(), await attr.text()).toBe(201);
+  const attributeId = ((await attr.json()) as { id: string }).id;
+
+  await page.request.post(`/api/attribute_groups/${groupId}/attributes/bulk-attach`, {
+    data: { attributeCodes: [attrCode] },
+    headers: { ...bearer, accept: 'application/json', 'content-type': 'application/json' },
+  });
+  await page.request.post(`/api/object_types/${objectTypeId}/groups/${groupId}`, {
+    headers: bearer,
+  });
+  await page.request.post(`/api/object_types/${objectTypeId}/attributes/bulk-attach`, {
+    data: { attributeIds: [attributeId] },
+    headers: { ...bearer, accept: 'application/json', 'content-type': 'application/json' },
+  });
+  const listConfig = await page.request.patch(
+    `/api/object_types/${objectTypeId}/attributes/${attributeId}/list-config`,
+    {
+      data: { show_in_list: true, list_position: 10 },
+      headers: { ...bearer, accept: 'application/json', 'content-type': 'application/json' },
+    },
+  );
+  expect(listConfig.status(), await listConfig.text()).toBe(200);
+
+  const objectCode = uniqueSku('EDIT');
+  const obj = await page.request.post('/api/objects', {
+    data: { code: objectCode, objectTypeId, attributes: {} },
+    headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/ld+json' },
+  });
+  expect(obj.status(), await obj.text()).toBe(201);
+
+  // Excel view, edit the attribute cell.
+  await page.goto(`/objects/${otCode}`);
+  await page.getByRole('tab', { name: 'Excel' }).click();
+  const header = page.getByRole('columnheader', { name: attrLabel });
+  await expect(header).toBeVisible();
+
+  const newValue = `Bawelna-${stamp}`;
+  const patchResponse = page.waitForResponse(
+    (r) =>
+      /\/api\/objects\/[^/]+$/.test(r.url()) &&
+      r.request().method() === 'PATCH' &&
+      r.request().postData()?.includes(attrCode) === true,
+  );
+  // The row's attribute cell starts empty (—); click it, type, commit.
+  const cell = page.getByRole('cell').filter({ hasText: '—' }).first();
+  await cell.click();
+  await page.keyboard.type(newValue);
+  await page.keyboard.press('Enter');
+  const patch = await patchResponse;
+  expect(patch.status()).toBe(200);
+
+  // Value persists after reload (server truth).
+  await page.reload();
+  await page.getByRole('tab', { name: 'Excel' }).click();
+  await expect(page.getByRole('cell', { name: newValue })).toBeVisible();
+});

--- a/apps/admin/src/components/catalog/excel-like-grid.tsx
+++ b/apps/admin/src/components/catalog/excel-like-grid.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 export interface ExcelColumn<T extends Record<string, unknown>> {
   key: keyof T & string;
   label: string;
-  type: 'text' | 'number' | 'select' | 'boolean';
+  type: 'text' | 'number' | 'select' | 'boolean' | 'date';
   width?: number;
   readOnly?: boolean;
   options?: ReadonlyArray<string>;
@@ -21,6 +21,8 @@ export interface ExcelColumn<T extends Record<string, unknown>> {
    * resize commits report this key so overrides land on the model.
    */
   modelKey?: string;
+  /** GRID-P6-02 — options for a select editor ({code, label} pairs). */
+  selectOptions?: ReadonlyArray<{ code: string; label: string }>;
 }
 
 interface CellAddress {
@@ -204,6 +206,8 @@ export function ExcelLikeGrid<T extends Record<string, unknown>>({
       coerced = Number.isNaN(parsed) ? null : parsed;
     } else if (col.type === 'boolean') {
       coerced = newValue === 'true';
+    } else if ('' === newValue) {
+      coerced = null;
     }
     onCommit(editing.rowIdx, editing.colKey, coerced);
     setEditing(null);
@@ -259,6 +263,68 @@ export function ExcelLikeGrid<T extends Record<string, unknown>>({
 
   const widthOf = (col: ExcelColumn<T>): number | undefined => liveWidths[col.key] ?? col.width;
 
+  const renderEditor = (col: ExcelColumn<T>, value: unknown): React.ReactNode => {
+    const commonKeyDown = (e: React.KeyboardEvent): void => {
+      if (e.key === 'Escape') setEditing(null);
+    };
+    if (col.type === 'select') {
+      return (
+        // biome-ignore lint/a11y/noAutofocus: spreadsheet cell editor must grab focus on open
+        <select
+          ref={(el) => {
+            if (el !== null) el.focus();
+          }}
+          defaultValue={String(value ?? '')}
+          onBlur={(e) => commitEdit(e.target.value)}
+          onChange={(e) => commitEdit(e.target.value)}
+          onKeyDown={commonKeyDown}
+          className="w-full bg-background outline-none"
+        >
+          <option value="">—</option>
+          {(col.selectOptions ?? []).map((opt) => (
+            <option key={opt.code} value={opt.code}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      );
+    }
+    if (col.type === 'boolean') {
+      return (
+        <select
+          ref={(el) => {
+            if (el !== null) el.focus();
+          }}
+          defaultValue={value === true || value === 'true' ? 'true' : 'false'}
+          onBlur={(e) => commitEdit(e.target.value)}
+          onChange={(e) => commitEdit(e.target.value)}
+          onKeyDown={commonKeyDown}
+          className="w-full bg-background outline-none"
+        >
+          <option value="true">✓</option>
+          <option value="false">✗</option>
+        </select>
+      );
+    }
+    const inputType = col.type === 'number' ? 'number' : col.type === 'date' ? 'date' : 'text';
+    return (
+      <input
+        ref={editorRef}
+        type={inputType}
+        defaultValue={String(value ?? '')}
+        onBlur={(e) => commitEdit(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            commitEdit((e.target as HTMLInputElement).value);
+          } else if (e.key === 'Escape') {
+            setEditing(null);
+          }
+        }}
+        className="w-full bg-background outline-none"
+      />
+    );
+  };
+
   const renderCell = (row: T, rowIdx: number, colIdx: number) => {
     const col = columns[colIdx];
     if (col === undefined) return null;
@@ -286,19 +352,7 @@ export function ExcelLikeGrid<T extends Record<string, unknown>>({
         } ${col.readOnly === true ? 'bg-muted/40 text-muted-foreground' : 'cursor-cell'}`}
       >
         {isEditing ? (
-          <input
-            ref={editorRef}
-            defaultValue={String(value ?? '')}
-            onBlur={(e) => commitEdit(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                commitEdit((e.target as HTMLInputElement).value);
-              } else if (e.key === 'Escape') {
-                setEditing(null);
-              }
-            }}
-            className="w-full bg-background outline-none"
-          />
+          renderEditor(col, value)
         ) : col.renderDisplay !== undefined ? (
           col.renderDisplay(row)
         ) : (

--- a/apps/admin/src/components/objects/universal-list-page.tsx
+++ b/apps/admin/src/components/objects/universal-list-page.tsx
@@ -679,6 +679,23 @@ export function UniversalListPage({
       next.set(row.id, { ...next.get(row.id), [colKey]: value });
       return next;
     });
+    // GRID-P6-02 — attribute column edits carry the `attr:{code}` excel
+    // key; PATCH the attribute and optimistically overlay the raw
+    // envelope so the cell shows the new reading before the refetch.
+    const attrCode = colKey.startsWith('attr:') ? colKey.slice('attr:'.length) : null;
+    if (attrCode !== null) {
+      const column = visibleColumns.find((c) => c.key === attrCode);
+      const envelope = column?.type === 'select' ? { option_code: value } : { value };
+      setOptimisticEdits((prev) => {
+        const next = new Map(prev);
+        const base = next.get(row.id) ?? {};
+        next.set(row.id, {
+          ...base,
+          attributesIndexed: { ...(row.attributesIndexed ?? {}), [attrCode]: envelope },
+        });
+        return next;
+      });
+    }
     try {
       if (colKey === 'enabled') {
         await jsonFetch(`/api/objects/${row.id}`, {
@@ -692,10 +709,28 @@ export function UniversalListPage({
           body: { attributes: { name: value } },
           contentType: 'application/merge-patch+json',
         });
+      } else if (attrCode !== null) {
+        await jsonFetch(`/api/objects/${row.id}`, {
+          method: 'PATCH',
+          body: { attributes: { [attrCode]: value } },
+          contentType: 'application/merge-patch+json',
+        });
       } else {
         return;
       }
-      refetch();
+      if (attrCode !== null) {
+        // The attributesIndexed overlay is an object, so the value-equality
+        // self-clear never fires; await the refetched truth then drop it.
+        await listQuery.refetch();
+        setOptimisticEdits((prev) => {
+          if (!prev.has(row.id)) return prev;
+          const next = new Map(prev);
+          next.delete(row.id);
+          return next;
+        });
+      } else {
+        refetch();
+      }
     } catch (err) {
       setOptimisticEdits((prev) => {
         if (!prev.has(row.id)) return prev;

--- a/apps/admin/src/lib/grid/excel-columns.tsx
+++ b/apps/admin/src/lib/grid/excel-columns.tsx
@@ -38,6 +38,17 @@ function optionLabelFor(
   };
 }
 
+/** GRID-P6-02 — attribute type → excel inline editor type. */
+const EXCEL_EDITOR_TYPE: Record<string, 'text' | 'number' | 'select' | 'boolean' | 'date'> = {
+  number: 'number',
+  metric: 'number',
+  price: 'number',
+  boolean: 'boolean',
+  date: 'date',
+  datetime: 'date',
+  select: 'select',
+};
+
 const EXCEL_WIDTH_BY_TYPE: Record<string, number> = {
   number: 110,
   metric: 110,
@@ -130,13 +141,24 @@ export function toExcelColumns(
     if (column.hidden) continue;
     const label = pickLabel(column.label, locale, column.key);
     if (column.source === 'attribute' && !column.key.startsWith('__')) {
+      const editorType = EXCEL_EDITOR_TYPE[column.type] ?? 'text';
+      const selectOptions =
+        column.type === 'select'
+          ? Object.entries(optionLabels[column.key] ?? {}).map(([code, labelMap]) => ({
+              code,
+              label: pickLabel(labelMap, locale, code),
+            }))
+          : undefined;
       out.push({
         key: `${EXCEL_ATTR_KEY_PREFIX}${column.key}`,
         modelKey: column.key,
         label,
-        type: 'text',
+        type: editorType,
         width: column.width ?? EXCEL_WIDTH_BY_TYPE[column.type] ?? 170,
-        readOnly: true, // typed editors land in GRID-P6-02
+        // GRID-P6-02 — editable = RBAC edit + inline-editable type
+        // (list-schema `editable` flag). Otherwise read-only.
+        readOnly: !column.editable,
+        ...(selectOptions !== undefined ? { selectOptions } : {}),
         renderDisplay: (row) => (
           <GridAttributeCell
             column={column}


### PR DESCRIPTION
## Co (P6-02 — typed inline editors w Excel view; **stacked na #2506** P6-01)

Edytowalne kolumny atrybutowe (flaga `editable` z list-schema, #2506) tracą blokadę read-only w Excel view.

- `ExcelLikeGrid` renderuje **edytor per typ kolumny**: date input, number input, dropdown boolean (✓/✗), dropdown select (labelki opcji), text dla reszty. Escape=cancel, Enter/blur=commit.
- `toExcelColumns`: kolumna atrybutowa `readOnly = !editable`; typ edytora + `selectOptions` mapowane z `optionLabels`.
- Commit: PATCH `/api/objects/{id}` `{attributes:{[code]:value}}` (provenance `manual` nadaje write path). **Optimistic overlay** `attributesIndexed` + await-refetch-then-clear (obiektowy overlay nie samo-czyści się przez value-equality). Błąd → rollback + toast.

## Świadome odejścia (MVP)
- Media / relation / multiselect / wysiwyg / localizable / scopable → read-only (edycja przez detail page); flaga `editable` już to odzwierciedla (BE).
- **Provenance badge na komórce** odłożony — lista nie niesie per-cell provenance; wymaga rozszerzenia payloadu (osobny follow-up).
- **Client-side walidacja z validation_rules** — MVP polega na autorytatywnym 422 z BE (rollback+toast); pre-walidacja to drobny follow-up.
- Bulk TSV paste na atrybuty = **P6-03** (osobny PR).

## Bramki
- FE: vitest 187/187, tsc 0, biome 0, build OK, max-lines baseline.
- **Live smoke na pim.localhost (PASSED):** reveal `Marka` (brand/text) → edycja komórki → PATCH 200 `{"attributes":{"brand":"..."}}` → **reload potwierdza persystencję**, konsola czysta. Relation (`accessory`) poprawnie read-only.
- E2E `2401-inline-attribute-edit.spec.ts` (custom OT + editable text + edycja + persystencja) — walidacja na CI (lokalnie blokuje DNS setup, jak 2387/2398).

Closes #2401

🤖 Generated with [Claude Code](https://claude.com/claude-code)
