### PR TITLE
feat(workflow): review queue type filter + submitter names (#2517)

### DIFF
--- a/apps/admin/src/features/workflow/ReviewQueuePage.tsx
+++ b/apps/admin/src/features/workflow/ReviewQueuePage.tsx
@@ -23,6 +23,14 @@ import {
   type WorkflowLogEntry,
 } from '@/lib/workflow/api';
 
+import {
+  avatarInitial,
+  avatarTone,
+  kindLabelDefault,
+  objectHref,
+  relativeTime,
+} from './task-presentation';
+
 /**
  * WFL-P3-02 (#2424) — the review queue: every object waiting for a
  * decision, with the submitter's comment and completeness, decidable
@@ -39,6 +47,7 @@ import {
 interface ReviewRow {
   id: string;
   code: string;
+  kind: string;
   label: string;
   completenessPct: number;
   submitted: WorkflowLogEntry | null;
@@ -69,6 +78,7 @@ export function ReviewQueuePage() {
   const { t, i18n } = useTranslation();
   const { identity } = useIdentity();
   const [rows, setRows] = useState<ReviewRow[]>([]);
+  const [kindFilter, setKindFilter] = useState<string>('all');
   const [loading, setLoading] = useState(true);
   const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
   const [decision, setDecision] = useState<{
@@ -98,6 +108,7 @@ export function ReviewQueuePage() {
             return {
               id: item.id,
               code: item.code ?? item.id,
+              kind: item.kind ?? 'product',
               label: objectLabel(item, i18n.language),
               completenessPct: item.completenessPct ?? 0,
               submitted,
@@ -156,9 +167,20 @@ export function ReviewQueuePage() {
     };
   }, [tenantId, reload]);
 
-  const allSelected = rows.length > 0 && selected.size === rows.length;
+  // #2517 — filter by ObjectType (Produkt / Kategoria / …) with counts.
+  const kindCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const row of rows) counts.set(row.kind, (counts.get(row.kind) ?? 0) + 1);
+    return counts;
+  }, [rows]);
+  const visibleRows = useMemo(
+    () => (kindFilter === 'all' ? rows : rows.filter((row) => row.kind === kindFilter)),
+    [rows, kindFilter],
+  );
+
+  const allSelected = visibleRows.length > 0 && visibleRows.every((row) => selected.has(row.id));
   const toggleAll = () => {
-    setSelected(allSelected ? new Set() : new Set(rows.map((row) => row.id)));
+    setSelected(allSelected ? new Set() : new Set(visibleRows.map((row) => row.id)));
   };
   const toggleOne = (id: string) => {
     setSelected((previous) => {
@@ -230,40 +252,73 @@ export function ReviewQueuePage() {
 
   return (
     <div data-testid="review-queue-page">
-      <div className="mb-2 flex items-center justify-end gap-2">
-        {canDecide && selected.size > 0 ? (
-          <>
-            <Button
-              size="sm"
-              onClick={() => {
-                setComment('');
-                setDecision({ transition: 'approve', ids: selectedIds });
-              }}
-              data-testid="queue-bulk-approve"
+      <div className="mb-2 flex flex-wrap items-center gap-2">
+        <div className="flex flex-wrap items-center gap-1" data-testid="review-queue-kind-filter">
+          {[
+            {
+              id: 'all',
+              label: t('workflow.queue.kind_all', { defaultValue: 'Wszystkie' }),
+              count: rows.length,
+            },
+            ...[...kindCounts.entries()].map(([kind, count]) => ({
+              id: kind,
+              label: t(`workflow.kind.${kind}`, { defaultValue: kindLabelDefault(kind) }),
+              count,
+            })),
+          ].map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => setKindFilter(tab.id)}
+              data-testid={`review-queue-kind-${tab.id}`}
+              className={`inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-[13px] font-medium transition ${
+                kindFilter === tab.id ? 'bg-zinc-900 text-white' : 'text-zinc-600 hover:bg-zinc-100'
+              }`}
             >
-              {t('workflow.transition.approve', { defaultValue: 'Zatwierdź' })} ({selected.size})
-            </Button>
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => {
-                setComment('');
-                setDecision({ transition: 'reject', ids: selectedIds });
-              }}
-              data-testid="queue-bulk-reject"
-            >
-              {t('workflow.transition.reject', { defaultValue: 'Odrzuć' })} ({selected.size})
-            </Button>
-          </>
-        ) : null}
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={reload}
-          aria-label={t('common.refresh', { defaultValue: 'Odśwież' })}
-        >
-          <RefreshCw className="size-4" />
-        </Button>
+              {tab.label}
+              <span
+                className={`rounded-full px-1.5 text-[11px] ${kindFilter === tab.id ? 'bg-white/20' : 'bg-zinc-200/70'}`}
+              >
+                {tab.count}
+              </span>
+            </button>
+          ))}
+        </div>
+        <div className="ml-auto flex items-center gap-2">
+          {canDecide && selected.size > 0 ? (
+            <>
+              <Button
+                size="sm"
+                onClick={() => {
+                  setComment('');
+                  setDecision({ transition: 'approve', ids: selectedIds });
+                }}
+                data-testid="queue-bulk-approve"
+              >
+                {t('workflow.transition.approve', { defaultValue: 'Zatwierdź' })} ({selected.size})
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setComment('');
+                  setDecision({ transition: 'reject', ids: selectedIds });
+                }}
+                data-testid="queue-bulk-reject"
+              >
+                {t('workflow.transition.reject', { defaultValue: 'Odrzuć' })} ({selected.size})
+              </Button>
+            </>
+          ) : null}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={reload}
+            aria-label={t('common.refresh', { defaultValue: 'Odśwież' })}
+          >
+            <RefreshCw className="size-4" />
+          </Button>
+        </div>
       </div>
 
       {rows.length === 0 && !loading ? (
@@ -301,7 +356,7 @@ export function ReviewQueuePage() {
               </tr>
             </thead>
             <tbody>
-              {rows.map((row) => (
+              {visibleRows.map((row) => (
                 <tr key={row.id} className="border-t border-border" data-testid="review-queue-row">
                   <td className="px-3 py-2">
                     <input
@@ -312,22 +367,43 @@ export function ReviewQueuePage() {
                     />
                   </td>
                   <td className="px-3 py-2">
-                    <Link to={`/products/${row.id}`} className="font-medium hover:underline">
+                    <Link to={objectHref(row.kind, row.id)} className="font-medium hover:underline">
                       {row.label}
                     </Link>
-                    <div className="text-xs text-muted-foreground">{row.code}</div>
+                    <div className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+                      <span>{row.code}</span>
+                      <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[11px] text-zinc-600">
+                        {t(`workflow.kind.${row.kind}`, {
+                          defaultValue: kindLabelDefault(row.kind),
+                        })}
+                      </span>
+                    </div>
+                    {row.submitted?.comment != null && (
+                      <div className="mt-1 border-l-2 border-zinc-200 pl-2 text-xs italic text-zinc-500">
+                        {row.submitted.comment}
+                      </div>
+                    )}
                   </td>
                   <td className="px-3 py-2">{row.completenessPct}%</td>
                   <td className="px-3 py-2">
                     {row.submitted !== null ? (
-                      <>
-                        <div className="text-xs text-muted-foreground">
-                          {formatTime(row.submitted.created_at, i18n.language)}
+                      <div className="flex items-center gap-2">
+                        <span
+                          className={`grid size-6 shrink-0 place-items-center rounded-full text-[11px] font-semibold ${avatarTone(row.submitted.actor_name ?? row.id)}`}
+                          aria-hidden="true"
+                        >
+                          {avatarInitial(row.submitted.actor_name)}
+                        </span>
+                        <div className="leading-tight">
+                          <div className="text-[13px] text-zinc-700">
+                            {row.submitted.actor_name ??
+                              t('workflow.queue.system_actor', { defaultValue: 'System' })}
+                          </div>
+                          <div className="text-[11px] text-muted-foreground">
+                            {relativeTime(row.submitted.created_at, i18n.language)}
+                          </div>
                         </div>
-                        {row.submitted.comment !== null && (
-                          <div className="text-xs">{row.submitted.comment}</div>
-                        )}
-                      </>
+                      </div>
                     ) : (
                       <span className="text-xs text-muted-foreground">—</span>
                     )}
@@ -408,10 +484,4 @@ export function ReviewQueuePage() {
       </Dialog>
     </div>
   );
-}
-
-function formatTime(value: string, locale: string): string {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-  return new Intl.DateTimeFormat(locale, { dateStyle: 'short', timeStyle: 'short' }).format(date);
 }

--- a/apps/admin/src/features/workflow/task-presentation.ts
+++ b/apps/admin/src/features/workflow/task-presentation.ts
@@ -1,0 +1,58 @@
+/**
+ * WFL redesign (#2517) — shared presentation helpers for the workflow
+ * surfaces (review queue, task cards in the hub and on the dashboard):
+ * kind badges, submitter avatars, relative time and deadline framing.
+ */
+
+export type ObjectKind = 'product' | 'category' | 'asset' | string;
+
+/** Route to an object's detail page by kind (sugar paths per kind). */
+export function objectHref(kind: ObjectKind, id: string): string {
+  if (kind === 'category') return `/categories/${id}`;
+  if (kind === 'asset') return `/assets/${id}`;
+  return `/products/${id}`;
+}
+
+/** Polish default label for a built-in kind (i18n key overrides it). */
+export function kindLabelDefault(kind: ObjectKind): string {
+  if (kind === 'category') return 'Kategoria';
+  if (kind === 'asset') return 'Zasób';
+  if (kind === 'product') return 'Produkt';
+  return kind;
+}
+
+/** Uppercase first letter for an avatar chip. */
+export function avatarInitial(name: string | null, fallback = '?'): string {
+  const source = name?.trim();
+  if (source === undefined || source === '') return fallback;
+  return source.slice(0, 1).toUpperCase();
+}
+
+/** A deterministic pastel background for a submitter avatar. */
+export function avatarTone(seed: string): string {
+  const tones = [
+    'bg-indigo-100 text-indigo-700',
+    'bg-emerald-100 text-emerald-700',
+    'bg-amber-100 text-amber-700',
+    'bg-rose-100 text-rose-700',
+    'bg-sky-100 text-sky-700',
+    'bg-violet-100 text-violet-700',
+  ];
+  let hash = 0;
+  for (let i = 0; i < seed.length; i += 1) hash = (hash * 31 + seed.charCodeAt(i)) | 0;
+  return tones[Math.abs(hash) % tones.length] ?? 'bg-zinc-100 text-zinc-700';
+}
+
+/** "2 godz. temu" / "wczoraj" style relative time from an ISO timestamp. */
+export function relativeTime(iso: string, lang: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+  const diffMs = Date.now() - then;
+  const minutes = Math.round(diffMs / 60_000);
+  const rtf = new Intl.RelativeTimeFormat(lang, { numeric: 'auto' });
+  if (minutes < 60) return rtf.format(-minutes, 'minute');
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return rtf.format(-hours, 'hour');
+  const days = Math.round(hours / 24);
+  return rtf.format(-days, 'day');
+}

--- a/apps/admin/src/lib/workflow/api.ts
+++ b/apps/admin/src/lib/workflow/api.ts
@@ -28,6 +28,8 @@ export interface WorkflowLogEntry {
   from: string;
   to: string;
   actor_user_id: string | null;
+  /** #2517 — display name resolved from the actor id (null for system/CLI). */
+  actor_name: string | null;
   comment: string | null;
   context: Record<string, unknown> | null;
   created_at: string;

--- a/apps/api/src/Catalog/Presentation/Controller/ObjectWorkflowController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ObjectWorkflowController.php
@@ -8,6 +8,7 @@ use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Identity\Contracts\Attribute\RequiresPermission;
 use App\Identity\Contracts\Auth\CurrentUserProvider;
+use App\Identity\Contracts\Directory\UserDirectoryInterface;
 use App\Workflow\Contracts\EditorialWorkflowProviderInterface;
 use App\Workflow\Contracts\ObjectEditorialWorkflow;
 use App\Workflow\Contracts\TransitionLogEntry;
@@ -48,6 +49,7 @@ final class ObjectWorkflowController
         private readonly TransitionLogPort $transitionLog,
         private readonly CurrentUserProvider $currentUser,
         private readonly EditorialWorkflowProviderInterface $workflows,
+        private readonly UserDirectoryInterface $userDirectory,
     ) {
     }
 
@@ -162,9 +164,19 @@ final class ObjectWorkflowController
         $hasMore = \count($entries) > $limit;
         $entries = \array_slice($entries, 0, $limit);
 
+        // Batch-resolve the actor names once for the whole page (review
+        // queue "who submitted" + history timeline authorship, #2517).
+        $actorIds = [];
+        foreach ($entries as $entry) {
+            if (null !== $entry->actorUserId) {
+                $actorIds[] = $entry->actorUserId->toRfc4122();
+            }
+        }
+        $names = $this->userDirectory->resolve($actorIds);
+
         return new JsonResponse([
             'object_id' => $object->getId()->toRfc4122(),
-            'items' => \array_map(self::serializeEntry(...), $entries),
+            'items' => \array_map(static fn (TransitionLogEntry $entry): array => self::serializeEntry($entry, $names), $entries),
             'next_cursor' => $hasMore && [] !== $entries
                 ? $entries[\count($entries) - 1]->id->toRfc4122()
                 : null,
@@ -293,14 +305,22 @@ final class ObjectWorkflowController
     /**
      * @return array<string, mixed>
      */
-    private static function serializeEntry(TransitionLogEntry $entry): array
+    /**
+     * @param array<string, array{name: string, email: string}> $names actor id → display data
+     *
+     * @return array<string, mixed>
+     */
+    private static function serializeEntry(TransitionLogEntry $entry, array $names = []): array
     {
+        $actorId = $entry->actorUserId?->toRfc4122();
+
         return [
             'id' => $entry->id->toRfc4122(),
             'transition' => $entry->transition,
             'from' => $entry->fromPlace,
             'to' => $entry->toPlace,
-            'actor_user_id' => $entry->actorUserId?->toRfc4122(),
+            'actor_user_id' => $actorId,
+            'actor_name' => null !== $actorId ? ($names[$actorId]['name'] ?? null) : null,
             'comment' => $entry->comment,
             'context' => $entry->context,
             'created_at' => $entry->createdAt->format(DateTimeInterface::ATOM),

--- a/apps/api/src/Identity/Application/SqlUserDirectory.php
+++ b/apps/api/src/Identity/Application/SqlUserDirectory.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application;
+
+use App\Identity\Contracts\Directory\UserDirectoryInterface;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+
+use const MB_CASE_TITLE;
+
+/**
+ * WFL redesign (#2517) — resolves user ids to a display label. The users
+ * table only carries `email` (dedicated name columns are deferred, see
+ * UserListResponseBuilder), so the label is derived from the email the
+ * same way the users list does, keeping both surfaces consistent.
+ */
+final readonly class SqlUserDirectory implements UserDirectoryInterface
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    public function resolve(array $userIds): array
+    {
+        $ids = \array_values(\array_unique(\array_filter($userIds, static fn (string $id): bool => '' !== $id)));
+        if ([] === $ids) {
+            return [];
+        }
+
+        /** @var list<array{id: string, email: string}> $rows */
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT id, email FROM users WHERE id IN (:ids)',
+            ['ids' => $ids],
+            ['ids' => ArrayParameterType::STRING],
+        );
+
+        $out = [];
+        foreach ($rows as $row) {
+            $email = $row['email'];
+            $out[$row['id']] = ['name' => $this->deriveName($email), 'email' => $email];
+        }
+
+        return $out;
+    }
+
+    private function deriveName(string $email): string
+    {
+        $localPart = \explode('@', $email, 2)[0];
+        $normalised = \preg_replace('/[._-]+/', ' ', $localPart);
+        if (null === $normalised || '' === \trim($normalised)) {
+            return $email;
+        }
+
+        return \mb_convert_case(\trim($normalised), MB_CASE_TITLE, 'UTF-8');
+    }
+}

--- a/apps/api/src/Identity/Contracts/Directory/UserDirectoryInterface.php
+++ b/apps/api/src/Identity/Contracts/Directory/UserDirectoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Contracts\Directory;
+
+/**
+ * WFL redesign (#2517) — cross-BC seam to turn actor / submitter UUIDs
+ * into a human label + email for the review queue and task cards. Read
+ * side only; other bounded contexts store user ids and resolve display
+ * data through this port instead of reaching into Identity entities
+ * (deptrac).
+ */
+interface UserDirectoryInterface
+{
+    /**
+     * Batch-resolve user ids to their display name + email. Unknown ids
+     * are omitted from the result. Tenant isolation is enforced by RLS /
+     * the query scope.
+     *
+     * @param list<string> $userIds RFC-4122 uuids
+     *
+     * @return array<string, array{name: string, email: string}> keyed by user id
+     */
+    public function resolve(array $userIds): array;
+}


### PR DESCRIPTION
## Summary
Redesign kolejki „Do przeglądu" wg screenu 2 + fundament pod submitter-names współdzielony z kartami zadań (T4).

Closes #2517

## Backend
- **Nowy seam `UserDirectoryInterface`** (Identity Contracts) + impl `SqlUserDirectory` — batch-resolve id usera → nazwa (derywowana z emaila tak jak lista userów) + email. Read-only, przez Contracts (deptrac-clean).
- `GET /api/objects/{id}/workflow/transitions` zwraca teraz `actor_name` per wpis.

## Frontend
- **Filtr typu** (taby Wszystkie / Produkt N / Kategoria N / …) z licznikami; filtruje wiersze per `kind`.
- Badge kind + **kind-aware link** (produkt→/products, kategoria→/categories, asset→/assets).
- Kolumna „Zgłosił": avatar + **nazwa** + czas względny (było: goły timestamp). Komentarz przeniesiony pod nazwę obiektu.
- Wspólne helpery prezentacji (`task-presentation.ts`: kind label, avatar, relative time) do reuse w kartach zadań (T4/T6).

## Quality gates
- PHPStan max 0, deptrac 0, cs-fixer czysto (BE). tsc/biome 0, build OK, guardy (jsonfetch-useeffect, max-lines) bez regresji (FE).
- Istniejący `wfl-p3-02-review-queue.spec.ts` pokrywa wiersz + inline approve (komentarz nadal w wierszu).

## Smoke (dev stack)
`POST submit_for_review` → `GET .../workflow/transitions` zwraca `actor_name: "Admin"` (derywowane z admin@demo.localhost). Kolejka renderuje badge + submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
