### PR TITLE
feat(api-configurator): live profile preview in the builder — real scoped rows (#2550)

### DIFF
--- a/apps/admin/src/features/api-configurator/producer/profile-builder/ProfileBuilderPage.tsx
+++ b/apps/admin/src/features/api-configurator/producer/profile-builder/ProfileBuilderPage.tsx
@@ -16,6 +16,7 @@ import {
   type ProfileDetail,
   slugify,
 } from './builder-helpers';
+import { ProfilePreviewPanel } from './ProfilePreviewPanel';
 
 const HUB = '/integrations/api-configurator';
 
@@ -270,6 +271,14 @@ export function ProfileBuilderPage() {
           onSelectNone={() => setSelectedAttrs(new Set())}
         />
       </div>
+
+      {/* #2550 — live preview of what the integrator receives for this config. */}
+      <ProfilePreviewPanel
+        apiUrl={apiUrl}
+        includedAttributes={[...selectedAttrs]}
+        objectTypeIds={[...selectedTypes]}
+        filters={parseFilters() ?? {}}
+      />
 
       {saveError !== null ? (
         <div className="rounded-xl border border-rose-200 bg-rose-50/60 p-3 text-[12.5px] text-rose-800">

--- a/apps/admin/src/features/api-configurator/producer/profile-builder/ProfilePreviewPanel.tsx
+++ b/apps/admin/src/features/api-configurator/producer/profile-builder/ProfilePreviewPanel.tsx
@@ -1,0 +1,108 @@
+import { useCustomMutation } from '@refinedev/core';
+import { FlaskConical, Info } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+
+import { SectionLabel, SecurityNote } from '../../components/primitives';
+
+interface PreviewItem {
+  id: string;
+  code: string;
+  kind: string;
+  attributes: Record<string, unknown>;
+}
+
+/**
+ * #2550 — live profile preview. POSTs the CURRENT (possibly-unsaved) builder
+ * config to `/api/profiles/preview`, which scopes real objects by the
+ * profile's filters + ObjectType list and projects them to the attribute
+ * allow-list — so the operator sees exactly what a partner integration would
+ * receive over the API, without minting a key or saving first (draft-config).
+ */
+export function ProfilePreviewPanel({
+  apiUrl,
+  includedAttributes,
+  objectTypeIds,
+  filters,
+}: {
+  apiUrl: string;
+  includedAttributes: string[];
+  objectTypeIds: string[];
+  filters: Record<string, unknown>;
+}) {
+  const { t } = useTranslation();
+  const { mutate, mutation } = useCustomMutation();
+  const [items, setItems] = useState<PreviewItem[] | null>(null);
+
+  const runTest = (): void => {
+    mutate(
+      {
+        url: `${apiUrl}/profiles/preview`,
+        method: 'post',
+        values: { includedAttributes, objectTypeIds, filters, limit: 5 },
+      },
+      {
+        onSuccess: (response) => {
+          const data = response.data as { items?: PreviewItem[] };
+          setItems(data.items ?? []);
+        },
+      },
+    );
+  };
+
+  return (
+    <section
+      className="soft-shadow rounded-2xl border border-zinc-200 bg-white p-5"
+      data-testid="profile-preview-panel"
+    >
+      <SectionLabel
+        right={
+          <Button type="button" size="sm" onClick={runTest} disabled={mutation.isPending}>
+            <FlaskConical className="mr-1 size-4" aria-hidden="true" />
+            {t('api_configurator.builder.preview.test', { defaultValue: 'Testuj' })}
+          </Button>
+        }
+      >
+        {t('api_configurator.builder.preview.title', { defaultValue: 'Podgląd / Test wyników' })}
+      </SectionLabel>
+      <p className="mb-3 text-[12.5px] leading-relaxed text-zinc-600">
+        {t('api_configurator.builder.preview.hint', {
+          defaultValue:
+            'To widzi integrator przez API — realne obiekty przefiltrowane wg profilu, z wybranymi atrybutami.',
+        })}
+      </p>
+
+      {items === null ? (
+        <SecurityNote tone="zinc" icon={<Info className="size-4" />}>
+          {t('api_configurator.builder.preview.idle', {
+            defaultValue: 'Kliknij „Testuj”, aby zobaczyć próbkę realnych danych dla tego profilu.',
+          })}
+        </SecurityNote>
+      ) : items.length === 0 ? (
+        <p className="text-[12.5px] text-zinc-500" data-testid="profile-preview-empty">
+          {t('api_configurator.builder.preview.empty', {
+            defaultValue: 'Brak obiektów pasujących do filtra profilu.',
+          })}
+        </p>
+      ) : (
+        <div className="space-y-2" data-testid="profile-preview-items">
+          {items.map((item) => (
+            <div key={item.id} className="rounded-xl border border-zinc-100 bg-zinc-50/60 p-3">
+              <div className="mb-1 flex items-center gap-2">
+                <span className="font-mono text-[12px] font-medium text-zinc-900">{item.code}</span>
+                <span className="rounded bg-zinc-200/70 px-1.5 py-0.5 text-[10.5px] text-zinc-600">
+                  {item.kind}
+                </span>
+              </div>
+              <pre className="overflow-x-auto whitespace-pre-wrap break-words text-[11.5px] text-zinc-600">
+                {JSON.stringify(item.attributes, null, 2)}
+              </pre>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/api/src/ApiConfigurator/Application/ApiProfileResponseFilter.php
+++ b/apps/api/src/ApiConfigurator/Application/ApiProfileResponseFilter.php
@@ -45,4 +45,23 @@ final readonly class ApiProfileResponseFilter
 
         return $row;
     }
+
+    /**
+     * #2550 — prune a bare attribute map to the allow-list (empty = keep all).
+     * Used by the live preview, which projects a draft config's attribute set
+     * before a profile is saved.
+     *
+     * @param array<string, mixed> $attributes
+     * @param list<string>         $included
+     *
+     * @return array<string, mixed>
+     */
+    public function projectAttributes(array $attributes, array $included): array
+    {
+        if ([] === $included) {
+            return $attributes;
+        }
+
+        return array_intersect_key($attributes, array_flip($included));
+    }
 }

--- a/apps/api/src/ApiConfigurator/Presentation/Controller/ProfileTestController.php
+++ b/apps/api/src/ApiConfigurator/Presentation/Controller/ProfileTestController.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace App\ApiConfigurator\Presentation\Controller;
 
 use ApiPlatform\OpenApi\Factory\OpenApiFactoryInterface;
+use App\ApiConfigurator\Application\ApiProfileResponseFilter;
 use App\ApiConfigurator\Domain\Entity\ApiProfile;
 use App\ApiConfigurator\Domain\Repository\ApiProfileRepositoryInterface;
+use App\Catalog\Contracts\Query\ObjectSamplePort;
 use App\Identity\Contracts\Attribute\RequiresPermission;
 use stdClass;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -20,11 +23,14 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
  * - `GET /api/profiles/{code}/test` — returns a deterministic
  *   sample shape derived from the profile's `includedAttributes`.
  *   The integrator can see the response contract before any real
- *   `CatalogObject` exists. Live data preview (fetch a real row +
- *   project per profile) ships in a follow-up — it requires a
- *   read-only `Catalog` contract that ApiConfigurator does not own
- *   today (Deptrac: ApiConfigurator → only Catalog_Contracts /
- *   Channel_Contracts).
+ *   `CatalogObject` exists.
+ *
+ * - `POST /api/profiles/preview` (#2550) — the LIVE preview: takes the
+ *   current (possibly-unsaved) profile config in the body, fetches a bounded
+ *   sample of real objects scoped by its filters + ObjectType list via the
+ *   {@see ObjectSamplePort} Catalog contract, and projects each row to the
+ *   profile's attribute allow-list — so the admin sees exactly what an
+ *   integrator would receive, without minting an API key.
  *
  * - `GET /api/profiles/{code}/openapi.json` — emits the AP4
  *   OpenAPI document narrowed to the sugar paths the profile
@@ -40,6 +46,8 @@ final class ProfileTestController
     public function __construct(
         private readonly ApiProfileRepositoryInterface $profiles,
         private readonly OpenApiFactoryInterface $openApiFactory,
+        private readonly ObjectSamplePort $objectSamples,
+        private readonly ApiProfileResponseFilter $responseFilter,
     ) {
     }
 
@@ -64,6 +72,34 @@ final class ProfileTestController
         ]);
     }
 
+    #[Route('/api/profiles/preview', name: 'pim_api_profiles_preview', methods: ['POST'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'api_profile', action: 'read')]
+    public function preview(Request $request): JsonResponse
+    {
+        $content = $request->getContent();
+        $decoded = json_decode('' === $content ? '{}' : $content, true);
+        $body = \is_array($decoded) ? $decoded : [];
+
+        $included = $this->stringList($body['includedAttributes'] ?? null);
+        $objectTypeIds = $this->stringList($body['objectTypeIds'] ?? null);
+        /** @var array<string, mixed> $filters */
+        $filters = \is_array($body['filters'] ?? null) ? $body['filters'] : [];
+        $limit = \is_int($body['limit'] ?? null) ? $body['limit'] : 5;
+
+        $items = [];
+        foreach ($this->objectSamples->sample($objectTypeIds, $filters, $limit) as $sample) {
+            $items[] = [
+                'id' => $sample->id,
+                'code' => $sample->code,
+                'kind' => $sample->kind,
+                'attributes' => $this->responseFilter->projectAttributes($sample->attributes, $included),
+            ];
+        }
+
+        return new JsonResponse(['items' => $items, 'count' => \count($items)]);
+    }
+
     #[Route(
         '/api/profiles/{code}/openapi.json',
         name: 'pim_api_profiles_openapi',
@@ -86,6 +122,25 @@ final class ProfileTestController
         $payload = $this->narrowOpenApiToProfile($payload, $profile);
 
         return new JsonResponse($payload);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringList(mixed $value): array
+    {
+        if (!\is_array($value)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($value as $item) {
+            if (\is_string($item)) {
+                $out[] = $item;
+            }
+        }
+
+        return $out;
     }
 
     private function loadProfile(string $code): ApiProfile

--- a/apps/api/src/Catalog/Application/Query/ObjectSampleReader.php
+++ b/apps/api/src/Catalog/Application/Query/ObjectSampleReader.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Query;
+
+use App\Catalog\Contracts\Query\ObjectSample;
+use App\Catalog\Contracts\Query\ObjectSamplePort;
+use App\Catalog\Domain\Entity\CatalogObject;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * #2550 — {@see ObjectSamplePort} implementation. Applies the profile's
+ * canonical scope (ObjectType list + status/enabled/completeness) as a bounded
+ * DQL query and returns the denormalised rows. Tenant isolation comes from the
+ * Doctrine TenantFilter + RLS, so no explicit tenant clause is needed. Mirrors
+ * the axes {@see \App\Catalog\Infrastructure\ApiPlatform\State\ProfileScopeApplier}
+ * applies on the live API so the preview matches what an integrator receives.
+ */
+final readonly class ObjectSampleReader implements ObjectSamplePort
+{
+    private const int MAX_LIMIT = 50;
+
+    /** @var array<string, string> */
+    private const array COMPLETENESS_OPERATORS = [
+        'eq' => '=',
+        'gt' => '>',
+        'gte' => '>=',
+        'lt' => '<',
+        'lte' => '<=',
+    ];
+
+    public function __construct(private EntityManagerInterface $em)
+    {
+    }
+
+    public function sample(array $objectTypeIds, array $canonicalFilters, int $limit): array
+    {
+        $qb = $this->em->createQueryBuilder()
+            ->select('o')
+            ->from(CatalogObject::class, 'o')
+            ->setMaxResults(max(1, min($limit, self::MAX_LIMIT)));
+
+        $validTypeIds = array_values(array_filter(
+            $objectTypeIds,
+            static fn (string $id): bool => Uuid::isValid($id),
+        ));
+        if ([] !== $validTypeIds) {
+            $qb->andWhere('IDENTITY(o.objectType) IN (:otids)')->setParameter('otids', $validTypeIds);
+        }
+
+        $status = $canonicalFilters['status'] ?? null;
+        if (\is_string($status) && '' !== $status) {
+            $qb->andWhere('o.status = :status')->setParameter('status', $status);
+        }
+
+        $enabled = match ($canonicalFilters['enabled'] ?? null) {
+            true, 'true', '1', 1 => true,
+            false, 'false', '0', 0 => false,
+            default => null,
+        };
+        if (null !== $enabled) {
+            $qb->andWhere('o.enabled = :enabled')->setParameter('enabled', $enabled);
+        }
+
+        $completeness = $canonicalFilters['completeness'] ?? null;
+        if (\is_array($completeness)) {
+            foreach ($completeness as $op => $threshold) {
+                $sqlOperator = self::COMPLETENESS_OPERATORS[$op] ?? null;
+                if (null === $sqlOperator || !is_numeric($threshold)) {
+                    continue;
+                }
+                $qb->andWhere(\sprintf('o.completenessPct %s :cmp_%s', $sqlOperator, $op))
+                    ->setParameter('cmp_'.$op, (int) $threshold);
+            }
+        }
+
+        $rows = [];
+        /** @var CatalogObject $object */
+        foreach ($qb->getQuery()->getResult() as $object) {
+            $rows[] = new ObjectSample(
+                $object->getId()->toRfc4122(),
+                $object->getCode(),
+                $object->getKind()->value,
+                $object->getAttributesIndexed(),
+            );
+        }
+
+        return $rows;
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Query/ObjectSample.php
+++ b/apps/api/src/Catalog/Contracts/Query/ObjectSample.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Query;
+
+/**
+ * #2550 — a scoped, denormalised object row for the live profile preview.
+ *
+ * Primitive-only projection (no Catalog Domain types) so a consumer BC
+ * (ApiConfigurator) can render "what the integrator sees" without crossing
+ * into Catalog\Domain. `attributes` is the object's denormalised
+ * `attributes_indexed` map (attribute code => value); the caller prunes it to
+ * the profile's allow-list.
+ */
+final readonly class ObjectSample
+{
+    /**
+     * @param array<string, mixed> $attributes attribute code => indexed value
+     */
+    public function __construct(
+        public string $id,
+        public string $code,
+        public string $kind,
+        public array $attributes,
+    ) {
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Query/ObjectSamplePort.php
+++ b/apps/api/src/Catalog/Contracts/Query/ObjectSamplePort.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Query;
+
+/**
+ * #2550 — cross-BC read of a scoped SAMPLE of catalog objects for the live
+ * profile preview (ApiConfigurator). Applies the profile's canonical scope
+ * (ObjectType list + status/enabled/completeness query-param filters — the
+ * same axes {@see \App\Catalog\Infrastructure\ApiPlatform\State\ProfileScopeApplier}
+ * enforces on the live API) and returns a bounded set of denormalised rows,
+ * so the admin can preview exactly what a partner integration would receive
+ * without minting an API key.
+ */
+interface ObjectSamplePort
+{
+    /**
+     * @param list<string>         $objectTypeIds    ObjectType uuids the profile exposes ([] = any)
+     * @param array<string, mixed> $canonicalFilters query-param dict (status / enabled / completeness)
+     * @param int                  $limit            max rows to return (clamped)
+     *
+     * @return list<ObjectSample>
+     */
+    public function sample(array $objectTypeIds, array $canonicalFilters, int $limit): array;
+}

--- a/apps/api/tests/Api/ApiConfigurator/ProfilePreviewApiTest.php
+++ b/apps/api/tests/Api/ApiConfigurator/ProfilePreviewApiTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\ApiConfigurator;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * #2550 — the live profile preview endpoint. Takes a draft (unsaved) profile
+ * config and returns a bounded sample of REAL objects, scoped by the filters +
+ * ObjectType list and projected to the attribute allow-list — exactly what a
+ * partner integration would receive over the API.
+ */
+final class ProfilePreviewApiTest extends ApiConfiguratorApiTestCase
+{
+    #[Test]
+    public function previewReturnsScopedAndProjectedRowsForADraftConfig(): void
+    {
+        $productType = $this->seedProducts();
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/profiles/preview', [
+            'json' => [
+                'objectTypeIds' => [$productType->getId()->toRfc4122()],
+                'filters' => ['status' => 'published'],
+                'includedAttributes' => ['name'],
+                'limit' => 5,
+            ],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        /** @var array{items: list<array{code: string, attributes: array<string, mixed>}>, count: int} $body */
+        $body = $response->toArray();
+        $items = $body['items'];
+        $codes = array_column($items, 'code');
+        self::assertContains('PUB-1', $codes, 'published object is in scope');
+        self::assertNotContains('DRAFT-1', $codes, 'draft must not leak into the preview');
+
+        // Field projection: only the allow-listed `name` survives; `brand` is dropped.
+        $published = null;
+        foreach ($items as $item) {
+            if ('PUB-1' === $item['code']) {
+                $published = $item;
+            }
+        }
+        self::assertNotNull($published);
+        self::assertSame(['name'], array_keys($published['attributes']));
+        self::assertSame('Widget', $published['attributes']['name']);
+    }
+
+    #[Test]
+    public function previewIsEmptyWhenNothingMatchesTheFilter(): void
+    {
+        $productType = $this->seedProducts();
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/profiles/preview', [
+            'json' => [
+                'objectTypeIds' => [$productType->getId()->toRfc4122()],
+                'filters' => ['status' => 'archived'],
+            ],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        /** @var array{items: list<mixed>, count: int} $body */
+        $body = $response->toArray();
+        self::assertSame(0, $body['count']);
+        self::assertSame([], $body['items']);
+    }
+
+    private function seedProducts(): ObjectType
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $productType = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt', 'en' => 'Product']);
+        $productType->assignTenant($tenant);
+        $em->persist($productType);
+
+        $published = new CatalogObject($productType, 'PUB-1');
+        $published->assignTenant($tenant);
+        $published->forceStatus(CatalogObject::STATUS_PUBLISHED);
+        $published->updateAttributeIndex(['name' => 'Widget', 'brand' => 'Festo']);
+        $em->persist($published);
+
+        $draft = new CatalogObject($productType, 'DRAFT-1');
+        $draft->assignTenant($tenant);
+        $draft->updateAttributeIndex(['name' => 'Draft widget']);
+        $em->persist($draft);
+
+        $em->flush();
+
+        return $productType;
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -20376,6 +20376,32 @@
                 "x-cortex-permission": "api_profile.read"
             }
         },
+        "/api/profiles/preview": {
+            "post": {
+                "operationId": "api_profiles_preview_post",
+                "tags": [
+                    "profiles"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api profiles preview",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "api_profile.read"
+            }
+        },
         "/api/profiles/{code}/openapi.json": {
             "get": {
                 "operationId": "api_profiles_code_openapi_json_get",


### PR DESCRIPTION
## Summary

Producer profile builder now has a **live preview**: klik „Testuj" pokazuje realne obiekty przefiltrowane wg bieżącej (możliwie niezapisanej) konfiguracji profilu i zrzutowane do wybranych atrybutów — dokładnie to, co integrator dostaje przez API, bez zapisu profilu i bez mintowania klucza (draft-config-via-query). Domyka lukę widoczności efektu #2527/#2530 (scoping filtrów w live-API) w UI.

Closes #2550. Follow-up do #95 (dotąd `/profiles/{code}/test` zwracał tylko kształt odpowiedzi, bez realnych wierszy).

## Backend changes
- **Catalog Contracts seam** (deptrac-safe): `ObjectSample` (primitive-only DTO `{id, code, kind, attributes}`) + `ObjectSamplePort::sample(objectTypeIds, canonicalFilters, limit): list<ObjectSample>`.
- **`ObjectSampleReader`** (Catalog Application, auto-aliased do portu) — bounded DQL nad `CatalogObject`, scoping wg ObjectType list + `status`/`enabled`/`completeness` (te same osie co `ProfileScopeApplier` na live-API), `MAX_LIMIT=50`, tenant izolacja z TenantFilter+RLS.
- **`ProfileTestController::preview()`** — `POST /api/profiles/preview` czyta draft body `{includedAttributes, objectTypeIds, filters, limit}`, woła port, rzutuje atrybuty przez `ApiProfileResponseFilter::projectAttributes()` (nowa metoda; pusty allow-list = wszystkie), zwraca `{items, count}`. Perm: `api_profile:read`.
- OpenAPI snapshot zregenerowany (`docs/api-spec/v0.json`).

## Frontend changes
- **`ProfilePreviewPanel.tsx`** — `useCustomMutation` POST `/profiles/preview` z bieżącym stanem buildera; renderuje karty (code + kind + JSON atrybutów), stan idle i empty. Testids: `profile-preview-panel`, `profile-preview-empty`, `profile-preview-items`.
- **`ProfileBuilderPage.tsx`** — panel wpięty pod builder, karmiony `selectedAttrs`/`selectedTypes`/`parseFilters()`.

## Quality gates
- PHPStan max: 0 (scoped na nowe pliki + kontroler).
- cs-fixer: czysto (per-file).
- FE: `tsc` czysto, `biome check` czysto, `lint-jsonfetch-useeffect` bez regresji (baseline 61), `lint-admin-max-lines` bez regresji (baseline 21), `admin build` OK.
- ApiTest: `ProfilePreviewApiTest` (scoped-by-status + projekcja do allow-listy; empty gdy brak dopasowań) — wykonywany w CI (api-* shard).

## Smoke test plan (operator)
1. Login (admin@demo.localhost / changeme).
2. `https://pim.localhost/integrations/api-configurator/producer` → nowy/edytuj profil.
3. Wybierz ObjectType (Produkt) + atrybuty (np. `name`), w polu Filtry `{ "status": "published" }`.
4. Klik „Testuj" → panel pokazuje realne opublikowane produkty z samym `name`.
5. Zmień filtr na `{ "status": "draft" }` → inny zestaw. DevTools Console bez errorów.

## Świadome odejścia
- BE endpoint już live-smoke'owany (status=published → 3 realne produkty, status=draft → inny zestaw). Browser smoke panelu do potwierdzenia po merge (endpoint działa, panel = cienki wrapper na zweryfikowanym endpoincie).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
