### PR TITLE
fix(admin): surface real role-save error instead of generic toast (#2553)

### DIFF
--- a/apps/admin/e2e/settings-roles-editor-save.spec.ts
+++ b/apps/admin/e2e/settings-roles-editor-save.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * fix #2553 — the role EDITOR save flow had no e2e (only the list did), so a
+ * save that failed with a non-JSON/HTML response surfaced a blanket
+ * „Operacja na roli nie powiodła się" toast that hid the real cause. This spec
+ * pins both halves of the fix in a single login (the auth rate-limiter is
+ * shared across the RBAC suite):
+ *
+ *  1. Happy path — toggle a permission, save, expect `PATCH /api/roles/{id}`
+ *     → 200 and the success toast.
+ *  2. Resilience — when the PATCH returns a 200 HTML body (the FrankenPHP
+ *     dev-cache-corruption shape), the toast surfaces the server's synthesized
+ *     reason ("Server returned 200 with text/html …") instead of the generic
+ *     message. The synthesized detail is emitted in English by lib/http.ts, so
+ *     the assertion is locale-independent.
+ */
+test('Settings → Role editor — save surfaces real errors + happy path', async ({ page }) => {
+  await loginAsAdmin(page);
+
+  // Load the list and pull a real role id from its response (deterministic,
+  // avoids brittle card-name locators). Prefer a custom role so the mutated
+  // permission set does not touch a system template other specs may assert on.
+  await page.goto('/settings/roles');
+  const listResponse = await page.waitForResponse(
+    (r) =>
+      r.url().includes('/api/roles') &&
+      r.request().method() === 'GET' &&
+      !/\/api\/roles\/[0-9a-f-]{36}/.test(r.url()),
+    { timeout: 30_000 },
+  );
+  const listJson = (await listResponse.json()) as {
+    member?: Array<{ id: string; type?: string }>;
+    'hydra:member'?: Array<{ id: string; type?: string }>;
+  };
+  const items = listJson.member ?? listJson['hydra:member'] ?? [];
+  expect(items.length).toBeGreaterThan(0);
+  const target = items.find((r) => r.type === 'custom') ?? items[0];
+
+  // Deep-link into the editor; it hydrates from GET /api/roles/{id}.
+  await page.goto(`/settings/roles/${target.id}/edit`);
+  await page.waitForResponse(
+    (r) => r.url().includes(`/api/roles/${target.id}`) && r.request().method() === 'GET',
+    { timeout: 30_000 },
+  );
+
+  // Permission checkboxes carry aria-pressed; toggling one dirties the form.
+  const firstPermission = page.locator('button[aria-pressed]').first();
+  await firstPermission.waitFor({ state: 'visible', timeout: 15_000 });
+
+  // --- 1. Happy path: PATCH round-trips 200 + success toast. ---
+  await firstPermission.click();
+  const patchOk = page.waitForResponse(
+    (r) => r.url().includes(`/api/roles/${target.id}`) && r.request().method() === 'PATCH',
+    { timeout: 30_000 },
+  );
+  await page.getByRole('button', { name: /zapisz zmiany|save changes/i }).click();
+  expect((await patchOk).status()).toBe(200);
+  await expect(page.getByText(/zapisano zmiany|saved changes/i)).toBeVisible({ timeout: 15_000 });
+
+  // --- 2. Resilience: an HTML fatal on PATCH surfaces the real reason. ---
+  await page.route(`**/api/roles/${target.id}`, async (route) => {
+    if (route.request().method() === 'PATCH') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: '<html><body>Fatal error: dev cache corruption</body></html>',
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.locator('button[aria-pressed]').first().click();
+  await page.getByRole('button', { name: /zapisz zmiany|save changes/i }).click();
+
+  // The generic fallback must NOT swallow the cause — the synthesized detail
+  // names the actual server response.
+  await expect(
+    page.getByText(/server returned 200 with text\/html|content-type when JSON was expected/i),
+  ).toBeVisible({ timeout: 15_000 });
+});

--- a/apps/admin/src/features/settings/roles/RoleEditorPage.tsx
+++ b/apps/admin/src/features/settings/roles/RoleEditorPage.tsx
@@ -19,7 +19,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { toast } from '@/components/ui/toast';
-import { jsonFetch } from '@/lib/http';
+import { httpErrorDetail, jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
 import {
@@ -314,6 +314,10 @@ export function RoleEditorPage() {
     event.preventDefault();
     if (submitting || name.trim().length === 0) return;
     setSubmitting(true);
+    // Track whether the base-permissions PATCH already persisted, so a later
+    // failure in the attribute-permissions PUT can report the partial success
+    // instead of a blanket "everything failed" (the two calls are independent).
+    let baseSaved = false;
     try {
       const permissionCodes = Array.from(selected);
 
@@ -330,6 +334,7 @@ export function RoleEditorPage() {
           accept: 'application/json',
           contentType: 'application/json',
         });
+        baseSaved = true;
 
         const attrPayload = Object.entries(attrDraft)
           .filter(([, level]) => level !== null)
@@ -366,14 +371,22 @@ export function RoleEditorPage() {
     } catch (error: unknown) {
       const status = (error as { status?: number; body?: ApiProblem })?.status;
       const body = (error as { body?: ApiProblem })?.body;
+      // The server's RFC 7807 `detail` (or the synthesized non-JSON message
+      // http.ts builds for HTML fatal pages) is far more useful than a blanket
+      // "operation failed" — surface it wherever we don't have a tailored copy.
+      const detail = httpErrorDetail(error);
       if (status === 409 && body?.code === 'duplicate_code') {
         toast.error(body?.detail ?? t('settings.roles.editor.error_duplicate'));
       } else if (status === 400) {
-        toast.error(body?.detail ?? t('settings.roles.editor.error_validation'));
+        toast.error(detail ?? body?.detail ?? t('settings.roles.editor.error_validation'));
       } else if (status === 403) {
         toast.error(t('settings.roles.editor.error_forbidden'));
+      } else if (baseSaved) {
+        // PATCH persisted the base permissions; only the attribute-permissions
+        // PUT failed — tell the operator their core change was NOT lost.
+        toast.error(detail ?? t('settings.roles.editor.error_attribute_permissions'));
       } else {
-        toast.error(t('settings.roles.editor.error_generic'));
+        toast.error(detail ?? t('settings.roles.editor.error_generic'));
       }
     } finally {
       setSubmitting(false);

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -891,6 +891,7 @@
         "error_delete_forbidden": "Only custom roles can be deleted.",
         "error_in_use": "Cannot delete — {{count}} user(s) still hold this role.",
         "error_generic": "Role operation failed.",
+        "error_attribute_permissions": "Role permissions saved, but saving attribute permissions failed. Refresh and try again.",
         "group": {
           "products": "Products",
           "categories": "Categories",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -901,6 +901,7 @@
         "error_delete_forbidden": "Tylko role customowe można usunąć.",
         "error_in_use": "Nie można usunąć — rolę nadal posiada {{count}} użytkownik(ów).",
         "error_generic": "Operacja na roli nie powiodła się.",
+        "error_attribute_permissions": "Uprawnienia roli zapisane, ale zapis uprawnień atrybutów nie powiódł się. Odśwież i spróbuj ponownie.",
         "group": {
           "products": "Produkty",
           "categories": "Kategorie",


### PR DESCRIPTION
## Summary
Naprawia mylący toast „Operacja na roli nie powiodła się" przy zapisie roli w Settings → Role. Endpoint działa (zweryfikowane live: no-op `PATCH /api/roles/{id}` → 200); defekt był **we froncie** — ślepe mapowanie każdego nietypowego błędu na generyczny komunikat, który ukrywał prawdziwą przyczynę.

## Root cause
[`RoleEditorPage.tsx`](apps/admin/src/features/settings/roles/RoleEditorPage.tsx) catch mapował **każdy** status ≠ {400, 403, 409-duplicate} na `error_generic`. Faktyczny powód (np. FrankenPHP dev-cache-corruption → HTML-fatal zamiast JSON, dla którego `lib/http.ts` syntetyzuje RFC7807 `detail`) nigdy nie docierał do UI. Dodatkowo zapis robi DWA requesty (`PATCH /api/roles/{id}` → `PUT /api/roles/{id}/attribute-permissions`); porażka PUT po udanym PATCH raportowała totalną porażkę mimo że base perms już się zapisały.

## Frontend changes
- Fallback catch pokazuje `httpErrorDetail(error)` (prawdziwy `detail` serwera / syntetyczny komunikat „Server returned … Body starts with: …") zamiast `error_generic`.
- `baseSaved` rozróżnia częściową porażkę: gdy PATCH przeszedł a PUT padł → dedykowany komunikat, że uprawnienia bazowe zapisane.
- i18n: nowy klucz `settings.roles.editor.error_attribute_permissions` (pl + en).
- **Nowy e2e** `settings-roles-editor-save.spec.ts` — pierwsza pokrywa flow ZAPISU roli: (1) happy path toggle → `PATCH` 200 → toast sukcesu, (2) resilience — HTML-fatal na PATCH → toast z prawdziwym powodem (nie generic). Jeden login (rate-limiter współdzielony w suicie RBAC).

## Backend changes
Brak — endpoint działa poprawnie, zmiana wyłącznie FE (odporność + diagnostyka).

## Quality gates
- tsc (admin): 0.
- Biome strict: 0 (4 pliki).
- Guards: max-lines 21/baseline, jsonfetch-useeffect 61/baseline, i18n-parity OK.
- Playwright `settings-roles-editor-save`: wykonywany w CI (E2E shard).

## Smoke test plan (operator)
1. Login (admin@demo.localhost / changeme).
2. Settings → Role → edytuj rolę, przełącz uprawnienie, Zapisz → toast sukcesu (`PATCH` 200 w Network).
3. (Diagnostyka) jeśli toast błędu — teraz pokazuje prawdziwy powód serwera zamiast „Operacja na roli nie powiodła się".

## Świadome odejścia
- **FrankenPHP dev-cache-corruption to problem środowiskowy** (memory `frankenphp-dev-cache-corruption`) — ten PR NIE naprawia cache, czyni FE odpornym i diagnostycznym. Jeśli oryginalny błąd był z tego powodu, leczenie stacku (nuke `var/cache/dev` + warmup + restart api worker) jest osobne.
- e2e nie uruchamiany lokalnie (współdzielony login rate-limiter + mutacja roli na live-stacku); walidacja w CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
