### PR TITLE
fix(catalog): make Nazwa/Cena and all simple attributes editable in Excel view

### DIFF
--- a/apps/admin/e2e/2389-column-manager.spec.ts
+++ b/apps/admin/e2e/2389-column-manager.spec.ts
@@ -15,6 +15,15 @@ import { loginAsAdmin } from './helpers/auth';
 test('column manager: hide, reorder, reset — persisted per ObjectType', async ({ page }) => {
   await loginAsAdmin(page);
   await page.goto('/products');
+  await page.getByTestId('grid-header-code').waitFor();
+  // Clear any column prefs left by earlier tests so we start from the
+  // ObjectType default (localStorage is shared across specs).
+  await page.evaluate(() => {
+    for (const k of Object.keys(localStorage)) {
+      if (/pim\.objectList\..*\.columns$/.test(k)) localStorage.removeItem(k);
+    }
+  });
+  await page.reload();
   await expect(page.getByTestId('grid-header-completeness')).toBeVisible();
 
   // Hide "Kompletność".
@@ -27,29 +36,34 @@ test('column manager: hide, reorder, reset — persisted per ObjectType', async 
   await expect(page.getByTestId('grid-header-code')).toBeVisible();
   await expect(page.getByTestId('grid-header-completeness')).toHaveCount(0);
 
-  // Reorder: move "__sync" down one slot — its neighbour (__price) is
-  // visible, so the change is observable in the header row. (a11y
-  // buttons — drag is covered by the same handler; buttons are
-  // deterministic in CI.)
-  const headersBefore = await page
-    .locator('[data-testid^="grid-header-"]')
-    .evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-testid')));
+  // Reorder via the manager and verify against the manager's own row
+  // order — deterministic regardless of which columns are hidden (the
+  // manager lists every column; moving one always changes that order,
+  // unlike grid headers where a move past a hidden column is invisible).
+  const managerOrder = async (): Promise<Array<string | null>> => {
+    await page.getByTestId('column-manager-trigger').click();
+    await page.locator('[data-testid^="column-manager-row-"]').first().waitFor();
+    const order = await page
+      .locator('[data-testid^="column-manager-row-"]')
+      .evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-testid')));
+    await page.keyboard.press('Escape');
+    return order;
+  };
+
+  const orderBefore = await managerOrder();
   await page.getByTestId('column-manager-trigger').click();
-  await page.getByTestId('column-manager-down-__sync').click();
+  await page.getByTestId('column-manager-up-__variant').click();
   await page.keyboard.press('Escape');
-  const headersAfter = await page
-    .locator('[data-testid^="grid-header-"]')
-    .evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-testid')));
-  expect(headersAfter).not.toEqual(headersBefore);
+  const orderAfter = await managerOrder();
+  expect(orderAfter).not.toEqual(orderBefore);
 
   await page.reload();
   await expect(page.getByTestId('grid-header-code')).toBeVisible();
-  const headersReloaded = await page
-    .locator('[data-testid^="grid-header-"]')
-    .evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-testid')));
-  expect(headersReloaded).toEqual(headersAfter);
+  await page.getByTestId('grid-header-__variant').waitFor();
+  const orderReloaded = await managerOrder();
+  expect(orderReloaded).toEqual(orderAfter);
 
-  // Reset → completeness is back, categories back in place.
+  // Reset → completeness is back.
   await page.getByTestId('column-manager-trigger').click();
   await page.getByTestId('column-manager-reset').click();
   await page.keyboard.press('Escape');
@@ -62,9 +76,11 @@ test('header drag-resize persists and the identifier stays sticky', async ({ pag
 
   const header = page.getByTestId('grid-header-__categories');
   await expect(header).toBeVisible();
+  await page.waitForTimeout(300);
   const before = (await header.boundingBox())?.width ?? 0;
 
   const handle = page.getByTestId('grid-resize-__categories');
+  await handle.scrollIntoViewIfNeeded();
   const box = await handle.boundingBox();
   if (box === null) throw new Error('resize handle not visible');
   await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
@@ -76,6 +92,7 @@ test('header drag-resize persists and the identifier stays sticky', async ({ pag
   expect(after).toBeGreaterThan(before + 40);
 
   await page.reload();
+  await page.waitForTimeout(300);
   const persisted = (await page.getByTestId('grid-header-__categories').boundingBox())?.width ?? 0;
   expect(Math.abs(persisted - after)).toBeLessThan(4);
 

--- a/apps/admin/e2e/2401b-default-columns-editable.spec.ts
+++ b/apps/admin/e2e/2401b-default-columns-editable.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * GRID-P6-02 follow-up (#2401) — the default product Excel view surfaces
+ * the real, editable `name` and `price` attribute columns (not the
+ * read-only derived view-seeds), so Nazwa and Cena are inline-editable
+ * out of the box. Computed (completeness/sync), relation (categories)
+ * and derived (variant) columns stay read-only.
+ */
+
+test('Nazwa and Cena are editable by default; computed columns are not', async ({ page }) => {
+  test.setTimeout(90_000);
+  await loginAsAdmin(page);
+  await page.goto('/products');
+  await page.getByTestId('grid-header-code').waitFor();
+  await page.getByRole('tab', { name: 'Excel' }).click();
+  await page.getByRole('columnheader', { name: 'Nazwa' }).waitFor();
+
+  const headers = page.locator('table thead th');
+  const count = await headers.count();
+  const indexOf = async (label: string): Promise<number> => {
+    for (let i = 0; i < count; i += 1) {
+      if ((await headers.nth(i).innerText()).trim() === label) return i;
+    }
+    return -1;
+  };
+  const cellEditable = async (col: number): Promise<boolean> => {
+    const cls =
+      (await page.locator('table tbody tr').first().locator('td').nth(col).getAttribute('class')) ??
+      '';
+    return !cls.includes('bg-muted');
+  };
+
+  const cenaIdx = await indexOf('Cena');
+  expect(cenaIdx).toBeGreaterThanOrEqual(0);
+  expect(await cellEditable(cenaIdx)).toBe(true);
+  expect(await cellEditable(await indexOf('Nazwa'))).toBe(true);
+  // Computed / relation columns stay read-only.
+  expect(await cellEditable(await indexOf('Kompletność'))).toBe(false);
+  expect(await cellEditable(await indexOf('Kanały'))).toBe(false);
+
+  // Editing Cena PATCHes the price attribute with the {amount, currency}
+  // envelope and persists after reload.
+  const amount = String(100 + Math.floor(Math.random() * 800));
+  const patch = page.waitForResponse(
+    (r) => /\/api\/objects\/[^/]+$/.test(r.url()) && r.request().method() === 'PATCH',
+    { timeout: 15_000 },
+  );
+  await page.locator('table tbody tr').first().locator('td').nth(cenaIdx).click();
+  await page.keyboard.type(amount);
+  await page.keyboard.press('Enter');
+  const resp = await patch;
+  expect(resp.status()).toBe(200);
+  expect(resp.request().postData() ?? '').toContain('"price"');
+  expect(resp.request().postData() ?? '').toContain('"amount"');
+
+  await page.reload();
+  await page.getByRole('tab', { name: 'Excel' }).click();
+  await page.getByRole('columnheader', { name: 'Nazwa' }).waitFor();
+  await expect(page.locator('table tbody tr').first().locator('td').nth(cenaIdx)).toContainText(
+    amount,
+  );
+});

--- a/apps/admin/src/components/objects/universal-list-page.tsx
+++ b/apps/admin/src/components/objects/universal-list-page.tsx
@@ -146,10 +146,22 @@ const PRODUCT_FACETS = ['status', 'brand'];
  * showed them. Hidden by default until the user opts in (column manager,
  * GRID-P2-01); stored prefs override this.
  */
-const DEFAULT_COLUMN_OVERRIDES: GridColumnOverride[] = [
-  { key: 'status', hidden: true },
-  { key: 'updatedAt', hidden: true },
-];
+/**
+ * GRID-P1-03 / #2401 follow-up — schema always emits `status`/`updatedAt`
+ * (legacy grid hid them). For products we also surface the real, editable
+ * `name` and `price` attribute columns by default (they are `show_in_list`
+ * =false so they start hidden) INSTEAD of the read-only `__name`/`__price`
+ * view-seeds, so the default Nazwa/Cena columns are inline-editable.
+ */
+function defaultColumnOverrides(hasName: boolean, hasPrice: boolean): GridColumnOverride[] {
+  return [
+    { key: 'code' },
+    ...(hasName ? [{ key: 'name', hidden: false }] : []),
+    ...(hasPrice ? [{ key: 'price', hidden: false }] : []),
+    { key: 'status', hidden: true },
+    { key: 'updatedAt', hidden: true },
+  ];
+}
 
 export interface UniversalListPageProps {
   /** ObjectType UUID — drives schema fetch, search scope, and storage keys. */
@@ -234,7 +246,7 @@ export function UniversalListPage({
   // derived columns (name fallback, categories, sync, price, variant
   // axis) fill the gaps the list-schema cannot know about; seeds whose
   // key already exists as a schema column are skipped by the resolver.
-  const schemaQuery = useListSchema(objectTypeId);
+  const schemaQuery = useListSchema(objectTypeId, { full: true });
   const gridViewColumns = useMemo<ViewColumnSeed[]>(() => {
     const schemaColumns = schemaQuery.data?.columns ?? [];
     const has = (key: string): boolean => schemaColumns.some((column) => column.key === key);
@@ -283,7 +295,10 @@ export function UniversalListPage({
     resetOverrides,
   } = useGridColumns(objectTypeId, {
     viewColumns: gridViewColumns,
-    defaultOverrides: DEFAULT_COLUMN_OVERRIDES,
+    defaultOverrides: defaultColumnOverrides(
+      (schemaQuery.data?.columns ?? []).some((c) => c.key === 'name'),
+      isProduct && (schemaQuery.data?.columns ?? []).some((c) => c.key === 'price'),
+    ),
     // GRID-P3-02 — resolve against the full catalogue so any attached
     // attribute can be revealed as a column by the manager.
     fullSchema: true,
@@ -775,9 +790,23 @@ export function UniversalListPage({
     // key; PATCH the attribute and optimistically overlay the raw
     // envelope so the cell shows the new reading before the refetch.
     const attrCode = colKey.startsWith('attr:') ? colKey.slice('attr:'.length) : null;
+    let attrPayload: unknown = value;
     if (attrCode !== null) {
       const column = visibleColumns.find((c) => c.key === attrCode);
-      const envelope = column?.type === 'select' ? { option_code: value } : { value };
+      let envelope: Record<string, unknown>;
+      if (column?.type === 'select') {
+        envelope = { option_code: value };
+      } else if (column?.type === 'price') {
+        // Price is an {amount, currency} envelope — edit the amount,
+        // keep the existing currency (or default PLN).
+        const prev = row.attributesIndexed?.[attrCode] as { currency?: unknown } | undefined;
+        const currency = typeof prev?.currency === 'string' ? prev.currency : 'PLN';
+        const amount = value === null ? null : Number(value);
+        envelope = { amount, currency };
+        attrPayload = value === null ? null : { amount, currency };
+      } else {
+        envelope = { value };
+      }
       setOptimisticEdits((prev) => {
         const next = new Map(prev);
         const base = next.get(row.id) ?? {};
@@ -804,7 +833,7 @@ export function UniversalListPage({
       } else if (attrCode !== null) {
         await jsonFetch(`/api/objects/${row.id}`, {
           method: 'PATCH',
-          body: { attributes: { [attrCode]: value } },
+          body: { attributes: { [attrCode]: attrPayload } },
           contentType: 'application/merge-patch+json',
         });
       } else {

--- a/apps/api/src/Catalog/Application/Query/GetObjectTypeListSchema/GetObjectTypeListSchemaHandler.php
+++ b/apps/api/src/Catalog/Application/Query/GetObjectTypeListSchema/GetObjectTypeListSchemaHandler.php
@@ -245,9 +245,14 @@ final readonly class GetObjectTypeListSchemaHandler
 
     private function isEditableAttribute(Attribute $attribute): bool
     {
+        // GRID-P6-02 follow-up — localizable / scopable simple attributes
+        // (name, price, ...) ARE inline-editable in the grid; the edit
+        // writes the base value (default locale / unscoped), the same
+        // behaviour the list already applies to the name column. Only the
+        // type + edit permission gate inline editability; the grid has no
+        // locale/channel switcher yet, so per-locale/channel editing of a
+        // specific dimension stays on the detail page.
         return \in_array($attribute->getType(), self::INLINE_EDITABLE_TYPES, true)
-            && !$attribute->isLocalizable()
-            && !$attribute->isScopable()
             && $this->attributePermissions->canEditAttribute($attribute->getId());
     }
 

--- a/apps/api/tests/Unit/Catalog/Application/Query/GetObjectTypeListSchemaHandlerTest.php
+++ b/apps/api/tests/Unit/Catalog/Application/Query/GetObjectTypeListSchemaHandlerTest.php
@@ -123,8 +123,9 @@ final class GetObjectTypeListSchemaHandlerTest extends TestCase
         self::assertTrue($byKey['material']['editable']);
         // Media has no inline editor → not editable even with permission.
         self::assertFalse($byKey['gallery']['editable']);
-        // Localizable needs the locale/channel context → not editable in MVP.
-        self::assertFalse($byKey['name']['editable']);
+        // Localizable simple attribute IS inline-editable (writes the base
+        // value) — GRID-P6-02 follow-up relaxed the loc/scop exclusion.
+        self::assertTrue($byKey['name']['editable']);
         // System columns are never inline-editable through this flag.
         self::assertFalse($byKey['code']['editable']);
     }


### PR DESCRIPTION
## Problem (zgłoszony przez operatora)

W widoku Excel edytowalna była tylko kolumna Nazwa. Oczekiwanie: każda kolumna będąca atrybutem możliwym do pokazania na liście (nazwa, cena, wartości liczbowe…) edytowalna inline. Wyliczane (Kompletność, Kanały) — read-only OK.

## Root cause (dwie warstwy)

1. **Flaga `editable` z P6-02 wykluczała localizable/scopable** → `name` (localizable) i `price` (scopable) były read-only. Tylko hardcoded view-seed Nazwa dawał edycję.
2. **Domyślny widok produktu pokazywał read-only view-seedy `__name`/`__price`** (derived) zamiast realnych atrybutów. Po ujawnieniu realnego `price` powstawały DWIE „Cena" (read-only view-seed + editable atrybut).

## Fix

- **BE:** `isEditableAttribute` liczy tylko typ + `canEditAttribute` (usunięte wykluczenie localizable/scopable). Edycja zapisuje **wartość bazową** (domyślne locale / bez kanału) — jak już robiła Nazwa. To odblokowuje name, price i wszystkie proste atrybuty (221→ z name/price).
- **FE:** domyślny widok produktu pokazuje **realne edytowalne kolumny name/price** (sprawdzane w pełnej schemie) zamiast view-seedów. Cena edytuje `amount`, zachowuje `currency` (envelope `{amount, currency}`).
- Wyliczane (Kompletność/Kanały), relacje (Kategorie), multiselect, asset → **read-only** (MVP, wymagają dedykowanych edytorów).

## Bramki
- FE: vitest 187/187, tsc 0, biome 0 errors, build OK. BE: PHPStan max 0 (kontener), cs-fixer, unit test zaktualizowany (localizable→editable).
- **Live smoke na pim.localhost (PASSED):** domyślny widok Excel `["SKU"=ro,"Nazwa"=EDIT,"Cena"=EDIT,"Kompletność"=ro,"Kanały"=ro,"Kategorie"=ro,"Wariant"=ro]`; edycja Cena → **PATCH 200 `{"attributes":{"price":{"amount":892,"currency":"PLN"}}}` → reload „892,00 zł"** (persystencja + format waluty); konsola czysta.
- E2E `2401b-default-columns-editable.spec.ts` (browser-only → CI-safe).

Closes #2401 (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
