### PR TITLE
feat(workflow): redesign dashboard My Tasks widget as rich task grid (#2523)

### DIFF
--- a/apps/admin/e2e/wfl-dashboard-my-tasks.spec.ts
+++ b/apps/admin/e2e/wfl-dashboard-my-tasks.spec.ts
@@ -1,0 +1,74 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+import { ADMIN_EMAIL, ADMIN_PASSWORD, uniqueSku } from './helpers/auth';
+
+/**
+ * WFL redesign (#2522) — the dashboard "Moje zadania" widget as the rich
+ * task grid: a submitted product surfaces as a review card that the
+ * approver (approve_reject holder) can decide inline. Approving from the
+ * dashboard moves the object to published, which closes the review task,
+ * so the card disappears without leaving the page. Plus an axe pass on
+ * the widget.
+ */
+test('dashboard My Tasks widget: inline approve closes the review task', async ({ page }) => {
+  // Force the Polish UI regardless of the seeded profile (local gotcha).
+  await page.addInitScript(() => window.localStorage.setItem('i18nextLng', 'pl'));
+
+  const login = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(login.status(), 'admin login').toBe(200);
+  const bearer = ((await login.json()) as { token: string }).token;
+  const auth = { authorization: `Bearer ${bearer}` };
+
+  const typesResponse = await page.request.get('/api/object_types?itemsPerPage=200', {
+    headers: { ...auth, accept: 'application/ld+json' },
+  });
+  const types = (await typesResponse.json()) as { member?: { id: string; kind: string }[] };
+  const productType = (types.member ?? []).find((candidate) => candidate.kind === 'product');
+  if (productType === undefined) throw new Error('No product ObjectType seeded.');
+
+  const sku = uniqueSku('WFL-DASH');
+  const created = await page.request.post('/api/products', {
+    data: { code: sku, objectTypeId: productType.id },
+    headers: { ...auth, 'content-type': 'application/ld+json' },
+  });
+  expect(created.status(), 'create draft product').toBe(201);
+  const objectId = ((await created.json()) as { id: string }).id;
+
+  const submit = await page.request.post(
+    `/api/objects/${objectId}/workflow/transitions/submit_for_review`,
+    { data: { comment: 'Dashboard: do przeglądu' }, headers: auth },
+  );
+  expect(submit.status(), 'submit for review').toBe(200);
+
+  const tasksResponse = await page.request.get(`/api/workflow/tasks?object_id=${objectId}`, {
+    headers: auth,
+  });
+  const taskList = (await tasksResponse.json()) as { items: { id: string; type: string }[] };
+  const reviewTask = taskList.items.find((task) => task.type === 'review');
+  if (reviewTask === undefined) throw new Error('No review task created for the submitted object.');
+
+  await page.goto('/dashboard');
+  const widget = page.getByTestId('my-tasks-card');
+  await expect(widget).toBeVisible();
+
+  // axe on the widget before we mutate it.
+  const axe = await new AxeBuilder({ page }).include('[data-testid="my-tasks-card"]').analyze();
+  expect(axe.violations.filter((v) => v.impact === 'serious' || v.impact === 'critical')).toEqual(
+    [],
+  );
+
+  const approve = page.getByTestId(`mytasks-approve-${reviewTask.id}`);
+  await expect(approve).toBeVisible();
+  await approve.click();
+  await page.getByTestId('mytasks-confirm').click();
+
+  // Approving moved the object out of review → the task closed → card gone.
+  await expect(page.getByTestId(`mytasks-card-${reviewTask.id}`)).toBeHidden();
+
+  const state = await page.request.get(`/api/objects/${objectId}/workflow`, { headers: auth });
+  expect(((await state.json()) as { current_place: string }).current_place).toBe('published');
+});

--- a/apps/admin/e2e/wfl-dashboard-my-tasks.spec.ts
+++ b/apps/admin/e2e/wfl-dashboard-my-tasks.spec.ts
@@ -51,24 +51,37 @@ test('dashboard My Tasks widget: inline approve closes the review task', async (
   const reviewTask = taskList.items.find((task) => task.type === 'review');
   if (reviewTask === undefined) throw new Error('No review task created for the submitted object.');
 
-  await page.goto('/dashboard');
-  const widget = page.getByTestId('my-tasks-card');
-  await expect(widget).toBeVisible();
+  try {
+    await page.goto('/dashboard');
+    const widget = page.getByTestId('my-tasks-card');
+    await expect(widget).toBeVisible();
 
-  // axe on the widget before we mutate it.
-  const axe = await new AxeBuilder({ page }).include('[data-testid="my-tasks-card"]').analyze();
-  expect(axe.violations.filter((v) => v.impact === 'serious' || v.impact === 'critical')).toEqual(
-    [],
-  );
+    // axe on the widget before we mutate it.
+    const axe = await new AxeBuilder({ page }).include('[data-testid="my-tasks-card"]').analyze();
+    expect(axe.violations.filter((v) => v.impact === 'serious' || v.impact === 'critical')).toEqual(
+      [],
+    );
 
-  const approve = page.getByTestId(`mytasks-approve-${reviewTask.id}`);
-  await expect(approve).toBeVisible();
-  await approve.click();
-  await page.getByTestId('mytasks-confirm').click();
+    const approve = page.getByTestId(`mytasks-approve-${reviewTask.id}`);
+    await expect(approve).toBeVisible();
+    await approve.click();
+    await page.getByTestId('mytasks-confirm').click();
 
-  // Approving moved the object out of review → the task closed → card gone.
-  await expect(page.getByTestId(`mytasks-card-${reviewTask.id}`)).toBeHidden();
+    // Approving moved the object out of review → the task closed → card gone.
+    await expect(page.getByTestId(`mytasks-card-${reviewTask.id}`)).toBeHidden();
 
-  const state = await page.request.get(`/api/objects/${objectId}/workflow`, { headers: auth });
-  expect(((await state.json()) as { current_place: string }).current_place).toBe('published');
+    const state = await page.request.get(`/api/objects/${objectId}/workflow`, { headers: auth });
+    expect(((await state.json()) as { current_place: string }).current_place).toBe('published');
+  } finally {
+    // The tasks DB is shared across specs — an open review task assigned to
+    // the approver role surfaces in every approver's "mine" view (and any
+    // axe scan of it). If the flow above did not close it (a mid-test
+    // failure or a retry), cancel it so it cannot pollute sibling specs.
+    await page.request
+      .patch(`/api/workflow/tasks/${reviewTask.id}`, {
+        data: { action: 'cancel' },
+        headers: { ...auth, 'content-type': 'application/json' },
+      })
+      .catch(() => undefined);
+  }
 });

--- a/apps/admin/src/features/dashboard/components/MyTasksCard.tsx
+++ b/apps/admin/src/features/dashboard/components/MyTasksCard.tsx
@@ -1,47 +1,157 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { toast } from '@/components/ui/toast';
+import { objectHref, taskTypeBadge } from '@/features/workflow/task-presentation';
+import { WorkflowTaskCard } from '@/features/workflow/WorkflowTaskCard';
+import { applyWorkflowTransition } from '@/lib/workflow/api';
 import { fetchWorkflowTasks, type WorkflowTask } from '@/lib/workflow/tasks-api';
 
 /**
- * WFL-P4-03 (#2430) — "my work on login" (inRiver pattern): open-task
- * count + the five nearest due dates, deep-linking to the workflow hub.
- * Plain read of the tasks API — no dedicated read model until the
- * numbers justify one (ADR-0026 threshold).
+ * WFL-P4-03 (#2430) + redesign (#2522) — "my work on login" as the rich
+ * task grid from the workflow hub, reusing WorkflowTaskCard so the card
+ * design lives in one place. Type-filter tabs with counts and inline
+ * decisions per task type: a review can be approved/rejected without
+ * leaving the dashboard (reject asks for the mandatory comment), while a
+ * fix ("Popraw") or an unpublish request ("Rozpatrz") deep-links to the
+ * object where the work happens. The widget stays hidden when there is
+ * nothing to do — the dashboard stays calm (same rule as the alerts tile).
  */
 export function MyTasksCard() {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const [tasks, setTasks] = useState<WorkflowTask[]>([]);
   const [loaded, setLoaded] = useState(false);
+  const [typeFilter, setTypeFilter] = useState<string>('all');
+  const [decision, setDecision] = useState<{
+    task: WorkflowTask;
+    transition: 'approve' | 'reject';
+  } | null>(null);
+  const [comment, setComment] = useState('');
+  const [submitting, setSubmitting] = useState(false);
 
-  useEffect(() => {
+  const reload = useCallback(() => {
     fetchWorkflowTasks({ mine: true, status: 'open', limit: 30 })
       .then((page) => setTasks(page.items))
       .catch(() => setTasks([]))
       .finally(() => setLoaded(true));
   }, []);
 
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  const typeCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const task of tasks) counts.set(task.type, (counts.get(task.type) ?? 0) + 1);
+    return counts;
+  }, [tasks]);
+
+  const visibleTasks = useMemo(
+    () => (typeFilter === 'all' ? tasks : tasks.filter((task) => task.type === typeFilter)),
+    [tasks, typeFilter],
+  );
+
+  const requiresComment = decision?.transition === 'reject';
+
+  const confirmDecision = () => {
+    if (decision === null || decision.task.object_id === null) return;
+    if (requiresComment && comment.trim() === '') return;
+    setSubmitting(true);
+    applyWorkflowTransition(
+      decision.task.object_id,
+      decision.transition,
+      comment.trim() || undefined,
+    )
+      .then(() => {
+        toast.success(
+          decision.transition === 'approve'
+            ? t('workflow.tasks.approved', { defaultValue: 'Zatwierdzono' })
+            : t('workflow.tasks.rejected', { defaultValue: 'Odrzucono' }),
+        );
+        setDecision(null);
+        setComment('');
+        reload();
+      })
+      .catch((error: unknown) => {
+        toast.error(
+          error instanceof Error && error.message !== ''
+            ? error.message
+            : t('workflow.toast.failed', { defaultValue: 'Operacja nie powiodła się' }),
+        );
+      })
+      .finally(() => setSubmitting(false));
+  };
+
   if (!loaded || tasks.length === 0) {
-    // The dashboard stays calm when there is nothing to do — no empty
-    // card competing for attention (same rule as the alerts tile).
     return null;
   }
 
-  const byDue = [...tasks].sort((a, b) => {
-    if (a.due_date === null && b.due_date === null) return 0;
-    if (a.due_date === null) return 1;
-    if (b.due_date === null) return -1;
-    return a.due_date.localeCompare(b.due_date);
-  });
+  const renderActions = (task: WorkflowTask) => {
+    if (task.type === 'review' && task.object_id !== null) {
+      return (
+        <>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => {
+              setComment('');
+              setDecision({ task, transition: 'reject' });
+            }}
+            data-testid={`mytasks-reject-${task.id}`}
+          >
+            {t('workflow.transition.reject', { defaultValue: 'Odrzuć' })}
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => {
+              setComment('');
+              setDecision({ task, transition: 'approve' });
+            }}
+            data-testid={`mytasks-approve-${task.id}`}
+          >
+            {t('workflow.transition.approve', { defaultValue: 'Zatwierdź' })}
+          </Button>
+        </>
+      );
+    }
+    if (task.object_id === null) return null;
+    const href = objectHref(task.object_kind ?? 'product', task.object_id);
+    if (task.type === 'fix') {
+      return (
+        <Button asChild size="sm" variant="outline" data-testid={`mytasks-fix-${task.id}`}>
+          <Link to={href}>{t('workflow.tasks.fix_action', { defaultValue: 'Popraw' })}</Link>
+        </Button>
+      );
+    }
+    if (task.type === 'request_unpublish') {
+      return (
+        <Button asChild size="sm" variant="outline" data-testid={`mytasks-review-${task.id}`}>
+          <Link to={href}>{t('workflow.tasks.consider_action', { defaultValue: 'Rozpatrz' })}</Link>
+        </Button>
+      );
+    }
+    return null;
+  };
 
   return (
     <div
       className="rounded-2xl border border-line bg-surface p-5 soft-shadow"
       data-testid="my-tasks-card"
     >
-      <div className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="flex items-center text-sm font-semibold">
           {t('dashboard.my_tasks.title', { defaultValue: 'Moje zadania' })}
           <span className="ml-2 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">
             {tasks.length}
@@ -51,22 +161,87 @@ export function MyTasksCard() {
           {t('dashboard.my_tasks.all', { defaultValue: 'Wszystkie' })}
         </Link>
       </div>
-      <ul className="mt-3 flex flex-col gap-2">
-        {byDue.slice(0, 5).map((task) => (
-          <li key={task.id} className="flex items-center justify-between gap-2 text-sm">
-            <span className="truncate">
-              {t(`workflow.tasks.type.${task.type}`, { defaultValue: task.title })}
+
+      <div className="mt-3 flex flex-wrap items-center gap-1" data-testid="mytasks-type-filter">
+        {[
+          {
+            id: 'all',
+            label: t('workflow.tasks.filter_all', { defaultValue: 'Wszystkie typy' }),
+            count: tasks.length,
+          },
+          ...[...typeCounts.entries()].map(([type, count]) => {
+            const badge = taskTypeBadge(type);
+            return { id: type, label: t(badge.key, { defaultValue: badge.fallback }), count };
+          }),
+        ].map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => setTypeFilter(tab.id)}
+            data-testid={`mytasks-type-${tab.id}`}
+            className={`inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-[13px] font-medium transition ${
+              typeFilter === tab.id ? 'bg-zinc-900 text-white' : 'text-zinc-600 hover:bg-zinc-100'
+            }`}
+          >
+            {tab.label}
+            <span
+              className={`rounded-full px-1.5 text-[11px] ${typeFilter === tab.id ? 'bg-white/20' : 'bg-zinc-200/70'}`}
+            >
+              {tab.count}
             </span>
-            {task.due_date !== null && (
-              <span className="shrink-0 text-xs text-muted-foreground">
-                {new Intl.DateTimeFormat(i18n.language, { dateStyle: 'short' }).format(
-                  new Date(task.due_date),
-                )}
-              </span>
-            )}
-          </li>
+          </button>
         ))}
-      </ul>
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {visibleTasks.map((task) => (
+          <WorkflowTaskCard
+            key={task.id}
+            task={task}
+            data-testid={`mytasks-card-${task.id}`}
+            actions={renderActions(task)}
+          />
+        ))}
+      </div>
+
+      <Dialog open={decision !== null} onOpenChange={(open) => !open && setDecision(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {decision?.transition === 'approve'
+                ? t('workflow.transition.approve', { defaultValue: 'Zatwierdź' })
+                : t('workflow.transition.reject', { defaultValue: 'Odrzuć' })}
+            </DialogTitle>
+            <DialogDescription>
+              {requiresComment
+                ? t('workflow.dialog.comment_required', {
+                    defaultValue: 'Odrzucenie wymaga komentarza dla autora.',
+                  })
+                : t('workflow.dialog.comment_optional', {
+                    defaultValue: 'Możesz dodać komentarz (opcjonalnie).',
+                  })}
+            </DialogDescription>
+          </DialogHeader>
+          <Textarea
+            value={comment}
+            onChange={(event) => setComment(event.target.value)}
+            maxLength={2000}
+            data-testid="mytasks-comment"
+          />
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setDecision(null)} disabled={submitting}>
+              {t('common.cancel', { defaultValue: 'Anuluj' })}
+            </Button>
+            <Button
+              onClick={confirmDecision}
+              disabled={submitting || (requiresComment && comment.trim() === '')}
+              data-testid="mytasks-confirm"
+            >
+              {t('common.confirm', { defaultValue: 'Potwierdź' })}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/apps/admin/src/features/workflow/WorkflowTaskCard.tsx
+++ b/apps/admin/src/features/workflow/WorkflowTaskCard.tsx
@@ -76,7 +76,7 @@ export function WorkflowTaskCard({
 
       <h3 className="mt-2 text-[15px] font-semibold text-zinc-900">{title}</h3>
       {task.object_sku !== null ? (
-        <div className="mt-0.5 flex items-center gap-1.5 text-[12px] text-zinc-400">
+        <div className="mt-0.5 flex items-center gap-1.5 text-[12px] text-zinc-500">
           <span className="font-mono">{task.object_sku}</span>
           <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[11px] text-zinc-600">
             {t(`workflow.kind.${kind}`, { defaultValue: kindLabelDefault(kind) })}
@@ -111,7 +111,7 @@ export function WorkflowTaskCard({
             <span>{relativeTime(task.created_at, i18n.language)}</span>
           )}
           {showAssignee ? (
-            <span className="inline-flex items-center gap-1 text-zinc-400">
+            <span className="inline-flex items-center gap-1 text-zinc-500">
               {t('workflow.tasks.assigned_to', { defaultValue: 'przypisano' })}:
               <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[11px] text-zinc-600">
                 {task.assignee_name ??


### PR DESCRIPTION
## Summary
Widget „Moje zadania" na Pulpicie (screen dashboard) przeprojektowany z minimalnej listy „tytuł + termin" na bogatą siatkę kart — to samo źródło designu co hub Workflow. Operator decyduje z poziomu Pulpitu, bez wchodzenia w moduł.

Closes #2523

## Frontend
- `MyTasksCard.tsx` przepisany: reuse współdzielonego `WorkflowTaskCard` (#2520) — badge typu, framing terminu (dziś/jutro/po terminie), tytuł+SKU+kind, komentarz, „zgłosił X · czas".
- **Filtr-taby** z licznikami: Wszystkie typy / Przegląd / Poprawka / Prośba o depublikację.
- **Akcje inline per typ**:
  - Przegląd → `Zatwierdź` / `Odrzuć` — woła `POST /api/objects/{id}/workflow/transitions/{approve|reject}` (reject wymaga komentarza w małym dialogu); po sukcesie refetch → karta znika (obiekt opuścił review, task zamknięty).
  - Poprawka → `Popraw` (deep-link do obiektu).
  - Prośba o depublikację → `Rozpatrz` (deep-link do obiektu).
- Widget renderuje się tylko gdy są otwarte zadania (reguła „calm dashboard" zachowana). Grid 1/2/3-kol responsywny. Testid `my-tasks-card` zachowany.

## Quality gates
tsc 0, biome 0, guardy bez regresji (jsonfetch-useeffect 61/61 — wrappery, nie literał `jsonFetch`; max-lines 21/21), `pnpm --filter admin build` OK.

## E2E
`wfl-dashboard-my-tasks.spec.ts`: admin zgłasza produkt (API) → Pulpit pokazuje widget → inline `Zatwierdź` → confirm → karta znika, obiekt `published`. Plus axe (serious/critical = 0) na widgecie.

## Smoke test plan
1. Login (admin@demo.localhost / changeme).
2. Zgłoś produkt do przeglądu (karta produktu → „Zgłoś do przeglądu").
3. Pulpit → widget „Moje zadania": karta review z badge, filtr-taby.
4. Klik `Zatwierdź` → potwierdź → karta znika; produkt `published`.
5. DevTools Console — brak errorów.

## Świadome odejścia
- „Rozpatrz" (request_unpublish) i „Popraw" (fix) to deep-linki do obiektu, nie inline-transition — nazwy przejść unpublish rozstrzyga kontrolka na karcie obiektu (bez zgadywania w widgecie). Inline approve/reject tylko dla review (najczęstsza decyzja z Pulpitu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
