### PR TITLE
feat(workflow): product-detail reviewer hint + history authorship (#2521)

### DIFF
--- a/apps/admin/src/features/catalog/products/components/workflow-history-sheet.tsx
+++ b/apps/admin/src/features/catalog/products/components/workflow-history-sheet.tsx
@@ -94,8 +94,9 @@ function HistoryRow({ entry, locale }: { entry: WorkflowLogEntry; locale: string
         {t(`workflow.place.${entry.from}`, { defaultValue: entry.from })}
         {' → '}
         {t(`workflow.place.${entry.to}`, { defaultValue: entry.to })}
-        {entry.actor_user_id === null &&
-          ` · ${t('workflow.history.system', { defaultValue: 'System' })}`}
+      </p>
+      <p className="mt-0.5 text-[11px] text-zinc-500">
+        {entry.actor_name ?? t('workflow.history.system', { defaultValue: 'System' })}
       </p>
       {entry.comment !== null && <p className="mt-1 text-sm">{entry.comment}</p>}
       {(autoUnpublish || bulk) && (

--- a/apps/admin/src/features/catalog/products/components/workflow-status-control.tsx
+++ b/apps/admin/src/features/catalog/products/components/workflow-status-control.tsx
@@ -162,7 +162,7 @@ export function WorkflowStatusControl({ objectId }: { objectId: string }) {
               : state.reviewer.label}
           </span>
           {' · '}
-          <Link to="/workflow/settings" className="text-indigo-600 hover:text-indigo-500">
+          <Link to="/workflow/settings" className="text-indigo-600 underline hover:text-indigo-500">
             {t('workflow.control.change_routing', {
               defaultValue: 'zmień w Ustawieniach przepływu →',
             })}

--- a/apps/admin/src/features/catalog/products/components/workflow-status-control.tsx
+++ b/apps/admin/src/features/catalog/products/components/workflow-status-control.tsx
@@ -1,6 +1,7 @@
 import { History } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -89,61 +90,85 @@ export function WorkflowStatusControl({ objectId }: { objectId: string }) {
       .finally(() => setSubmitting(false));
   };
 
+  const canSubmit = state.transitions.some((transition) => transition.name === 'submit_for_review');
+
   return (
-    <div className="flex flex-wrap items-center gap-2" data-testid="workflow-status-control">
-      <StatusPill
-        variant={placePillVariant(state.current_place)}
-        label={t(`workflow.place.${state.current_place}`, {
-          defaultValue: state.current_place,
+    <div className="space-y-1.5">
+      <div className="flex flex-wrap items-center gap-2" data-testid="workflow-status-control">
+        <StatusPill
+          variant={placePillVariant(state.current_place)}
+          label={t(`workflow.place.${state.current_place}`, {
+            defaultValue: state.current_place,
+          })}
+        />
+        {state.transitions.map((transition) => {
+          const label = t(`workflow.transition.${transition.name}`, {
+            defaultValue: transition.name,
+          });
+          const button = (
+            <Button
+              key={transition.name}
+              variant="outline"
+              size="sm"
+              disabled={!transition.enabled || submitting}
+              onClick={() => {
+                setComment('');
+                setPending(transition);
+              }}
+              data-testid={`workflow-transition-${transition.name}`}
+            >
+              {label}
+            </Button>
+          );
+          if (transition.enabled) {
+            return button;
+          }
+          return (
+            <Tooltip key={transition.name}>
+              <TooltipTrigger asChild>
+                {/* span wrapper: disabled buttons swallow pointer events */}
+                <span>{button}</span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                {transition.blockers.map((blocker) => (
+                  <p key={blocker.code} className="text-xs">
+                    {blocker.message}
+                  </p>
+                ))}
+              </TooltipContent>
+            </Tooltip>
+          );
         })}
-      />
-      {state.transitions.map((transition) => {
-        const label = t(`workflow.transition.${transition.name}`, {
-          defaultValue: transition.name,
-        });
-        const button = (
-          <Button
-            key={transition.name}
-            variant="outline"
-            size="sm"
-            disabled={!transition.enabled || submitting}
-            onClick={() => {
-              setComment('');
-              setPending(transition);
-            }}
-            data-testid={`workflow-transition-${transition.name}`}
-          >
-            {label}
-          </Button>
-        );
-        if (transition.enabled) {
-          return button;
-        }
-        return (
-          <Tooltip key={transition.name}>
-            <TooltipTrigger asChild>
-              {/* span wrapper: disabled buttons swallow pointer events */}
-              <span>{button}</span>
-            </TooltipTrigger>
-            <TooltipContent className="max-w-xs">
-              {transition.blockers.map((blocker) => (
-                <p key={blocker.code} className="text-xs">
-                  {blocker.message}
-                </p>
-              ))}
-            </TooltipContent>
-          </Tooltip>
-        );
-      })}
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={() => setHistoryOpen(true)}
-        aria-label={t('workflow.history.open', { defaultValue: 'Historia workflow' })}
-        data-testid="workflow-history-open"
-      >
-        <History className="size-4" />
-      </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setHistoryOpen(true)}
+          aria-label={t('workflow.history.open', { defaultValue: 'Historia workflow' })}
+          data-testid="workflow-history-open"
+        >
+          <History className="size-4" />
+        </Button>
+      </div>
+
+      {state.reviewer !== undefined && canSubmit ? (
+        <p className="text-[11px] text-zinc-500" data-testid="workflow-reviewer-hint">
+          {t('workflow.control.routes_to', { defaultValue: 'Po zgłoszeniu zadanie trafi do:' })}{' '}
+          <span className="font-medium text-zinc-700">
+            {state.reviewer.type === 'role'
+              ? t('workflow.control.role_label', {
+                  defaultValue: 'Rola: {{label}}',
+                  label: state.reviewer.label,
+                })
+              : state.reviewer.label}
+          </span>
+          {' · '}
+          <Link to="/workflow/settings" className="text-indigo-600 hover:text-indigo-500">
+            {t('workflow.control.change_routing', {
+              defaultValue: 'zmień w Ustawieniach przepływu →',
+            })}
+          </Link>
+        </p>
+      ) : null}
 
       <Dialog open={pending !== null} onOpenChange={(open) => !open && setPending(null)}>
         <DialogContent>

--- a/apps/admin/src/lib/workflow/api.ts
+++ b/apps/admin/src/lib/workflow/api.ts
@@ -15,11 +15,18 @@ export interface WorkflowTransitionOption {
   blockers: { code: string; message: string }[];
 }
 
+/** #2521 — the recipient a review task will land on (role or a person). */
+export interface WorkflowReviewer {
+  type: 'role' | 'user';
+  label: string;
+}
+
 export interface WorkflowState {
   object_id: string;
   workflow: string;
   current_place: string;
   transitions: WorkflowTransitionOption[];
+  reviewer?: WorkflowReviewer;
 }
 
 export interface WorkflowLogEntry {

--- a/apps/api/src/Catalog/Presentation/Controller/ObjectWorkflowController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ObjectWorkflowController.php
@@ -11,6 +11,7 @@ use App\Identity\Contracts\Auth\CurrentUserProvider;
 use App\Identity\Contracts\Directory\UserDirectoryInterface;
 use App\Workflow\Contracts\EditorialWorkflowProviderInterface;
 use App\Workflow\Contracts\ObjectEditorialWorkflow;
+use App\Workflow\Contracts\TaskAssignee;
 use App\Workflow\Contracts\TransitionLogEntry;
 use App\Workflow\Contracts\TransitionLogPort;
 use DateTimeInterface;
@@ -63,14 +64,38 @@ final class ObjectWorkflowController
     public function state(string $id): JsonResponse
     {
         $object = $this->loadObject($id);
-        $workflow = $this->workflows->for($object, $object->getObjectType()->getId()->toRfc4122());
+        $objectTypeId = $object->getObjectType()->getId()->toRfc4122();
+        $workflow = $this->workflows->for($object, $objectTypeId);
 
         return new JsonResponse([
             'object_id' => $object->getId()->toRfc4122(),
             'workflow' => ObjectEditorialWorkflow::NAME,
             'current_place' => $object->getStatus(),
             'transitions' => $this->describeTransitions($workflow, $object),
+            'reviewer' => $this->resolveReviewer($objectTypeId),
         ]);
+    }
+
+    /**
+     * #2521 — the recipient a review task will land on, so the product
+     * detail can show "Po zgłoszeniu zadanie trafi do: …". Mirrors the
+     * task-automation resolution (configured reviewer, else the built-in
+     * role), enriched with a user display name via the directory seam.
+     *
+     * @return array{type: string, label: string}
+     */
+    private function resolveReviewer(string $objectTypeId): array
+    {
+        $assignee = $this->workflows->reviewerFor($objectTypeId)
+            ?? TaskAssignee::role(ObjectEditorialWorkflow::REVIEWER_ROLE);
+
+        if (null !== $assignee->userId) {
+            $names = $this->userDirectory->resolve([$assignee->userId]);
+
+            return ['type' => 'user', 'label' => $names[$assignee->userId]['name'] ?? $assignee->userId];
+        }
+
+        return ['type' => 'role', 'label' => (string) $assignee->roleCode];
     }
 
     #[Route(


### PR DESCRIPTION
## Summary
Karta produktu (screeny 5-7): inline „Po zgłoszeniu zadanie trafi do: <akceptant>" + link do Ustawień przepływu; panel Historia workflow pokazuje autora przejścia.

Closes #2521

## Backend
- `GET /api/objects/{id}/workflow` (discovery) zwraca `reviewer: {type: role|user, label}` — resolved akceptant (skonfigurowany przez `EditorialWorkflowProvider.reviewerFor`, fallback wbudowana rola; nazwa usera z `UserDirectory` seam). Live smoke (flaga OFF): `reviewer: {type: role, label: approver}`.

## Frontend
- `workflow-status-control.tsx`: pod przyciskami przejść linia „Po zgłoszeniu zadanie trafi do: Rola: <label>" (lub nazwa osoby) + `zmień w Ustawieniach przepływu →` (link do `/workflow/settings`), gdy dostępne `submit_for_review`.
- `workflow-history-sheet.tsx`: timeline pokazuje `actor_name` (z #2517) zamiast tylko flagi „System".

## Quality gates
PHPStan max 0, deptrac 0, cs-fixer czysto (BE). tsc/biome 0, build OK, guardy bez regresji, snapshot OpenAPI bez zmian (custom-route body poza eksportem). Istniejący `wfl-p3-01-workflow-status-control.spec.ts` — testid `workflow-status-control` zachowany.

## Świadome odejście
Pełny modal „podgląd jako rola" (screen 6) nie odtworzony — kontrolka pozostaje inline na nagłówku produktu (mniej inwazyjne, zachowuje istniejące testy); role-preview = ewentualny follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
