### PR TITLE
feat(admin): typed TSV paste onto attribute columns with skip report (GRID-P6-03)

### DIFF
--- a/apps/admin/e2e/2402-tsv-paste.spec.ts
+++ b/apps/admin/e2e/2402-tsv-paste.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * GRID-P6-03 (#2402) — typed TSV paste onto the Excel grid. Paste from a
+ * selected (non-editing) anchor cell coerces each cell to its column
+ * type and reports applied vs skipped cells in a toast. Read-only cells
+ * (SKU) are skipped. Browser clipboard (permissions granted) so it runs
+ * on CI without the pim.localhost DNS caveat.
+ */
+
+test.use({ permissions: ['clipboard-read', 'clipboard-write'] });
+
+test('pastes a TSV block, coercing values and reporting skips', async ({ page }) => {
+  test.setTimeout(90_000);
+  await loginAsAdmin(page);
+  await page.goto('/products');
+  await page.getByTestId('grid-header-code').waitFor();
+  await page.getByRole('tab', { name: 'Excel' }).click();
+  // Wait for the real schema columns (Nazwa) — the fallback set has no
+  // editable column at index 1, so pasting before load skips everything.
+  await expect(page.getByRole('columnheader', { name: 'Nazwa' })).toBeVisible();
+
+  // A 2-column block: col A lands on SKU (read-only → skipped), col B on
+  // the next column (name, editable → applied).
+  const value = `Paste-${Date.now().toString(36)}`;
+  await page.evaluate((val) => {
+    return navigator.clipboard.writeText(`skipped-a\t${val}-1\nskipped-b\t${val}-2`);
+  }, value);
+
+  // Select the read-only SKU anchor (no edit mode) and paste. The commit
+  // PATCH is async; wait for it explicitly (the toast fires synchronously
+  // before the request resolves).
+  const patch = page.waitForResponse(
+    (r) => /\/api\/objects\/[^/]+$/.test(r.url()) && r.request().method() === 'PATCH',
+    { timeout: 15_000 },
+  );
+  await page.locator('table tbody tr').first().locator('td').nth(0).click();
+  await page.keyboard.press('Control+v');
+
+  // The batch toast reports the paste (some applied, some skipped since
+  // the SKU column is read-only).
+  await expect(page.getByText(/wklejono|pasted/i)).toBeVisible({ timeout: 10_000 });
+  const patchResp = await patch;
+  expect(patchResp.status()).toBe(200);
+  expect(patchResp.request().postData() ?? '').toContain('name');
+
+  // The pasted name value persists after reload.
+  await page.reload();
+  await page.getByRole('tab', { name: 'Excel' }).click();
+  await expect(
+    page
+      .locator('table tbody td')
+      .filter({ hasText: `${value}-1` })
+      .first(),
+  ).toBeVisible();
+});

--- a/apps/admin/src/components/catalog/excel-cell-coerce.ts
+++ b/apps/admin/src/components/catalog/excel-cell-coerce.ts
@@ -1,0 +1,34 @@
+import type { ExcelColumn } from './excel-like-grid';
+
+/**
+ * GRID-P6-03 (#2402) — coerce a raw string (typed cell edit or pasted
+ * TSV) to the column's value type. Returns `{ ok: false }` when the
+ * input cannot be parsed so paste can reject-and-report it; select maps
+ * by option label OR code. Shared by single-cell commit and paste so
+ * both validate identically.
+ */
+export function coerceExcelValue<T extends Record<string, unknown>>(
+  col: ExcelColumn<T>,
+  raw: string,
+): { ok: true; value: unknown } | { ok: false } {
+  if (raw === '') return { ok: true, value: null };
+  if (col.type === 'number') {
+    const parsed = Number.parseFloat(raw);
+    return Number.isNaN(parsed) ? { ok: false } : { ok: true, value: parsed };
+  }
+  if (col.type === 'boolean') {
+    const t = raw.trim().toLowerCase();
+    if (['true', '1', 'tak', 'yes', '✓'].includes(t)) return { ok: true, value: true };
+    if (['false', '0', 'nie', 'no', '✗'].includes(t)) return { ok: true, value: false };
+    return { ok: false };
+  }
+  if (col.type === 'select') {
+    const options = col.selectOptions ?? [];
+    const byCode = options.find((o) => o.code === raw.trim());
+    if (byCode !== undefined) return { ok: true, value: byCode.code };
+    const byLabel = options.find((o) => o.label.toLowerCase() === raw.trim().toLowerCase());
+    if (byLabel !== undefined) return { ok: true, value: byLabel.code };
+    return { ok: false };
+  }
+  return { ok: true, value: raw };
+}

--- a/apps/admin/src/components/catalog/excel-like-grid.tsx
+++ b/apps/admin/src/components/catalog/excel-like-grid.tsx
@@ -74,12 +74,15 @@ export function ExcelLikeGrid<T extends Record<string, unknown>>({
   rows,
   columns,
   onCommit,
+  onPasteReport,
   density = 'normal',
   onColumnResize,
 }: {
   rows: T[];
   columns: ExcelColumn<T>[];
   onCommit: (rowIdx: number, colKey: string, value: unknown) => void;
+  /** GRID-P6-03 — batch paste summary (applied vs skipped cells). */
+  onPasteReport?: (applied: number, skipped: number) => void;
   /** GRID-P2-03 — compact rows for spreadsheet-style work. */
   density?: 'normal' | 'compact';
   /** GRID-P2-02 — resize commit keyed by the column's `modelKey`. */
@@ -196,21 +199,56 @@ export function ExcelLikeGrid<T extends Record<string, unknown>>({
     setEditing({ rowIdx, colKey });
   };
 
-  const commitEdit = (newValue: string): void => {
-    if (editing === null) return;
-    const col = columns.find((c) => c.key === editing.colKey);
-    if (col === undefined) return;
-    let coerced: unknown = newValue;
+  // GRID-P6-03 — coerce a raw string to the column's value type. Returns
+  // `{ ok: false }` when the input cannot be parsed (paste rejects it and
+  // reports a skip); select maps by option label OR code.
+  const coerceValue = (
+    col: ExcelColumn<T>,
+    raw: string,
+  ): { ok: true; value: unknown } | { ok: false } => {
+    if ('' === raw) return { ok: true, value: null };
     if (col.type === 'number') {
-      const parsed = Number.parseFloat(newValue);
-      coerced = Number.isNaN(parsed) ? null : parsed;
-    } else if (col.type === 'boolean') {
-      coerced = newValue === 'true';
-    } else if ('' === newValue) {
-      coerced = null;
+      const parsed = Number.parseFloat(raw);
+      return Number.isNaN(parsed) ? { ok: false } : { ok: true, value: parsed };
     }
-    onCommit(editing.rowIdx, editing.colKey, coerced);
+    if (col.type === 'boolean') {
+      const t = raw.trim().toLowerCase();
+      if (['true', '1', 'tak', 'yes', '✓'].includes(t)) return { ok: true, value: true };
+      if (['false', '0', 'nie', 'no', '✗'].includes(t)) return { ok: true, value: false };
+      return { ok: false };
+    }
+    if (col.type === 'select') {
+      const options = col.selectOptions ?? [];
+      const byCode = options.find((o) => o.code === raw.trim());
+      if (byCode !== undefined) return { ok: true, value: byCode.code };
+      const byLabel = options.find((o) => o.label.toLowerCase() === raw.trim().toLowerCase());
+      if (byLabel !== undefined) return { ok: true, value: byLabel.code };
+      return { ok: false };
+    }
+    return { ok: true, value: raw };
+  };
+
+  // GRID-P6-03 — exit edit mode AND return focus to the table so the
+  // next Ctrl+V/Ctrl+C reaches the grid keydown handler (single-click
+  // edit otherwise leaves focus in the removed <input>, breaking paste).
+  const stopEditing = (): void => {
     setEditing(null);
+    requestAnimationFrame(() => gridRef.current?.focus());
+  };
+
+  const commitEdit = (newValue: string): void => {
+    if (editing === null) {
+      stopEditing();
+      return;
+    }
+    const col = columns.find((c) => c.key === editing.colKey);
+    if (col === undefined) {
+      stopEditing();
+      return;
+    }
+    const result = coerceValue(col, newValue);
+    if (result.ok) onCommit(editing.rowIdx, editing.colKey, result.value);
+    stopEditing();
   };
 
   const handleKeyDown = useCallback(
@@ -236,17 +274,32 @@ export function ExcelLikeGrid<T extends Record<string, unknown>>({
         event.preventDefault();
         void (async () => {
           const text = await navigator.clipboard.readText();
-          const lines = text.split(/\r?\n/);
+          const lines = text
+            .split(/\r?\n/)
+            .filter((l, idx, arr) => l !== '' || idx < arr.length - 1);
+          let applied = 0;
+          let skipped = 0;
           for (let i = 0; i < lines.length; i += 1) {
             const cells = lines[i]?.split('\t') ?? [];
             for (let j = 0; j < cells.length; j += 1) {
               const colKey = columns[colIndex(active.colKey) + j]?.key;
               if (colKey === undefined) continue;
               const col = columns.find((c) => c.key === colKey);
-              if (col === undefined || col.readOnly === true) continue;
-              onCommit(active.rowIdx + i, colKey, cells[j]);
+              if (col === undefined) continue;
+              if (col.readOnly === true) {
+                skipped += 1;
+                continue;
+              }
+              const result = coerceValue(col, cells[j] ?? '');
+              if (!result.ok) {
+                skipped += 1;
+                continue;
+              }
+              onCommit(active.rowIdx + i, colKey, result.value);
+              applied += 1;
             }
           }
+          if (applied > 0 || skipped > 0) onPasteReport?.(applied, skipped);
         })();
         return;
       }
@@ -265,7 +318,7 @@ export function ExcelLikeGrid<T extends Record<string, unknown>>({
 
   const renderEditor = (col: ExcelColumn<T>, value: unknown): React.ReactNode => {
     const commonKeyDown = (e: React.KeyboardEvent): void => {
-      if (e.key === 'Escape') setEditing(null);
+      if (e.key === 'Escape') stopEditing();
     };
     if (col.type === 'select') {
       return (

--- a/apps/admin/src/components/catalog/excel-like-grid.tsx
+++ b/apps/admin/src/components/catalog/excel-like-grid.tsx
@@ -1,5 +1,6 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { coerceExcelValue } from './excel-cell-coerce';
 
 export interface ExcelColumn<T extends Record<string, unknown>> {
   key: keyof T & string;
@@ -199,38 +200,8 @@ export function ExcelLikeGrid<T extends Record<string, unknown>>({
     setEditing({ rowIdx, colKey });
   };
 
-  // GRID-P6-03 — coerce a raw string to the column's value type. Returns
-  // `{ ok: false }` when the input cannot be parsed (paste rejects it and
-  // reports a skip); select maps by option label OR code.
-  const coerceValue = (
-    col: ExcelColumn<T>,
-    raw: string,
-  ): { ok: true; value: unknown } | { ok: false } => {
-    if ('' === raw) return { ok: true, value: null };
-    if (col.type === 'number') {
-      const parsed = Number.parseFloat(raw);
-      return Number.isNaN(parsed) ? { ok: false } : { ok: true, value: parsed };
-    }
-    if (col.type === 'boolean') {
-      const t = raw.trim().toLowerCase();
-      if (['true', '1', 'tak', 'yes', '✓'].includes(t)) return { ok: true, value: true };
-      if (['false', '0', 'nie', 'no', '✗'].includes(t)) return { ok: true, value: false };
-      return { ok: false };
-    }
-    if (col.type === 'select') {
-      const options = col.selectOptions ?? [];
-      const byCode = options.find((o) => o.code === raw.trim());
-      if (byCode !== undefined) return { ok: true, value: byCode.code };
-      const byLabel = options.find((o) => o.label.toLowerCase() === raw.trim().toLowerCase());
-      if (byLabel !== undefined) return { ok: true, value: byLabel.code };
-      return { ok: false };
-    }
-    return { ok: true, value: raw };
-  };
-
   // GRID-P6-03 — exit edit mode AND return focus to the table so the
-  // next Ctrl+V/Ctrl+C reaches the grid keydown handler (single-click
-  // edit otherwise leaves focus in the removed <input>, breaking paste).
+  // next Ctrl+V/Ctrl+C reaches the grid keydown handler.
   const stopEditing = (): void => {
     setEditing(null);
     requestAnimationFrame(() => gridRef.current?.focus());
@@ -246,7 +217,7 @@ export function ExcelLikeGrid<T extends Record<string, unknown>>({
       stopEditing();
       return;
     }
-    const result = coerceValue(col, newValue);
+    const result = coerceExcelValue(col, newValue);
     if (result.ok) onCommit(editing.rowIdx, editing.colKey, result.value);
     stopEditing();
   };
@@ -290,7 +261,7 @@ export function ExcelLikeGrid<T extends Record<string, unknown>>({
                 skipped += 1;
                 continue;
               }
-              const result = coerceValue(col, cells[j] ?? '');
+              const result = coerceExcelValue(col, cells[j] ?? '');
               if (!result.ok) {
                 skipped += 1;
                 continue;

--- a/apps/admin/src/components/objects/universal-list-page.tsx
+++ b/apps/admin/src/components/objects/universal-list-page.tsx
@@ -1161,6 +1161,24 @@ export function UniversalListPage({
           columns={excelColumns}
           density={density}
           onColumnResize={handleColumnResize}
+          onPasteReport={(applied, skipped) => {
+            if (skipped > 0) {
+              toast.info(
+                t('grid.paste.report_mixed', {
+                  applied,
+                  skipped,
+                  defaultValue: 'Wklejono {{applied}}, pominięto {{skipped}}',
+                }),
+              );
+            } else if (applied > 0) {
+              toast.success(
+                t('grid.paste.report_ok', {
+                  applied,
+                  defaultValue: 'Wklejono {{applied}} komórek',
+                }),
+              );
+            }
+          }}
           onCommit={(rowIdx, colKey, value) => {
             const row = visible[rowIdx];
             if (row === undefined) return;

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -4166,6 +4166,10 @@
       "aria": "Row density"
     },
     "resize_aria": "Resize column {{label}}",
-    "sort_aria": "Sort by: {{label}}"
+    "sort_aria": "Sort by: {{label}}",
+    "paste": {
+      "report_mixed": "Pasted {{applied}}, skipped {{skipped}}",
+      "report_ok": "Pasted {{applied}} cells"
+    }
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -4188,6 +4188,10 @@
       "aria": "Gęstość wierszy"
     },
     "resize_aria": "Zmień szerokość kolumny {{label}}",
-    "sort_aria": "Sortuj po: {{label}}"
+    "sort_aria": "Sortuj po: {{label}}",
+    "paste": {
+      "report_mixed": "Wklejono {{applied}}, pominięto {{skipped}}",
+      "report_ok": "Wklejono {{applied}} komórek"
+    }
   }
 }


### PR DESCRIPTION
## Co (P6-03 — typed TSV paste + raport pominiętych)

Wklejanie bloku TSV w Excel view **koeruje każdą komórkę do typu kolumny** przed commitem: parsowanie number, synonimy boolean (true/1/tak/✓...), **select mapowany po labelu LUB kodzie opcji**, tekst dla reszty. Niepasujące i read-only komórki są **pomijane i raportowane w zbiorczym toaście** („Wklejono X, pominięto Y"). Coercion współdzielony z single-cell commit — obie ścieżki walidują identycznie.

Dodatkowo: `stopEditing()` przywraca focus tabeli po wyjściu z edycji, żeby kolejny Ctrl+V/Ctrl+C dosięgał handlera grida (single-click-edit gubił focus w usuniętym inpucie).

## Świadome odejścia
- **Bulk paste startuje z zaznaczonej (nie-edytowanej) komórki** — spreadsheet-standard „zaznacz zakres → wklej"; single-click-edit na komórce edytowalnej to istniejąca interakcja (UI-02.25). Paste z read-only kotwicy / po Escape działa.
- Async wynik per komórka (BE 422) nadal rolluje się per-cell (rollback+toast z P6-02) — raport pokrywa walidację client-side; pełna agregacja async wyników to nadmiarowy scope.

## Bramki
- FE: vitest 187/187, tsc 0, biome 0, build OK, max-lines baseline.
- **Live smoke na pim.localhost (PASSED):** blok 2-wierszowy `skip\t{val}` na kotwicy SKU (read-only) → **PATCH 200 `{"attributes":{"name":"..."}}` ×2, toast „Wklejono 2, pominięto 2"**, wartość persystuje po reload; select mapuje label→code.
- E2E `2402-tsv-paste.spec.ts` (browser clipboard z permissions → CI-safe): paste → coercion → skip report → persystencja.

Closes #2402

🤖 Generated with [Claude Code](https://claude.com/claude-code)
