### PR TITLE
feat(workflow): configurable approver routing — reviewer per definition (backend)

### DIFF
--- a/apps/api/migrations/Version20260712100000.php
+++ b/apps/api/migrations/Version20260712100000.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * #2513 — configurable workflow approver: add the definition-level
+ * `reviewer` JSONB column ({role_code}|{user_id}|null). Null = the
+ * built-in reviewer role. Defensive/idempotent (guarded on
+ * information_schema) so re-runs and drift-healed databases are no-ops.
+ */
+final class Version20260712100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add reviewer JSONB column to workflow_definitions (configurable approver, #2513)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name = 'workflow_definitions'
+                      AND column_name = 'reviewer'
+                ) THEN
+                    ALTER TABLE workflow_definitions ADD COLUMN reviewer JSONB DEFAULT NULL;
+                END IF;
+            END
+            $$;
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE workflow_definitions DROP COLUMN IF EXISTS reviewer');
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Event/ObjectSubmittedForReview.php
+++ b/apps/api/src/Catalog/Contracts/Event/ObjectSubmittedForReview.php
@@ -21,6 +21,10 @@ final readonly class ObjectSubmittedForReview implements DomainEvent, TenantAwar
         public Uuid $objectId,
         public Uuid $tenantId,
         public ?string $comment = null,
+        // #2513 — lets the task automation resolve the ObjectType-specific
+        // workflow definition (and its configured reviewer). Optional for
+        // backward compatibility with pre-#2513 serialized messages.
+        public ?Uuid $objectTypeId = null,
         public DateTimeImmutable $occurredOn = new DateTimeImmutable(),
     ) {
     }

--- a/apps/api/src/Catalog/Contracts/Event/ObjectUnpublishRequested.php
+++ b/apps/api/src/Catalog/Contracts/Event/ObjectUnpublishRequested.php
@@ -23,6 +23,10 @@ final readonly class ObjectUnpublishRequested implements DomainEvent, TenantAwar
         public Uuid $tenantId,
         public ?Uuid $requesterId = null,
         public ?string $comment = null,
+        // #2513 — lets the task automation resolve the ObjectType-specific
+        // workflow definition (and its configured reviewer). Optional for
+        // backward compatibility with pre-#2513 serialized messages.
+        public ?Uuid $objectTypeId = null,
         public DateTimeImmutable $occurredOn = new DateTimeImmutable(),
     ) {
     }

--- a/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
+++ b/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
@@ -363,7 +363,12 @@ class CatalogObject extends AggregateRoot implements TenantScoped, Blameable, Ed
     public function recordSubmittedForReview(?string $comment): void
     {
         if (null !== $this->tenant) {
-            $this->recordThat(new ObjectSubmittedForReview($this->id, $this->tenant->getId(), $comment));
+            $this->recordThat(new ObjectSubmittedForReview(
+                $this->id,
+                $this->tenant->getId(),
+                $comment,
+                $this->objectType->getId(),
+            ));
         }
     }
 
@@ -391,7 +396,13 @@ class CatalogObject extends AggregateRoot implements TenantScoped, Blameable, Ed
     public function recordUnpublishRequested(?Uuid $requesterId, ?string $comment): void
     {
         if (null !== $this->tenant) {
-            $this->recordThat(new ObjectUnpublishRequested($this->id, $this->tenant->getId(), $requesterId, $comment));
+            $this->recordThat(new ObjectUnpublishRequested(
+                $this->id,
+                $this->tenant->getId(),
+                $requesterId,
+                $comment,
+                $this->objectType->getId(),
+            ));
         }
     }
 

--- a/apps/api/src/Workflow/Application/EditorialWorkflowProvider.php
+++ b/apps/api/src/Workflow/Application/EditorialWorkflowProvider.php
@@ -7,6 +7,7 @@ namespace App\Workflow\Application;
 use App\Shared\Application\TenantContext;
 use App\Workflow\Contracts\EditorialWorkflowProviderInterface;
 use App\Workflow\Contracts\ObjectEditorialWorkflow;
+use App\Workflow\Contracts\TaskAssignee;
 use App\Workflow\Domain\Entity\WorkflowDefinition;
 use Doctrine\ORM\EntityManagerInterface;
 use SplObjectStorage;
@@ -54,16 +55,7 @@ final class EditorialWorkflowProvider implements EditorialWorkflowProviderInterf
     public function for(object $subject, ?string $objectTypeId = null): WorkflowInterface
     {
         unset($subject);
-        if (!$this->customDefinitionsEnabled) {
-            return $this->staticWorkflow;
-        }
-
-        $tenant = $this->tenantContext->get();
-        if (null === $tenant) {
-            return $this->staticWorkflow;
-        }
-
-        $definition = $this->resolveDefinition($objectTypeId);
+        $definition = $this->governingDefinition($objectTypeId);
         if (null === $definition) {
             return $this->staticWorkflow;
         }
@@ -77,6 +69,39 @@ final class EditorialWorkflowProvider implements EditorialWorkflowProviderInterf
         }
 
         return $this->cache[$cacheKey];
+    }
+
+    public function reviewerFor(?string $objectTypeId): ?TaskAssignee
+    {
+        $definition = $this->governingDefinition($objectTypeId);
+        if (null === $definition) {
+            return null;
+        }
+
+        $reviewer = $definition->getReviewer();
+        if (null === $reviewer) {
+            return null;
+        }
+
+        return TaskAssignee::fromDefinition($reviewer);
+    }
+
+    /**
+     * The enabled tenant definition that governs this ObjectType, or null
+     * when custom definitions are off / there is no tenant / no enabled
+     * definition applies (callers fall back to the static machine).
+     */
+    private function governingDefinition(?string $objectTypeId): ?WorkflowDefinition
+    {
+        if (!$this->customDefinitionsEnabled) {
+            return null;
+        }
+
+        if (null === $this->tenantContext->get()) {
+            return null;
+        }
+
+        return $this->resolveDefinition($objectTypeId);
     }
 
     private function resolveDefinition(?string $objectTypeId): ?WorkflowDefinition

--- a/apps/api/src/Workflow/Application/WorkflowDefinitionValidator.php
+++ b/apps/api/src/Workflow/Application/WorkflowDefinitionValidator.php
@@ -29,11 +29,18 @@ final readonly class WorkflowDefinitionValidator
      * @param list<array<string, mixed>> $places
      * @param list<array<string, mixed>> $transitions
      * @param list<string>               $previousPlaceNames places of the stored shape (empty for a new definition)
+     * @param array<string, mixed>|null  $reviewer           #2513 XOR {role_code}|{user_id}|null
+     * @param string|null                $tenantId           scope for reviewer role/user existence checks
      *
      * @return list<array{field: string, message: string}>
      */
-    public function validate(array $places, array $transitions, array $previousPlaceNames = []): array
-    {
+    public function validate(
+        array $places,
+        array $transitions,
+        array $previousPlaceNames = [],
+        ?array $reviewer = null,
+        ?string $tenantId = null,
+    ): array {
         $errors = [];
 
         $placeNames = [];
@@ -128,6 +135,15 @@ final readonly class WorkflowDefinitionValidator
             }
         }
 
+        // #2513 — the configured reviewer must be a real role or user of
+        // this tenant (XOR). A global role (tenant_id NULL, e.g. built-in
+        // `approver`) is accepted too.
+        if (null !== $reviewer) {
+            foreach ($this->reviewerErrors($reviewer, $tenantId) as $error) {
+                $errors[] = $error;
+            }
+        }
+
         // Removing a place with live markings would strand objects.
         $removed = \array_diff($previousPlaceNames, $placeNames);
         foreach ($removed as $place) {
@@ -149,6 +165,56 @@ final readonly class WorkflowDefinitionValidator
         return false !== $this->connection->fetchOne(
             'SELECT 1 FROM permissions WHERE code = :code',
             ['code' => $code],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $reviewer
+     *
+     * @return list<array{field: string, message: string}>
+     */
+    private function reviewerErrors(array $reviewer, ?string $tenantId): array
+    {
+        $roleCode = $reviewer['role_code'] ?? null;
+        $userId = $reviewer['user_id'] ?? null;
+
+        $hasRole = \is_string($roleCode) && '' !== $roleCode;
+        $hasUser = \is_string($userId) && '' !== $userId;
+
+        if ($hasRole && $hasUser) {
+            return [['field' => 'reviewer', 'message' => 'reviewer is a role OR a user, not both.']];
+        }
+        if (!$hasRole && !$hasUser) {
+            return [['field' => 'reviewer', 'message' => 'reviewer must set role_code or user_id.']];
+        }
+        if (null === $tenantId) {
+            // No tenant scope to check against — accept the shape.
+            return [];
+        }
+
+        if ($hasRole && !$this->reviewerRoleExists($roleCode, $tenantId)) {
+            return [['field' => 'reviewer', 'message' => \sprintf('Unknown role "%s" in this tenant.', $roleCode)]];
+        }
+        if ($hasUser && !$this->reviewerUserExists($userId, $tenantId)) {
+            return [['field' => 'reviewer', 'message' => 'Unknown user in this tenant.']];
+        }
+
+        return [];
+    }
+
+    private function reviewerRoleExists(string $code, string $tenantId): bool
+    {
+        return false !== $this->connection->fetchOne(
+            'SELECT 1 FROM roles WHERE code = :code AND (tenant_id = :tenant OR tenant_id IS NULL)',
+            ['code' => $code, 'tenant' => $tenantId],
+        );
+    }
+
+    private function reviewerUserExists(string $userId, string $tenantId): bool
+    {
+        return false !== $this->connection->fetchOne(
+            "SELECT 1 FROM users WHERE id = :id AND tenant_id = :tenant AND status = 'active'",
+            ['id' => $userId, 'tenant' => $tenantId],
         );
     }
 }

--- a/apps/api/src/Workflow/Contracts/EditorialWorkflowProviderInterface.php
+++ b/apps/api/src/Workflow/Contracts/EditorialWorkflowProviderInterface.php
@@ -17,4 +17,14 @@ use Symfony\Component\Workflow\WorkflowInterface;
 interface EditorialWorkflowProviderInterface
 {
     public function for(object $subject, ?string $objectTypeId = null): WorkflowInterface;
+
+    /**
+     * #2513 — the configured recipient of auto-created review /
+     * request-unpublish tasks for the governing definition (same
+     * resolution as {@see self::for()}). Null when custom definitions
+     * are off, no enabled definition applies, or the definition leaves
+     * the reviewer unset — the caller then falls back to the built-in
+     * reviewer role.
+     */
+    public function reviewerFor(?string $objectTypeId): ?TaskAssignee;
 }

--- a/apps/api/src/Workflow/Contracts/TaskAssignee.php
+++ b/apps/api/src/Workflow/Contracts/TaskAssignee.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Workflow\Contracts;
+
+use InvalidArgumentException;
+
+/**
+ * #2513 — the configured recipient of an auto-created workflow task
+ * (review / request-unpublish). Exactly one of roleCode / userId is set
+ * (XOR), mirroring {@see \App\Workflow\Domain\Entity\WorkflowTask}'s
+ * assignee shape. Resolved from a tenant's WorkflowDefinition by
+ * {@see EditorialWorkflowProviderInterface::reviewerFor()}; a null
+ * result means "fall back to the built-in reviewer role".
+ */
+final readonly class TaskAssignee
+{
+    private function __construct(
+        public ?string $roleCode,
+        public ?string $userId,
+    ) {
+        if ((null === $roleCode) === (null === $userId)) {
+            throw new InvalidArgumentException('TaskAssignee is a role OR a user, not both or neither.');
+        }
+    }
+
+    public static function role(string $roleCode): self
+    {
+        return new self($roleCode, null);
+    }
+
+    public static function user(string $userId): self
+    {
+        return new self(null, $userId);
+    }
+
+    /**
+     * @param array<string, mixed> $reviewer definition JSONB: {role_code}|{user_id}
+     */
+    public static function fromDefinition(array $reviewer): ?self
+    {
+        $roleCode = $reviewer['role_code'] ?? null;
+        if (\is_string($roleCode) && '' !== $roleCode) {
+            return self::role($roleCode);
+        }
+
+        $userId = $reviewer['user_id'] ?? null;
+        if (\is_string($userId) && '' !== $userId) {
+            return self::user($userId);
+        }
+
+        return null;
+    }
+}

--- a/apps/api/src/Workflow/Domain/Entity/WorkflowDefinition.php
+++ b/apps/api/src/Workflow/Domain/Entity/WorkflowDefinition.php
@@ -31,6 +31,16 @@ class WorkflowDefinition implements TenantScoped
     /** @var list<array<string, mixed>> */
     private array $transitions;
 
+    /**
+     * #2513 — configured task recipient (review / request-unpublish),
+     * XOR shape `{role_code}` | `{user_id}` | null. Null = the built-in
+     * reviewer role. Definition-level (one approver per ObjectType), not
+     * per-transition.
+     *
+     * @var array<string, mixed>|null
+     */
+    private ?array $reviewer = null;
+
     private bool $enabled = false;
     private DateTimeImmutable $createdAt;
     private DateTimeImmutable $updatedAt;
@@ -38,14 +48,21 @@ class WorkflowDefinition implements TenantScoped
     /**
      * @param list<array<string, mixed>> $places
      * @param list<array<string, mixed>> $transitions
+     * @param array<string, mixed>|null  $reviewer
      */
-    public function __construct(string $name, array $places, array $transitions, ?Uuid $objectTypeId = null)
-    {
+    public function __construct(
+        string $name,
+        array $places,
+        array $transitions,
+        ?Uuid $objectTypeId = null,
+        ?array $reviewer = null,
+    ) {
         $this->id = Uuid::v7();
         $this->name = $name;
         $this->places = $places;
         $this->transitions = $transitions;
         $this->objectTypeId = $objectTypeId;
+        $this->reviewer = $reviewer;
         $this->createdAt = new DateTimeImmutable();
         $this->updatedAt = $this->createdAt;
     }
@@ -96,15 +113,30 @@ class WorkflowDefinition implements TenantScoped
     }
 
     /**
+     * @return array<string, mixed>|null
+     */
+    public function getReviewer(): ?array
+    {
+        return $this->reviewer;
+    }
+
+    /**
      * @param list<array<string, mixed>> $places
      * @param list<array<string, mixed>> $transitions
+     * @param array<string, mixed>|null  $reviewer
      */
-    public function updateShape(string $name, array $places, array $transitions, ?Uuid $objectTypeId): void
-    {
+    public function updateShape(
+        string $name,
+        array $places,
+        array $transitions,
+        ?Uuid $objectTypeId,
+        ?array $reviewer = null,
+    ): void {
         $this->name = $name;
         $this->places = $places;
         $this->transitions = $transitions;
         $this->objectTypeId = $objectTypeId;
+        $this->reviewer = $reviewer;
         $this->touch();
     }
 

--- a/apps/api/src/Workflow/Domain/Repository/WorkflowTaskRepositoryInterface.php
+++ b/apps/api/src/Workflow/Domain/Repository/WorkflowTaskRepositoryInterface.php
@@ -24,12 +24,13 @@ interface WorkflowTaskRepositoryInterface
     /**
      * Newest-first page (UUIDv7 cursor). `$mineUserId` matches direct
      * assignment OR membership in the assignee role (both role paths).
-     * `$mineExtraRoleCodes` widens that membership with virtual roles the
-     * caller is not a member of but is entitled to act as — e.g. the
-     * reviewer role for a `workflow.approve_reject` holder, so the task
-     * inbox matches the notification fan-out audience (#2495).
+     * `$mineReviewerTaskTypes` widens "mine" for a caller entitled to act
+     * on reviewer work — a `workflow.approve_reject` holder sees every
+     * task of these types regardless of who it is routed to (role OR a
+     * specific user), so the inbox matches the notification fan-out and
+     * survives a configurable approver (#2513, generalizes #2495).
      *
-     * @param list<string> $mineExtraRoleCodes
+     * @param list<WorkflowTaskType> $mineReviewerTaskTypes
      *
      * @return list<WorkflowTask>
      */
@@ -40,7 +41,7 @@ interface WorkflowTaskRepositoryInterface
         ?Uuid $objectId = null,
         ?Uuid $mineUserId = null,
         ?DateTimeImmutable $dueBefore = null,
-        array $mineExtraRoleCodes = [],
+        array $mineReviewerTaskTypes = [],
     ): array;
 
     /**

--- a/apps/api/src/Workflow/Infrastructure/Doctrine/DoctrineWorkflowTaskRepository.php
+++ b/apps/api/src/Workflow/Infrastructure/Doctrine/DoctrineWorkflowTaskRepository.php
@@ -43,7 +43,7 @@ final readonly class DoctrineWorkflowTaskRepository implements WorkflowTaskRepos
         ?Uuid $objectId = null,
         ?Uuid $mineUserId = null,
         ?DateTimeImmutable $dueBefore = null,
-        array $mineExtraRoleCodes = [],
+        array $mineReviewerTaskTypes = [],
     ): array {
         $builder = $this->entityManager->createQueryBuilder()
             ->select('t')
@@ -65,16 +65,24 @@ final readonly class DoctrineWorkflowTaskRepository implements WorkflowTaskRepos
                 ->setParameter('dueBefore', $dueBefore);
         }
         if (null !== $mineUserId) {
-            $roleCodes = array_values(array_unique(
-                [...$this->roleCodesOf($mineUserId), ...$mineExtraRoleCodes],
-            ));
-            if ([] === $roleCodes) {
-                $builder->andWhere('t.assigneeUserId = :me')->setParameter('me', $mineUserId);
-            } else {
-                $builder->andWhere('t.assigneeUserId = :me OR t.assigneeRoleCode IN (:roles)')
-                    ->setParameter('me', $mineUserId)
-                    ->setParameter('roles', $roleCodes);
+            // Direct assignment OR membership in the assignee role. A
+            // caller entitled to act on reviewer work additionally sees
+            // every task of $mineReviewerTaskTypes regardless of the
+            // configured assignee (role OR a specific user) — #2513.
+            $clauses = ['t.assigneeUserId = :me'];
+            $builder->setParameter('me', $mineUserId);
+
+            $roleCodes = $this->roleCodesOf($mineUserId);
+            if ([] !== $roleCodes) {
+                $clauses[] = 't.assigneeRoleCode IN (:roles)';
+                $builder->setParameter('roles', $roleCodes);
             }
+            if ([] !== $mineReviewerTaskTypes) {
+                $clauses[] = 't.type IN (:reviewerTypes)';
+                $builder->setParameter('reviewerTypes', $mineReviewerTaskTypes);
+            }
+
+            $builder->andWhere(\implode(' OR ', $clauses));
         }
 
         /** @var list<WorkflowTask> $rows */

--- a/apps/api/src/Workflow/Infrastructure/Doctrine/Orm/Mapping/WorkflowDefinition.orm.xml
+++ b/apps/api/src/Workflow/Infrastructure/Doctrine/Orm/Mapping/WorkflowDefinition.orm.xml
@@ -30,6 +30,11 @@
                 <option name="jsonb">true</option>
             </options>
         </field>
+        <field name="reviewer" type="json" column="reviewer" nullable="true">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
 
         <field name="enabled" type="boolean">
             <options>

--- a/apps/api/src/Workflow/Infrastructure/Messenger/WorkflowTaskAutomation.php
+++ b/apps/api/src/Workflow/Infrastructure/Messenger/WorkflowTaskAutomation.php
@@ -10,7 +10,9 @@ use App\Catalog\Contracts\Event\ObjectSubmittedForReview;
 use App\Catalog\Contracts\Event\ObjectUnpublished;
 use App\Catalog\Contracts\Event\ObjectUnpublishRequested;
 use App\Identity\Contracts\Auth\CurrentUserProvider;
+use App\Workflow\Contracts\EditorialWorkflowProviderInterface;
 use App\Workflow\Contracts\ObjectEditorialWorkflow;
+use App\Workflow\Contracts\TaskAssignee;
 use App\Workflow\Contracts\TransitionLogPort;
 use App\Workflow\Contracts\WorkflowTaskType;
 use App\Workflow\Domain\Entity\WorkflowTask;
@@ -45,6 +47,7 @@ final readonly class WorkflowTaskAutomation
         private WorkflowTaskRepositoryInterface $tasks,
         private TransitionLogPort $transitionLog,
         private CurrentUserProvider $currentUser,
+        private EditorialWorkflowProviderInterface $workflows,
     ) {
     }
 
@@ -55,11 +58,13 @@ final readonly class WorkflowTaskAutomation
             return;
         }
 
+        $assignee = $this->resolveReviewer($event->objectTypeId);
         $this->tasks->save(new WorkflowTask(
             title: 'Review request',
             type: WorkflowTaskType::Review,
             objectId: $event->objectId,
-            assigneeRoleCode: ObjectEditorialWorkflow::REVIEWER_ROLE,
+            assigneeUserId: $assignee->userId !== null ? Uuid::fromString($assignee->userId) : null,
+            assigneeRoleCode: $assignee->roleCode,
             createdBy: $this->currentUser->userId(),
             comment: $event->comment,
             context: ['object_id' => $event->objectId->toRfc4122()],
@@ -112,15 +117,29 @@ final readonly class WorkflowTaskAutomation
             return;
         }
 
+        $assignee = $this->resolveReviewer($event->objectTypeId);
         $this->tasks->save(new WorkflowTask(
             title: 'Unpublish request',
             type: WorkflowTaskType::RequestUnpublish,
             objectId: $event->objectId,
-            assigneeRoleCode: ObjectEditorialWorkflow::REVIEWER_ROLE,
+            assigneeUserId: $assignee->userId !== null ? Uuid::fromString($assignee->userId) : null,
+            assigneeRoleCode: $assignee->roleCode,
             createdBy: $event->requesterId,
             comment: $event->comment,
             context: ['object_id' => $event->objectId->toRfc4122()],
         ));
+    }
+
+    /**
+     * #2513 — the configured reviewer for this ObjectType's definition,
+     * or the built-in reviewer role when custom definitions are off / no
+     * reviewer is set. A definition that points at a user routes the task
+     * straight to that person's inbox.
+     */
+    private function resolveReviewer(?Uuid $objectTypeId): TaskAssignee
+    {
+        return $this->workflows->reviewerFor($objectTypeId?->toRfc4122())
+            ?? TaskAssignee::role(ObjectEditorialWorkflow::REVIEWER_ROLE);
     }
 
     private function closeOpen(Uuid $objectId, WorkflowTaskType $type): void

--- a/apps/api/src/Workflow/Presentation/Controller/WorkflowDefinitionsController.php
+++ b/apps/api/src/Workflow/Presentation/Controller/WorkflowDefinitionsController.php
@@ -173,8 +173,10 @@ final class WorkflowDefinitionsController
     }
 
     /**
-     * #2513 — normalize the reviewer envelope to `{role_code}` | `{user_id}`
-     * | null. The validator rejects the XOR / existence violations.
+     * #2513 — collect the reviewer keys that are actually set. Both keys
+     * are preserved so an ambiguous `{role_code, user_id}` reaches the
+     * validator and is rejected (XOR) rather than silently resolved; an
+     * empty envelope is null (no configured reviewer).
      *
      * @return array<string, mixed>|null
      */
@@ -184,17 +186,17 @@ final class WorkflowDefinitionsController
             return null;
         }
 
+        $out = [];
         $roleCode = $reviewer['role_code'] ?? null;
         if (\is_string($roleCode) && '' !== $roleCode) {
-            return ['role_code' => $roleCode];
+            $out['role_code'] = $roleCode;
         }
-
         $userId = $reviewer['user_id'] ?? null;
         if (\is_string($userId) && '' !== $userId) {
-            return ['user_id' => $userId];
+            $out['user_id'] = $userId;
         }
 
-        return null;
+        return [] === $out ? null : $out;
     }
 
     /**

--- a/apps/api/src/Workflow/Presentation/Controller/WorkflowDefinitionsController.php
+++ b/apps/api/src/Workflow/Presentation/Controller/WorkflowDefinitionsController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Workflow\Presentation\Controller;
 
 use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\TenantContext;
 use App\Workflow\Application\WorkflowDefinitionValidator;
 use App\Workflow\Domain\Entity\WorkflowDefinition;
 use DateTimeInterface;
@@ -34,6 +35,7 @@ final class WorkflowDefinitionsController
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly WorkflowDefinitionValidator $validator,
+        private readonly TenantContext $tenantContext,
     ) {
     }
 
@@ -68,10 +70,10 @@ final class WorkflowDefinitionsController
     #[RequiresPermission(module: 'workflow', action: 'manage_definitions')]
     public function create(Request $request): JsonResponse
     {
-        [$name, $places, $transitions, $objectTypeId] = $this->parseShape($request);
-        $this->assertValid($places, $transitions);
+        [$name, $places, $transitions, $objectTypeId, $reviewer] = $this->parseShape($request);
+        $this->assertValid($places, $transitions, [], $reviewer);
 
-        $definition = new WorkflowDefinition($name, $places, $transitions, $objectTypeId);
+        $definition = new WorkflowDefinition($name, $places, $transitions, $objectTypeId, $reviewer);
         $this->entityManager->persist($definition);
         $this->entityManager->flush();
 
@@ -88,7 +90,7 @@ final class WorkflowDefinitionsController
     public function update(string $id, Request $request): JsonResponse
     {
         $definition = $this->load($id);
-        [$name, $places, $transitions, $objectTypeId] = $this->parseShape($request);
+        [$name, $places, $transitions, $objectTypeId, $reviewer] = $this->parseShape($request);
 
         $previousPlaces = [];
         foreach ($definition->getPlaces() as $place) {
@@ -96,9 +98,9 @@ final class WorkflowDefinitionsController
                 $previousPlaces[] = $place['name'];
             }
         }
-        $this->assertValid($places, $transitions, $definition->isEnabled() ? $previousPlaces : []);
+        $this->assertValid($places, $transitions, $definition->isEnabled() ? $previousPlaces : [], $reviewer);
 
-        $definition->updateShape($name, $places, $transitions, $objectTypeId);
+        $definition->updateShape($name, $places, $transitions, $objectTypeId, $reviewer);
         $this->entityManager->flush();
 
         return new JsonResponse(self::serialize($definition));
@@ -147,7 +149,7 @@ final class WorkflowDefinitionsController
     }
 
     /**
-     * @return array{0: string, 1: list<array<string, mixed>>, 2: list<array<string, mixed>>, 3: ?Uuid}
+     * @return array{0: string, 1: list<array<string, mixed>>, 2: list<array<string, mixed>>, 3: ?Uuid, 4: array<string, mixed>|null}
      */
     private function parseShape(Request $request): array
     {
@@ -167,7 +169,32 @@ final class WorkflowDefinitionsController
             $objectTypeId = Uuid::fromString($body['object_type_id']);
         }
 
-        return [\trim($name), $places, $transitions, $objectTypeId];
+        return [\trim($name), $places, $transitions, $objectTypeId, $this->parseReviewer($body['reviewer'] ?? null)];
+    }
+
+    /**
+     * #2513 — normalize the reviewer envelope to `{role_code}` | `{user_id}`
+     * | null. The validator rejects the XOR / existence violations.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function parseReviewer(mixed $reviewer): ?array
+    {
+        if (!\is_array($reviewer)) {
+            return null;
+        }
+
+        $roleCode = $reviewer['role_code'] ?? null;
+        if (\is_string($roleCode) && '' !== $roleCode) {
+            return ['role_code' => $roleCode];
+        }
+
+        $userId = $reviewer['user_id'] ?? null;
+        if (\is_string($userId) && '' !== $userId) {
+            return ['user_id' => $userId];
+        }
+
+        return null;
     }
 
     /**
@@ -197,10 +224,12 @@ final class WorkflowDefinitionsController
      * @param list<array<string, mixed>> $places
      * @param list<array<string, mixed>> $transitions
      * @param list<string>               $previousPlaces
+     * @param array<string, mixed>|null  $reviewer
      */
-    private function assertValid(array $places, array $transitions, array $previousPlaces = []): void
+    private function assertValid(array $places, array $transitions, array $previousPlaces = [], ?array $reviewer = null): void
     {
-        $errors = $this->validator->validate($places, $transitions, $previousPlaces);
+        $tenantId = $this->tenantContext->get()?->getId()->toRfc4122();
+        $errors = $this->validator->validate($places, $transitions, $previousPlaces, $reviewer, $tenantId);
         if ([] !== $errors) {
             throw new UnprocessableEntityHttpException(\json_encode(['violations' => $errors], JSON_THROW_ON_ERROR));
         }
@@ -217,6 +246,7 @@ final class WorkflowDefinitionsController
             'object_type_id' => $definition->getObjectTypeId()?->toRfc4122(),
             'places' => $definition->getPlaces(),
             'transitions' => $definition->getTransitions(),
+            'reviewer' => $definition->getReviewer(),
             'enabled' => $definition->isEnabled(),
             'updated_at' => $definition->getUpdatedAt()->format(DateTimeInterface::ATOM),
         ];

--- a/apps/api/src/Workflow/Presentation/Controller/WorkflowTasksController.php
+++ b/apps/api/src/Workflow/Presentation/Controller/WorkflowTasksController.php
@@ -91,13 +91,14 @@ final class WorkflowTasksController
 
         $mine = $request->query->getBoolean('mine') ? $this->requireUserId() : null;
 
-        // Review / request-unpublish tasks are assigned to the reviewer
-        // role; a caller who holds workflow.approve_reject can act on them
-        // even without being a member of that role, so widen "mine" to
-        // match the notification fan-out audience (#2495).
-        $mineExtraRoleCodes = null !== $mine
+        // A caller who holds workflow.approve_reject can act on reviewer
+        // work even when it is routed to another role or a specific user
+        // (configurable approver, #2513), so "mine" surfaces every
+        // review / request-unpublish task for them — matching the
+        // notification fan-out audience (generalizes #2495).
+        $mineReviewerTaskTypes = null !== $mine
             && $this->permissions->userHasPermission($mine, ObjectEditorialWorkflow::PERMISSION_APPROVE_REJECT)
-                ? [ObjectEditorialWorkflow::REVIEWER_ROLE]
+                ? [WorkflowTaskType::Review, WorkflowTaskType::RequestUnpublish]
                 : [];
 
         $rows = $this->tasks->page(
@@ -107,7 +108,7 @@ final class WorkflowTasksController
             $objectId,
             $mine,
             $dueBefore,
-            $mineExtraRoleCodes,
+            $mineReviewerTaskTypes,
         );
         $hasMore = \count($rows) > $limit;
         $rows = \array_slice($rows, 0, $limit);

--- a/apps/api/tests/Api/Catalog/WorkflowDefinitionsApiTest.php
+++ b/apps/api/tests/Api/Catalog/WorkflowDefinitionsApiTest.php
@@ -77,6 +77,85 @@ final class WorkflowDefinitionsApiTest extends CatalogApiTestCase
     }
 
     #[Test]
+    public function reviewerRoleRoundtripsAndUnknownReviewersAreRejected(): void
+    {
+        // #2513 — a definition carries one configurable approver.
+        $admin = $this->authenticatedClient();
+
+        // Role reviewer that exists in the tenant → 201 + serialized back.
+        $shape = $this->validShape('Z akceptantem');
+        $shape['reviewer'] = ['role_code' => 'approver'];
+        $created = $admin->request('POST', '/api/workflow/definitions', ['json' => $shape])->toArray();
+        self::assertSame(['role_code' => 'approver'], $created['reviewer']);
+        $id = $created['id'];
+        self::assertIsString($id);
+        $fetched = $admin->request('GET', '/api/workflow/definitions/'.$id)->toArray();
+        self::assertSame(['role_code' => 'approver'], $fetched['reviewer']);
+
+        // Unknown role → 422.
+        $shape['reviewer'] = ['role_code' => 'no_such_role'];
+        $unknown = $admin->request('POST', '/api/workflow/definitions', ['json' => $shape]);
+        self::assertSame(422, $unknown->getStatusCode());
+        self::assertStringContainsString('reviewer', $unknown->getContent(false));
+
+        // Both role and user (XOR violation) → 422.
+        $shape['reviewer'] = ['role_code' => 'approver', 'user_id' => '019f2bb4-0000-7000-8000-000000000000'];
+        $xor = $admin->request('POST', '/api/workflow/definitions', ['json' => $shape]);
+        self::assertSame(422, $xor->getStatusCode());
+
+        // A user id that is not in this tenant → 422.
+        $shape['reviewer'] = ['user_id' => '019f2bb4-0000-7000-8000-000000000000'];
+        $foreignUser = $admin->request('POST', '/api/workflow/definitions', ['json' => $shape]);
+        self::assertSame(422, $foreignUser->getStatusCode());
+    }
+
+    #[Test]
+    public function providerResolvesReviewerFromDefinition(): void
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $object = $this->seedProduct('WFL-DEF-REVIEWER');
+        $productTypeId = $object->getObjectType()->getId()->toRfc4122();
+
+        $definition = new WorkflowDefinition(
+            'Z akceptantem',
+            [['name' => 'draft'], ['name' => 'published']],
+            [['name' => 'publish_direct', 'from' => 'draft', 'to' => 'published']],
+            $object->getObjectType()->getId(),
+            ['role_code' => 'catalog_manager'],
+        );
+        $definition->assignTenant($tenant);
+        $definition->setEnabled(true);
+        $em->persist($definition);
+        $em->flush();
+
+        $provider = new EditorialWorkflowProvider(
+            self::getContainer()->get(Registry::class)->get($object, 'object_editorial'),
+            $em,
+            self::getContainer()->get(TenantContext::class),
+            self::getContainer()->get(EventDispatcherInterface::class),
+            customDefinitionsEnabled: true,
+        );
+        $assignee = $provider->reviewerFor($productTypeId);
+        self::assertNotNull($assignee);
+        self::assertSame('catalog_manager', $assignee->roleCode);
+        self::assertNull($assignee->userId);
+
+        // Flag off → no configured reviewer (caller falls back to approver).
+        $offProvider = new EditorialWorkflowProvider(
+            self::getContainer()->get(Registry::class)->get($object, 'object_editorial'),
+            $em,
+            self::getContainer()->get(TenantContext::class),
+            self::getContainer()->get(EventDispatcherInterface::class),
+            customDefinitionsEnabled: false,
+        );
+        self::assertNull($offProvider->reviewerFor($productTypeId));
+    }
+
+    #[Test]
     public function providerBuildsTheDbMachineWithMetadataWhenFlagIsOn(): void
     {
         $em = $this->em();

--- a/apps/api/tests/Api/Catalog/WorkflowTasksApiTest.php
+++ b/apps/api/tests/Api/Catalog/WorkflowTasksApiTest.php
@@ -10,13 +10,18 @@ use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
 use App\Identity\Domain\Entity\User;
 use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
+use App\Workflow\Contracts\WorkflowTaskType;
+use App\Workflow\Domain\Entity\WorkflowTask;
+use App\Workflow\Domain\Repository\WorkflowTaskRepositoryInterface;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * Pakiet F = WFL-P4-01 (#2428) + WFL-P4-02 (#2429) — the task loop:
@@ -113,6 +118,38 @@ final class WorkflowTasksApiTest extends CatalogApiTestCase
         self::assertIsArray($notMineItems);
         $notMineTypes = \array_column(\array_filter($notMineItems, 'is_array'), 'type');
         self::assertNotContains('review', $notMineTypes, 'a non-approver without the permission never sees review tasks in mine');
+    }
+
+    #[Test]
+    public function mineSurfacesUserAssignedReviewTaskForApprovePermissionHolder(): void
+    {
+        // #2513 — a configurable approver can route the review task to a
+        // specific user. An approve_reject holder still sees it in mine
+        // (generalizes #2495 beyond role assignment; the role-code match
+        // would have missed a user-assigned task).
+        $this->createUserWithRole('mkt-ua@demo.localhost', 'marketing');
+        $assignee = self::getContainer()->get(UserRepositoryInterface::class)->findByEmail('mkt-ua@demo.localhost');
+        \assert($assignee instanceof User);
+        $id = $this->seedProduct('WFL-T-UA');
+
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $task = new WorkflowTask(
+            title: 'Review request',
+            type: WorkflowTaskType::Review,
+            objectId: Uuid::fromString($id),
+            assigneeUserId: $assignee->getId(),
+            createdBy: $assignee->getId(),
+        );
+        self::getContainer()->get(WorkflowTaskRepositoryInterface::class)->save($task);
+
+        $admin = $this->authenticatedClient();
+        $mine = $admin->request('GET', '/api/workflow/tasks?mine=1&status=open&object_id='.$id)->toArray();
+        $items = $mine['items'];
+        self::assertIsArray($items);
+        $types = \array_column(\array_filter($items, 'is_array'), 'type');
+        self::assertContains('review', $types, 'approve_reject holder sees a user-assigned review task in mine');
     }
 
     #[Test]

--- a/apps/api/tests/Unit/Workflow/WorkflowTaskAutomationTest.php
+++ b/apps/api/tests/Unit/Workflow/WorkflowTaskAutomationTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Workflow;
+
+use App\Catalog\Contracts\Event\ObjectSubmittedForReview;
+use App\Identity\Contracts\Auth\CurrentUserProvider;
+use App\Shared\Domain\Tenant;
+use App\Workflow\Contracts\EditorialWorkflowProviderInterface;
+use App\Workflow\Contracts\TaskAssignee;
+use App\Workflow\Contracts\TransitionLogEntry;
+use App\Workflow\Contracts\TransitionLogPort;
+use App\Workflow\Contracts\WorkflowTaskType;
+use App\Workflow\Domain\Entity\WorkflowTask;
+use App\Workflow\Domain\Repository\WorkflowTaskRepositoryInterface;
+use App\Workflow\Infrastructure\Messenger\WorkflowTaskAutomation;
+use DateTimeImmutable;
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Workflow\WorkflowInterface;
+
+/**
+ * #2513 — the review-task recipient follows the definition's configured
+ * approver (role OR a specific user), falling back to the built-in
+ * reviewer role when the provider returns nothing (flag off / no
+ * reviewer configured).
+ */
+final class WorkflowTaskAutomationTest extends TestCase
+{
+    #[Test]
+    public function submitRoutesReviewTaskToTheConfiguredRole(): void
+    {
+        [$repo, $automation] = $this->makeAutomation(TaskAssignee::role('senior_editor'));
+
+        $automation->onSubmittedForReview($this->submitEvent());
+
+        $task = $repo->saved[0] ?? null;
+        self::assertInstanceOf(WorkflowTask::class, $task);
+        self::assertSame(WorkflowTaskType::Review, $task->getType());
+        self::assertSame('senior_editor', $task->getAssigneeRoleCode());
+        self::assertNull($task->getAssigneeUserId());
+    }
+
+    #[Test]
+    public function submitRoutesReviewTaskToTheConfiguredUser(): void
+    {
+        $userId = '019f2bb4-1111-7000-8000-000000000001';
+        [$repo, $automation] = $this->makeAutomation(TaskAssignee::user($userId));
+
+        $automation->onSubmittedForReview($this->submitEvent());
+
+        $task = $repo->saved[0] ?? null;
+        self::assertInstanceOf(WorkflowTask::class, $task);
+        self::assertNull($task->getAssigneeRoleCode());
+        self::assertSame($userId, $task->getAssigneeUserId()?->toRfc4122());
+    }
+
+    #[Test]
+    public function submitFallsBackToApproverWhenNoReviewerConfigured(): void
+    {
+        [$repo, $automation] = $this->makeAutomation(null);
+
+        $automation->onSubmittedForReview($this->submitEvent());
+
+        $task = $repo->saved[0] ?? null;
+        self::assertInstanceOf(WorkflowTask::class, $task);
+        self::assertSame('approver', $task->getAssigneeRoleCode());
+        self::assertNull($task->getAssigneeUserId());
+    }
+
+    private function submitEvent(): ObjectSubmittedForReview
+    {
+        return new ObjectSubmittedForReview(
+            objectId: Uuid::v7(),
+            tenantId: Uuid::v7(),
+            comment: 'Gotowe',
+            objectTypeId: Uuid::v7(),
+        );
+    }
+
+    /**
+     * @return array{0: RecordingWorkflowTaskRepository, 1: WorkflowTaskAutomation}
+     */
+    private function makeAutomation(?TaskAssignee $reviewer): array
+    {
+        $repo = new RecordingWorkflowTaskRepository();
+
+        $log = new class implements TransitionLogPort {
+            public function pageForObject(Uuid $objectId, int $limit, ?Uuid $before = null): array
+            {
+                return [];
+            }
+
+            public function latestForObject(Uuid $objectId, string $transition): ?TransitionLogEntry
+            {
+                return null;
+            }
+        };
+
+        $currentUser = new class implements CurrentUserProvider {
+            public function userId(): ?Uuid
+            {
+                return null;
+            }
+
+            public function tenant(): ?Tenant
+            {
+                return null;
+            }
+        };
+
+        $provider = new class($reviewer) implements EditorialWorkflowProviderInterface {
+            public function __construct(private readonly ?TaskAssignee $reviewer)
+            {
+            }
+
+            public function for(object $subject, ?string $objectTypeId = null): WorkflowInterface
+            {
+                throw new LogicException('not used');
+            }
+
+            public function reviewerFor(?string $objectTypeId): ?TaskAssignee
+            {
+                return $this->reviewer;
+            }
+        };
+
+        return [$repo, new WorkflowTaskAutomation($repo, $log, $currentUser, $provider)];
+    }
+}
+
+/**
+ * Named (non-anonymous) so PHPStan keeps the concrete type through
+ * {@see WorkflowTaskAutomationTest::makeAutomation()}'s return tuple.
+ */
+final class RecordingWorkflowTaskRepository implements WorkflowTaskRepositoryInterface
+{
+    /** @var list<WorkflowTask> */
+    public array $saved = [];
+
+    public function save(WorkflowTask $task): void
+    {
+        $this->saved[] = $task;
+    }
+
+    public function find(Uuid $id): ?WorkflowTask
+    {
+        return null;
+    }
+
+    public function page(
+        int $limit,
+        ?Uuid $before = null,
+        ?\App\Workflow\Contracts\WorkflowTaskStatus $status = null,
+        ?Uuid $objectId = null,
+        ?Uuid $mineUserId = null,
+        ?DateTimeImmutable $dueBefore = null,
+        array $mineReviewerTaskTypes = [],
+    ): array {
+        return [];
+    }
+
+    public function openTasksFor(Uuid $objectId, WorkflowTaskType $type): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
## Summary
Rdzeń konfigurowalnego workflow (opcja A, redesign UX). Zadania review i request-unpublish routują się teraz do **konfigurowalnego akceptanta per definicja** (rola LUB konkretny user), zamiast zahardkodowanej roli `approver`. Dotyczy dowolnego ObjectType. Za flagą `WORKFLOW_CUSTOM_DEFINITIONS` (OFF → bez zmian, fallback `approver`).

Closes #2513

## Backend changes
- `WorkflowDefinition.reviewer` JSONB (`{role_code}|{user_id}|null`) + ORM + **idempotentna migracja** `Version20260712100000` (guard `information_schema`).
- VO `App\Workflow\Contracts\TaskAssignee` (XOR role/user).
- `EditorialWorkflowProviderInterface::reviewerFor(?objectTypeId): ?TaskAssignee` — resolvuje governing definition (ObjectType-specific > global; flaga OFF/brak → null).
- Zdarzenia `ObjectSubmittedForReview` + `ObjectUnpublishRequested` wzbogacone o `objectTypeId` (emisja z `CatalogObject`), by automation zresolvował definicję ObjectType-specific.
- `WorkflowTaskAutomation` czyta reviewera z definicji (XOR user>rola>fallback `approver`).
- `WorkflowDefinitionValidator` waliduje reviewera (rola/user istnieje w tenancie, XOR) — raw DBAL, bez łamania deptrac.
- `WorkflowDefinitionsController` payload/serializacja `reviewer` + tenant do walidatora.
- **Mine uogólnione (#2513, rozszerza #2495):** posiadacz `workflow.approve_reject` widzi każdy review/request_unpublish niezależnie od tego, czy assignee to rola czy konkretny user (poprzedni role-code match gubił user-assignment).

## Testy
- `WorkflowTaskAutomationTest` (unit): routing do roli / usera / fallback approver.
- `WorkflowDefinitionsApiTest`: reviewer rola roundtrip 200; nieznana rola 422; XOR 422; obcy user 422; `providerResolvesReviewerFromDefinition` (+ flaga OFF → null).
- `WorkflowTasksApiTest`: mine widzi user-assigned review task dla approve_reject holdera.

## Quality gates
- PHPStan max 0 (na zmianach), deptrac 0, php-cs-fixer czysto. OpenAPI snapshot bez zmian (custom-route body poza eksportem). Pełne PHPUnit/ApiTestCase w CI.

## Świadome odejścia
- Jeden akceptant na definicję (nie per-przejście) — decyzja operatora.
- Writable per-tenant toggle flagi = follow-up (flaga env pozostaje master).

## Smoke plan (po merge, dev stack)
Flaga ON → definicja Produkt z reviewer=custom rola → submit → review task `assignee_role_code=<custom>`; user tej roli + approve_reject holder widzą w „Moje zadania"; flaga OFF → fallback `approver`. Proof w komentarzu issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
