### PR TITLE
docs(agent): record GRID epic marathon progress and lessons

### DIFF
--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -3,6 +3,27 @@
 > Zwięzły status bieżący (CLAUDE.md §Workflow pkt 2). Pełna historia: `git log`, GitHub Issues/milestones, `agent/lessons.md`, `Project Plan/*`.
 > Przepisany 2026-06-13 (poprzednie 2066 linii append-only logu, m.in. epiki NUI/UI/RBAC — w historii gita).
 
+## 2026-07-12: Epik GRID — MARATON (dopracowanie grida per ObjectType: column manager + custom columns + sort + inline edit + saved views)
+- **Backlog:** `Project Plan/feature-grid-tickets.md` (23 tickety GRID-P{faza}-{nn}, #2385–#2407, milestone'y #66–#73, label epik-GRID). Strategia PR: 23 tickety → 13 PR-ów (sekcja „Strategia PR" — powód: quality-php na paths-ignore = pełne bramki na każdym PR z kodem).
+- **✅ DOSTARCZONE i zmergowane (11 ticketów, każdy live-smoke proof na pim.localhost):**
+  - **M1** (#2497/#2499) — dynamiczne kolumny z list-schema: `useGridColumns` model, `resolveGridColumns` (RBAC-safe merge overrides), rejestr cell-rendererów per typ atrybutu, oba widoki (grid+Excel) z ViewColumnSeeds; fallback przy braku schemy.
+  - **M2** (#2501) — column manager (show/hide + drag-reorder @dnd-kit + reset), header resize (clamp 60–640, live width + commit na pointerup), sticky identyfikator, density compact/normal. Wszystko persist localStorage per OT.
+  - **ADR-0028** (#2502) — strategia sortu: Postgres JSONB path (benchmark 50k: p95 12–25ms bez indeksu, 20–40× zapasu; Meili odrzucony operacyjnie), NULLS LAST + tie-breaker id, LIMIT/OFFSET dla sortowanych. `docs/perf/grid-attribute-sort-benchmark.md`.
+  - **M3** (#2503) — `?full=1`: dowolny atrybut ObjectType jako kolumna (281 na demo), default→hidden (manager odkrywa), chip AttributeGroup; RBAC 3-state w obu trybach.
+  - **M4-BE** (#2505) — SavedView config: `SavedViewConfigValidator` (unknown key/typ → 400 RFC7807), default per (tenant,object_type_id,user_id), system view (user_id NULL) → PATCH/DELETE 403; owner-scoped przez CurrentUserProvider.
+  - **P5 sort** (#2507) — `AttributeOrderFilter` `?order[attribute.{code}]` wg ADR-0028 (cast per typ, jednolity 400 dla unknown/unsortable/restricted), DQL JSONB_PATH_TEXT/NUMERIC, OrderById + pola systemowe, klikalne nagłówki + URL-persist. Fix: list-url-seed strip sort.
+  - **P6-01** (#2506) — flaga `editable` per kolumna (canEditAttribute + typ inline-editowalny; media/relation/multiselect/localizable → false).
+  - **P6-02** (#2508) — typed inline editors w Excel view (date/number/boolean/select-dropdown z labelkami), commit PATCH atrybutu + optimistic overlay + rollback.
+  - **M4-FE** (#2509) — round-trip config przez saved views (filters+columns+sort+density+variants+page_size); reloadToken refetch; fix pre-existing resource mismatch (rail 'products' vs save 'product').
+  - **P6-03** (#2510 merged) — typed TSV paste + coercion (select label→code) + skip report toast; `coerceExcelValue` współdzielony z single-cell commit.
+- **⏸ ODŁOŻONE do świeżego kontekstu (świadomy quality-stop, EPIK MARATHON RULE — decyzja bliska architektonicznej):**
+  - **M7 grid-export (#2403 P7-01 + #2404 P7-02)** — endpoint `POST /api/objects/grid-export` reużywający ExportBuilder/ColumnResolver/ValueSerializer + async job + MinIO + przycisk FE. Duża integracja silnika Export (model sesji/async) — wymaga dokładnego studium, żeby nie dostarczyć zepsutego eksportu.
+  - **M8-P8-01 wirtualizacja wierszy (#2405)** — restrukturyzacja render grida (page-scroll → kontener stałej wysokości) zderza się ze sticky columns (P2-02) + variant tree + selekcją (świeżo dostarczone). Paginacja i tak cappuje 200 wierszy — potrzeba umiarkowana. Ryzyko regresji > wartość przy tej długości sesji.
+  - **M8-P8-02 journey E2E (#2406)** + **P8-03 closeout+screencast (#2407)** — po M7 i P8-01.
+- **Gotchas maratonu → sekcje niżej + memory `grid-epic-backlog`:** biome-ignore w JSX = 1 linia; inline @var ginie przez cs-fixer (użyj typowanego helpera); PR-head desync po force-pushu → close+nowy PR; stale FrankenPHP worker → cache:clear+restart przed live-E2E; toast paste fire'uje przed async PATCH (waitForResponse w E2E); paste wymaga focusu tabeli (stopEditing restore).
+
+## 2026-07-11 (wieczór): 3 bug-fixy po smoke operatora WFL
+
 ## 2026-07-11 (wieczór): 3 bug-fixy po smoke operatora WFL (#2491/#2493/#2495 — wszystkie merged + closed z proofem)
 - **Kontekst:** operator manualnie smoke-testował workflow po zamknięciu epiku; zgłosił 3 niezależne problemy → 3 osobne issues/PR-y (SKILL-BUG-FIX-TICKET, plan `~/.claude/plans/graceful-gathering-scott.md`).
 - **#2491 (PR #2492) — edytor roli 500:** schema drift `role_attribute_permissions` (composite PK bez `id`; migracja `CREATE TABLE IF NOT EXISTS` z `id` była no-opem) → `GET/PUT /api/roles/{id}/attribute-permissions` 500 → mylący toast „Operacja na roli nie powiodła się". Fix: defensywna migracja `Version20260711150000` (ADD id + swap PK, guard na `information_schema`). CI zielone bo testowa DB z mappingów. Smoke: GET/PUT→200, dev DB zmigrowana.

--- a/agent/lessons.md
+++ b/agent/lessons.md
@@ -3077,3 +3077,28 @@ M4 (P4-01..08) + M5 Hardening (P5-01..05) — wszystkie zmergowane. Epik APIC ko
 - **ViewColumnSeeds** — kolumny widokowe spoza schemy (kategorie, sync, cena, fallback nazwy) wchodzą do modelu kolumn jako seedy (`resolveGridColumns(schema, overrides, viewColumns)`) zamiast żyć obok modelu; column manager (M2) zarządza nimi jak każdą kolumną, a seed kolidujący z kluczem schemy jest pomijany (schema wygrywa). Klucze `__`-prefiksowane nie zderzą się z kodami atrybutów.
 - **Parity przez `defaultOverrides`** — schema zawsze emituje `status`/`updatedAt`, legacy grid ich nie pokazywał; hook `useGridColumns(id, {defaultOverrides})` aplikuje ukrycia tylko gdy brak stored prefs (null-vs-[] rozróżnia „brak prefsów" od „user zresetował").
 - **Excel: rich display bez łamania TSV** — `ExcelColumn.renderDisplay` renderuje bogatą komórkę, a wiersz niesie płaską projekcję tekstową pod tym samym kluczem (`attr:{code}`), więc clipboard `String(row[key])` działa bez zmian w gridzie.
+
+## Lessons z epiku GRID — maraton 2026-07-12 (M1–M6 + M4 + P5)
+
+### Toolchain / CI gotchas (kosztowały najwięcej czasu)
+- **`biome-ignore` w JSX MUSI być pojedynczą linią** bezpośrednio nad węzłem. Multi-line `//` komentarz → biome czyta tylko komentarz najbliższy węzłowi; dyrektywa na pierwszej z kilku linii = nie działa. ZAWSZE re-run `biome check` po dodaniu ignore (build/tsc NIE łapią tego).
+- **Inline `/** @var array<string,mixed> */` ginie przez cs-fixer** → degradowany do jednogwiazdkowego `/* */`, który PHPStan ignoruje → typ pozostaje `array<mixed,mixed>`. Zamiast inline @var użyj typowanego helpera (`asConfigArray(mixed): array<string,mixed>`).
+- **PR-head desync po `git push -f` rebase'a**: GitHub PR utyka na STARYM SHA (`gh pr view --json headRefOid` ≠ remote head), nowe pushe nie odpalają `synchronize`, PR w kółko pokazuje stary czerwony run. Fix: **zamknij + utwórz NOWY PR** z tego samego brancha. Retarget PR na `main` PRZED merge bazy stackowanego PR-a unika auto-close przez `--delete-branch`.
+- **Rebase stacked brancha po squash-merge bazy:** `git rebase --onto origin/main <ostatni-commit-bazy> <branch>` — zwykły `git rebase origin/main` zderza oryginalne commity ze squashem (konflikt).
+- **Pusty commit / commit poza `apps/admin/**` nie odpala frontend workflow** (paths whitelist) → re-trigger = realna zmiana w apps/admin.
+- **Dodanie zależności do konstruktora** → poprawić WSZYSTKIE `new Handler(...)` w unit testach (PHPStan „N parameters, M required").
+- **Nowy AP filter** (`api_platform.filter`) surface'uje się w OpenAPI → regeneruj `docs/api-spec/v0.json`; manualny `?query` param (`$request->query`) NIE surface'uje.
+- **PHPStan/cs-fixer w worktree bez kontenera:** `docker run --rm -v $PWD:/app -v pim_api_vendor:/app/vendor -w /app php:8.4-cli php -d memory_limit=2G vendor/bin/phpstan analyse <pliki>` — WYMAGA skopiowania `var/cache/dev/App_KernelDevDebugContainer.xml` z głównego drzewa. Analiza podzbioru plików daje false-positive „Ignored error pattern not matched" — to NIE realne błędy.
+
+### Live-E2E na dev-stacku (worktree pattern)
+- **Serwowane drzewo = główny `~/dev/PIM`, nie worktree.** By live-testować branch: `git -C ~/dev/PIM checkout --detach <branch>`, potem **ZAWSZE** `docker compose exec api php bin/console cache:clear --no-warmup && docker compose restart api` (FrankenPHP worker cache'uje stary kod → fałszywe regresje E2E: fallback columns, stary schema). Po teście wróć na `main`.
+- **Toast fire'uje synchronicznie PRZED async PATCH** — E2E asertujący skutek edycji/paste musi `waitForResponse(PATCH)` zamiast sprawdzać licznik zaraz po toaście.
+- **Single-click-edit gubi focus tabeli** (input usuwany z DOM) → Ctrl+V/Ctrl+C nie dochodzi do grid keydown. Fix: `stopEditing()` z `requestAnimationFrame(() => gridRef.current?.focus())`.
+- **Schema-load timing:** paste/interakcja przed załadowaniem list-schema trafia w fallback columns (SKU/Status/Kompletność/Zmodyfikowano) → E2E czeka na realny nagłówek (`columnheader "Nazwa"`) przed akcją.
+- **INFRA:** baza pada „No space left on device" gdy MinIO volume pełny (osierocone WAL pgBackrest); `docker run --rm -v pim_minio_data:/data alpine du -sh /data/*` → usuń stare archiwa. Rate-limit auth 5/15min → `docker compose restart redis`.
+
+### Decyzje świadome
+- **Custom column = dowolny atrybut** (nie silnik formuł PIMcore) — decyzja operatora.
+- **Sort: Postgres JSONB path, bez indeksów wyrażeniowych w MVP** (ADR-0028, benchmark 50k rozstrzygnął; Meili szybszy w izolacji ale operacyjnie droższy).
+- **P6-01 rozdzielony od P6-02** mimo strategii bundlowania — P6-02 (typed editors) to duży samodzielny kawałek; flaga BE nie jest „martwym kodem".
+- **M7 (grid-export) + P8-01 (wirtualizacja wierszy) odłożone** do świeżego kontekstu — złożone/ryzykowne przy tej długości sesji (quality-stop, nie token-budget excuse).


### PR DESCRIPTION
Status + lekcje po segmencie maratonu epiku GRID. **11 ticketów zmergowanych** (M1, M2, ADR-0028, M3, M4-BE, P5, P6-01, P6-02, M4-FE, P6-03 — #2385–#2402), każdy z live-smoke proofem. M7 (grid-export) + M8-P8-01 (wirtualizacja wierszy) świadomie odłożone do świeżego kontekstu (udokumentowany plan). Gotchas toolchain/CI/live-E2E w lessons.md.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)