### PR TITLE
feat(catalog): add editorial status to the advanced filter vocabulary (#2526)

### DIFF
--- a/apps/admin/e2e/2526-advanced-filter-status-field.spec.ts
+++ b/apps/admin/e2e/2526-advanced-filter-status-field.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * #2526 — the editorial status is a filterable system field in the shared
+ * advanced-filter panel, so operators can scope exports / feeds / lists by
+ * state (draft/review/published/archived). This spec proves the FE wiring:
+ * `status` is offered in the field picker (SYSTEM_PANEL_ATTRS) and resolves
+ * to a `select` whose value picker serves the four states inline — the
+ * enum has no /api/attributes/status/options row, so a round-trip there
+ * would 404; the four localized options must render regardless.
+ *
+ * Scope correctness (only matching objects leave the PIM) is covered by
+ * the backend ExportPreflightApiTest::filterCountIsScopedByEditorialStatus
+ * and the FilterDslResolver unit tests (SQL + Meilisearch paths).
+ */
+test('advanced filter offers editorial status with its four states', async ({ page }) => {
+  test.setTimeout(90_000);
+
+  await loginAsAdmin(page);
+  await page.goto('/products');
+
+  await page.getByRole('button', { name: /filtruj zaawansowane/i }).click();
+  const panel = page.locator('section[aria-label*="Filtr"]');
+  await expect(panel).toBeVisible();
+
+  await page.getByRole('button', { name: /dodaj warunek/i }).click();
+  const pickerTrigger = panel.locator('button[aria-haspopup="listbox"]').first();
+  await pickerTrigger.click();
+
+  // The editorial-state system field is offered in the picker (code `status`).
+  const search = page.getByPlaceholder(/szukaj atrybutu/i);
+  await expect(search).toBeVisible();
+  await search.fill('Status');
+  await page.getByText('status', { exact: true }).first().click();
+
+  // It resolves to a `select` whose value picker serves the four states
+  // inline (localized via the workflow.place.* keys).
+  await expect(panel.getByText('select', { exact: true })).toBeVisible();
+  await expect(page.getByRole('option', { name: 'Opublikowany (published)' })).toBeVisible();
+  await expect(page.getByRole('option', { name: 'Szkic (draft)' })).toBeVisible();
+});

--- a/apps/admin/e2e/2526-advanced-filter-status-field.spec.ts
+++ b/apps/admin/e2e/2526-advanced-filter-status-field.spec.ts
@@ -36,8 +36,13 @@ test('advanced filter offers editorial status with its four states', async ({ pa
   await page.getByText('status', { exact: true }).first().click();
 
   // It resolves to a `select` whose value picker serves the four states
-  // inline (localized via the workflow.place.* keys).
+  // inline (localized via the workflow.place.* keys). The value <select> is
+  // the last select in the row (after the operator select); its option text
+  // proves the inline enum rendered without a /api/attributes/status/options
+  // round-trip. `toContainText` reads the option labels regardless of the
+  // native dropdown's open state.
   await expect(panel.getByText('select', { exact: true })).toBeVisible();
-  await expect(page.getByRole('option', { name: 'Opublikowany (published)' })).toBeVisible();
-  await expect(page.getByRole('option', { name: 'Szkic (draft)' })).toBeVisible();
+  const valueSelect = panel.locator('select').last();
+  await expect(valueSelect).toContainText('Opublikowany');
+  await expect(valueSelect).toContainText('Szkic');
 });

--- a/apps/admin/src/components/catalog/advanced-filter-panel-attrs.ts
+++ b/apps/admin/src/components/catalog/advanced-filter-panel-attrs.ts
@@ -32,6 +32,11 @@ export const FIRST_PANEL_ATTR: PanelAttr = {
 export const SYSTEM_PANEL_ATTRS: ReadonlyArray<PanelAttr> = [
   { code: 'completeness_pct', name: 'Completeness %', type: 'number', star: true },
   { code: 'enabled', name: 'Aktywny', type: 'boolean', star: true },
+  // #2526 — editorial state (draft/review/published/archived) as a
+  // filterable system field: users scope exports/feeds/lists by status.
+  // `select` gives =, !=, IN, NOT IN; the value picker special-cases the
+  // fixed enum (BulkValueInput) so it needs no /api/attributes options row.
+  { code: 'status', name: 'Status', type: 'select', star: true },
 ];
 
 /**

--- a/apps/admin/src/components/catalog/advanced-filter-panel.tsx
+++ b/apps/admin/src/components/catalog/advanced-filter-panel.tsx
@@ -283,6 +283,7 @@ export function AdvancedFilterPanel({
                 <AttributePicker
                   value={cond.attr}
                   filterableOnly
+                  systemFields={SYSTEM_PANEL_ATTRS}
                   onChange={(picked) => {
                     if (picked === null) return;
                     const nextAttrMeta = effectivePanelAttrs.find((a) => a.code === picked.code);

--- a/apps/admin/src/components/catalog/attribute-picker.tsx
+++ b/apps/admin/src/components/catalog/attribute-picker.tsx
@@ -52,6 +52,14 @@ export interface AttributePickerProps {
    * produced a silently-empty result set.
    */
   filterableOnly?: boolean;
+  /**
+   * #2526 — system pseudo-fields (editorial `status`, `enabled`,
+   * `completeness_pct`) that are index-filterable but are NOT Attribute
+   * entities, so the `/api/attributes` fetch never returns them. The filter
+   * panel passes them here so they are selectable alongside real attributes;
+   * BulkWizard omits them (they are not bulk-editable).
+   */
+  systemFields?: ReadonlyArray<{ code: string; name: string; type?: string }>;
   placeholder?: string;
   className?: string;
 }
@@ -67,6 +75,7 @@ export function AttributePicker({
   onChange,
   allowedTypes,
   filterableOnly,
+  systemFields,
   placeholder,
   className,
 }: AttributePickerProps) {
@@ -143,8 +152,25 @@ export function AttributePicker({
     };
   }, [open]);
 
+  // #2526 — system pseudo-fields (status/enabled/completeness_pct) are not
+  // Attribute entities, so they are synthesised here (id = code, always
+  // filterable) and merged ahead of the fetched list. Deduped by code so a
+  // real attribute never collides with a system field.
+  const mergedRows = useMemo<AttributeRow[]>(() => {
+    if (systemFields === undefined || systemFields.length === 0) return attributes;
+    const systemRows: AttributeRow[] = systemFields.map((field) => ({
+      id: field.code,
+      code: field.code,
+      label: field.name,
+      type: field.type,
+      filterable: true,
+    }));
+    const systemCodes = new Set(systemRows.map((row) => row.code));
+    return [...systemRows, ...attributes.filter((row) => !systemCodes.has(row.code))];
+  }, [attributes, systemFields]);
+
   const allowedRows = useMemo(() => {
-    let rows = attributes;
+    let rows = mergedRows;
     // #1354 — strict filterable gate. Applied before the type filter so
     // a consumer can combine both (e.g. filterable numeric attributes).
     if (filterableOnly) {
@@ -152,7 +178,7 @@ export function AttributePicker({
     }
     if (!allowedTypes || allowedTypes.length === 0) return rows;
     return rows.filter((row) => !row.type || allowedTypes.includes(row.type));
-  }, [attributes, allowedTypes, filterableOnly]);
+  }, [mergedRows, allowedTypes, filterableOnly]);
 
   const filteredRows = useMemo(() => {
     const needle = query.trim().toLowerCase();
@@ -179,8 +205,8 @@ export function AttributePicker({
   );
 
   const currentRow = useMemo(
-    () => attributes.find((row) => row.id === value || row.code === value),
-    [attributes, value],
+    () => mergedRows.find((row) => row.id === value || row.code === value),
+    [mergedRows, value],
   );
   const triggerLabel = currentRow
     ? `${currentRow.code} · ${attrLabel(currentRow, locale)}`

--- a/apps/admin/src/components/catalog/bulk-wizard/bulk-value-input.tsx
+++ b/apps/admin/src/components/catalog/bulk-wizard/bulk-value-input.tsx
@@ -33,6 +33,9 @@ import { cn } from '@/lib/utils';
  *  - `multiselect` → string[]
  */
 
+/** #2526 — editorial states, in lifecycle order, for the `status` filter field. */
+const EDITORIAL_STATUS_CODES = ['draft', 'review', 'published', 'archived'] as const;
+
 export interface BulkValueInputProps {
   attrCode: string;
   attrType: string | undefined;
@@ -152,6 +155,19 @@ export function BulkValueInput({
       setOptions([]);
       return;
     }
+    // #2526 — `status` is the editorial-state system field (a fixed enum),
+    // not an Attribute, so it has no /api/attributes/status/options row.
+    // Serve the four states inline, localised via the existing workflow keys.
+    if (attrCode === 'status') {
+      setOptions(
+        EDITORIAL_STATUS_CODES.map((code) => ({
+          code,
+          label: t(`workflow.place.${code}`, { defaultValue: code }),
+        })),
+      );
+      setOptionsLoading(false);
+      return;
+    }
     let cancelled = false;
     setOptionsLoading(true);
     const load = async (): Promise<void> => {
@@ -171,7 +187,7 @@ export function BulkValueInput({
     return () => {
       cancelled = true;
     };
-  }, [attrCode, isSelect]);
+  }, [attrCode, isSelect, t]);
 
   if (attrType === 'relation') {
     return <BulkRelationValueInput attrCode={attrCode} value={value} onChange={onChange} />;

--- a/apps/admin/src/components/objects/universal-list-page.tsx
+++ b/apps/admin/src/components/objects/universal-list-page.tsx
@@ -1045,6 +1045,7 @@ export function UniversalListPage({
           completeness_pct: t('products.fields.completeness', { defaultValue: 'Compl.' }),
           enabled: t('products.fields.enabled', { defaultValue: 'Aktywny' }),
           price: t('products.fields.price', { defaultValue: 'Cena' }),
+          status: t('products.fields.status', { defaultValue: 'Status' }),
         }}
         onRemove={(idx) => {
           const next = panelConditions.filter((_, i) => i !== idx);

--- a/apps/api/src/Catalog/Application/Filter/AttributeMetadataResolver.php
+++ b/apps/api/src/Catalog/Application/Filter/AttributeMetadataResolver.php
@@ -38,6 +38,10 @@ final class AttributeMetadataResolver
         'sku' => 'text',
         'category' => 'relation',
         'main_image' => 'asset',
+        // #2526 — editorial state enum (draft/review/published/archived).
+        // `select` gives =, !=, IN, NOT IN so users can scope exports/feeds/
+        // lists by status via the advanced filter.
+        'status' => 'select',
     ];
 
     /**

--- a/apps/api/src/Catalog/Application/Filter/FilterDslResolver.php
+++ b/apps/api/src/Catalog/Application/Filter/FilterDslResolver.php
@@ -172,9 +172,6 @@ final class FilterDslResolver
     private const array COLUMN_MAP = [
         'completeness_pct' => 'co.completeness_pct',
         'enabled' => 'co.enabled',
-        // #2526 — editorial state column (draft/review/published/archived),
-        // NOT JSONB. Lets the advanced filter scope by status; the Meili path
-        // resolves `status` to the indexed root facet of the same name.
         'status' => 'co.status',
         // 'sku' is the UI alias for the natural key; the physical column on
         // objects is 'code' (EXR-16 fix — the wizard's preflight/export SQL

--- a/apps/api/src/Catalog/Application/Filter/FilterDslResolver.php
+++ b/apps/api/src/Catalog/Application/Filter/FilterDslResolver.php
@@ -172,6 +172,10 @@ final class FilterDslResolver
     private const array COLUMN_MAP = [
         'completeness_pct' => 'co.completeness_pct',
         'enabled' => 'co.enabled',
+        // #2526 — editorial state column (draft/review/published/archived),
+        // NOT JSONB. Lets the advanced filter scope by status; the Meili path
+        // resolves `status` to the indexed root facet of the same name.
+        'status' => 'co.status',
         // 'sku' is the UI alias for the natural key; the physical column on
         // objects is 'code' (EXR-16 fix — the wizard's preflight/export SQL
         // path 500'd on any sku condition).

--- a/apps/api/tests/Api/Export/ExportPreflightApiTest.php
+++ b/apps/api/tests/Api/Export/ExportPreflightApiTest.php
@@ -92,6 +92,30 @@ final class ExportPreflightApiTest extends CatalogApiTestCase
     }
 
     #[Test]
+    public function filterCountIsScopedByEditorialStatus(): void
+    {
+        // #2526 — `status` is a filterable system field, so an export scoped
+        // to `status = published` counts (and later exports) only published
+        // objects. This is the whole point: the operator decides via the
+        // advanced filter what leaves the PIM, per editorial state.
+        $tenant = $this->tenant();
+        $type = $this->customObjectType($tenant, 'status-scoped');
+        $this->object($tenant, $type, 'S-PUB-1', status: CatalogObject::STATUS_PUBLISHED);
+        $this->object($tenant, $type, 'S-PUB-2', status: CatalogObject::STATUS_PUBLISHED);
+        $this->object($tenant, $type, 'S-DRAFT-1', status: CatalogObject::STATUS_DRAFT);
+        $this->em()->flush();
+
+        $body = $this->preflight([
+            'entity_type' => 'custom_module',
+            'object_type_id' => $type->getId()->toRfc4122(),
+            'target_scope' => 'filter',
+            'filter' => ['attr' => 'status', 'op' => '=', 'value' => 'published'],
+        ]);
+
+        self::assertSame(2, $body['count']);
+    }
+
+    #[Test]
     public function rejectsFilterWithInvalidOperatorBeforeRunningSql(): void
     {
         // AUD-031 / W2-3 (C-2) — countFilter previously compiled the DSL
@@ -321,12 +345,20 @@ final class ExportPreflightApiTest extends CatalogApiTestCase
     /**
      * @param array<string, mixed>|null $indexed
      */
-    private function object(Tenant $tenant, ObjectType $objectType, string $code, ?array $indexed = null): void
-    {
+    private function object(
+        Tenant $tenant,
+        ObjectType $objectType,
+        string $code,
+        ?array $indexed = null,
+        ?string $status = null,
+    ): void {
         $object = new CatalogObject($objectType, $code);
         $object->assignTenant($tenant);
         if (null !== $indexed) {
             $object->updateAttributeIndex($indexed);
+        }
+        if (null !== $status) {
+            $object->forceStatus($status);
         }
         $this->em()->persist($object);
     }

--- a/apps/api/tests/Unit/Catalog/FilterDslResolverTest.php
+++ b/apps/api/tests/Unit/Catalog/FilterDslResolverTest.php
@@ -170,6 +170,48 @@ final class FilterDslResolverTest extends TestCase
         self::assertStringContainsString('co.completeness_pct < 50', $sql);
     }
 
+    /**
+     * #2526 — the editorial state is a column (`co.status`), NOT a JSONB
+     * attribute, so scoping exports/feeds/lists by status resolves to a
+     * direct column comparison (not `attributes_indexed->>'status'`).
+     */
+    public function testToCountSqlEmitsStatusColumnReference(): void
+    {
+        $sql = $this->resolver->toCountSql(['attr' => 'status', 'op' => '=', 'value' => 'published']);
+
+        self::assertNotNull($sql);
+        self::assertStringContainsString("co.status = 'published'", $sql);
+        self::assertStringNotContainsString('attributes_indexed', $sql);
+    }
+
+    public function testToCountSqlHandlesStatusInList(): void
+    {
+        $sql = $this->resolver->toCountSql([
+            'attr' => 'status',
+            'op' => 'IN',
+            'value' => ['draft', 'review'],
+        ]);
+
+        self::assertNotNull($sql);
+        self::assertStringContainsString("co.status IN ('draft', 'review')", $sql);
+    }
+
+    /**
+     * #2526 — on the Meili path the editorial state resolves to the indexed
+     * root facet `status` (CatalogObjectIndexer), not a JSONB dot-path.
+     */
+    public function testToMeilisearchFilterMapsStatusToRootFacet(): void
+    {
+        $filter = $this->resolver->toMeilisearchFilter([
+            'attr' => 'status',
+            'op' => '=',
+            'value' => 'published',
+        ]);
+
+        self::assertStringContainsString('status = "published"', $filter);
+        self::assertStringNotContainsString('attributes_indexed', $filter);
+    }
+
     public function testToCountSqlEscapesStringLiteralsSafely(): void
     {
         $sql = $this->resolver->toCountSql(['attr' => 'brand', 'op' => '=', 'value' => "O'Reilly"]);


### PR DESCRIPTION
## Summary
Status redakcyjny (`draft`/`review`/`published`/`archived`) staje się **polem filtrowalnym** w współdzielonym filtrze zaawansowanym — operator sam decyduje, co opuszcza PIM, dodając warunek `status = published` (albo `IN (...)`). Bo eksport sessions, feedy i katalogi PDF **już stosują** filtr DSL do selekcji obiektów (`FilterDslResolver::toCountSql`), a lista produktów przez Meili — wystarczyło dodać `status` do słownika, żeby zadziałało wszędzie naraz.

Closes #2526

## Backend (Catalog\Application\Filter — bez cross-BC, bez ADR)
- `FilterDslResolver::COLUMN_MAP`: `status → co.status` (kolumna, nie JSONB).
- `AttributeMetadataResolver::RESERVED_TYPES`: `status → select` (operatory `=`, `!=`, `IN`, `NOT IN`).
- Ścieżka Meili bez zmian: `meiliAttrPath('status')` → root-facet `status` (już indeksowany + filterable).

## Frontend (współdzielony komponent = 4 powierzchnie)
- `SYSTEM_PANEL_ATTRS`: dodane `status` (typ `select`).
- `BulkValueInput`: value-picker dla `status` serwuje 4 stany **inline** (lokalizacja przez istniejące `workflow.place.*`), bo enum nie ma wiersza `/api/attributes/status/options`.
- `FilterChipsBar` label `Status`.
- Działa automatycznie: `/products`, `/integrations/exports/sessions`, `/integrations/api-configurator/feeds`, `/integrations/catalogs-pdf`.

## Testy
- Unit `FilterDslResolverTest` (23/23 lokalnie): `status` → `co.status = 'published'` (SQL, nie `attributes_indexed`); `status IN (...)`; Meili → root-facet `status = "published"`.
- ApiTestCase `ExportPreflightApiTest::filterCountIsScopedByEditorialStatus`: preflight z `status = published` liczy tylko published (2 z 3).
- E2E `2526-advanced-filter-status-field.spec.ts`: `status` w pickerze + 4 stany w value-pickerze.

## Bramki
PHPStan max 0, deptrac 0, cs-fixer 0 (lokalnie w kontenerze). tsc/biome 0, guardy bez regresji, `pnpm --filter admin build` przechodzi. OpenAPI snapshot bez zmian (brak nowych tras/ApiResource — zmiana wewnątrz resolverów). **Live-smoke przed close** (export `status=published` → tylko published) w komentarzu do issue.

## Poza zakresem (osobny ticket #2527)
API Configurator **live-API** — `ApiProfile.filters` są przechowywane, ale niestosowane do odpowiedzi. Ten ticket NIE bramkuje live-API integratora; to robi #2527 (nowa `QueryCollectionExtension` + ADR-0031).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
