### PR TITLE
feat(admin): round-trip grid config through saved views (GRID-P4-02)

### DIFF
--- a/apps/admin/e2e/2395-saved-view-roundtrip.spec.ts
+++ b/apps/admin/e2e/2395-saved-view-roundtrip.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * GRID-P4-02 (#2395) — the grid config round-trips through a saved view.
+ * Hide a column + set compact + save; the view tab appears immediately
+ * (reloadToken refetch); reset dirties the state; restoring the view
+ * brings the columns and density back. Browser-only (no page.request)
+ * so it runs on CI without the pim.localhost DNS caveat.
+ */
+
+test('saves and restores column visibility + density through a saved view', async ({ page }) => {
+  test.setTimeout(90_000);
+  await loginAsAdmin(page);
+  await page.goto('/products');
+  await page.getByTestId('grid-header-code').waitFor();
+
+  // Hide "completeness" and switch to compact density.
+  await page.getByTestId('column-manager-trigger').click();
+  await page.getByTestId('column-manager-row-completeness').getByRole('checkbox').click();
+  await page.keyboard.press('Escape');
+  await page.getByTestId('density-compact').click();
+  await expect(page.getByTestId('grid-header-completeness')).toHaveCount(0);
+
+  // Save the view — its config carries columns + density.
+  const viewName = `E2E-view-${Date.now().toString(36)}`;
+  const post = page.waitForResponse(
+    (r) => r.url().includes('/api/saved-views') && r.request().method() === 'POST',
+  );
+  await page.getByRole('button', { name: /zapisz widok|save view/i }).click();
+  const dialog = page.getByRole('dialog');
+  await dialog.getByLabel(/name/i).fill(viewName);
+  await dialog.getByRole('button', { name: /zapisz widok|save view/i }).click();
+  const postResp = await post;
+  expect(postResp.status()).toBe(201);
+  const body = postResp.request().postData() ?? '';
+  expect(body).toContain('"columns"');
+  expect(body).toContain('"density":"compact"');
+
+  // The tab appears without a reload (reloadToken refetch).
+  const tab = page.getByRole('tab', { name: viewName });
+  await expect(tab).toBeVisible();
+
+  // Dirty the state: back to defaults.
+  await page.getByTestId('density-normal').click();
+  await page.getByTestId('column-manager-trigger').click();
+  await page.getByTestId('column-manager-reset').click();
+  await page.keyboard.press('Escape');
+  await expect(page.getByTestId('grid-header-completeness')).toBeVisible();
+
+  // Restore the view → columns + density come back.
+  await tab.click();
+  await expect(page.getByTestId('grid-header-completeness')).toHaveCount(0);
+  await expect(page.getByTestId('density-compact')).toHaveAttribute('aria-selected', 'true');
+});

--- a/apps/admin/src/components/catalog/save-view-modal.tsx
+++ b/apps/admin/src/components/catalog/save-view-modal.tsx
@@ -8,6 +8,8 @@ import { jsonFetch } from '@/lib/http';
 
 interface SaveViewModalProps {
   resource: string;
+  /** GRID-P4-03 — scopes the saved view (and its default) to this ObjectType. */
+  objectTypeId?: string;
   config: Record<string, unknown>;
   onClose: () => void;
   onSaved: (slug: string) => void;
@@ -18,7 +20,13 @@ interface SaveViewModalProps {
  * list page. Posts to `/api/saved-views` (UI-02.7). Includes an
  * "is default" checkbox + readable preview of what will be persisted.
  */
-export function SaveViewModal({ resource, config, onClose, onSaved }: SaveViewModalProps) {
+export function SaveViewModal({
+  resource,
+  objectTypeId,
+  config,
+  onClose,
+  onSaved,
+}: SaveViewModalProps) {
   const { t } = useTranslation();
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -38,6 +46,7 @@ export function SaveViewModal({ resource, config, onClose, onSaved }: SaveViewMo
           name: name.trim(),
           description: description.trim() === '' ? undefined : description.trim(),
           resource,
+          object_type_id: objectTypeId,
           config,
           is_default: isDefault,
         },
@@ -149,11 +158,27 @@ function describeConfig(config: Record<string, unknown>): string[] {
   if (typeof config.variants_mode === 'string') {
     lines.push(`Variants mode: ${config.variants_mode}`);
   }
-  if (Array.isArray(config.visible_columns)) {
-    lines.push(`Visible columns: ${config.visible_columns.length}`);
+  if (Array.isArray(config.columns)) {
+    const visible = (config.columns as Array<{ hidden?: boolean }>).filter(
+      (c) => c?.hidden !== true,
+    );
+    lines.push(`Kolumny: ${visible.length} widocznych`);
+  }
+  const sort = config.sort;
+  if (
+    sort !== null &&
+    typeof sort === 'object' &&
+    typeof (sort as { key?: unknown }).key === 'string'
+  ) {
+    lines.push(
+      `Sortowanie: ${(sort as { key: string }).key} ${(sort as { dir?: string }).dir ?? ''}`,
+    );
+  }
+  if (typeof config.density === 'string') {
+    lines.push(`Gęstość: ${config.density}`);
   }
   if (typeof config.page_size === 'number') {
-    lines.push(`Page size: ${config.page_size}`);
+    lines.push(`Rozmiar strony: ${config.page_size}`);
   }
   return lines;
 }

--- a/apps/admin/src/components/catalog/saved-views-rail.tsx
+++ b/apps/admin/src/components/catalog/saved-views-rail.tsx
@@ -18,6 +18,8 @@ interface SavedView {
 
 interface SavedViewsRailProps {
   resource?: string;
+  /** GRID-P4-02 — bump to force a refetch after a view is saved. */
+  reloadToken?: number;
   activeSlug: string | null;
   onApply: (view: SavedView) => void;
   onSaveCurrent: () => void;
@@ -40,6 +42,7 @@ export function SavedViewsRail({
   onApply,
   onSaveCurrent,
   currentTotal = null,
+  reloadToken = 0,
 }: SavedViewsRailProps) {
   const { t } = useTranslation();
   const [views, setViews] = useState<SavedView[]>([]);
@@ -77,7 +80,7 @@ export function SavedViewsRail({
     return () => {
       cancelled = true;
     };
-  }, [resource]);
+  }, [resource, reloadToken]);
 
   const focusTabAt = (index: number): void => {
     const target = tabRefs.current[index];

--- a/apps/admin/src/components/objects/universal-list-page.tsx
+++ b/apps/admin/src/components/objects/universal-list-page.tsx
@@ -407,6 +407,7 @@ export function UniversalListPage({
 
   const [activeViewSlug, setActiveViewSlug] = useState<string | null>(null);
   const [showSaveViewModal, setShowSaveViewModal] = useState(false);
+  const [savedViewsReloadToken, setSavedViewsReloadToken] = useState(0);
   const [expandedMasters, setExpandedMasters] = useState<Set<string>>(new Set());
   const {
     presets: smartPresets,
@@ -701,6 +702,21 @@ export function UniversalListPage({
     setActiveSmartPresetId(null);
   };
 
+  // GRID-P4-02 (#2395) — the SavedView config the grid round-trips:
+  // filters + columns (order/hidden/width) + sort + density + variants
+  // + page size. Shape matches the BE validator (GRID-P4-01).
+  const buildViewConfig = (): Record<string, unknown> => {
+    const config: Record<string, unknown> = {
+      filters,
+      variants_mode: hasVariants ? variantsMode : 'flat',
+      page_size: pageSize,
+      columns: overridesFromColumns(allColumns),
+    };
+    if (sort !== null) config.sort = sort;
+    if (density !== 'normal') config.density = density;
+    return config;
+  };
+
   const handleApplySavedView = (view: { slug: string; config: Record<string, unknown> }): void => {
     setActiveViewSlug(view.slug);
     const cfg = view.config;
@@ -710,6 +726,36 @@ export function UniversalListPage({
     }
     const mode = cfg.variants_mode;
     if (mode === 'tree' || mode === 'flat') setVariantsMode(mode);
+    if (
+      typeof cfg.page_size === 'number' &&
+      PAGE_SIZE_OPTIONS.includes(cfg.page_size as PageSize)
+    ) {
+      setPageSize(cfg.page_size as PageSize);
+    }
+    // Columns: apply as quick-pref overrides. Keys absent from the schema
+    // (deleted attribute / RBAC) are dropped by the resolver, so a stale
+    // saved column silently disappears instead of breaking the render.
+    if (Array.isArray(cfg.columns)) {
+      const overrides = (cfg.columns as unknown[]).filter(
+        (c): c is GridColumnOverride =>
+          c !== null && typeof c === 'object' && typeof (c as GridColumnOverride).key === 'string',
+      );
+      setOverrides(overrides);
+    }
+    const cfgSort = cfg.sort;
+    if (
+      cfgSort !== null &&
+      typeof cfgSort === 'object' &&
+      typeof (cfgSort as { key?: unknown }).key === 'string' &&
+      ((cfgSort as { dir?: unknown }).dir === 'asc' ||
+        (cfgSort as { dir?: unknown }).dir === 'desc')
+    ) {
+      setSort(cfgSort as { key: string; dir: 'asc' | 'desc' });
+      setPage(1);
+    } else {
+      setSort(null);
+    }
+    setDensity(cfg.density === 'compact' ? 'compact' : 'normal');
   };
 
   const handleExcelCommit = async (
@@ -786,6 +832,8 @@ export function UniversalListPage({
       </div>
 
       <SavedViewsRail
+        resource={objectTypeCode}
+        reloadToken={savedViewsReloadToken}
         activeSlug={activeViewSlug}
         onApply={(view) => {
           handleApplySavedView({ slug: view.slug, config: view.config });
@@ -1235,12 +1283,14 @@ export function UniversalListPage({
       {showSaveViewModal ? (
         <SaveViewModal
           resource={objectTypeCode}
-          config={{ filters, variants_mode: variantsMode }}
+          objectTypeId={objectTypeId}
+          config={buildViewConfig()}
           onClose={() => {
             setShowSaveViewModal(false);
           }}
           onSaved={(slug) => {
             setActiveViewSlug(slug);
+            setSavedViewsReloadToken((n) => n + 1);
           }}
         />
       ) : null}


### PR DESCRIPTION
## Co (P4-02 — round-trip config grida przez saved views)

`SaveViewModal` zapisuje **pełny stan grida**: filters + columns (kolejność/hidden/width przez `overridesFromColumns`) + sort + density + variants_mode + page_size, scope'owane do ObjectType (`object_type_id`). Wybór widoku odtwarza wszystko: kolumny → quick-pref overrides (klucze spoza schemy dropowane cicho), sort → reset na stronę 1, density/page_size/filters/variants. Domyka wieloletni dług `visible_columns` (deklarowane w modalu, nigdy nie zapisywane).

## Fix pre-existing bugu (odkryty przy okazji)
**Modal zapisywał `resource=objectTypeCode` ("product"), a `SavedViewsRail` domyślnie pytał `resource='products'`** (plural) → zapisane widoki NIGDY się nie pokazywały. Ujednolicone (`resource={objectTypeCode}` na rail). Dodatkowo rail nie odświeżał się po zapisie → `reloadToken` wymusza refetch.

## Bramki
- FE: vitest 187/187, tsc 0, biome 0, build OK, max-lines baseline.
- **Live smoke na pim.localhost (PASSED):** hide completeness + compact → zapisz → **tab widoku pojawia się natychmiast** (bez reload) → reset do defaults → klik widoku → completeness ukryte + compact aktywne przywrócone; POST body zawiera `columns` + `density:compact`; konsola czysta.
- E2E `2395-saved-view-roundtrip.spec.ts` (browser-only → działa na CI bez DNS caveat): save→tab→reset→restore + asercja POST body.

Closes #2395

🤖 Generated with [Claude Code](https://claude.com/claude-code)
