### PR TITLE
fix(catalog): redesign product-detail workflow entry as a modal (#2529)

### DIFF
--- a/apps/admin/e2e/wfl-p3-01-workflow-status-control.spec.ts
+++ b/apps/admin/e2e/wfl-p3-01-workflow-status-control.spec.ts
@@ -49,13 +49,18 @@ test('workflow control: submit -> approve loop with history on product detail', 
   await expect(control).toBeVisible();
   await expect(control.getByText(/Szkic|Draft/).first()).toBeVisible();
 
+  // #2529 — the transition buttons live in the Workflow modal now, opened
+  // from the breadcrumb "Workflow" chip.
+  await page.getByTestId('workflow-open').click();
+  await expect(page.getByTestId('workflow-modal')).toBeVisible();
+
   // Submit for review with a comment.
   await page.getByTestId('workflow-transition-submit_for_review').click();
   await page.getByTestId('workflow-comment').fill('E2E: proszę o przegląd');
   await page.getByTestId('workflow-confirm').click();
   await expect(control.getByText(/W przeglądzie|In review/).first()).toBeVisible();
 
-  // Approve — admin holds workflow.approve_reject.
+  // Approve — admin holds workflow.approve_reject (modal stays open, reloaded).
   await page.getByTestId('workflow-transition-approve').click();
   await page.getByTestId('workflow-confirm').click();
   await expect(control.getByText(/Opublikowany|Published/).first()).toBeVisible();

--- a/apps/admin/e2e/wfl-p5-03-definition-builder.spec.ts
+++ b/apps/admin/e2e/wfl-p5-03-definition-builder.spec.ts
@@ -100,6 +100,10 @@ test('definition builder: custom place shows up on the product without a deploy'
 
     await page.goto(`/products/${created.id}`);
     await expect(page.getByTestId('workflow-status-control')).toBeVisible();
+    // #2529 — transitions live in the Workflow modal (Administrator tab shows
+    // the full set, including this custom machine's renamed transitions).
+    await page.getByTestId('workflow-open').click();
+    await expect(page.getByTestId('workflow-modal')).toBeVisible();
     await expect(page.getByTestId('workflow-transition-to_translation')).toBeVisible();
     // The static machine's submit button is gone under the custom machine.
     await expect(page.getByTestId('workflow-transition-submit_for_review')).toHaveCount(0);

--- a/apps/admin/e2e/wfl-p6-02-collaboration-loop.spec.ts
+++ b/apps/admin/e2e/wfl-p6-02-collaboration-loop.spec.ts
@@ -84,6 +84,8 @@ test('editorial loop across marketing and approver, plus axe on the hub', async 
   await marketing.page.goto(`/products/${objectId}`);
   const marketingControl = marketing.page.getByTestId('workflow-status-control');
   await expect(marketingControl).toBeVisible();
+  // #2529 — transitions live in the Workflow modal (breadcrumb chip).
+  await marketing.page.getByTestId('workflow-open').click();
   await marketing.page.getByTestId('workflow-transition-submit_for_review').click();
   await marketing.page.getByTestId('workflow-comment').fill('Loop: gotowe do przeglądu');
   await marketing.page.getByTestId('workflow-confirm').click();
@@ -122,6 +124,7 @@ test('editorial loop across marketing and approver, plus axe on the hub', async 
   // Fix + resubmit (draft again after reject).
   await marketing.page.goto(`/products/${objectId}`);
   await expect(marketingControl.getByText(/Szkic|Draft/).first()).toBeVisible();
+  await marketing.page.getByTestId('workflow-open').click();
   await marketing.page.getByTestId('workflow-transition-submit_for_review').click();
   await marketing.page.getByTestId('workflow-comment').fill('Loop: poprawione');
   await marketing.page.getByTestId('workflow-confirm').click();

--- a/apps/admin/src/features/catalog/products/components/product-detail-header.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-header.tsx
@@ -122,7 +122,7 @@ export function ProductDetailHeader({
               <ArrowLeft className="size-4" />
             </Link>
           </Button>
-          <div className="text-[12px] text-zinc-500">
+          <div className="flex flex-wrap items-center text-[12px] text-zinc-500">
             <span>{objectTypeLabel ?? t('products.title', { defaultValue: 'Produkty' })}</span>
             <span className="mx-1.5 text-zinc-300">/</span>
             <span>{breadcrumbCategory}</span>
@@ -130,6 +130,12 @@ export function ProductDetailHeader({
               <>
                 <span className="mx-1.5 text-zinc-300">/</span>
                 <span className="font-medium text-zinc-900">{skuValue}</span>
+              </>
+            ) : null}
+            {mode === 'edit' && id !== '' ? (
+              <>
+                <span className="mx-1.5 text-zinc-300">·</span>
+                <WorkflowStatusControl objectId={id} />
               </>
             ) : null}
           </div>
@@ -296,13 +302,6 @@ export function ProductDetailHeader({
                     <span className="rounded-full bg-white px-2 py-1 text-[11px] font-medium text-zinc-700 soft-shadow">
                       {objectTypeName}
                     </span>
-                  </div>
-                ) : null}
-                {/* WFL-P3-01 (#2423) — editorial state chip + guard-aware
-                    transition buttons + history (self-fetching control). */}
-                {mode === 'edit' ? (
-                  <div className="mt-2.5">
-                    <WorkflowStatusControl objectId={id} />
                   </div>
                 ) : null}
               </>

--- a/apps/admin/src/features/catalog/products/components/workflow-history-sheet.tsx
+++ b/apps/admin/src/features/catalog/products/components/workflow-history-sheet.tsx
@@ -3,7 +3,8 @@ import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
-import { fetchWorkflowLog, type WorkflowLogEntry } from '@/lib/workflow/api';
+import { StatusPill } from '@/components/ui-v2/status-pill';
+import { fetchWorkflowLog, placePillVariant, type WorkflowLogEntry } from '@/lib/workflow/api';
 
 /**
  * Pakiet E (WFL-P3-05 #2427) — transition history timeline (Pimcore
@@ -90,11 +91,19 @@ function HistoryRow({ entry, locale }: { entry: WorkflowLogEntry; locale: string
           {formatTime(entry.created_at, locale)}
         </span>
       </div>
-      <p className="text-xs text-muted-foreground">
-        {t(`workflow.place.${entry.from}`, { defaultValue: entry.from })}
-        {' → '}
-        {t(`workflow.place.${entry.to}`, { defaultValue: entry.to })}
-      </p>
+      <div className="mt-1 flex items-center gap-1.5">
+        <StatusPill
+          variant={placePillVariant(entry.from)}
+          label={t(`workflow.place.${entry.from}`, { defaultValue: entry.from })}
+        />
+        <span className="text-zinc-400" aria-hidden="true">
+          →
+        </span>
+        <StatusPill
+          variant={placePillVariant(entry.to)}
+          label={t(`workflow.place.${entry.to}`, { defaultValue: entry.to })}
+        />
+      </div>
       <p className="mt-0.5 text-[11px] text-zinc-500">
         {entry.actor_name ?? t('workflow.history.system', { defaultValue: 'System' })}
       </p>

--- a/apps/admin/src/features/catalog/products/components/workflow-modal.tsx
+++ b/apps/admin/src/features/catalog/products/components/workflow-modal.tsx
@@ -1,0 +1,336 @@
+import { History, Shield } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { toast } from '@/components/ui/toast';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { StatusPill } from '@/components/ui-v2/status-pill';
+import {
+  applyWorkflowTransition,
+  placePillVariant,
+  type WorkflowState,
+  type WorkflowTransitionOption,
+} from '@/lib/workflow/api';
+
+/**
+ * WFL redesign (#2529) — the Workflow modal opened from the product-detail
+ * breadcrumb chip. Replaces the inline transition buttons with the approved
+ * design: current state, a "podgląd jako rola" preview (which actions each
+ * role can perform, per the RBAC map — educational), the guard-aware
+ * transition buttons (still discovery-driven for enabled/blockers), the
+ * reviewer routing hint (#2521) and the permission note, plus a footer that
+ * opens the history panel.
+ *
+ * Role preview is a static role->transition map (Variant A): it filters the
+ * shown actions to what the selected role could do; whether the CURRENT user
+ * may actually apply one still comes from the discovery `enabled` flag.
+ */
+const ROLE_TABS = [
+  {
+    key: 'submitter',
+    labelKey: 'workflow.role.submitter',
+    fallback: 'Wprowadzający',
+    transitions: ['submit_for_review'],
+  },
+  {
+    key: 'approver',
+    labelKey: 'workflow.role.approver',
+    fallback: 'Akceptant',
+    transitions: ['submit_for_review', 'approve', 'reject', 'unpublish'],
+  },
+  {
+    key: 'admin',
+    labelKey: 'workflow.role.admin',
+    fallback: 'Administrator',
+    transitions: [
+      'submit_for_review',
+      'publish',
+      'approve',
+      'reject',
+      'unpublish',
+      'archive',
+      'restore',
+    ],
+  },
+] as const;
+
+interface WorkflowModalProps {
+  objectId: string;
+  state: WorkflowState;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onApplied: () => void;
+  onOpenHistory: () => void;
+}
+
+export function WorkflowModal({
+  objectId,
+  state,
+  open,
+  onOpenChange,
+  onApplied,
+  onOpenHistory,
+}: WorkflowModalProps) {
+  const { t } = useTranslation();
+  const [roleKey, setRoleKey] = useState<string>('admin');
+  const [pending, setPending] = useState<WorkflowTransitionOption | null>(null);
+  const [comment, setComment] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const requiresComment = pending?.name === 'reject';
+  const activeRole = ROLE_TABS.find((role) => role.key === roleKey);
+  // Administrator previews the full set (incl. custom-definition transitions
+  // whose names are not in the built-in RBAC map); the narrower roles filter
+  // to their allowed built-in transitions.
+  const visibleTransitions =
+    activeRole === undefined || activeRole.key === 'admin'
+      ? state.transitions
+      : state.transitions.filter((transition) =>
+          activeRole.transitions.some((name) => name === transition.name),
+        );
+  const canSubmit = state.transitions.some((transition) => transition.name === 'submit_for_review');
+
+  const close = (next: boolean) => {
+    if (!next) {
+      setPending(null);
+      setComment('');
+    }
+    onOpenChange(next);
+  };
+
+  const confirm = () => {
+    if (pending === null) return;
+    if (requiresComment && comment.trim() === '') return;
+    setSubmitting(true);
+    applyWorkflowTransition(objectId, pending.name, comment.trim() || undefined)
+      .then((result) => {
+        toast.success(
+          t('workflow.toast.applied', {
+            defaultValue: 'Status zmieniony: {{place}}',
+            place: t(`workflow.place.${result.current_place}`, {
+              defaultValue: result.current_place,
+            }),
+          }),
+        );
+        setPending(null);
+        setComment('');
+        onApplied();
+      })
+      .catch((error: unknown) => {
+        toast.error(
+          error instanceof Error && error.message !== ''
+            ? error.message
+            : t('workflow.toast.failed', { defaultValue: 'Przejście nie powiodło się' }),
+        );
+      })
+      .finally(() => setSubmitting(false));
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={close}>
+      <DialogContent className="max-w-lg" data-testid="workflow-modal">
+        <DialogHeader>
+          <DialogTitle>{t('workflow.modal.title', { defaultValue: 'Workflow' })}</DialogTitle>
+          <DialogDescription>
+            {t('workflow.modal.subtitle', {
+              defaultValue: 'Zmień stan wpisu i skieruj zadanie dalej.',
+            })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <span className="text-[10.5px] font-semibold uppercase tracking-wider text-zinc-500">
+              {t('workflow.modal.state', { defaultValue: 'Stan' })}
+            </span>
+            <StatusPill
+              variant={placePillVariant(state.current_place)}
+              label={t(`workflow.place.${state.current_place}`, {
+                defaultValue: state.current_place,
+              })}
+            />
+          </div>
+          <div
+            className="inline-flex items-center rounded-lg bg-zinc-100 p-0.5"
+            role="tablist"
+            data-testid="workflow-role-tabs"
+          >
+            {ROLE_TABS.map((role) => (
+              <button
+                key={role.key}
+                type="button"
+                role="tab"
+                aria-selected={roleKey === role.key}
+                onClick={() => setRoleKey(role.key)}
+                data-testid={`workflow-role-${role.key}`}
+                className={`rounded-md px-2.5 py-1 text-[12px] font-medium transition ${
+                  roleKey === role.key
+                    ? 'bg-white text-zinc-900 shadow-sm'
+                    : 'text-zinc-500 hover:text-zinc-700'
+                }`}
+              >
+                {t(role.labelKey, { defaultValue: role.fallback })}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <p className="mb-1.5 text-[10.5px] font-semibold uppercase tracking-wider text-zinc-500">
+            {t('workflow.modal.actions', { defaultValue: 'Dostępne akcje' })}
+          </p>
+          {visibleTransitions.length === 0 ? (
+            <p className="text-[13px] text-zinc-500">
+              {t('workflow.modal.no_actions', {
+                defaultValue: 'Brak akcji dla tej roli w bieżącym stanie.',
+              })}
+            </p>
+          ) : (
+            <div className="flex flex-wrap items-center gap-2">
+              {visibleTransitions.map((transition) => {
+                const label = t(`workflow.transition.${transition.name}`, {
+                  defaultValue: transition.name,
+                });
+                const isPrimary =
+                  transition.name === 'submit_for_review' || transition.name === 'approve';
+                const button = (
+                  <Button
+                    key={transition.name}
+                    variant={isPrimary ? 'default' : 'outline'}
+                    size="sm"
+                    disabled={!transition.enabled || submitting}
+                    onClick={() => {
+                      setComment('');
+                      setPending(transition);
+                    }}
+                    data-testid={`workflow-transition-${transition.name}`}
+                  >
+                    {label}
+                  </Button>
+                );
+                if (transition.enabled) return button;
+                return (
+                  <Tooltip key={transition.name}>
+                    <TooltipTrigger asChild>
+                      <span>{button}</span>
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-xs">
+                      {transition.blockers.map((blocker) => (
+                        <p key={blocker.code} className="text-xs">
+                          {blocker.message}
+                        </p>
+                      ))}
+                    </TooltipContent>
+                  </Tooltip>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {pending !== null ? (
+          <div
+            className="rounded-lg border border-zinc-200 p-3"
+            data-testid="workflow-confirm-panel"
+          >
+            <p className="mb-1.5 text-[13px] font-medium text-zinc-900">
+              {t(`workflow.transition.${pending.name}`, { defaultValue: pending.name })}
+            </p>
+            <p className="mb-2 text-[12px] text-zinc-500">
+              {requiresComment
+                ? t('workflow.dialog.comment_required', {
+                    defaultValue: 'Odrzucenie wymaga komentarza dla autora.',
+                  })
+                : t('workflow.dialog.comment_optional', {
+                    defaultValue: 'Możesz dodać komentarz (opcjonalnie).',
+                  })}
+            </p>
+            <Textarea
+              value={comment}
+              onChange={(event) => setComment(event.target.value)}
+              maxLength={2000}
+              placeholder={t('workflow.dialog.comment_placeholder', { defaultValue: 'Komentarz…' })}
+              data-testid="workflow-comment"
+            />
+            <div className="mt-2 flex justify-end gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setPending(null)}
+                disabled={submitting}
+              >
+                {t('common.cancel', { defaultValue: 'Anuluj' })}
+              </Button>
+              <Button
+                size="sm"
+                onClick={confirm}
+                disabled={submitting || (requiresComment && comment.trim() === '')}
+                data-testid="workflow-confirm"
+              >
+                {t('common.confirm', { defaultValue: 'Potwierdź' })}
+              </Button>
+            </div>
+          </div>
+        ) : null}
+
+        <div className="space-y-1.5 rounded-lg bg-zinc-50 p-3 text-[12px] text-zinc-500">
+          {state.reviewer !== undefined && canSubmit ? (
+            <p data-testid="workflow-reviewer-hint">
+              {t('workflow.control.routes_to', { defaultValue: 'Po zgłoszeniu zadanie trafi do:' })}{' '}
+              <span className="font-medium text-zinc-700">
+                {state.reviewer.type === 'role'
+                  ? t('workflow.control.role_label', {
+                      defaultValue: 'Rola: {{label}}',
+                      label: state.reviewer.label,
+                    })
+                  : state.reviewer.label}
+              </span>
+              {' · '}
+              <Link
+                to="/workflow/settings"
+                className="text-indigo-600 underline hover:text-indigo-500"
+              >
+                {t('workflow.control.change_routing', {
+                  defaultValue: 'zmień w Ustawieniach przepływu →',
+                })}
+              </Link>
+            </p>
+          ) : null}
+          <p className="inline-flex items-center gap-1.5">
+            <Shield className="size-3.5 shrink-0" aria-hidden="true" />
+            {t('workflow.modal.permission_note', {
+              defaultValue: '„Opublikuj" i „Archiwizuj" wymagają uprawnienia Zatwierdzanie.',
+            })}
+          </p>
+        </div>
+
+        <DialogFooter className="sm:justify-between">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onOpenHistory}
+            data-testid="workflow-history-open"
+            className="gap-1.5"
+          >
+            <History className="size-4" />
+            {t('workflow.history.title', { defaultValue: 'Historia workflow' })}
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => close(false)}>
+            {t('common.close', { defaultValue: 'Zamknij' })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin/src/features/catalog/products/components/workflow-status-control.tsx
+++ b/apps/admin/src/features/catalog/products/components/workflow-status-control.tsx
@@ -1,46 +1,27 @@
-import { History } from 'lucide-react';
+import { GitBranch, History } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router';
 
-import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { Textarea } from '@/components/ui/textarea';
-import { toast } from '@/components/ui/toast';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { StatusPill } from '@/components/ui-v2/status-pill';
-import {
-  applyWorkflowTransition,
-  fetchWorkflowState,
-  placePillVariant,
-  type WorkflowState,
-  type WorkflowTransitionOption,
-} from '@/lib/workflow/api';
+import { fetchWorkflowState, placePillVariant, type WorkflowState } from '@/lib/workflow/api';
 
 import { WorkflowHistorySheet } from './workflow-history-sheet';
+import { WorkflowModal } from './workflow-modal';
 
 /**
- * Pakiet E (WFL-P3-01 #2423) — editorial state control on the product
- * header (Pimcore pattern: status chip + transition buttons). Buttons
- * mirror the guard-aware discovery endpoint 1:1 — a blocked transition
- * renders disabled with the blocker reasons in a tooltip (missing
- * permission code / completeness gate with the missing attributes), so
- * the FE never re-implements authorization. Reject requires a comment
- * (PRD §3.8 review loop); every other transition takes an optional one.
+ * Pakiet E (WFL-P3-01 #2423) + redesign (#2529) — the editorial workflow
+ * entry point in the product-detail breadcrumb: a status pill mirroring the
+ * machine, a "Workflow" chip that opens the {@link WorkflowModal} (state +
+ * role preview + guard-aware transitions + reviewer routing) and a history
+ * icon that opens the {@link WorkflowHistorySheet}. The transition buttons
+ * themselves moved into the modal (approved design) — this component is now
+ * the compact trigger. Users without `workflow.view` see nothing (the
+ * discovery call fails silently).
  */
 export function WorkflowStatusControl({ objectId }: { objectId: string }) {
   const { t } = useTranslation();
   const [state, setState] = useState<WorkflowState | null>(null);
-  const [pending, setPending] = useState<WorkflowTransitionOption | null>(null);
-  const [comment, setComment] = useState('');
-  const [submitting, setSubmitting] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
 
   const reload = useCallback(() => {
@@ -60,159 +41,43 @@ export function WorkflowStatusControl({ objectId }: { objectId: string }) {
     return null;
   }
 
-  const requiresComment = pending?.name === 'reject';
-
-  const confirm = () => {
-    if (pending === null) return;
-    if (requiresComment && comment.trim() === '') return;
-    setSubmitting(true);
-    applyWorkflowTransition(objectId, pending.name, comment.trim() || undefined)
-      .then((result) => {
-        toast.success(
-          t('workflow.toast.applied', {
-            defaultValue: 'Status zmieniony: {{place}}',
-            place: t(`workflow.place.${result.current_place}`, {
-              defaultValue: result.current_place,
-            }),
-          }),
-        );
-        setPending(null);
-        setComment('');
-        reload();
-      })
-      .catch((error: unknown) => {
-        toast.error(
-          error instanceof Error && error.message !== ''
-            ? error.message
-            : t('workflow.toast.failed', { defaultValue: 'Przejście nie powiodło się' }),
-        );
-      })
-      .finally(() => setSubmitting(false));
-  };
-
-  const canSubmit = state.transitions.some((transition) => transition.name === 'submit_for_review');
-
   return (
-    <div className="space-y-1.5">
-      <div className="flex flex-wrap items-center gap-2" data-testid="workflow-status-control">
-        <StatusPill
-          variant={placePillVariant(state.current_place)}
-          label={t(`workflow.place.${state.current_place}`, {
-            defaultValue: state.current_place,
-          })}
-        />
-        {state.transitions.map((transition) => {
-          const label = t(`workflow.transition.${transition.name}`, {
-            defaultValue: transition.name,
-          });
-          const button = (
-            <Button
-              key={transition.name}
-              variant="outline"
-              size="sm"
-              disabled={!transition.enabled || submitting}
-              onClick={() => {
-                setComment('');
-                setPending(transition);
-              }}
-              data-testid={`workflow-transition-${transition.name}`}
-            >
-              {label}
-            </Button>
-          );
-          if (transition.enabled) {
-            return button;
-          }
-          return (
-            <Tooltip key={transition.name}>
-              <TooltipTrigger asChild>
-                {/* span wrapper: disabled buttons swallow pointer events */}
-                <span>{button}</span>
-              </TooltipTrigger>
-              <TooltipContent className="max-w-xs">
-                {transition.blockers.map((blocker) => (
-                  <p key={blocker.code} className="text-xs">
-                    {blocker.message}
-                  </p>
-                ))}
-              </TooltipContent>
-            </Tooltip>
-          );
-        })}
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => setHistoryOpen(true)}
-          aria-label={t('workflow.history.open', { defaultValue: 'Historia workflow' })}
-          data-testid="workflow-history-open"
-        >
-          <History className="size-4" />
-        </Button>
-      </div>
+    <span className="inline-flex items-center gap-1.5" data-testid="workflow-status-control">
+      <StatusPill
+        variant={placePillVariant(state.current_place)}
+        label={t(`workflow.place.${state.current_place}`, { defaultValue: state.current_place })}
+      />
+      <button
+        type="button"
+        onClick={() => setModalOpen(true)}
+        data-testid="workflow-open"
+        className="inline-flex items-center gap-1 rounded-full border border-zinc-200 bg-white px-2 py-0.5 text-[12px] font-medium text-zinc-600 transition hover:border-zinc-300 hover:text-zinc-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900"
+      >
+        <GitBranch className="size-3.5" aria-hidden="true" />
+        {t('workflow.modal.title', { defaultValue: 'Workflow' })}
+      </button>
+      <button
+        type="button"
+        onClick={() => setHistoryOpen(true)}
+        aria-label={t('workflow.history.title', { defaultValue: 'Historia workflow' })}
+        data-testid="workflow-history-icon"
+        className="grid size-6 place-items-center rounded-full text-zinc-400 transition hover:bg-zinc-100 hover:text-zinc-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900"
+      >
+        <History className="size-3.5" />
+      </button>
 
-      {state.reviewer !== undefined && canSubmit ? (
-        <p className="text-[11px] text-zinc-500" data-testid="workflow-reviewer-hint">
-          {t('workflow.control.routes_to', { defaultValue: 'Po zgłoszeniu zadanie trafi do:' })}{' '}
-          <span className="font-medium text-zinc-700">
-            {state.reviewer.type === 'role'
-              ? t('workflow.control.role_label', {
-                  defaultValue: 'Rola: {{label}}',
-                  label: state.reviewer.label,
-                })
-              : state.reviewer.label}
-          </span>
-          {' · '}
-          <Link to="/workflow/settings" className="text-indigo-600 underline hover:text-indigo-500">
-            {t('workflow.control.change_routing', {
-              defaultValue: 'zmień w Ustawieniach przepływu →',
-            })}
-          </Link>
-        </p>
-      ) : null}
-
-      <Dialog open={pending !== null} onOpenChange={(open) => !open && setPending(null)}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>
-              {t(`workflow.transition.${pending?.name ?? ''}`, {
-                defaultValue: pending?.name ?? '',
-              })}
-            </DialogTitle>
-            <DialogDescription>
-              {requiresComment
-                ? t('workflow.dialog.comment_required', {
-                    defaultValue: 'Odrzucenie wymaga komentarza dla autora.',
-                  })
-                : t('workflow.dialog.comment_optional', {
-                    defaultValue: 'Możesz dodać komentarz (opcjonalnie).',
-                  })}
-            </DialogDescription>
-          </DialogHeader>
-          <Textarea
-            value={comment}
-            onChange={(event) => setComment(event.target.value)}
-            maxLength={2000}
-            placeholder={t('workflow.dialog.comment_placeholder', {
-              defaultValue: 'Komentarz…',
-            })}
-            data-testid="workflow-comment"
-          />
-          <DialogFooter>
-            <Button variant="ghost" onClick={() => setPending(null)} disabled={submitting}>
-              {t('common.cancel', { defaultValue: 'Anuluj' })}
-            </Button>
-            <Button
-              onClick={confirm}
-              disabled={submitting || (requiresComment && comment.trim() === '')}
-              data-testid="workflow-confirm"
-            >
-              {t('common.confirm', { defaultValue: 'Potwierdź' })}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
+      <WorkflowModal
+        objectId={objectId}
+        state={state}
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+        onApplied={reload}
+        onOpenHistory={() => {
+          setModalOpen(false);
+          setHistoryOpen(true);
+        }}
+      />
       <WorkflowHistorySheet objectId={objectId} open={historyOpen} onOpenChange={setHistoryOpen} />
-    </div>
+    </span>
   );
 }


### PR DESCRIPTION
## Summary
Detal ObjectType (produkt) — strefa workflow doprowadzona do zatwierdzonego designu (3 screeny operatora). To **odłożony fragment T5** (w #2522 zdeferowano „pełny modal podgląd-jako-rola").

Closes #2529

## Zmiany (FE)
- **Breadcrumb** (`product-detail-header.tsx`): status pill + chip „⇄ Workflow" + ikona historii — zamiast inline-przycisków w karcie.
- **Modal Workflow** (`workflow-modal.tsx`, nowy): stan + **zakładki podglądu-jako-rola** `Wprowadzający/Akceptant/Administrator` (statyczna mapa RBAC filtrująca pokazane akcje; Administrator = pełny zestaw, w tym przejścia custom-definicji), guard-aware przyciski przejść z **inline krokiem komentarza**, hint akceptanta (#2521) + nota o uprawnieniu, stopka → panel Historia.
- **Kontrolka** (`workflow-status-control.tsx`): teraz kompaktowy trigger (pill + chip + ikona), zarządza otwarciem modala/historii, reload po przejściu.
- **Historia** (`workflow-history-sheet.tsx`): wiersze pokazują `from→to` jako pary status-pills.

## Podgląd-jako-rola (Wariant A)
Statyczna mapa rola→przejścia (edukacyjnie „kto co może"); faktyczne enabled/blockers dalej z discovery (bieżący user). Administrator pokazuje wszystko (nie gubi transition custom-definicji). Wariant B (BE `?preview_role=` re-ewaluacja guardów) = follow-up.

## Testy
- **Zaktualizowane istniejące e2e** (twardy wymóg — entrypoint przeniesiony do modala): `wfl-p3-01`, `wfl-p6-02`, `wfl-p5-03` klikają najpierw chip „Workflow", potem przejścia w modalu. Testidy zachowane (`workflow-transition-*`, `workflow-comment`, `workflow-confirm`, `workflow-history-open`).
- Weryfikacja przeglądarkowa (loginAsAdmin + goto draft produktu): chip otwiera modal, zakładki ról renderują, przełączanie ról działa, `submit_for_review` widoczny. ✓ (page.request-owe specy padają lokalnie tylko na DNS `pim.localhost` w Node — CI resolvuje).

## Bramki
tsc 0, biome 0, guardy bez regresji (jsonfetch 61/61, max-lines 21/21), `pnpm --filter admin build` OK. i18n przez `t()` z defaultValue (spójnie z resztą workflow FE).

## Świadome odejście
- Podgląd-jako-rola = statyczna mapa (Wariant A); dokładna BE-re-ewaluacja per rola = follow-up.
- Modal nie odtwarza dosłownie każdego piksela — zachowuje istniejące testidy i logikę discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
