### PR TITLE
feat(integration): rule-based outbound-sync filter (Z PIM scope) (#2549)

### DIFF
--- a/apps/admin/src/features/api-configurator/consumer/sync/OutboundFilterSection.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/sync/OutboundFilterSection.tsx
@@ -1,0 +1,121 @@
+import { Send } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { AdvancedFilterPanel } from '@/components/catalog/advanced-filter-panel';
+import { Button } from '@/components/ui/button';
+import {
+  conditionsToDsl,
+  dslToFlatConditions,
+  type FilterCondition,
+  type FilterDsl,
+} from '@/lib/filters/filter-dsl';
+
+import { SectionLabel } from '../../components/primitives';
+
+/**
+ * #2549 — the "Z PIM (wysyłka)" outbound scope for a SyncBinding. Rendered only
+ * for a write flow (SyncConfigScreen gates it on `dir !== 'inbound'`), so a
+ * PIM-side filter can never be set on an import. Reuses the same
+ * {@link AdvancedFilterPanel} (FilterDsl) as the grid / export / feeds, so the
+ * operator builds `status = published AND kategoria = X` visually. The parent
+ * owns the persisted DSL; this component edits it and reports changes back.
+ */
+export function OutboundFilterSection({
+  dsl,
+  onDslChange,
+}: {
+  dsl: FilterDsl | null;
+  onDslChange: (dsl: FilterDsl | null) => void;
+}) {
+  const { t } = useTranslation();
+  const [conditions, setConditions] = useState<FilterCondition[]>([]);
+  const [matchOperator, setMatchOperator] = useState<'AND' | 'OR'>('AND');
+  const [open, setOpen] = useState(false);
+
+  // Hydrate the flat editor from the stored DSL. A nested (AND/OR-of-groups)
+  // DSL can't render flat; fall back to an empty editor (the stored filter
+  // still applies on the backend until re-saved).
+  useEffect(() => {
+    setConditions(dslToFlatConditions(dsl) ?? []);
+    setMatchOperator(
+      dsl !== null && typeof dsl === 'object' && 'operator' in dsl && dsl.operator === 'OR'
+        ? 'OR'
+        : 'AND',
+    );
+  }, [dsl]);
+
+  const commit = (next: FilterCondition[], operator: 'AND' | 'OR'): void => {
+    setConditions(next);
+    setMatchOperator(operator);
+    onDslChange(conditionsToDsl(next, operator));
+  };
+
+  return (
+    <section
+      className="soft-shadow rounded-2xl border border-zinc-200 bg-white p-5"
+      data-testid="outbound-filter-section"
+    >
+      <SectionLabel
+        right={
+          <span className="inline-flex items-center gap-1 text-[11px] font-medium text-zinc-500">
+            <Send className="size-3.5" aria-hidden="true" />
+            {t('api_configurator.sync.outbound_filter.tag', { defaultValue: 'Z PIM' })}
+          </span>
+        }
+      >
+        {t('api_configurator.sync.outbound_filter.title', {
+          defaultValue: 'Zakres wysyłki — które obiekty wysyłać',
+        })}
+      </SectionLabel>
+      <p className="mb-3 text-[12.5px] leading-relaxed text-zinc-600">
+        {t('api_configurator.sync.outbound_filter.hint', {
+          defaultValue:
+            'Filtr dotyczy wyłącznie danych wychodzących z PIM. Pusty = wysyłamy wszystkie obiekty tego typu.',
+        })}
+      </p>
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => setOpen((prev) => !prev)}
+          data-testid="outbound-filter-toggle"
+        >
+          {conditions.length === 0
+            ? t('api_configurator.sync.outbound_filter.set', {
+                defaultValue: 'Ustaw filtr wysyłki',
+              })
+            : t('api_configurator.sync.outbound_filter.edit', {
+                defaultValue: 'Edytuj filtr wysyłki',
+              })}
+        </Button>
+        <span className="text-[12px] text-zinc-500" data-testid="outbound-filter-summary">
+          {conditions.length === 0
+            ? t('api_configurator.sync.outbound_filter.none', {
+                defaultValue: 'Bez filtra — wszystkie obiekty',
+              })
+            : t('api_configurator.sync.outbound_filter.count', {
+                defaultValue: '{{count}} warunków',
+                count: conditions.length,
+              })}
+        </span>
+      </div>
+      <div className="relative mt-3">
+        <AdvancedFilterPanel
+          open={open}
+          conditions={conditions}
+          setConditions={(next) => commit(next, matchOperator)}
+          matchOperator={matchOperator}
+          setMatchOperator={(operator) => commit(conditions, operator)}
+          onApply={() => setOpen(false)}
+          onClose={() => setOpen(false)}
+          onClear={() => {
+            commit([], 'AND');
+            setOpen(false);
+          }}
+        />
+      </div>
+    </section>
+  );
+}

--- a/apps/admin/src/features/api-configurator/consumer/sync/SyncConfigScreen.tsx
+++ b/apps/admin/src/features/api-configurator/consumer/sync/SyncConfigScreen.tsx
@@ -7,7 +7,7 @@ import { useNavigate, useParams } from 'react-router';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useToast } from '@/components/ui/toast';
-
+import type { FilterDsl } from '@/lib/filters/filter-dsl';
 import {
   ApiToggle,
   Field,
@@ -17,6 +17,7 @@ import {
   type SyncDirection,
 } from '../../components/primitives';
 import type { RemoteEndpointRow } from '../wizard/steps/StepEndpoints';
+import { OutboundFilterSection } from './OutboundFilterSection';
 import { DirDiagram, EndpointSelect, ReadonlyValue } from './sync-components';
 
 type ConflictPolicy = 'lww' | 'pim_wins' | 'remote_wins';
@@ -34,6 +35,7 @@ interface SyncBindingRow {
   cursor: { field?: string; type?: string; state?: unknown } | null;
   isEnabled: boolean;
   nextRun: string | null;
+  outboundFilter: FilterDsl | null; // #2549 — outbound scope (null = send all)
 }
 
 interface ObjectTypeRow {
@@ -109,6 +111,7 @@ export function SyncConfigScreen({ embedded = false }: { embedded?: boolean } = 
   const [writeEndpointId, setWriteEndpointId] = useState('');
   const [enabled, setEnabled] = useState(true);
   const [newObjectTypeId, setNewObjectTypeId] = useState('');
+  const [outboundFilterDsl, setOutboundFilterDsl] = useState<FilterDsl | null>(null);
 
   // Hydrate the form from the loaded binding.
   useEffect(() => {
@@ -121,6 +124,7 @@ export function SyncConfigScreen({ embedded = false }: { embedded?: boolean } = 
     setReadEndpointId(binding.readEndpointId ?? '');
     setWriteEndpointId(binding.writeEndpointId ?? '');
     setEnabled(binding.isEnabled);
+    setOutboundFilterDsl(binding.outboundFilter);
   }, [binding]);
 
   const cronHuman =
@@ -174,6 +178,8 @@ export function SyncConfigScreen({ embedded = false }: { embedded?: boolean } = 
           readEndpoint: dir === 'outbound' ? null : readEndpointId === '' ? null : readEndpointId,
           writeEndpoint: dir === 'inbound' ? null : writeEndpointId === '' ? null : writeEndpointId,
           enabled,
+          // #2549 — `[]` clears; inbound never carries a PIM-side filter.
+          outboundFilter: dir === 'inbound' ? [] : (outboundFilterDsl ?? []),
         },
         successNotification: false,
       },
@@ -352,11 +358,8 @@ export function SyncConfigScreen({ embedded = false }: { embedded?: boolean } = 
               <div className="mb-2 text-[10.5px] font-medium uppercase tracking-wider text-zinc-500">
                 {t('api_configurator.sync.schedule.next_run')}
               </div>
-              {/* The API omits `nextRun` entirely when the binding has no
-                  schedule, so the value is `undefined` (not `null`) — a strict
-                  `!== null` would fall through to `new Date(undefined)` →
-                  "Invalid Date". Loose `!= null` catches both, matching
-                  DetailOverview. */}
+              {/* Loose `!= null`: the API omits `nextRun` (undefined) when
+                  unscheduled, so `!== null` would hit `new Date(undefined)`. */}
               {binding.nextRun != null ? (
                 <div className="flex items-center gap-2 text-[12px]">
                   <span className="h-1.5 w-1.5 rounded-full bg-zinc-900" />
@@ -409,6 +412,11 @@ export function SyncConfigScreen({ embedded = false }: { embedded?: boolean } = 
               </SecurityNote>
             </div>
           </section>
+        ) : null}
+
+        {/* #2549 — outbound scope; absent for inbound (no PIM-side import filter). */}
+        {dir !== 'inbound' ? (
+          <OutboundFilterSection dsl={outboundFilterDsl} onDslChange={setOutboundFilterDsl} />
         ) : null}
 
         {/* Conflict — bidirectional only */}

--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -752,9 +752,13 @@ parameters:
         # serializer/runner above (the implementation is Catalog-data-bound).
         App\Export\Application\Integration\ExportOutboundRecordReader:
             - App\Catalog\Domain\Entity\CatalogObject
+            - App\Catalog\Domain\Entity\ObjectType
             - App\Catalog\Domain\Entity\ObjectValue
             - App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface
             - App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface
+            # #2549 — outbound scope reuses the Catalog filter DSL compiler
+            # (same Export → Catalog\Application\Filter reach as SyncExportRunner).
+            - App\Catalog\Application\Filter\FilterDslResolver
         App\Export\Presentation\Controller\ExportPreflightController:
             - App\Catalog\Application\Filter\FilterDslResolver
             - App\Catalog\Domain\Entity\ObjectType

--- a/apps/api/migrations/Version20260713100000.php
+++ b/apps/api/migrations/Version20260713100000.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * #2549 — rule-based outbound-sync filter: add the `outbound_filter` JSONB
+ * column to sync bindings (a FilterDsl snapshot scoping which objects PIM
+ * pushes to the remote; null = send all). Defensive/idempotent (guarded on
+ * information_schema) so re-runs and drift-healed databases are no-ops.
+ */
+final class Version20260713100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add outbound_filter JSONB column to integration_sync_bindings (outbound-sync scope, #2549)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+                DO $$
+                BEGIN
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_schema = 'public'
+                          AND table_name = 'integration_sync_bindings'
+                          AND column_name = 'outbound_filter'
+                    ) THEN
+                        ALTER TABLE integration_sync_bindings ADD COLUMN outbound_filter JSONB DEFAULT NULL;
+                    END IF;
+                END
+                $$;
+            SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE integration_sync_bindings DROP COLUMN IF EXISTS outbound_filter');
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Integration/OutboundRecordReader.php
+++ b/apps/api/src/Catalog/Contracts/Integration/OutboundRecordReader.php
@@ -19,9 +19,11 @@ use Symfony\Component\Uid\Uuid;
 interface OutboundRecordReader
 {
     /**
-     * @param list<string> $codes the attribute codes to serialise per object
+     * @param list<string>              $codes  the attribute codes to serialise per object
+     * @param array<string, mixed>|null $filter #2549 — a FilterDsl snapshot scoping which
+     *                                          objects are emitted (null/empty = all)
      *
      * @return iterable<OutboundRecord>
      */
-    public function read(Uuid $objectTypeId, array $codes): iterable;
+    public function read(Uuid $objectTypeId, array $codes, ?array $filter = null): iterable;
 }

--- a/apps/api/src/Export/Application/Integration/ExportOutboundRecordReader.php
+++ b/apps/api/src/Export/Application/Integration/ExportOutboundRecordReader.php
@@ -4,16 +4,21 @@ declare(strict_types=1);
 
 namespace App\Export\Application\Integration;
 
+use App\Catalog\Application\Filter\FilterDslResolver;
 use App\Catalog\Contracts\Integration\OutboundRecord;
 use App\Catalog\Contracts\Integration\OutboundRecordReader;
 use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\Entity\ObjectValue;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
 use App\Export\Application\Builder\ValueSerializer;
 use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
 use Doctrine\ORM\EntityManagerInterface;
+use RuntimeException;
 use Symfony\Component\Uid\Uuid;
+use Throwable;
 
 /**
  * Export-side implementation of the outbound-sync read seam (APIC-P3-06).
@@ -34,10 +39,11 @@ final readonly class ExportOutboundRecordReader implements OutboundRecordReader
         private ValueSerializer $serializer,
         private TenantContext $tenantContext,
         private EntityManagerInterface $em,
+        private FilterDslResolver $filterDsl,
     ) {
     }
 
-    public function read(Uuid $objectTypeId, array $codes): iterable
+    public function read(Uuid $objectTypeId, array $codes, ?array $filter = null): iterable
     {
         $tenant = $this->tenantContext->get();
         if (null === $tenant) {
@@ -49,9 +55,18 @@ final readonly class ExportOutboundRecordReader implements OutboundRecordReader
             return;
         }
 
+        // #2549 — outbound scope: null = every object; a keyed set = only the
+        // ids matching the FilterDsl (skip everything else BEFORE loading its
+        // values, so the filtered-out set costs no per-object value query).
+        $allowedIds = $this->resolveFilterIds($filter, $tenant, $objectType);
+
         $wanted = array_fill_keys($codes, true);
 
         foreach ($this->objects->findByObjectType($objectType, $tenant) as $object) {
+            if (null !== $allowedIds && !isset($allowedIds[$object->getId()->toRfc4122()])) {
+                continue;
+            }
+
             $values = [];
             foreach ($this->globalValues($object) as $code => $objectValue) {
                 if (isset($wanted[$code])) {
@@ -61,6 +76,48 @@ final readonly class ExportOutboundRecordReader implements OutboundRecordReader
 
             yield new OutboundRecord($object->getId()->toRfc4122(), $values);
         }
+    }
+
+    /**
+     * Compile the outbound FilterDsl into tenant-scoped SQL and return the
+     * matching object ids as a keyed set (id => true) for O(1) lookup, or null
+     * when no filter is set. Mirrors {@see \App\Export\Application\Sync\SyncExportRunner::resolveFilterIds()}.
+     *
+     * @param array<string, mixed>|null $filter
+     *
+     * @return array<string, true>|null
+     */
+    private function resolveFilterIds(?array $filter, Tenant $tenant, ObjectType $objectType): ?array
+    {
+        if (null === $filter || [] === $filter) {
+            return null;
+        }
+
+        $whereClause = $this->filterDsl->toCountSql($filter);
+        if (null === $whereClause) {
+            throw new RuntimeException('Invalid outbound filter DSL on the sync binding.');
+        }
+
+        $sql = 'SELECT co.id FROM objects co '
+            .'WHERE co.tenant_id = :tenant AND co.object_type_id = :otid AND ('.$whereClause.')';
+
+        try {
+            $rows = $this->em->getConnection()->fetchFirstColumn($sql, [
+                'tenant' => $tenant->getId()->toRfc4122(),
+                'otid' => $objectType->getId()->toRfc4122(),
+            ]);
+        } catch (Throwable $error) {
+            throw new RuntimeException('Outbound filter scope SQL failed: '.$error->getMessage(), previous: $error);
+        }
+
+        $ids = [];
+        foreach ($rows as $id) {
+            if (\is_string($id)) {
+                $ids[$id] = true;
+            }
+        }
+
+        return $ids;
     }
 
     /**

--- a/apps/api/src/Integration/Generic/Application/Sync/OutboundSyncRunner.php
+++ b/apps/api/src/Integration/Generic/Application/Sync/OutboundSyncRunner.php
@@ -89,7 +89,7 @@ final readonly class OutboundSyncRunner
         // and the reader queries each object's values into the unit of work —
         // both accumulate across a 50k push, so clear every CLEAR_EVERY records
         // and reload the entities the loop keeps mutating.
-        foreach ($this->reader->read($binding->getObjectTypeId(), $codes) as $record) {
+        foreach ($this->reader->read($binding->getObjectTypeId(), $codes, $binding->getOutboundFilter()) as $record) {
             $this->push($run, $binding, $writeEndpoint, $record, $mappings, $matchCode, $action, $dryRun);
             $this->em->flush();
 

--- a/apps/api/src/Integration/Generic/Domain/Entity/SyncBinding.php
+++ b/apps/api/src/Integration/Generic/Domain/Entity/SyncBinding.php
@@ -59,6 +59,18 @@ class SyncBinding extends AggregateRoot implements TenantScoped
 
     private string $conflictPolicy = ConflictPolicy::Lww->value;
 
+    /**
+     * #2549 — rule-based OUTBOUND scope: a FilterDsl snapshot narrowing which
+     * objects PIM sends to the remote (e.g. only `status = published`). null /
+     * empty = send every object of the type (backward-compat). Applies only to
+     * the write (outbound) flow; inbound reads ignore it. Compiled at run time
+     * via the Catalog FilterDslResolver in the Export reader, so a malformed
+     * DSL fails the run rather than the save (the FE builder emits valid DSL).
+     *
+     * @var array<string, mixed>|null
+     */
+    private ?array $outboundFilter = null;
+
     /** The PIM target acting as the upsert match key; null until mappings are set. */
     #[Assert\Length(max: 255)]
     private ?string $matchKeyMapping = null;
@@ -209,6 +221,23 @@ class SyncBinding extends AggregateRoot implements TenantScoped
     public function setConflictPolicy(ConflictPolicy $conflictPolicy): void
     {
         $this->conflictPolicy = $conflictPolicy->value;
+        $this->touch();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getOutboundFilter(): ?array
+    {
+        return $this->outboundFilter;
+    }
+
+    /**
+     * @param array<string, mixed>|null $outboundFilter
+     */
+    public function setOutboundFilter(?array $outboundFilter): void
+    {
+        $this->outboundFilter = $outboundFilter;
         $this->touch();
     }
 

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/SyncBindingInput.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/SyncBindingInput.php
@@ -55,4 +55,14 @@ final class SyncBindingInput
 
     #[Groups(['sync_binding:create'])]
     public bool $enabled = true;
+
+    /**
+     * #2549 — FilterDsl snapshot scoping the OUTBOUND push (null = send all).
+     * Applies only to the write flow; the FE builder emits a valid DSL and the
+     * Export reader compiles it at run time.
+     *
+     * @var array<string, mixed>|null
+     */
+    #[Groups(['sync_binding:create'])]
+    public ?array $outboundFilter = null;
 }

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/SyncBindingPatchInput.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/Resource/SyncBindingPatchInput.php
@@ -45,4 +45,13 @@ final class SyncBindingPatchInput
 
     #[Groups(['sync_binding:patch'])]
     public ?bool $enabled = null;
+
+    /**
+     * #2549 — FilterDsl snapshot scoping the OUTBOUND push. Present-and-empty
+     * (`[]`) clears the scope (send all); absent = leave unchanged.
+     *
+     * @var array<string, mixed>|null
+     */
+    #[Groups(['sync_binding:patch'])]
+    public ?array $outboundFilter = null;
 }

--- a/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/State/SyncBindingProcessor.php
+++ b/apps/api/src/Integration/Generic/Infrastructure/ApiPlatform/State/SyncBindingProcessor.php
@@ -83,6 +83,7 @@ final readonly class SyncBindingProcessor implements ProcessorInterface
         $binding->setConflictPolicy(ConflictPolicy::from($data->conflictPolicy));
         $binding->setMatchKeyMapping($data->matchKeyMapping);
         $binding->setEnabled($data->enabled);
+        $binding->setOutboundFilter([] === $data->outboundFilter ? null : $data->outboundFilter);
 
         // Persist first so the tenant is stamped, then compute the (jittered)
         // next run off the assigned tenant.
@@ -125,6 +126,10 @@ final readonly class SyncBindingProcessor implements ProcessorInterface
         }
         if (null !== $data->matchKeyMapping) {
             $binding->setMatchKeyMapping($data->matchKeyMapping);
+        }
+        if (null !== $data->outboundFilter) {
+            // `[]` is the explicit "clear the scope" signal (send all again).
+            $binding->setOutboundFilter([] === $data->outboundFilter ? null : $data->outboundFilter);
         }
         if (null !== $data->enabled) {
             $binding->setEnabled($data->enabled);

--- a/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Orm/Mapping/SyncBinding.orm.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/Doctrine/Orm/Mapping/SyncBinding.orm.xml
@@ -42,6 +42,11 @@
                 <option name="jsonb">true</option>
             </options>
         </field>
+        <field name="outboundFilter" type="json" column="outbound_filter" nullable="true">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
         <field name="conflictPolicy" type="string" length="16" column="conflict_policy"/>
         <field name="matchKeyMapping" type="string" length="255" column="match_key_mapping" nullable="true"/>
         <field name="enabled" type="boolean">

--- a/apps/api/src/Integration/Generic/Infrastructure/Serializer/SyncBinding.xml
+++ b/apps/api/src/Integration/Generic/Infrastructure/Serializer/SyncBinding.xml
@@ -42,6 +42,9 @@
         <attribute name="cursor">
             <group>admin:read</group>
         </attribute>
+        <attribute name="outboundFilter">
+            <group>admin:read</group>
+        </attribute>
         <attribute name="isEnabled">
             <group>admin:read</group>
         </attribute>

--- a/apps/api/tests/Integration/Integration/Generic/OutboundSyncRunnerTest.php
+++ b/apps/api/tests/Integration/Integration/Generic/OutboundSyncRunnerTest.php
@@ -100,6 +100,29 @@ final class OutboundSyncRunnerTest extends KernelTestCase
     }
 
     #[Test]
+    public function outboundFilterPushesOnlyMatchingObjects(): void
+    {
+        // #2549 — a binding scoped to `status = published` pushes only the
+        // published object; the draft is never sent to the remote.
+        $this->seedObject('PUB-1', 'Published', CatalogObject::STATUS_PUBLISHED);
+        $this->seedObject('DRAFT-1', 'Draft');
+        $binding = $this->seedBinding();
+        $binding->setOutboundFilter(['attr' => 'status', 'op' => '=', 'value' => 'published']);
+        $this->em()->flush();
+
+        $requester = new RecordingRequester(default: new GenericRestResponse(201, [], '{}', 1, 2));
+        $run = $this->runner($requester)->run($binding);
+        $this->em()->flush();
+
+        self::assertSame(SyncRunStatus::Success, $run->getStatus());
+        self::assertSame(1, $run->getCreatedCount());
+        self::assertCount(1, $requester->calls);
+        $body = json_decode((string) $requester->calls[0]['body'], true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($body);
+        self::assertSame('PUB-1', $body['sku']);
+    }
+
+    #[Test]
     public function dryRunBuildsPayloadsWithoutCallingRemote(): void
     {
         $this->seedObject('A-1', 'Widget');
@@ -116,10 +139,13 @@ final class OutboundSyncRunnerTest extends KernelTestCase
         self::assertSame(SyncRunStatus::Success, $run->getStatus());
     }
 
-    private function seedObject(string $sku, string $name): void
+    private function seedObject(string $sku, string $name, ?string $status = null): void
     {
         $em = $this->em();
         $object = new CatalogObject($this->productType, $sku);
+        if (null !== $status) {
+            $object->forceStatus($status);
+        }
         $em->persist($object);
         $em->persist(new ObjectValue($object, $this->sku, ['value' => $sku]));
         $em->persist(new ObjectValue($object, $this->name, ['value' => $name]));

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -28129,6 +28129,19 @@
                         "default": "lww",
                         "type": "string"
                     },
+                    "outboundFilter": {
+                        "description": "#2549 \u2014 rule-based OUTBOUND scope: a FilterDsl snapshot narrowing which\nobjects PIM sends to the remote (e.g. only `status = published`). null /\nempty = send every object of the type (backward-compat). Applies only to\nthe write (outbound) flow; inbound reads ignore it. Compiled at run time\nvia the Catalog FilterDslResolver in the Export reader, so a malformed\nDSL fails the run rather than the save (the FE builder emits valid DSL).",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "additionalProperties": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
                     "matchKeyMapping": {
                         "maxLength": 255,
                         "description": "The PIM target acting as the upsert match key; null until mappings are set.",
@@ -28262,6 +28275,19 @@
                     "enabled": {
                         "default": true,
                         "type": "boolean"
+                    },
+                    "outboundFilter": {
+                        "description": "#2549 \u2014 FilterDsl snapshot scoping the OUTBOUND push (null = send all).",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "additionalProperties": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
                     }
                 }
             },
@@ -28340,6 +28366,19 @@
                             "boolean",
                             "null"
                         ]
+                    },
+                    "outboundFilter": {
+                        "description": "#2549 \u2014 FilterDsl snapshot scoping the OUTBOUND push. Present-and-empty\n(`[]`) clears the scope (send all); absent = leave unchanged.",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "additionalProperties": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
                     }
                 }
             },
@@ -28395,6 +28434,19 @@
                             "conflictPolicy": {
                                 "default": "lww",
                                 "type": "string"
+                            },
+                            "outboundFilter": {
+                                "description": "#2549 \u2014 rule-based OUTBOUND scope: a FilterDsl snapshot narrowing which\nobjects PIM sends to the remote (e.g. only `status = published`). null /\nempty = send every object of the type (backward-compat). Applies only to\nthe write (outbound) flow; inbound reads ignore it. Compiled at run time\nvia the Catalog FilterDslResolver in the Export reader, so a malformed\nDSL fails the run rather than the save (the FE builder emits valid DSL).",
+                                "type": [
+                                    "object",
+                                    "null"
+                                ],
+                                "additionalProperties": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
                             },
                             "matchKeyMapping": {
                                 "maxLength": 255,


### PR DESCRIPTION
## Summary
Outbound sync (PIM → zewnętrzny system) dostał **rule-based filtr „które obiekty wysyłać"** (np. `status=published AND kategoria=X`). Dotąd wypychał wszystkie obiekty typu.

Closes #2549

## Backend
- `SyncBinding.outboundFilter` (JSONB, FilterDsl snapshot) + getter/setter + ORM + **migracja idempotentna** (`Version20260713100000`). DTO Input/Patch + Processor (`[]` czyści). Read projection (`Serializer/SyncBinding.xml`) eksponuje pole.
- `ExportOutboundRecordReader::read()` — nowy param `?array $filter`; jeśli obecny → `FilterDslResolver::toCountSql()` → `SELECT co.id ... WHERE tenant+object_type+(filter)` → skip obiektów spoza zbioru **przed** ładowaniem wartości (wzorzec `SyncExportRunner::resolveFilterIds`). `OutboundSyncRunner` przekazuje `binding.getOutboundFilter()`.
- Kształt = **FilterDsl** (jak feedy/eksport/grid) — obsługuje relacje/atrybuty + AND/OR. Walidacja przy runie (FE builder emituje poprawny DSL) → Integration processor nie sięga `Catalog\Application` (deptrac 0, dopisany reach dla readera).

## Frontend (model kierunek-first)
- Sekcja **„Z PIM (wysyłka)"** (`OutboundFilterSection`) w `SyncConfigScreen`, renderowana **tylko gdy `dir !== 'inbound'`** — strukturalnie niemożliwe ustawić filtr na inbound. Nota „Filtr dotyczy wyłącznie danych wychodzących z PIM".
- Filtr = **`AdvancedFilterPanel`** (FilterDsl) — ten sam builder co grid/eksport/feedy. Zapis przez PATCH `outboundFilter`.

## Testy
- Kernel `OutboundSyncRunnerTest::outboundFilterPushesOnlyMatchingObjects`: binding `status=published` + published+draft → **tylko** published wypchnięty (1 call, sku=PUB-1).
- Istniejące testy outbound bez regresji.

## Bramki
PHPStan max 0, deptrac 0, cs-fixer 0, api-max-lines OK, admin-max-lines OK (sekcja wydzielona, SyncConfigScreen 499). tsc/biome 0, build OK. OpenAPI regen (outbound_filter). Migracja zaaplikowana na dev.

## Świadome odejścia
- Inbound source-side filter (które rekordy zewn. API pobrać) = osobny ticket.
- Placements-based scope świadomie odrzucone (decyzja operatora — rule-based).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
