### PR TITLE
fix(workflow): enable configurable approver end-to-end (flag + seeded reviewer) (#2555)

### DIFF
--- a/apps/api/.env
+++ b/apps/api/.env
@@ -93,7 +93,11 @@ APP_DEFAULT_TENANT_CODE=demo
 # /api/object_types POST + the modeling UI Create button (Faza 1
 # ADR-013 will tie this to per-role permissions).
 CATALOG_ENABLE_CUSTOM_OBJECT_TYPES=true
-WORKFLOW_CUSTOM_DEFINITIONS=false
+# ON by default (#2555): the configurable-approver feature (WFL redesign
+# #2514–#2524) routes review tasks to the per-ObjectType definition reviewer.
+# With no enabled definition the provider still serves the static YAML machine,
+# so this is safe even for tenants that never open the flow-settings builder.
+WORKFLOW_CUSTOM_DEFINITIONS=true
 # CPDF-P0-03 / CPDF-P6-03 (ADR-0027) — PDF renderer selection for Catalog PDF.
 # `dompdf` is the in-process default (zero infra); `gotenberg` activates the
 # headless-Chromium sidecar and additionally needs GOTENBERG_URL (e.g.

--- a/apps/api/src/DataFixtures/AppFixtures.php
+++ b/apps/api/src/DataFixtures/AppFixtures.php
@@ -198,6 +198,39 @@ class AppFixtures extends Fixture implements DependentFixtureInterface
             $manager->persist($admin);
         }
 
+        // #2555 — a dedicated non-owner REVIEWER persona holding the built-in
+        // `approver` role. Review tasks route to the per-ObjectType definition
+        // reviewer when one is enabled, otherwise to `approver` (the fallback);
+        // without any user holding it, review tasks are visible only to Owners
+        // via the `workflow.approve_reject` override. Seeding this reviewer
+        // makes the flow demonstrable end-to-end on a fresh DB via the fallback
+        // path. We deliberately do NOT seed an enabled product WorkflowDefinition
+        // here: an enabled product definition in the shared fixtures would leak
+        // into the product-driving workflow e2e specs (wfl-p5-03 / wfl-p6-02),
+        // which build/drive their own product definitions. Per-ObjectType
+        // reviewers are configured through the (now unhidden) flow-settings UI.
+        $demoTenant = null;
+        foreach ($tenants as $tenant) {
+            if ('demo' === $tenant->getCode()) {
+                $demoTenant = $tenant;
+                break;
+            }
+        }
+        \assert(null !== $demoTenant, 'The demo tenant must exist.');
+
+        $reviewerRole = $this->roleRepository->findByCode('approver', $demoTenant);
+        \assert(null !== $reviewerRole, 'SeedTenantPrdRolesService must create approver per tenant.');
+        $reviewerEmail = 'reviewer@demo.localhost';
+        $reviewerStub = new User($demoTenant, $reviewerEmail, '', []);
+        $reviewer = new User(
+            $demoTenant,
+            $reviewerEmail,
+            $this->passwordHasher->hashPassword($reviewerStub, self::DEFAULT_ADMIN_PASSWORD),
+            [],
+        );
+        $reviewer->addRole($reviewerRole);
+        $manager->persist($reviewer);
+
         // AUD-003 (#1575): the platform operator (operator panel + break-glass)
         // is a SEPARATE principal from any tenant Owner. It holds ONLY the
         // global `platform_operator` role (the `platform.*` grants) and no

--- a/apps/api/tests/Api/Identity/MeEndpointTest.php
+++ b/apps/api/tests/Api/Identity/MeEndpointTest.php
@@ -74,11 +74,12 @@ final class MeEndpointTest extends ApiTestCase
         // constants on Tenant).
         self::assertSame('starter', $body['tenant']['plan'] ?? null);
         self::assertArrayHasKey('last_login_at', $body);
-        // WFL-P5-03 (#2433) — runtime feature flags for the SPA. The test
-        // env runs with WORKFLOW_CUSTOM_DEFINITIONS=false, so the flag is
-        // present and off.
+        // WFL-P5-03 (#2433) — runtime feature flags for the SPA. Since #2555
+        // WORKFLOW_CUSTOM_DEFINITIONS defaults ON, so the flag is present and
+        // true (with no enabled definition the provider still serves the
+        // static machine, so this stays safe).
         self::assertIsArray($body['feature_flags'] ?? null);
-        self::assertFalse($body['feature_flags']['workflow_custom_definitions'] ?? null);
+        self::assertTrue($body['feature_flags']['workflow_custom_definitions'] ?? null);
     }
 
     #[Test]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -186,9 +186,9 @@ services:
       AWS_ASSETS_KEY: ${MINIO_ROOT_USER:-minioadmin}
       AWS_ASSETS_SECRET: ${MINIO_ROOT_PASSWORD:-minioadmin}
       # WFL-P5-01/P5-03 - tenant-editable workflow definitions (ADR-0029).
-      # Default OFF; the Playwright CI job and local builder smoke flip it
-      # per-run without editing apps/api/.env.
-      WORKFLOW_CUSTOM_DEFINITIONS: ${WORKFLOW_CUSTOM_DEFINITIONS:-false}
+      # Default ON (#2555): configurable-approver routing. With no enabled
+      # definition the provider falls back to the static YAML machine.
+      WORKFLOW_CUSTOM_DEFINITIONS: ${WORKFLOW_CUSTOM_DEFINITIONS:-true}
       TRUSTED_PROXIES: 127.0.0.1,REMOTE_ADDR
       TRUSTED_HOSTS: '^pim\.localhost$$|^localhost$$|^api$$'
       # CI sentinel — propagated from GitHub Actions so docker-entrypoint.sh
@@ -248,8 +248,8 @@ services:
       APP_ENV: ${APP_ENV:-dev}
       # WFL-P5-01 - the bulk change_status handler resolves the workflow
       # through the same provider as the request path; keep both sides of
-      # the stack on one flag value.
-      WORKFLOW_CUSTOM_DEFINITIONS: ${WORKFLOW_CUSTOM_DEFINITIONS:-false}
+      # the stack on one flag value (default ON, #2555).
+      WORKFLOW_CUSTOM_DEFINITIONS: ${WORKFLOW_CUSTOM_DEFINITIONS:-true}
       # The worker is a headless background consumer (import/export/reindex) —
       # it never serves the web profiler. APP_DEBUG=1 (the dev default) makes
       # Symfony's debug caches (DoctrineBundle DebugDataHolder, the profiler's


### PR DESCRIPTION
## Summary
Udostępnia konfigurowalny akceptant. Analiza „nie da się wygenerować review taska" wykazała: pipeline działa (10 otwartych review-tasków w skrzynce admina), ale (a) operator zatwierdzał własne zgłoszenia w ~2 s, (b) zadania trafiały do roli `approver`/`catalog_manager` której **żaden user nie miał** → widoczne tylko dla Ownera przez override `workflow.approve_reject`, (c) flaga `WORKFLOW_CUSTOM_DEFINITIONS=OFF` ignorowała skonfigurowanego reviewera. Decyzja operatora: „włącz flagę + przypisz reviewera".

Closes #2555.

## Backend changes
- **Flaga ON domyślnie** — `apps/api/.env` + oba `docker-compose.yml` defaults `${WORKFLOW_CUSTOM_DEFINITIONS:-true}`. Konfigurowalny akceptant (WFL redesign #2514–#2524) aktywny: review taski routują do `WorkflowDefinition.reviewer` per ObjectType gdy definicja jest włączona, w przeciwnym razie do wbudowanej roli `approver`. Bez włączonej definicji provider wciąż serwuje statyczną maszynę YAML → flip bezpieczny.
- **Seed** (`AppFixtures`): non-owner reviewer `reviewer@demo.localhost` z rolą `approver` → review taski docierają do realnego reviewera przez ścieżkę fallback na świeżej DB (nie tylko Ownera przez override).
- **`MeEndpointTest`** zaktualizowany: `feature_flags.workflow_custom_definitions` teraz `true`.

## Świadomie NIE seeduję definicji
Włączona **definicja produktowa** w współdzielonych fixtures **wyciekłaby do product-driving specy** workflow (`wfl-p5-03` buduje własną definicję produktu z custom miejscem; `wfl-p6-02` gna pełną pętlę edytorską produktu) — dokładnie hazard, przed którym ostrzega autor `wfl-flow-settings` („asset jako wyspa"). Dlatego seed daje tylko reviewer-persona na ścieżce fallback; per-ObjectType reviewery konfiguruje się w (odblokowanym flagą) UI „Ustawienia przepływu".

## Blast radius (zweryfikowany)
- **0 PHPUnit tests** zakładają literał flagi (poza `MeEndpointTest`, naprawiony): routing-testy self-pinują providera albo polegają na pustej-definicji test-DB.
- **Playwright**: pierwsza wersja (z seedowaną definicją) łamała `wfl-p5-03` + `wfl-p6-02` — usunięcie seedowanej definicji je naprawia (fallback = stan sprzed zmiany).
- **Fixtures load** zwalidowany na throwaway DB: reviewer@demo (approver), 0 workflow_definitions.

## Quality gates
- PHPStan max: 0 (AppFixtures + MeEndpointTest). cs-fixer: czysto. deptrac: 0 errors (brak importu Workflow). Reszta w CI.

## Live-smoke (dev stack, flaga ON) — PROOF
1. `/api/auth/me` → `feature_flags: {workflow_custom_definitions: true}`.
2. **Configured path**: definicja „Przepływ — Produkt" (reviewer catalog_manager) → submit → task `assignee_role_code=catalog_manager` → catalog_manager user widzi w „Moje zadania".
3. **Fallback path** (jak seed): definicja disabled → submit → task `assignee_role_code=approver` → approver user widzi w „Moje zadania".
(artefakty smoke posprzątane; definicja operatora przywrócona do enabled/catalog_manager).

## Smoke test plan (operator)
1. Login (admin@demo.localhost / changeme). Sidebar → „Ustawienia przepływu" jest teraz widoczne.
2. Po `pim:db:reset` → zaloguj jako `reviewer@demo.localhost` / changeme → „Moje zadania" pokazuje review taski (routowane do `approver`).
3. Skonfiguruj reviewera per ObjectType w „Ustawienia przepływu" → nowe zgłoszenia routują do wybranej roli/usera.

## Świadome odejścia
- Per-tenant writable toggle flagi = follow-up (plan WFL redesign). Tu włączamy globalnie.
- Brak seedowanej definicji per powyższe (kolizja ze specami); reviewer-persona przez fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
