### PR TITLE
feat(workflow): rich task cards + shared WorkflowTaskCard (#2519)

### DIFF
--- a/apps/admin/src/features/workflow/TasksPanel.tsx
+++ b/apps/admin/src/features/workflow/TasksPanel.tsx
@@ -1,22 +1,26 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router';
 import { Button } from '@/components/ui/button';
 import { toast } from '@/components/ui/toast';
 import { EmptyState } from '@/components/ui-v2/empty-state';
 import { actOnWorkflowTask, fetchWorkflowTasks, type WorkflowTask } from '@/lib/workflow/tasks-api';
 
+import { taskTypeBadge } from './task-presentation';
+import { WorkflowTaskCard } from './WorkflowTaskCard';
+
 /**
- * WFL-P4-03 (#2430) — the task inbox (inRiver pattern: "my work" on
- * login): open tasks assigned to me (directly or via my roles) or the
- * tenant-wide list, with type labels, overdue highlighting and inline
+ * WFL-P4-03 (#2430) + redesign (#2518) — the task inbox: open tasks
+ * assigned to me (directly / via role / as an approve_reject holder) or
+ * the tenant-wide list, shown as rich cards (type badge, deadline,
+ * object title + SKU, submitter, assignee) with a type filter and inline
  * complete/cancel. Cursor pages older entries.
  */
 export function TasksPanel({ mine }: { mine: boolean }) {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const [tasks, setTasks] = useState<WorkflowTask[]>([]);
   const [cursor, setCursor] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [typeFilter, setTypeFilter] = useState<string>('all');
 
   const reload = useCallback(() => {
     setLoading(true);
@@ -60,6 +64,16 @@ export function TasksPanel({ mine }: { mine: boolean }) {
     });
   };
 
+  const typeCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const task of tasks) counts.set(task.type, (counts.get(task.type) ?? 0) + 1);
+    return counts;
+  }, [tasks]);
+  const visibleTasks = useMemo(
+    () => (typeFilter === 'all' ? tasks : tasks.filter((task) => task.type === typeFilter)),
+    [tasks, typeFilter],
+  );
+
   if (tasks.length === 0 && !loading) {
     return (
       <EmptyState
@@ -71,79 +85,69 @@ export function TasksPanel({ mine }: { mine: boolean }) {
     );
   }
 
-  const today = new Date().toISOString().slice(0, 10);
-
   return (
-    <div className="mt-4 flex flex-col gap-2" data-testid="tasks-panel">
-      {tasks.map((task) => {
-        const overdue = task.due_date !== null && task.due_date < today;
-        return (
-          <div
-            key={task.id}
-            className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-border px-4 py-3"
-            data-testid="task-row"
+    <div className="mt-4" data-testid="tasks-panel">
+      <div className="mb-3 flex flex-wrap items-center gap-1" data-testid="tasks-type-filter">
+        {[
+          {
+            id: 'all',
+            label: t('workflow.tasks.filter_all', { defaultValue: 'Wszystkie typy' }),
+            count: tasks.length,
+          },
+          ...[...typeCounts.entries()].map(([type, count]) => {
+            const badge = taskTypeBadge(type);
+            return { id: type, label: t(badge.key, { defaultValue: badge.fallback }), count };
+          }),
+        ].map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => setTypeFilter(tab.id)}
+            data-testid={`tasks-type-${tab.id}`}
+            className={`inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-[13px] font-medium transition ${
+              typeFilter === tab.id ? 'bg-zinc-900 text-white' : 'text-zinc-600 hover:bg-zinc-100'
+            }`}
           >
-            <div className="min-w-0">
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-medium">
-                  {t(`workflow.tasks.type.${task.type}`, { defaultValue: task.title })}
-                </span>
-                {task.due_date !== null && (
-                  <span
-                    className={
-                      overdue
-                        ? 'rounded bg-brick-50 px-1.5 py-0.5 text-[10px] font-semibold text-brick-700'
-                        : 'rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] text-zinc-600'
-                    }
-                  >
-                    {formatDate(task.due_date, i18n.language)}
-                  </span>
-                )}
-                {task.assignee_role_code !== null && (
-                  <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] text-zinc-600">
-                    {task.assignee_role_code}
-                  </span>
-                )}
-              </div>
-              {task.comment !== null && (
-                <p className="mt-0.5 truncate text-xs text-muted-foreground">{task.comment}</p>
-              )}
-              {task.object_id !== null && (
-                <Link
-                  to={`/products/${task.object_id}`}
-                  className="text-xs text-primary hover:underline"
+            {tab.label}
+            <span
+              className={`rounded-full px-1.5 text-[11px] ${typeFilter === tab.id ? 'bg-white/20' : 'bg-zinc-200/70'}`}
+            >
+              {tab.count}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {visibleTasks.map((task) => (
+          <WorkflowTaskCard
+            key={task.id}
+            task={task}
+            showAssignee={!mine}
+            actions={
+              <>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => act(task, 'complete')}
+                  data-testid={`task-complete-${task.id}`}
                 >
-                  {t('workflow.tasks.open_object', { defaultValue: 'Otwórz obiekt' })}
-                </Link>
-              )}
-            </div>
-            <div className="flex gap-1">
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => act(task, 'complete')}
-                data-testid={`task-complete-${task.id}`}
-              >
-                {t('workflow.tasks.complete', { defaultValue: 'Ukończ' })}
-              </Button>
-              <Button size="sm" variant="ghost" onClick={() => act(task, 'cancel')}>
-                {t('workflow.tasks.cancel', { defaultValue: 'Anuluj' })}
-              </Button>
-            </div>
-          </div>
-        );
-      })}
+                  {t('workflow.tasks.complete', { defaultValue: 'Ukończ' })}
+                </Button>
+                <Button size="sm" variant="ghost" onClick={() => act(task, 'cancel')}>
+                  {t('workflow.tasks.cancel', { defaultValue: 'Anuluj' })}
+                </Button>
+              </>
+            }
+          />
+        ))}
+      </div>
+
       {cursor !== null && (
-        <Button variant="outline" size="sm" onClick={loadOlder}>
+        <Button variant="outline" size="sm" className="mt-3" onClick={loadOlder}>
           {t('workflow.history.older', { defaultValue: 'Pokaż starsze' })}
         </Button>
       )}
     </div>
   );
-}
-
-function formatDate(value: string, locale: string): string {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-  return new Intl.DateTimeFormat(locale, { dateStyle: 'short' }).format(date);
 }

--- a/apps/admin/src/features/workflow/WorkflowTaskCard.tsx
+++ b/apps/admin/src/features/workflow/WorkflowTaskCard.tsx
@@ -1,0 +1,132 @@
+import { Calendar, ExternalLink } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+
+import type { WorkflowTask } from '@/lib/workflow/tasks-api';
+
+import {
+  avatarInitial,
+  avatarTone,
+  deadlineFraming,
+  kindLabelDefault,
+  objectHref,
+  relativeTime,
+  taskTypeBadge,
+} from './task-presentation';
+
+/**
+ * WFL redesign (#2518) — the shared task card used by the workflow hub
+ * ("Moje zadania" / "Wszystkie zadania") and the dashboard widget (#2519):
+ * type badge, deadline framing, object title + SKU + kind, the submitter
+ * comment and "who submitted", an optional assignee line ("Wszystkie"
+ * tab) and a caller-provided action slot (complete/cancel in the hub,
+ * approve/reject/… on the dashboard).
+ */
+interface WorkflowTaskCardProps {
+  task: WorkflowTask;
+  /** Show the "przypisano: …" line (tenant-wide "Wszystkie zadania" view). */
+  showAssignee?: boolean;
+  /** Action buttons rendered in the card footer. */
+  actions?: ReactNode;
+  'data-testid'?: string;
+}
+
+export function WorkflowTaskCard({
+  task,
+  showAssignee = false,
+  actions,
+  'data-testid': testId = 'task-card',
+}: WorkflowTaskCardProps) {
+  const { t, i18n } = useTranslation();
+  const type = taskTypeBadge(task.type);
+  const deadline = deadlineFraming(task.due_date, i18n.language);
+  const kind = task.object_kind ?? 'product';
+  const title =
+    task.object_title ?? task.title ?? t('workflow.tasks.untitled', { defaultValue: 'Obiekt' });
+
+  return (
+    <div className="rounded-2xl border border-zinc-200 bg-white p-4" data-testid={testId}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className={`rounded-md px-2 py-0.5 text-[12px] font-medium ${type.tone}`}>
+            {t(type.key, { defaultValue: type.fallback })}
+          </span>
+          {deadline !== null ? (
+            <span
+              className={`inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[12px] ${
+                deadline.overdue ? 'bg-rose-50 text-rose-600' : 'bg-zinc-100 text-zinc-500'
+              }`}
+            >
+              <Calendar className="size-3" aria-hidden="true" />
+              {t(deadline.key, { defaultValue: deadline.fallback, date: deadline.date })}
+            </span>
+          ) : null}
+        </div>
+        {task.object_id !== null ? (
+          <Link
+            to={objectHref(kind, task.object_id)}
+            className="inline-flex shrink-0 items-center gap-1 text-[12px] text-zinc-500 hover:text-zinc-700"
+          >
+            {t('workflow.tasks.open_object', { defaultValue: 'Otwórz obiekt' })}
+            <ExternalLink className="size-3" aria-hidden="true" />
+          </Link>
+        ) : null}
+      </div>
+
+      <h3 className="mt-2 text-[15px] font-semibold text-zinc-900">{title}</h3>
+      {task.object_sku !== null ? (
+        <div className="mt-0.5 flex items-center gap-1.5 text-[12px] text-zinc-400">
+          <span className="font-mono">{task.object_sku}</span>
+          <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[11px] text-zinc-600">
+            {t(`workflow.kind.${kind}`, { defaultValue: kindLabelDefault(kind) })}
+          </span>
+        </div>
+      ) : null}
+
+      {task.comment !== null ? (
+        <p className="mt-2 border-l-2 border-zinc-200 pl-2 text-[13px] italic text-zinc-500">
+          „{task.comment}"
+        </p>
+      ) : null}
+
+      <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-3 text-[12px] text-zinc-500">
+          {task.created_by_name !== null ? (
+            <span className="inline-flex items-center gap-1.5">
+              <span
+                className={`grid size-5 place-items-center rounded-full text-[10px] font-semibold ${avatarTone(task.created_by_name)}`}
+                aria-hidden="true"
+              >
+                {avatarInitial(task.created_by_name)}
+              </span>
+              {t('workflow.tasks.submitted_by', {
+                defaultValue: 'zgłosił {{name}}',
+                name: task.created_by_name,
+              })}
+              {' · '}
+              {relativeTime(task.created_at, i18n.language)}
+            </span>
+          ) : (
+            <span>{relativeTime(task.created_at, i18n.language)}</span>
+          )}
+          {showAssignee ? (
+            <span className="inline-flex items-center gap-1 text-zinc-400">
+              {t('workflow.tasks.assigned_to', { defaultValue: 'przypisano' })}:
+              <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[11px] text-zinc-600">
+                {task.assignee_name ??
+                  (task.assignee_role_code !== null
+                    ? t('workflow.tasks.role_prefix', {
+                        defaultValue: 'Rola: {{role}}',
+                        role: task.assignee_role_code,
+                      })
+                    : t('workflow.tasks.unassigned', { defaultValue: 'nieprzypisane' }))}
+              </span>
+            </span>
+          ) : null}
+        </div>
+        {actions !== undefined ? <div className="flex items-center gap-1.5">{actions}</div> : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/workflow/task-presentation.ts
+++ b/apps/admin/src/features/workflow/task-presentation.ts
@@ -43,6 +43,80 @@ export function avatarTone(seed: string): string {
   return tones[Math.abs(hash) % tones.length] ?? 'bg-zinc-100 text-zinc-700';
 }
 
+export type WorkflowTaskType = 'review' | 'fix' | 'request_unpublish' | 'custom' | string;
+
+/** Colored badge tone + i18n key/default for a task type. */
+export function taskTypeBadge(type: WorkflowTaskType): {
+  tone: string;
+  key: string;
+  fallback: string;
+} {
+  switch (type) {
+    case 'review':
+      return {
+        tone: 'bg-amber-100 text-amber-700',
+        key: 'workflow.tasks.type.review',
+        fallback: 'Przegląd',
+      };
+    case 'fix':
+      return {
+        tone: 'bg-rose-100 text-rose-700',
+        key: 'workflow.tasks.type.fix',
+        fallback: 'Poprawka',
+      };
+    case 'request_unpublish':
+      return {
+        tone: 'bg-sky-100 text-sky-700',
+        key: 'workflow.tasks.type.request_unpublish',
+        fallback: 'Prośba o depublikację',
+      };
+    default:
+      return {
+        tone: 'bg-violet-100 text-violet-700',
+        key: 'workflow.tasks.type.custom',
+        fallback: 'Własne',
+      };
+  }
+}
+
+export interface DeadlineFraming {
+  overdue: boolean;
+  key: string;
+  fallback: string;
+  date?: string;
+}
+
+/** Frame a due date as dziś / jutro / po terminie / a concrete date. */
+export function deadlineFraming(dueDate: string | null, lang: string): DeadlineFraming | null {
+  if (dueDate === null) return null;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const due = new Date(`${dueDate}T00:00:00`);
+  const diffDays = Math.round((due.getTime() - today.getTime()) / 86_400_000);
+  const shortDate = new Intl.DateTimeFormat(lang, { day: '2-digit', month: '2-digit' }).format(due);
+
+  if (diffDays < 0) {
+    return {
+      overdue: true,
+      key: 'workflow.tasks.overdue',
+      fallback: 'Po terminie: {{date}}',
+      date: shortDate,
+    };
+  }
+  if (diffDays === 0) {
+    return { overdue: false, key: 'workflow.tasks.due_today', fallback: 'Termin: dziś' };
+  }
+  if (diffDays === 1) {
+    return { overdue: false, key: 'workflow.tasks.due_tomorrow', fallback: 'Termin: jutro' };
+  }
+  return {
+    overdue: false,
+    key: 'workflow.tasks.due_on',
+    fallback: 'Termin: {{date}}',
+    date: shortDate,
+  };
+}
+
 /** "2 godz. temu" / "wczoraj" style relative time from an ISO timestamp. */
 export function relativeTime(iso: string, lang: string): string {
   const then = new Date(iso).getTime();

--- a/apps/admin/src/lib/workflow/tasks-api.ts
+++ b/apps/admin/src/lib/workflow/tasks-api.ts
@@ -12,11 +12,20 @@ export interface WorkflowTask {
   type: 'review' | 'fix' | 'request_unpublish' | 'custom';
   status: 'open' | 'done' | 'cancelled';
   object_id: string | null;
+  /** #2518 — object summary resolved server-side for the card. */
+  object_title: string | null;
+  object_sku: string | null;
+  object_kind: string | null;
   assignee_user_id: string | null;
   assignee_role_code: string | null;
+  /** #2518 — display name when the task is routed to a specific user. */
+  assignee_name: string | null;
   due_date: string | null;
   comment: string | null;
   context: Record<string, unknown> | null;
+  created_by: string | null;
+  /** #2518 — submitter display name (from the UserDirectory seam). */
+  created_by_name: string | null;
   created_at: string;
 }
 

--- a/apps/api/src/Catalog/Application/Query/ObjectSummaryReader.php
+++ b/apps/api/src/Catalog/Application/Query/ObjectSummaryReader.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Query;
+
+use App\Catalog\Application\Query\GetObjectSummary\GetObjectSummaryHandler;
+use App\Catalog\Application\Query\GetObjectSummary\GetObjectSummaryQuery;
+use App\Catalog\Contracts\Query\ObjectSummaryPort;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * WFL redesign (#2518) — batch adapter over the single-object summary
+ * handler. The task list resolves a page's worth of object ids at once;
+ * per-id resolution reuses the existing projection so the label logic
+ * stays in one place. Unknown / cross-tenant ids are simply omitted
+ * (RLS + the handler's null-on-missing keep isolation intact).
+ */
+final readonly class ObjectSummaryReader implements ObjectSummaryPort
+{
+    public function __construct(private GetObjectSummaryHandler $handler)
+    {
+    }
+
+    public function summariesByIds(array $objectIds): array
+    {
+        $out = [];
+        foreach (\array_unique($objectIds) as $rawId) {
+            if (!Uuid::isValid($rawId)) {
+                continue;
+            }
+            $summary = ($this->handler)(new GetObjectSummaryQuery(Uuid::fromString($rawId)));
+            if (null !== $summary) {
+                $out[$rawId] = $summary;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Query/ObjectSummaryPort.php
+++ b/apps/api/src/Catalog/Contracts/Query/ObjectSummaryPort.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Query;
+
+/**
+ * WFL redesign (#2518) — batch cross-BC read of {@see ObjectSummary} for
+ * a set of object ids. The workflow task list (Workflow BC) uses it to
+ * label task cards with the object's title / code / kind without
+ * crossing into Catalog's Domain (deptrac).
+ */
+interface ObjectSummaryPort
+{
+    /**
+     * @param list<string> $objectIds RFC-4122 uuids
+     *
+     * @return array<string, ObjectSummary> keyed by object id (missing ids omitted)
+     */
+    public function summariesByIds(array $objectIds): array;
+}

--- a/apps/api/src/Workflow/Presentation/Controller/WorkflowTasksController.php
+++ b/apps/api/src/Workflow/Presentation/Controller/WorkflowTasksController.php
@@ -281,8 +281,8 @@ final class WorkflowTasksController
             $userIds[] = $task->getCreatedBy()?->toRfc4122();
             $userIds[] = $task->getAssigneeUserId()?->toRfc4122();
         }
-        $objectIds = \array_values(\array_filter($objectIds));
-        $userIds = \array_values(\array_filter($userIds));
+        $objectIds = \array_values(\array_filter($objectIds, static fn (?string $v): bool => null !== $v));
+        $userIds = \array_values(\array_filter($userIds, static fn (?string $v): bool => null !== $v));
 
         return [
             [] === $objectIds ? [] : $this->objectSummaries->summariesByIds($objectIds),

--- a/apps/api/src/Workflow/Presentation/Controller/WorkflowTasksController.php
+++ b/apps/api/src/Workflow/Presentation/Controller/WorkflowTasksController.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace App\Workflow\Presentation\Controller;
 
+use App\Catalog\Contracts\Query\ObjectSummary;
+use App\Catalog\Contracts\Query\ObjectSummaryPort;
 use App\Identity\Contracts\Attribute\RequiresPermission;
 use App\Identity\Contracts\Auth\CurrentUserProvider;
+use App\Identity\Contracts\Directory\UserDirectoryInterface;
 use App\Identity\Contracts\Policy\PermissionCheckerInterface;
 use App\Workflow\Contracts\ObjectEditorialWorkflow;
 use App\Workflow\Contracts\WorkflowTaskStatus;
@@ -45,6 +48,8 @@ final class WorkflowTasksController
         private readonly DoctrineWorkflowTaskRepository $taskQueries,
         private readonly CurrentUserProvider $currentUser,
         private readonly PermissionCheckerInterface $permissions,
+        private readonly ObjectSummaryPort $objectSummaries,
+        private readonly UserDirectoryInterface $userDirectory,
     ) {
     }
 
@@ -113,8 +118,13 @@ final class WorkflowTasksController
         $hasMore = \count($rows) > $limit;
         $rows = \array_slice($rows, 0, $limit);
 
+        [$summaries, $names] = $this->resolveCardData($rows);
+
         return new JsonResponse([
-            'items' => \array_map(self::serialize(...), $rows),
+            'items' => \array_map(
+                static fn (WorkflowTask $task): array => self::serialize($task, $summaries, $names),
+                $rows,
+            ),
             'next_cursor' => $hasMore && [] !== $rows ? $rows[\count($rows) - 1]->getId()->toRfc4122() : null,
         ]);
     }
@@ -168,7 +178,9 @@ final class WorkflowTasksController
         );
         $this->tasks->save($task);
 
-        return new JsonResponse(self::serialize($task), 201);
+        [$summaries, $names] = $this->resolveCardData([$task]);
+
+        return new JsonResponse(self::serialize($task, $summaries, $names), 201);
     }
 
     #[Route(
@@ -211,7 +223,9 @@ final class WorkflowTasksController
 
         $this->tasks->save($task);
 
-        return new JsonResponse(self::serialize($task));
+        [$summaries, $names] = $this->resolveCardData([$task]);
+
+        return new JsonResponse(self::serialize($task, $summaries, $names));
     }
 
     /**
@@ -251,25 +265,72 @@ final class WorkflowTasksController
     }
 
     /**
+     * Batch-resolve the object summaries + user display names a page of
+     * task cards needs (#2518 review-queue seam reused). Keyed by id.
+     *
+     * @param list<WorkflowTask> $tasks
+     *
+     * @return array{0: array<string, ObjectSummary>, 1: array<string, array{name: string, email: string}>}
+     */
+    private function resolveCardData(array $tasks): array
+    {
+        $objectIds = [];
+        $userIds = [];
+        foreach ($tasks as $task) {
+            $objectIds[] = $task->getObjectId()?->toRfc4122();
+            $userIds[] = $task->getCreatedBy()?->toRfc4122();
+            $userIds[] = $task->getAssigneeUserId()?->toRfc4122();
+        }
+        $objectIds = \array_values(\array_filter($objectIds));
+        $userIds = \array_values(\array_filter($userIds));
+
+        return [
+            [] === $objectIds ? [] : $this->objectSummaries->summariesByIds($objectIds),
+            [] === $userIds ? [] : $this->userDirectory->resolve($userIds),
+        ];
+    }
+
+    /**
+     * @param array<string, ObjectSummary>                      $summaries object id → summary
+     * @param array<string, array{name: string, email: string}> $names     user id → display data
+     *
      * @return array<string, mixed>
      */
-    private static function serialize(WorkflowTask $task): array
+    private static function serialize(WorkflowTask $task, array $summaries = [], array $names = []): array
     {
+        $objectId = $task->getObjectId()?->toRfc4122();
+        $summary = null !== $objectId ? ($summaries[$objectId] ?? null) : null;
+        $createdBy = $task->getCreatedBy()?->toRfc4122();
+        $assigneeUserId = $task->getAssigneeUserId()?->toRfc4122();
+
         return [
             'id' => $task->getId()->toRfc4122(),
             'title' => $task->getTitle(),
             'type' => $task->getType()->value,
             'status' => $task->getStatus()->value,
-            'object_id' => $task->getObjectId()?->toRfc4122(),
-            'assignee_user_id' => $task->getAssigneeUserId()?->toRfc4122(),
+            'object_id' => $objectId,
+            'object_title' => null !== $summary ? self::summaryTitle($summary) : null,
+            'object_sku' => $summary?->code,
+            'object_kind' => $summary?->kind->value,
+            'assignee_user_id' => $assigneeUserId,
             'assignee_role_code' => $task->getAssigneeRoleCode(),
+            'assignee_name' => null !== $assigneeUserId ? ($names[$assigneeUserId]['name'] ?? null) : null,
             'due_date' => $task->getDueDate()?->format('Y-m-d'),
             'comment' => $task->getComment(),
             'context' => $task->getContext(),
-            'created_by' => $task->getCreatedBy()?->toRfc4122(),
+            'created_by' => $createdBy,
+            'created_by_name' => null !== $createdBy ? ($names[$createdBy]['name'] ?? null) : null,
             'resolved_by' => $task->getResolvedBy()?->toRfc4122(),
             'resolved_at' => $task->getResolvedAt()?->format(DateTimeInterface::ATOM),
             'created_at' => $task->getCreatedAt()->format(DateTimeInterface::ATOM),
         ];
+    }
+
+    private static function summaryTitle(ObjectSummary $summary): string
+    {
+        $label = $summary->label;
+        $first = \reset($label);
+
+        return $label['pl'] ?? $label['en'] ?? (false !== $first && '' !== $first ? $first : $summary->code);
     }
 }

--- a/apps/api/tests/Api/Catalog/WorkflowTasksApiTest.php
+++ b/apps/api/tests/Api/Catalog/WorkflowTasksApiTest.php
@@ -58,6 +58,10 @@ final class WorkflowTasksApiTest extends CatalogApiTestCase
         self::assertSame('review', $task['type']);
         self::assertSame('approver', $task['assignee_role_code']);
         self::assertSame('Do zadania', $task['comment']);
+        // #2518 — cards carry the resolved object summary + submitter name.
+        self::assertSame('product', $task['object_kind']);
+        self::assertSame('WFL-T-LOOP', $task['object_sku']);
+        self::assertNotNull($task['created_by_name'], 'submitter display name resolved');
 
         // Re-submit does not duplicate the open task.
         $reject = $approver->request('POST', '/api/objects/'.$id.'/workflow/transitions/reject', [


### PR DESCRIPTION
## Summary
Bogate karty zadań (screeny 3/4) + wspólny komponent `WorkflowTaskCard` reużywany przez hub i widget na Pulpicie (T6).

Closes #2519

## Backend
- Nowy batch seam `ObjectSummaryPort` (Catalog Contracts) + `ObjectSummaryReader` — id obiektu → tytuł/SKU/kind (reuse `GetObjectSummaryHandler`).
- `GET /api/workflow/tasks` wzbogacone: `object_title`, `object_sku`, `object_kind` (ObjectSummaryPort) + `created_by_name`, `assignee_name` (UserDirectory seam z #2518). Batch per strona.

## Frontend
- Wspólny `WorkflowTaskCard`: badge typu (Przegląd/Poprawka/Prośba o depublikację), termin (dziś/jutro/po terminie czerwony), tytuł + SKU + kind badge, komentarz, „zgłosił X · czas", opcjonalna linia „przypisano" (tab Wszystkie), slot akcji (Ukończ/Anuluj w hubie; Zatwierdź/Odrzuć/Popraw/Rozpatrz na dashboardzie w T6).
- `TasksPanel` (Moje/Wszystkie) → siatka kart + filtr typu z licznikami. Helpery prezentacji rozszerzone (`taskTypeBadge`, `deadlineFraming`).

## Quality gates
- PHPStan max 0, deptrac 0, cs-fixer czysto (BE). tsc/biome 0, build OK, guardy bez regresji (FE).
- `WorkflowTasksApiTest` rozszerzony: `object_kind/object_sku/created_by_name` w odpowiedzi.

## Smoke (dev stack)
`GET /api/workflow/tasks?mine=1` → `object_sku: WFL-CARD-SMOKE, object_kind: product, object_title: …, created_by_name: "Admin"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
