### PR TITLE
feat(admin): Ustawienia przepływu — flow settings page with approver picker (#2515)

### DIFF
--- a/apps/admin/e2e/wfl-flow-settings.spec.ts
+++ b/apps/admin/e2e/wfl-flow-settings.spec.ts
@@ -6,12 +6,15 @@ import { ADMIN_EMAIL, ADMIN_PASSWORD, loginAsAdmin } from './helpers/auth';
  * WFL redesign (#2515) — the "Ustawienia przepływu" page, reached from
  * the Workflow hub CTA. Picking an approver and saving creates + enables
  * a tenant definition for the selected ObjectType (the "własny" badge
- * confirms it). Requires WORKFLOW_CUSTOM_DEFINITIONS=true in CI (same as
- * the P5-03 builder spec).
+ * confirms it). Requires WORKFLOW_CUSTOM_DEFINITIONS=true in CI.
+ *
+ * The test configures the ASSET ObjectType on purpose: the other
+ * workflow specs drive product/category submit→approve loops against the
+ * shared CI database, so touching product/category here would leak an
+ * enabled definition (with a completeness gate) into them. Asset is an
+ * island; the created definition is disabled again on teardown.
  */
-test('flow settings: pick an approver and save enables the definition', async ({ page }) => {
-  // Clean slate: drop any pre-existing definitions so the type pill has no
-  // "własny" badge before we save (a Bearer for the setup calls).
+test('flow settings: pick an approver and save enables the asset definition', async ({ page }) => {
   const login = await page.request.post('/api/auth/login', {
     data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
     headers: { accept: 'application/json' },
@@ -19,40 +22,65 @@ test('flow settings: pick an approver and save enables the definition', async ({
   expect(login.status()).toBe(200);
   const { token } = (await login.json()) as { token: string };
   const bearer = { authorization: `Bearer ${token}` };
-  const existing = await page.request.get('/api/workflow/definitions', { headers: bearer });
-  const list = (await existing.json()) as { items: { id: string; enabled: boolean }[] };
-  for (const def of list.items) {
-    if (def.enabled) {
-      await page.request.post(`/api/workflow/definitions/${def.id}/disable`, { headers: bearer });
+
+  const assetTypeId = await assetObjectTypeId(page, bearer);
+
+  try {
+    await loginAsAdmin(page);
+    await page.goto('/workflow');
+
+    await page.getByTestId('workflow-settings-cta').click();
+    await expect(page).toHaveURL(/\/workflow\/settings$/);
+    await expect(page.getByTestId('workflow-settings-page')).toBeVisible();
+    await expect(page.getByTestId('workflow-role-legend')).toBeVisible();
+    await expect(page.getByTestId('workflow-state-diagram')).toBeVisible();
+
+    // Switch to the asset definition and pick the tenant-unique Approver
+    // role (Catalog Manager exists both global and per-tenant → strict mode).
+    await page.getByTestId('workflow-def-type-asset').click();
+    const picker = page.getByTestId('workflow-approver-picker');
+    await picker.getByRole('button').first().click();
+    await page
+      .getByRole('button', { name: /^Approver \(rola\)$/i })
+      .first()
+      .click();
+
+    await page.getByTestId('workflow-settings-save').click();
+
+    // The asset type pill now carries the "własny" badge (enabled def).
+    await expect(page.getByTestId('workflow-def-type-asset').getByText(/własny/i)).toBeVisible();
+
+    // Persisted: reloading keeps the approver selected.
+    await page.reload();
+    await page.getByTestId('workflow-def-type-asset').click();
+    await expect(page.getByTestId('workflow-approver-picker')).toContainText(/Approver/i);
+  } finally {
+    // Teardown: disable any asset definition we enabled so parallel/later
+    // specs see the static machine again.
+    const list = await page.request.get('/api/workflow/definitions', { headers: bearer });
+    const body = (await list.json()) as {
+      items: { id: string; object_type_id: string | null; enabled: boolean }[];
+    };
+    for (const def of body.items) {
+      if (def.object_type_id === assetTypeId && def.enabled) {
+        await page.request.post(`/api/workflow/definitions/${def.id}/disable`, { headers: bearer });
+      }
     }
   }
-
-  await loginAsAdmin(page);
-  await page.goto('/workflow');
-
-  await page.getByTestId('workflow-settings-cta').click();
-  await expect(page).toHaveURL(/\/workflow\/settings$/);
-  await expect(page.getByTestId('workflow-settings-page')).toBeVisible();
-  await expect(page.getByTestId('workflow-role-legend')).toBeVisible();
-  await expect(page.getByTestId('workflow-state-diagram')).toBeVisible();
-
-  // Product is the default selected type; pick a role approver. The
-  // combobox renders options as buttons behind a search input; narrow to
-  // the tenant "Approver" role (unique, unlike Catalog Manager which
-  // exists both global and per-tenant).
-  const picker = page.getByTestId('workflow-approver-picker');
-  await picker.getByRole('button').first().click();
-  await page
-    .getByRole('button', { name: /^Approver \(rola\)$/i })
-    .first()
-    .click();
-
-  await page.getByTestId('workflow-settings-save').click();
-
-  // The product type pill now carries the "własny" badge (enabled def).
-  await expect(page.getByTestId('workflow-def-type-product').getByText(/własny/i)).toBeVisible();
-
-  // Persisted: reloading keeps the approver selected.
-  await page.reload();
-  await expect(page.getByTestId('workflow-approver-picker')).toContainText(/Approver/i);
 });
+
+async function assetObjectTypeId(
+  page: import('@playwright/test').Page,
+  bearer: Record<string, string>,
+): Promise<string> {
+  const response = await page.request.get('/api/object_types?itemsPerPage=200', {
+    headers: { ...bearer, accept: 'application/ld+json' },
+  });
+  const body = (await response.json()) as {
+    'hydra:member'?: { id: string; kind: string }[];
+    member?: { id: string; kind: string }[];
+  };
+  const asset = (body['hydra:member'] ?? body.member ?? []).find((type) => type.kind === 'asset');
+  if (asset === undefined) throw new Error('No asset ObjectType seeded.');
+  return asset.id;
+}

--- a/apps/admin/e2e/wfl-flow-settings.spec.ts
+++ b/apps/admin/e2e/wfl-flow-settings.spec.ts
@@ -37,10 +37,15 @@ test('flow settings: pick an approver and save enables the definition', async ({
   await expect(page.getByTestId('workflow-state-diagram')).toBeVisible();
 
   // Product is the default selected type; pick a role approver. The
-  // combobox renders options as buttons behind a search input.
+  // combobox renders options as buttons behind a search input; narrow to
+  // the tenant "Approver" role (unique, unlike Catalog Manager which
+  // exists both global and per-tenant).
   const picker = page.getByTestId('workflow-approver-picker');
   await picker.getByRole('button').first().click();
-  await page.getByRole('button', { name: /Catalog Manager \(rola\)/i }).click();
+  await page
+    .getByRole('button', { name: /^Approver \(rola\)$/i })
+    .first()
+    .click();
 
   await page.getByTestId('workflow-settings-save').click();
 
@@ -49,5 +54,5 @@ test('flow settings: pick an approver and save enables the definition', async ({
 
   // Persisted: reloading keeps the approver selected.
   await page.reload();
-  await expect(page.getByTestId('workflow-approver-picker')).toContainText(/Catalog Manager/i);
+  await expect(page.getByTestId('workflow-approver-picker')).toContainText(/Approver/i);
 });

--- a/apps/admin/e2e/wfl-flow-settings.spec.ts
+++ b/apps/admin/e2e/wfl-flow-settings.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+
+import { ADMIN_EMAIL, ADMIN_PASSWORD, loginAsAdmin } from './helpers/auth';
+
+/**
+ * WFL redesign (#2515) — the "Ustawienia przepływu" page, reached from
+ * the Workflow hub CTA. Picking an approver and saving creates + enables
+ * a tenant definition for the selected ObjectType (the "własny" badge
+ * confirms it). Requires WORKFLOW_CUSTOM_DEFINITIONS=true in CI (same as
+ * the P5-03 builder spec).
+ */
+test('flow settings: pick an approver and save enables the definition', async ({ page }) => {
+  // Clean slate: drop any pre-existing definitions so the type pill has no
+  // "własny" badge before we save (a Bearer for the setup calls).
+  const login = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(login.status()).toBe(200);
+  const { token } = (await login.json()) as { token: string };
+  const bearer = { authorization: `Bearer ${token}` };
+  const existing = await page.request.get('/api/workflow/definitions', { headers: bearer });
+  const list = (await existing.json()) as { items: { id: string; enabled: boolean }[] };
+  for (const def of list.items) {
+    if (def.enabled) {
+      await page.request.post(`/api/workflow/definitions/${def.id}/disable`, { headers: bearer });
+    }
+  }
+
+  await loginAsAdmin(page);
+  await page.goto('/workflow');
+
+  await page.getByTestId('workflow-settings-cta').click();
+  await expect(page).toHaveURL(/\/workflow\/settings$/);
+  await expect(page.getByTestId('workflow-settings-page')).toBeVisible();
+  await expect(page.getByTestId('workflow-role-legend')).toBeVisible();
+  await expect(page.getByTestId('workflow-state-diagram')).toBeVisible();
+
+  // Product is the default selected type; pick a role approver. The
+  // combobox renders options as buttons behind a search input.
+  const picker = page.getByTestId('workflow-approver-picker');
+  await picker.getByRole('button').first().click();
+  await page.getByRole('button', { name: /Catalog Manager \(rola\)/i }).click();
+
+  await page.getByTestId('workflow-settings-save').click();
+
+  // The product type pill now carries the "własny" badge (enabled def).
+  await expect(page.getByTestId('workflow-def-type-product').getByText(/własny/i)).toBeVisible();
+
+  // Persisted: reloading keeps the approver selected.
+  await page.reload();
+  await expect(page.getByTestId('workflow-approver-picker')).toContainText(/Catalog Manager/i);
+});

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -196,6 +196,10 @@ const ProductShowPage = lazyPage(
 );
 const CatalogsPdfPage = lazyPage(() => import('@/features/catalogs-pdf'), 'CatalogsPdfPage');
 const WorkflowPage = lazyPage(() => import('@/features/workflow/WorkflowPage'), 'WorkflowPage');
+const WorkflowFlowSettingsPage = lazyPage(
+  () => import('@/features/workflow/settings'),
+  'WorkflowSettingsPage',
+);
 const CatalogWizardPage = lazyPage(
   () => import('@/features/catalogs-pdf/wizard/CatalogWizardPage'),
   'CatalogWizardPage',
@@ -593,6 +597,16 @@ function App() {
                     element={
                       <PermissionRoute anyOf={['workflow.view']}>
                         <WorkflowPage />
+                      </PermissionRoute>
+                    }
+                  />
+                  {/* WFL redesign (#2515) — flow settings live in the
+                      Workflow hub (topbar CTA), gated manage_definitions. */}
+                  <Route
+                    path="/workflow/settings"
+                    element={
+                      <PermissionRoute anyOf={['workflow.manage_definitions']}>
+                        <WorkflowFlowSettingsPage />
                       </PermissionRoute>
                     }
                   />

--- a/apps/admin/src/features/settings/workflow/__tests__/definition-form.test.ts
+++ b/apps/admin/src/features/settings/workflow/__tests__/definition-form.test.ts
@@ -78,6 +78,7 @@ describe('draftFromResource -> draftToPayload roundtrip', () => {
           completeness_gate: { min_completeness_pct: 90 },
         },
       ],
+      reviewer: null,
       enabled: true,
       updated_at: '2026-07-11T00:00:00+00:00',
     };

--- a/apps/admin/src/features/workflow/WorkflowPage.tsx
+++ b/apps/admin/src/features/workflow/WorkflowPage.tsx
@@ -1,7 +1,10 @@
-import { useState } from 'react';
+import { SlidersHorizontal } from 'lucide-react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
 
 import { PillTabs } from '@/components/ui-v2/pill-tabs';
+import { usePageActions } from '@/layout/page-actions-context';
 import { useIdentity } from '@/lib/identity';
 
 import { ReviewQueuePage } from './ReviewQueuePage';
@@ -11,13 +14,32 @@ import { TasksPanel } from './TasksPanel';
  * WFL-P3-02 + WFL-P4-03 — the workflow hub: the review queue (what
  * awaits a decision) next to the task inbox (what awaits MY work) and
  * the tenant-wide task list for deciders. Pill-tab layout per the
- * catalogs/exports hub pattern.
+ * catalogs/exports hub pattern. Deciders who can manage definitions get
+ * the "Ustawienia przepływu" CTA (WFL redesign #2515).
  */
 export function WorkflowPage() {
   const { t } = useTranslation();
   const { identity } = useIdentity();
   const canDecide = identity?.permissions.has('workflow.approve_reject') ?? false;
+  const canManageDefinitions = identity?.permissions.has('workflow.manage_definitions') ?? false;
   const [tab, setTab] = useState('review');
+
+  usePageActions(
+    useMemo(
+      () =>
+        canManageDefinitions ? (
+          <Link
+            to="/workflow/settings"
+            data-testid="workflow-settings-cta"
+            className="focus-ring inline-flex h-9 items-center gap-1.5 rounded-xl bg-zinc-900 px-3.5 text-[13px] font-semibold text-white transition hover:bg-zinc-800"
+          >
+            <SlidersHorizontal className="size-4" aria-hidden="true" />
+            {t('workflow.settings_cta', { defaultValue: 'Ustawienia przepływu' })}
+          </Link>
+        ) : null,
+      [canManageDefinitions, t],
+    ),
+  );
 
   const tabs = [
     { id: 'review', label: t('workflow.tabs.review', { defaultValue: 'Do przeglądu' }) },

--- a/apps/admin/src/features/workflow/settings/RoleLegend.tsx
+++ b/apps/admin/src/features/workflow/settings/RoleLegend.tsx
@@ -1,0 +1,107 @@
+import { Pencil, ShieldCheck } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+
+/**
+ * WFL redesign (#2515) — the "two roles, two settings" primer at the top
+ * of the flow-settings page. Answers the operator's recurring confusion:
+ * WHO may approve is an RBAC permission (Settings → Roles), WHOSE inbox a
+ * task lands in is configured here.
+ */
+export function RoleLegend() {
+  const { t } = useTranslation();
+
+  return (
+    <section
+      className="rounded-2xl border border-zinc-200 bg-white p-5"
+      data-testid="workflow-role-legend"
+    >
+      <h3 className="text-[15px] font-semibold text-zinc-900">
+        {t('workflow.settings.legend.title', {
+          defaultValue: 'Dwie role, dwa ustawienia — nie myl ich',
+        })}
+      </h3>
+      <p className="mt-1 max-w-3xl text-[13px] text-zinc-500">
+        {t('workflow.settings.legend.body', {
+          defaultValue:
+            'Kto może zatwierdzać ustawiasz w Uprawnieniach (rola). Tutaj ustalasz tylko, do czyjej skrzynki trafia zadanie do zrobienia.',
+        })}
+      </p>
+
+      <div className="mt-4 grid grid-cols-1 gap-3 lg:grid-cols-2">
+        <div className="rounded-2xl border border-zinc-200 bg-zinc-50/60 p-4">
+          <div className="flex items-center gap-2">
+            <span className="grid size-8 place-items-center rounded-xl bg-white text-indigo-500 shadow-sm">
+              <Pencil className="size-4" aria-hidden="true" />
+            </span>
+            <div>
+              <p className="text-[13px] font-semibold text-zinc-900">
+                {t('workflow.settings.legend.editor', { defaultValue: 'Wprowadzający dane' })}
+              </p>
+              <p className="text-[11px] text-zinc-500">
+                {t('workflow.settings.legend.editor_roles', {
+                  defaultValue: 'Redaktor · Menedżer katalogu · Młodszy redaktor',
+                })}
+              </p>
+            </div>
+          </div>
+          <p className="mt-3 text-[12px] text-zinc-600">
+            {t('workflow.settings.legend.editor_desc', {
+              defaultValue: 'Tworzy szkic, wypełnia dane i klika „Zgłoś do przeglądu".',
+            })}
+          </p>
+          <p className="mt-2 text-[11px] text-zinc-500">
+            {t('workflow.settings.legend.permission', { defaultValue: 'Uprawnienie' })}:{' '}
+            <span className="font-medium text-zinc-700">
+              {t('workflow.settings.legend.edit', { defaultValue: 'Edycja' })}
+            </span>
+          </p>
+        </div>
+
+        <div className="rounded-2xl border border-zinc-200 bg-zinc-50/60 p-4">
+          <div className="flex items-center gap-2">
+            <span className="grid size-8 place-items-center rounded-xl bg-white text-amber-500 shadow-sm">
+              <ShieldCheck className="size-4" aria-hidden="true" />
+            </span>
+            <div>
+              <p className="text-[13px] font-semibold text-zinc-900">
+                {t('workflow.settings.legend.reviewer', {
+                  defaultValue: 'Przeglądający / Akceptant',
+                })}
+              </p>
+              <p className="text-[11px] text-zinc-500">
+                {t('workflow.settings.legend.reviewer_roles', {
+                  defaultValue: 'Akceptant · Menedżer katalogu · Administrator',
+                })}
+              </p>
+            </div>
+          </div>
+          <p className="mt-3 text-[12px] text-zinc-600">
+            {t('workflow.settings.legend.reviewer_desc', {
+              defaultValue:
+                'Dostaje zadanie w skrzynce, zatwierdza (→ Opublikowany) lub odrzuca z komentarzem.',
+            })}
+          </p>
+          <p className="mt-2 text-[11px] text-zinc-500">
+            {t('workflow.settings.legend.permission', { defaultValue: 'Uprawnienie' })}:{' '}
+            <span className="font-medium text-zinc-700">
+              {t('workflow.settings.legend.approve', {
+                defaultValue: 'Zatwierdzanie / Odrzucanie',
+              })}
+            </span>
+          </p>
+        </div>
+      </div>
+
+      <Link
+        to="/settings/roles"
+        className="mt-4 inline-flex items-center gap-1.5 text-[12px] font-medium text-indigo-600 hover:text-indigo-500"
+      >
+        <ShieldCheck className="size-3.5" aria-hidden="true" />
+        {t('workflow.settings.legend.grant', {
+          defaultValue: 'Nadaj te uprawnienia rolom w Ustawienia → Role i uprawnienia →',
+        })}
+      </Link>
+    </section>
+  );
+}

--- a/apps/admin/src/features/workflow/settings/StateDiagram.tsx
+++ b/apps/admin/src/features/workflow/settings/StateDiagram.tsx
@@ -1,0 +1,120 @@
+import { ArrowRight } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * WFL redesign (#2515) — read-only visualization of the editorial
+ * machine (ADR-0029). The flow itself is fixed; the settings page lets
+ * the operator configure only the approver + gate, so this is a static
+ * diagram, not an editor.
+ */
+interface Stage {
+  place: string;
+  transition?: string;
+  captionKey: string;
+  captionDefault: string;
+}
+
+const STAGES: Stage[] = [
+  {
+    place: 'draft',
+    captionKey: 'workflow.settings.diagram.draft',
+    captionDefault: 'Wprowadzający wypełnia i zgłasza',
+  },
+  {
+    place: 'review',
+    transition: 'submit_for_review',
+    captionKey: 'workflow.settings.diagram.review',
+    captionDefault: 'Akceptant zatwierdza / odrzuca',
+  },
+  {
+    place: 'published',
+    transition: 'approve',
+    captionKey: 'workflow.settings.diagram.published',
+    captionDefault: 'Widoczny w kanałach sprzedaży',
+  },
+  {
+    place: 'archived',
+    transition: 'archive',
+    captionKey: 'workflow.settings.diagram.archived',
+    captionDefault: 'Wycofany z obiegu',
+  },
+];
+
+const PLACE_TONE: Record<string, string> = {
+  draft: 'bg-zinc-100 text-zinc-600',
+  review: 'bg-amber-100 text-amber-700',
+  published: 'bg-emerald-100 text-emerald-700',
+  archived: 'bg-zinc-100 text-zinc-400',
+};
+
+export function StateDiagram() {
+  const { t } = useTranslation();
+
+  return (
+    <section
+      className="rounded-2xl border border-zinc-200 bg-white p-5"
+      data-testid="workflow-state-diagram"
+    >
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-[15px] font-semibold text-zinc-900">
+            {t('workflow.settings.diagram.title', { defaultValue: 'Przepływ stanów' })}
+          </h3>
+          <p className="text-[12px] text-zinc-500">
+            {t('workflow.settings.diagram.subtitle', {
+              defaultValue: 'Ścieżka wpisu od szkicu do publikacji.',
+            })}
+          </p>
+        </div>
+        <span className="text-[11px] text-zinc-400">
+          {t('workflow.settings.diagram.meta', { defaultValue: '7 przejść · maszyna stanów' })}
+        </span>
+      </div>
+
+      <ol className="mt-4 flex flex-wrap items-start gap-1">
+        {STAGES.map((stage, index) => (
+          <li key={stage.place} className="flex items-start gap-1">
+            {index > 0 && stage.transition ? (
+              <div className="flex flex-col items-center px-1 pt-2 text-center">
+                <span className="text-[10px] font-medium text-zinc-500">
+                  {t(`workflow.transition.${stage.transition}`, { defaultValue: stage.transition })}
+                </span>
+                <ArrowRight className="mt-0.5 size-4 text-zinc-300" aria-hidden="true" />
+              </div>
+            ) : null}
+            <div className="flex w-36 flex-col items-center text-center">
+              <span
+                className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-[12px] font-medium ${PLACE_TONE[stage.place] ?? 'bg-zinc-100 text-zinc-600'}`}
+              >
+                <span className="size-1.5 rounded-full bg-current opacity-70" aria-hidden="true" />
+                {t(`workflow.place.${stage.place}`, { defaultValue: stage.place })}
+              </span>
+              <span className="mt-1.5 text-[11px] leading-tight text-zinc-500">
+                {t(stage.captionKey, { defaultValue: stage.captionDefault })}
+              </span>
+            </div>
+          </li>
+        ))}
+      </ol>
+
+      <div className="mt-4 flex flex-wrap gap-x-6 gap-y-1 border-t border-zinc-100 pt-3 text-[11px] text-zinc-500">
+        <span>
+          <span className="font-medium text-zinc-700">
+            {t('workflow.transition.reject', { defaultValue: 'Odrzuć' })}
+          </span>{' '}
+          {t('workflow.settings.diagram.reject_note', {
+            defaultValue: '— wraca do Szkic, zadanie „Poprawka" idzie do autora',
+          })}
+        </span>
+        <span>
+          <span className="font-medium text-zinc-700">
+            {t('workflow.transition.unpublish', { defaultValue: 'Cofnij publikację' })}
+          </span>{' '}
+          {t('workflow.settings.diagram.unpublish_note', {
+            defaultValue: '— z Opublikowany do Szkic',
+          })}
+        </span>
+      </div>
+    </section>
+  );
+}

--- a/apps/admin/src/features/workflow/settings/WorkflowSettingsPage.tsx
+++ b/apps/admin/src/features/workflow/settings/WorkflowSettingsPage.tsx
@@ -1,3 +1,4 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { GitBranch, Info, Send } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -5,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Combobox, type ComboboxOption } from '@/components/ui/combobox';
 import { toast } from '@/components/ui/toast';
-import { httpErrorDetail, jsonFetch } from '@/lib/http';
+import { httpErrorDetail } from '@/lib/http';
 import { hasFeature, useIdentity } from '@/lib/identity';
 import {
   createDefinition,
@@ -14,31 +15,12 @@ import {
   fetchDefinitions,
   setDefinitionEnabled,
   updateDefinition,
-  type WorkflowDefinitionResource,
 } from '@/lib/workflow/definitions-api';
+import { fetchApproverDirectory, fetchBuiltInObjectTypes } from '@/lib/workflow/directory-api';
 
 import { editorialPlaces, editorialTransitions, gateFromTransitions } from './editorial-shape';
 import { RoleLegend } from './RoleLegend';
 import { StateDiagram } from './StateDiagram';
-
-interface ObjectTypeOption {
-  id: string;
-  code: string;
-  label: string;
-}
-
-interface RolesResponse {
-  member?: Array<{ id: string; code: string; name: string }>;
-  items?: Array<{ id: string; code: string; name: string }>;
-}
-interface UsersResponse {
-  member?: Array<{ id: string; email: string; display_name: string }>;
-  items?: Array<{ id: string; email: string; display_name: string }>;
-}
-interface ObjectTypesResponse {
-  member?: Array<{ id: string; code: string; label?: Record<string, string> }>;
-  'hydra:member'?: Array<{ id: string; code: string; label?: Record<string, string> }>;
-}
 
 const REVIEWER_ROLE_PREFIX = 'role:';
 const REVIEWER_USER_PREFIX = 'user:';
@@ -56,10 +38,8 @@ export function WorkflowSettingsPage() {
   const { identity } = useIdentity();
   const flagOn = hasFeature(identity, 'workflow_custom_definitions');
 
-  const [objectTypes, setObjectTypes] = useState<ObjectTypeOption[]>([]);
+  const queryClient = useQueryClient();
   const [selectedTypeId, setSelectedTypeId] = useState<string | null>(null);
-  const [definitions, setDefinitions] = useState<WorkflowDefinitionResource[]>([]);
-  const [approverOptions, setApproverOptions] = useState<ComboboxOption[]>([]);
 
   const [reviewer, setReviewer] = useState<string>('');
   const [gatePct, setGatePct] = useState<number | null>(80);
@@ -68,57 +48,47 @@ export function WorkflowSettingsPage() {
     gatePct: 80,
   });
   const [saving, setSaving] = useState(false);
-  const [loaded, setLoaded] = useState(false);
 
-  // Catalogue load: built-in ObjectTypes + the role/user picker options.
+  const lang = i18n.language;
+  const objectTypesQuery = useQuery({
+    queryKey: ['workflow-settings', 'object-types', lang],
+    queryFn: () => fetchBuiltInObjectTypes(lang),
+  });
+  const objectTypes = useMemo(() => objectTypesQuery.data ?? [], [objectTypesQuery.data]);
+
+  const approverQuery = useQuery({
+    queryKey: ['workflow-settings', 'approver-options'],
+    queryFn: fetchApproverDirectory,
+  });
+  const approverOptions = useMemo<ComboboxOption[]>(() => {
+    const data = approverQuery.data;
+    if (data === undefined) return [];
+    return [
+      ...data.roles.map((role) => ({
+        value: REVIEWER_ROLE_PREFIX + role.code,
+        label: t('workflow.settings.approver.role_option', {
+          defaultValue: '{{name}} (rola)',
+          name: role.name || role.code,
+        }),
+      })),
+      ...data.users.map((user) => ({
+        value: REVIEWER_USER_PREFIX + user.id,
+        label: `${user.display_name || user.email} (${user.email})`,
+      })),
+    ];
+  }, [approverQuery.data, t]);
+
+  const definitionsQuery = useQuery({
+    queryKey: ['workflow-settings', 'definitions'],
+    queryFn: () => fetchDefinitions().then((body) => body.items),
+  });
+  const definitions = useMemo(() => definitionsQuery.data ?? [], [definitionsQuery.data]);
+  const loaded = definitionsQuery.isSuccess;
+
+  // Default the selected type to the first built-in once types arrive.
   useEffect(() => {
-    const lang = i18n.language;
-    jsonFetch<ObjectTypesResponse>('/api/object_types?itemsPerPage=200')
-      .then((body) => {
-        const members = body['hydra:member'] ?? body.member ?? [];
-        const options = members.map((type) => ({
-          id: type.id,
-          code: type.code,
-          label: type.label?.[lang] ?? type.label?.pl ?? type.code,
-        }));
-        setObjectTypes(options);
-        setSelectedTypeId((current) => current ?? options[0]?.id ?? null);
-      })
-      .catch(() => setObjectTypes([]));
-
-    Promise.all([
-      jsonFetch<RolesResponse>('/api/roles').catch(() => ({}) as RolesResponse),
-      jsonFetch<UsersResponse>('/api/users?itemsPerPage=500').catch(() => ({}) as UsersResponse),
-    ]).then(([rolesBody, usersBody]) => {
-      const roles = rolesBody.member ?? rolesBody.items ?? [];
-      const users = usersBody.member ?? usersBody.items ?? [];
-      setApproverOptions([
-        ...roles.map((role) => ({
-          value: REVIEWER_ROLE_PREFIX + role.code,
-          label: t('workflow.settings.approver.role_option', {
-            defaultValue: '{{name}} (rola)',
-            name: role.name || role.code,
-          }),
-        })),
-        ...users.map((user) => ({
-          value: REVIEWER_USER_PREFIX + user.id,
-          label: `${user.display_name || user.email} (${user.email})`,
-        })),
-      ]);
-    });
-  }, [i18n.language, t]);
-
-  const reloadDefinitions = useMemo(
-    () => () =>
-      fetchDefinitions()
-        .then((body) => setDefinitions(body.items))
-        .catch(() => setDefinitions([]))
-        .finally(() => setLoaded(true)),
-    [],
-  );
-  useEffect(() => {
-    void reloadDefinitions();
-  }, [reloadDefinitions]);
+    setSelectedTypeId((current) => current ?? objectTypes[0]?.id ?? null);
+  }, [objectTypes]);
 
   const currentDefinition = useMemo(
     () => definitions.find((d) => d.object_type_id === selectedTypeId) ?? null,
@@ -165,7 +135,7 @@ export function WorkflowSettingsPage() {
       .then((definition) =>
         definition.enabled ? definition : setDefinitionEnabled(definition.id, true),
       )
-      .then(() => reloadDefinitions())
+      .then(() => queryClient.invalidateQueries({ queryKey: ['workflow-settings', 'definitions'] }))
       .then(() => {
         setOriginal({ reviewer, gatePct });
         toast.success(t('workflow.settings.saved', { defaultValue: 'Definicja zapisana.' }));

--- a/apps/admin/src/features/workflow/settings/WorkflowSettingsPage.tsx
+++ b/apps/admin/src/features/workflow/settings/WorkflowSettingsPage.tsx
@@ -1,0 +1,452 @@
+import { GitBranch, Info, Send } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { Combobox, type ComboboxOption } from '@/components/ui/combobox';
+import { toast } from '@/components/ui/toast';
+import { httpErrorDetail, jsonFetch } from '@/lib/http';
+import { hasFeature, useIdentity } from '@/lib/identity';
+import {
+  createDefinition,
+  type DefinitionReviewer,
+  extractViolations,
+  fetchDefinitions,
+  setDefinitionEnabled,
+  updateDefinition,
+  type WorkflowDefinitionResource,
+} from '@/lib/workflow/definitions-api';
+
+import { editorialPlaces, editorialTransitions, gateFromTransitions } from './editorial-shape';
+import { RoleLegend } from './RoleLegend';
+import { StateDiagram } from './StateDiagram';
+
+interface ObjectTypeOption {
+  id: string;
+  code: string;
+  label: string;
+}
+
+interface RolesResponse {
+  member?: Array<{ id: string; code: string; name: string }>;
+  items?: Array<{ id: string; code: string; name: string }>;
+}
+interface UsersResponse {
+  member?: Array<{ id: string; email: string; display_name: string }>;
+  items?: Array<{ id: string; email: string; display_name: string }>;
+}
+interface ObjectTypesResponse {
+  member?: Array<{ id: string; code: string; label?: Record<string, string> }>;
+  'hydra:member'?: Array<{ id: string; code: string; label?: Record<string, string> }>;
+}
+
+const REVIEWER_ROLE_PREFIX = 'role:';
+const REVIEWER_USER_PREFIX = 'user:';
+
+/**
+ * WFL redesign (#2515) — the "Ustawienia przepływu" page. Configures the
+ * built-in editorial machine per built-in ObjectType: the operator picks
+ * the approver (a role OR a specific person) and the completeness gate,
+ * the flow itself is fixed. Wired to the tenant WorkflowDefinition CRUD
+ * (#2432) + the reviewer field (#2513); definitions only take runtime
+ * effect when WORKFLOW_CUSTOM_DEFINITIONS is on.
+ */
+export function WorkflowSettingsPage() {
+  const { t, i18n } = useTranslation();
+  const { identity } = useIdentity();
+  const flagOn = hasFeature(identity, 'workflow_custom_definitions');
+
+  const [objectTypes, setObjectTypes] = useState<ObjectTypeOption[]>([]);
+  const [selectedTypeId, setSelectedTypeId] = useState<string | null>(null);
+  const [definitions, setDefinitions] = useState<WorkflowDefinitionResource[]>([]);
+  const [approverOptions, setApproverOptions] = useState<ComboboxOption[]>([]);
+
+  const [reviewer, setReviewer] = useState<string>('');
+  const [gatePct, setGatePct] = useState<number | null>(80);
+  const [original, setOriginal] = useState<{ reviewer: string; gatePct: number | null }>({
+    reviewer: '',
+    gatePct: 80,
+  });
+  const [saving, setSaving] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  // Catalogue load: built-in ObjectTypes + the role/user picker options.
+  useEffect(() => {
+    const lang = i18n.language;
+    jsonFetch<ObjectTypesResponse>('/api/object_types?itemsPerPage=200')
+      .then((body) => {
+        const members = body['hydra:member'] ?? body.member ?? [];
+        const options = members.map((type) => ({
+          id: type.id,
+          code: type.code,
+          label: type.label?.[lang] ?? type.label?.pl ?? type.code,
+        }));
+        setObjectTypes(options);
+        setSelectedTypeId((current) => current ?? options[0]?.id ?? null);
+      })
+      .catch(() => setObjectTypes([]));
+
+    Promise.all([
+      jsonFetch<RolesResponse>('/api/roles').catch(() => ({}) as RolesResponse),
+      jsonFetch<UsersResponse>('/api/users?itemsPerPage=500').catch(() => ({}) as UsersResponse),
+    ]).then(([rolesBody, usersBody]) => {
+      const roles = rolesBody.member ?? rolesBody.items ?? [];
+      const users = usersBody.member ?? usersBody.items ?? [];
+      setApproverOptions([
+        ...roles.map((role) => ({
+          value: REVIEWER_ROLE_PREFIX + role.code,
+          label: t('workflow.settings.approver.role_option', {
+            defaultValue: '{{name}} (rola)',
+            name: role.name || role.code,
+          }),
+        })),
+        ...users.map((user) => ({
+          value: REVIEWER_USER_PREFIX + user.id,
+          label: `${user.display_name || user.email} (${user.email})`,
+        })),
+      ]);
+    });
+  }, [i18n.language, t]);
+
+  const reloadDefinitions = useMemo(
+    () => () =>
+      fetchDefinitions()
+        .then((body) => setDefinitions(body.items))
+        .catch(() => setDefinitions([]))
+        .finally(() => setLoaded(true)),
+    [],
+  );
+  useEffect(() => {
+    void reloadDefinitions();
+  }, [reloadDefinitions]);
+
+  const currentDefinition = useMemo(
+    () => definitions.find((d) => d.object_type_id === selectedTypeId) ?? null,
+    [definitions, selectedTypeId],
+  );
+
+  // Hydrate the editable fields from the selected ObjectType's definition.
+  // selectedTypeId is a dep on purpose: switching between two types that
+  // both lack a definition keeps currentDefinition === null, and we still
+  // want the form reset to defaults for the newly selected type.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset on type switch, not only on definition change
+  useEffect(() => {
+    const next = {
+      reviewer: reviewerToValue(currentDefinition?.reviewer ?? null),
+      gatePct: currentDefinition ? gateFromTransitions(currentDefinition.transitions) : 80,
+    };
+    setReviewer(next.reviewer);
+    setGatePct(next.gatePct);
+    setOriginal(next);
+  }, [currentDefinition, selectedTypeId]);
+
+  const dirty = reviewer !== original.reviewer || gatePct !== original.gatePct;
+
+  const save = () => {
+    if (selectedTypeId === null) return;
+    setSaving(true);
+    const selected = objectTypes.find((type) => type.id === selectedTypeId);
+    const payload = {
+      name: t('workflow.settings.definition_name', {
+        defaultValue: 'Przepływ — {{type}}',
+        type: selected?.label ?? selectedTypeId,
+      }),
+      object_type_id: selectedTypeId,
+      places: editorialPlaces(),
+      transitions: editorialTransitions(gatePct),
+      reviewer: valueToReviewer(reviewer),
+    };
+
+    const request = currentDefinition
+      ? updateDefinition(currentDefinition.id, payload)
+      : createDefinition(payload);
+
+    request
+      .then((definition) =>
+        definition.enabled ? definition : setDefinitionEnabled(definition.id, true),
+      )
+      .then(() => reloadDefinitions())
+      .then(() => {
+        setOriginal({ reviewer, gatePct });
+        toast.success(t('workflow.settings.saved', { defaultValue: 'Definicja zapisana.' }));
+      })
+      .catch((error: unknown) => {
+        const violations = extractViolations(error);
+        toast.error(
+          violations[0]?.message ??
+            httpErrorDetail(error) ??
+            t('workflow.settings.save_failed', { defaultValue: 'Zapis nie powiódł się.' }),
+        );
+      })
+      .finally(() => setSaving(false));
+  };
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-5 px-6 py-6" data-testid="workflow-settings-page">
+      <RoleLegend />
+
+      <section className="flex items-center justify-between rounded-2xl border border-zinc-200 bg-white p-5">
+        <div className="flex items-start gap-3">
+          <span className="grid size-9 place-items-center rounded-xl bg-emerald-50 text-emerald-600">
+            <GitBranch className="size-4" aria-hidden="true" />
+          </span>
+          <div>
+            <p className="text-[14px] font-semibold text-zinc-900">
+              {t('workflow.settings.flag.title', { defaultValue: 'Własne definicje przepływu' })}{' '}
+              <code className="rounded bg-zinc-100 px-1.5 py-0.5 font-mono text-[11px] text-zinc-500">
+                WORKFLOW_CUSTOM_DEFINITIONS
+              </code>
+            </p>
+            <p className="text-[12px] text-zinc-500">
+              {flagOn
+                ? t('workflow.settings.flag.on', {
+                    defaultValue:
+                      'Włączone — możesz wskazać własnego akceptanta (rolę lub osobę) per ObjectType.',
+                  })
+                : t('workflow.settings.flag.off', {
+                    defaultValue:
+                      'Wyłączone globalnie — definicje możesz zapisać, ale zaczną działać po włączeniu flagi przez administratora.',
+                  })}
+            </p>
+          </div>
+        </div>
+        <span
+          data-testid="workflow-flag-state"
+          className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-[12px] font-medium ${flagOn ? 'bg-emerald-50 text-emerald-700' : 'bg-zinc-100 text-zinc-500'}`}
+        >
+          <span
+            className={`size-2 rounded-full ${flagOn ? 'bg-emerald-500' : 'bg-zinc-400'}`}
+            aria-hidden="true"
+          />
+          {flagOn
+            ? t('workflow.settings.flag.enabled', { defaultValue: 'Włączone' })
+            : t('workflow.settings.flag.disabled', { defaultValue: 'Wyłączone' })}
+        </span>
+      </section>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-[13px] text-zinc-500">
+          {t('workflow.settings.definition_for', { defaultValue: 'Definicja dla:' })}
+        </span>
+        {objectTypes.map((type) => {
+          const active = type.id === selectedTypeId;
+          const configured = definitions.some((d) => d.object_type_id === type.id && d.enabled);
+          return (
+            <button
+              key={type.id}
+              type="button"
+              onClick={() => setSelectedTypeId(type.id)}
+              data-testid={`workflow-def-type-${type.code}`}
+              className={`inline-flex items-center gap-2 rounded-xl border px-3.5 py-2 text-[13px] font-medium transition ${
+                active
+                  ? 'border-zinc-900 bg-zinc-900 text-white'
+                  : 'border-zinc-200 bg-white text-zinc-700 hover:border-zinc-300'
+              }`}
+            >
+              {type.label}
+              {configured ? (
+                <span
+                  className={`rounded-full px-1.5 py-0.5 text-[10px] ${active ? 'bg-white/15 text-white' : 'bg-emerald-50 text-emerald-600'}`}
+                >
+                  {t('workflow.settings.own', { defaultValue: 'własny' })}
+                </span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+
+      <StateDiagram />
+
+      <section
+        className="rounded-2xl border border-zinc-200 bg-white p-5"
+        data-testid="workflow-approver"
+      >
+        <div className="flex items-center gap-2">
+          <span className="grid size-8 place-items-center rounded-xl bg-zinc-900 text-white">
+            <Send className="size-4" aria-hidden="true" />
+          </span>
+          <div>
+            <h3 className="text-[15px] font-semibold text-zinc-900">
+              {t('workflow.settings.approver.title', { defaultValue: 'Do kogo trafiają zadania' })}
+            </h3>
+            <p className="text-[12px] text-zinc-500">
+              {t('workflow.settings.approver.subtitle', {
+                defaultValue:
+                  'Jeden akceptant na całą definicję. Obsługuje zadania Przegląd i Prośba o depublikację.',
+              })}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <div>
+            <label
+              className="text-[13px] font-medium text-zinc-700"
+              htmlFor="workflow-approver-picker"
+            >
+              {t('workflow.settings.approver.label', {
+                defaultValue: 'Akceptant — rola albo konkretna osoba',
+              })}
+            </label>
+            <div
+              className="mt-1.5"
+              id="workflow-approver-picker"
+              data-testid="workflow-approver-picker"
+            >
+              <Combobox
+                options={approverOptions}
+                value={reviewer === '' ? null : reviewer}
+                onChange={(value) => setReviewer(value ?? '')}
+                placeholder={t('workflow.settings.approver.placeholder', {
+                  defaultValue: 'Domyślnie: rola Akceptant',
+                })}
+              />
+            </div>
+            <p className="mt-1.5 text-[11px] text-zinc-500">
+              {t('workflow.settings.approver.hint', {
+                defaultValue:
+                  'Ta osoba/rola zobaczy zadanie w „Moje zadania" od razu po zgłoszeniu.',
+              })}
+            </p>
+          </div>
+
+          <div className="rounded-2xl border border-zinc-200 bg-zinc-50/60 p-4">
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-zinc-400">
+              {t('workflow.settings.approver.audience', { defaultValue: 'Zadanie zobaczą' })}
+            </p>
+            <ol className="mt-2 space-y-2 text-[12px] text-zinc-600">
+              <li className="flex items-center gap-2">
+                <span className="grid size-5 place-items-center rounded-full bg-white text-[10px] font-semibold text-zinc-500 shadow-sm">
+                  1
+                </span>
+                {reviewer === ''
+                  ? t('workflow.settings.approver.default_role', {
+                      defaultValue: 'Rola: Akceptant — wskazany odbiorca',
+                    })
+                  : (approverOptions.find((o) => o.value === reviewer)?.label ?? reviewer)}
+              </li>
+              <li className="flex items-center gap-2">
+                <span className="grid size-5 place-items-center rounded-full bg-white text-[10px] font-semibold text-zinc-500 shadow-sm">
+                  2
+                </span>
+                {t('workflow.settings.approver.approvers', {
+                  defaultValue: 'Każdy z uprawnieniem „Zatwierdzanie/Odrzucanie"',
+                })}
+              </li>
+            </ol>
+            <p className="mt-3 flex items-start gap-1.5 text-[11px] text-zinc-500">
+              <Info className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+              {t('workflow.settings.approver.safety', {
+                defaultValue:
+                  'Bezpiecznik — zadanie nigdy nie utknie, gdy wskazana osoba jest niedostępna.',
+              })}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section
+        className="rounded-2xl border border-zinc-200 bg-white p-5"
+        data-testid="workflow-rules"
+      >
+        <h3 className="text-[15px] font-semibold text-zinc-900">
+          {t('workflow.settings.rules.title', { defaultValue: 'Reguły przejść' })}
+        </h3>
+        <div className="mt-3 space-y-3">
+          <div className="flex flex-wrap items-center gap-4 rounded-2xl border border-zinc-200 p-4">
+            <label className="flex items-center gap-2 text-[13px] text-zinc-700">
+              <input
+                type="checkbox"
+                className="size-4 rounded border-zinc-300"
+                checked={gatePct !== null}
+                onChange={(event) => setGatePct(event.target.checked ? (gatePct ?? 80) : null)}
+                data-testid="workflow-gate-toggle"
+              />
+              <span className="font-medium">
+                {t('workflow.settings.rules.gate', {
+                  defaultValue: 'Wymagaj kompletności przed publikacją',
+                })}
+              </span>
+            </label>
+            <input
+              type="range"
+              min={0}
+              max={100}
+              step={5}
+              value={gatePct ?? 0}
+              disabled={gatePct === null}
+              onChange={(event) => setGatePct(Number(event.target.value))}
+              data-testid="workflow-gate-slider"
+              className="h-1.5 flex-1 cursor-pointer accent-zinc-900 disabled:opacity-40"
+            />
+            <span className="w-12 text-right text-[13px] font-semibold tabular-nums text-zinc-700">
+              {gatePct ?? '—'}%
+            </span>
+          </div>
+          <div className="flex items-center justify-between rounded-2xl border border-zinc-200 p-4">
+            <div>
+              <p className="text-[13px] font-medium text-zinc-700">
+                {t('workflow.settings.rules.comment', {
+                  defaultValue: 'Komentarz wymagany przy „Odrzuć"',
+                })}
+              </p>
+              <p className="text-[11px] text-zinc-500">
+                {t('workflow.settings.rules.comment_desc', {
+                  defaultValue: 'Autor musi wiedzieć, co poprawić. Zawsze włączone.',
+                })}
+              </p>
+            </div>
+            <span className="rounded-full bg-zinc-100 px-3 py-1 text-[11px] text-zinc-500">
+              {t('workflow.settings.rules.locked', { defaultValue: 'zablokowane' })}
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <div className="sticky bottom-0 flex items-center justify-between gap-4 rounded-2xl border border-zinc-200 bg-white/95 p-4 backdrop-blur">
+        <p className="text-[12px] text-zinc-500">
+          {t('workflow.settings.footer', {
+            defaultValue:
+              'Zmiana odbiorcy zacznie obowiązywać dla nowych zgłoszeń. Bieżące zadania zostają u obecnego akceptanta.',
+          })}
+        </p>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            disabled={!dirty || saving}
+            onClick={() => {
+              setReviewer(original.reviewer);
+              setGatePct(original.gatePct);
+            }}
+          >
+            {t('workflow.settings.discard', { defaultValue: 'Odrzuć zmiany' })}
+          </Button>
+          <Button
+            onClick={save}
+            disabled={!dirty || saving || selectedTypeId === null || !loaded}
+            data-testid="workflow-settings-save"
+          >
+            {t('workflow.settings.save', { defaultValue: 'Zapisz definicję' })}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function reviewerToValue(reviewer: DefinitionReviewer): string {
+  if (reviewer === null) return '';
+  if ('role_code' in reviewer) return REVIEWER_ROLE_PREFIX + reviewer.role_code;
+  return REVIEWER_USER_PREFIX + reviewer.user_id;
+}
+
+function valueToReviewer(value: string): DefinitionReviewer {
+  if (value.startsWith(REVIEWER_ROLE_PREFIX)) {
+    return { role_code: value.slice(REVIEWER_ROLE_PREFIX.length) };
+  }
+  if (value.startsWith(REVIEWER_USER_PREFIX)) {
+    return { user_id: value.slice(REVIEWER_USER_PREFIX.length) };
+  }
+  return null;
+}

--- a/apps/admin/src/features/workflow/settings/editorial-shape.ts
+++ b/apps/admin/src/features/workflow/settings/editorial-shape.ts
@@ -1,0 +1,80 @@
+import type { DefinitionPlace, DefinitionTransition } from '@/lib/workflow/definitions-api';
+
+/**
+ * WFL redesign (#2515) — the "Ustawienia przepływu" page configures the
+ * built-in editorial machine (ADR-0029) per ObjectType: the operator
+ * picks the approver and the completeness gate, the flow itself is
+ * fixed. This helper mirrors `config/packages/workflow.yaml` so a saved
+ * definition drives the exact same machine — only reviewer + gate +
+ * (locked) reject-comment vary.
+ */
+
+export const EDITORIAL_PLACES: readonly string[] = ['draft', 'review', 'published', 'archived'];
+
+/** Transitions that land in `published` — the completeness gate applies here. */
+const PUBLISH_TRANSITIONS = ['approve', 'publish'] as const;
+
+export function editorialPlaces(): DefinitionPlace[] {
+  return EDITORIAL_PLACES.map((name) => ({ name }));
+}
+
+/**
+ * The canonical editorial transitions with the built-in permission map.
+ * `gatePct` (0-100) attaches a completeness gate to the publish-bound
+ * transitions; `null` clears it. `reject` always requires a comment.
+ */
+export function editorialTransitions(gatePct: number | null): DefinitionTransition[] {
+  const gate =
+    gatePct === null ? undefined : { completeness_gate: { min_completeness_pct: gatePct } };
+
+  const withGate = (name: (typeof PUBLISH_TRANSITIONS)[number]) =>
+    PUBLISH_TRANSITIONS.includes(name) ? gate : undefined;
+
+  return [
+    { name: 'submit_for_review', from: 'draft', to: 'review', permission: 'products.edit' },
+    {
+      name: 'publish',
+      from: 'draft',
+      to: 'published',
+      permission: 'workflow.approve_reject',
+      ...withGate('publish'),
+    },
+    {
+      name: 'approve',
+      from: 'review',
+      to: 'published',
+      permission: 'workflow.approve_reject',
+      ...withGate('approve'),
+    },
+    {
+      name: 'reject',
+      from: 'review',
+      to: 'draft',
+      permission: 'workflow.approve_reject',
+      comment_required: true,
+    },
+    {
+      name: 'unpublish',
+      from: 'published',
+      to: 'draft',
+      permission: 'workflow.transition.unpublish',
+    },
+    {
+      name: 'archive',
+      from: ['draft', 'published'],
+      to: 'archived',
+      permission: 'workflow.approve_reject',
+    },
+    { name: 'restore', from: 'archived', to: 'draft', permission: 'workflow.approve_reject' },
+  ];
+}
+
+/**
+ * Read the completeness gate back off a stored definition (the min pct
+ * on the `approve` transition), or null when no gate is set.
+ */
+export function gateFromTransitions(transitions: DefinitionTransition[]): number | null {
+  const approve = transitions.find((t) => t.name === 'approve');
+  const pct = approve?.completeness_gate?.min_completeness_pct;
+  return typeof pct === 'number' ? pct : null;
+}

--- a/apps/admin/src/features/workflow/settings/index.tsx
+++ b/apps/admin/src/features/workflow/settings/index.tsx
@@ -1,0 +1,1 @@
+export { WorkflowSettingsPage } from './WorkflowSettingsPage';

--- a/apps/admin/src/lib/workflow/definitions-api.ts
+++ b/apps/admin/src/lib/workflow/definitions-api.ts
@@ -24,12 +24,19 @@ export interface DefinitionTransition {
   completeness_gate?: { min_completeness_pct: number };
 }
 
+/**
+ * #2513 — the configured task recipient (review / request-unpublish),
+ * XOR role OR a specific user. Null = the built-in reviewer role.
+ */
+export type DefinitionReviewer = { role_code: string } | { user_id: string } | null;
+
 export interface WorkflowDefinitionResource {
   id: string;
   name: string;
   object_type_id: string | null;
   places: DefinitionPlace[];
   transitions: DefinitionTransition[];
+  reviewer: DefinitionReviewer;
   enabled: boolean;
   updated_at: string;
 }
@@ -39,6 +46,7 @@ export interface DefinitionPayload {
   object_type_id?: string;
   places: DefinitionPlace[];
   transitions: DefinitionTransition[];
+  reviewer?: DefinitionReviewer;
 }
 
 /** Field-scoped validator violation from the 422 response. */

--- a/apps/admin/src/lib/workflow/directory-api.ts
+++ b/apps/admin/src/lib/workflow/directory-api.ts
@@ -1,0 +1,54 @@
+import { jsonFetch } from '@/lib/http';
+
+/**
+ * WFL redesign (#2515) — read helpers for the flow-settings page: the
+ * built-in ObjectTypes to configure and the role/user directory for the
+ * approver picker. Kept out of the page component so the page loads them
+ * via useQuery without importing the raw transport (the jsonFetch +
+ * useEffect stale-data guard, ADR-0021).
+ */
+
+export interface BuiltInObjectType {
+  id: string;
+  code: string;
+  label: string;
+}
+
+export interface ApproverDirectory {
+  roles: Array<{ id: string; code: string; name: string }>;
+  users: Array<{ id: string; email: string; display_name: string }>;
+}
+
+interface ObjectTypesResponse {
+  member?: Array<{ id: string; code: string; label?: Record<string, string> }>;
+  'hydra:member'?: Array<{ id: string; code: string; label?: Record<string, string> }>;
+}
+interface RolesResponse {
+  member?: ApproverDirectory['roles'];
+  items?: ApproverDirectory['roles'];
+}
+interface UsersResponse {
+  member?: ApproverDirectory['users'];
+  items?: ApproverDirectory['users'];
+}
+
+export async function fetchBuiltInObjectTypes(lang: string): Promise<BuiltInObjectType[]> {
+  const body = await jsonFetch<ObjectTypesResponse>('/api/object_types?itemsPerPage=200');
+  const members = body['hydra:member'] ?? body.member ?? [];
+  return members.map((type) => ({
+    id: type.id,
+    code: type.code,
+    label: type.label?.[lang] ?? type.label?.pl ?? type.code,
+  }));
+}
+
+export async function fetchApproverDirectory(): Promise<ApproverDirectory> {
+  const [rolesBody, usersBody] = await Promise.all([
+    jsonFetch<RolesResponse>('/api/roles'),
+    jsonFetch<UsersResponse>('/api/users?itemsPerPage=500'),
+  ]);
+  return {
+    roles: rolesBody.member ?? rolesBody.items ?? [],
+    users: usersBody.member ?? usersBody.items ?? [],
+  };
+}


### PR DESCRIPTION
## Summary
Nowa strona **„Ustawienia przepływu"** w hubie Workflow (przycisk w topbarze, gated `workflow.manage_definitions`) — wg screenu 1 designu. Konfiguruje wbudowaną maszynę edytorską per built-in ObjectType: operator wybiera **akceptanta** (rola LUB konkretna osoba) + gate kompletności; sam przepływ jest stały.

Refs #2515 (część redesignu; T2 z 6)

## Frontend
- `WorkflowSettingsPage` + `RoleLegend` (primer „Dwie role, dwa ustawienia" + link do Ról) + `StateDiagram` (read-only wizualizacja flow) + `editorial-shape` (kanoniczne places/transitions 1:1 z `config/packages/workflow.yaml`, sparametryzowane gate'em).
- Selektor „Definicja dla: <built-in ObjectType>"; **Zapisz** tworzy/aktualizuje + enable definicji tenanta z `reviewer` (#2513) — badge „własny" oznacza skonfigurowane typy.
- Karta flagi odzwierciedla `WORKFLOW_CUSTOM_DEFINITIONS` (z `feature_flags`); przy OFF nota, że definicje zapiszą się ale zadziałają po włączeniu.
- Picker akceptanta = role + userzy tenanta (prefiksy `role:`/`user:`).
- Reguły: gate slider % (na `approve`/`publish`), komentarz-przy-odrzuceniu zablokowany ON.
- `definitions-api.ts`: typ `DefinitionReviewer` na resource + payload.
- Trasa `/workflow/settings` + CTA w hubie. Stary builder `/settings/workflow` zostaje (redirect/usunięcie = follow-up — świadome odejście).

## Quality gates
- tsc 0, biome 0, `pnpm --filter admin build` OK, vitest (definition-form) 6/6, guard max-lines bez regresji (pliki <500).
- Playwright `wfl-flow-settings.spec.ts`: hub CTA → strona → wybór akceptanta (Catalog Manager) → zapis → badge „własny" na typie Produkt → reload trzyma. Walidacja w CI (Playwright lokalnie nie działa — DNS).

## Smoke (API-level, potwierdzone na dev stacku)
Dokładny payload, który wysyła strona (kanoniczny editorial shape + `reviewer`), akceptowany: `POST /api/workflow/definitions` → **201**, `reviewer={role_code:catalog_manager}`, gate 80 na `approve`. Pełny routing zadań zweryfikowany w T1 (#2513): rola→catalog_manager, user→id, OFF→approver.

## Świadome odejścia
- Stary raw-builder pod `/settings/workflow` nie usunięty (dwa wejścia; redirect + hide sidebar = follow-up).
- Toggle flagi w UI odzwierciedla stan env (writable per-tenant = follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
