### PR TITLE
fix(workflow): block submit_for_review when required fields missing + translate blocker tooltip (#2558)

### DIFF
--- a/apps/admin/e2e/wfl-dashboard-my-tasks.spec.ts
+++ b/apps/admin/e2e/wfl-dashboard-my-tasks.spec.ts
@@ -31,8 +31,19 @@ test('dashboard My Tasks widget: inline approve closes the review task', async (
   if (productType === undefined) throw new Error('No product ObjectType seeded.');
 
   const sku = uniqueSku('WFL-DASH');
+  // #2558 — required attributes must be present or submit_for_review is
+  // blocked; fill them so the review task can be created.
   const created = await page.request.post('/api/products', {
-    data: { code: sku, objectTypeId: productType.id },
+    data: {
+      code: sku,
+      objectTypeId: productType.id,
+      attributes: {
+        sku,
+        name: `Dashboard ${sku}`,
+        description: 'Opis do przeglądu',
+        price: { amount: 49, currency: 'PLN' },
+      },
+    },
     headers: { ...auth, 'content-type': 'application/ld+json' },
   });
   expect(created.status(), 'create draft product').toBe(201);

--- a/apps/admin/e2e/wfl-p3-01-workflow-status-control.spec.ts
+++ b/apps/admin/e2e/wfl-p3-01-workflow-status-control.spec.ts
@@ -37,8 +37,20 @@ test('workflow control: submit -> approve loop with history on product detail', 
   );
   if (productType === undefined) throw new Error('No product ObjectType seeded.');
 
+  // #2558 — required attributes must be present or submit_for_review is
+  // blocked; fill them so the status-control loop can submit.
+  const e2eSku = uniqueSku('WFL-E2E');
   const createResponse = await page.request.post('/api/objects', {
-    data: { code: uniqueSku('WFL-E2E'), objectTypeId: productType.id },
+    data: {
+      code: e2eSku,
+      objectTypeId: productType.id,
+      attributes: {
+        sku: e2eSku,
+        name: `Status ${e2eSku}`,
+        description: 'Opis do przeglądu',
+        price: { amount: 10, currency: 'PLN' },
+      },
+    },
     headers: { ...bearer, 'content-type': 'application/ld+json' },
   });
   expect(createResponse.status()).toBe(201);

--- a/apps/admin/e2e/wfl-p3-02-review-queue.spec.ts
+++ b/apps/admin/e2e/wfl-p3-02-review-queue.spec.ts
@@ -34,8 +34,19 @@ test('review queue lists a submitted object and approve clears it', async ({ pag
   if (productType === undefined) throw new Error('No product ObjectType seeded.');
 
   const sku = uniqueSku('WFL-Q');
+  // #2558 — required attributes must be present or submit_for_review is
+  // blocked; fill them so the object reaches the review queue.
   const createResponse = await page.request.post('/api/objects', {
-    data: { code: sku, objectTypeId: productType.id },
+    data: {
+      code: sku,
+      objectTypeId: productType.id,
+      attributes: {
+        sku,
+        name: `Queue ${sku}`,
+        description: 'Opis do przeglądu',
+        price: { amount: 20, currency: 'PLN' },
+      },
+    },
     headers: { ...bearer, 'content-type': 'application/ld+json' },
   });
   expect(createResponse.status()).toBe(201);

--- a/apps/admin/e2e/wfl-p6-02-collaboration-loop.spec.ts
+++ b/apps/admin/e2e/wfl-p6-02-collaboration-loop.spec.ts
@@ -73,8 +73,20 @@ test('editorial loop across marketing and approver, plus axe on the hub', async 
   if (productType === undefined) throw new Error('No product ObjectType seeded.');
 
   const sku = uniqueSku('WFL-LOOP');
+  // #2558 — the product must carry its required attributes (sku/name/
+  // description/price) or submit_for_review is now blocked. Fill them at
+  // creation so the editorial loop can proceed.
   const created = await marketing.page.request.post('/api/products', {
-    data: { code: sku, objectTypeId: productType.id },
+    data: {
+      code: sku,
+      objectTypeId: productType.id,
+      attributes: {
+        sku,
+        name: `Loop ${sku}`,
+        description: 'Opis produktu do przeglądu',
+        price: { amount: 99, currency: 'PLN' },
+      },
+    },
     headers: { ...marketingAuth, 'content-type': 'application/ld+json' },
   });
   expect(created.status(), 'marketing creates draft').toBe(201);

--- a/apps/admin/src/features/catalog/products/components/workflow-modal.tsx
+++ b/apps/admin/src/features/catalog/products/components/workflow-modal.tsx
@@ -226,11 +226,21 @@ export function WorkflowModal({
                       <span>{button}</span>
                     </TooltipTrigger>
                     <TooltipContent className="max-w-xs">
-                      {transition.blockers.map((blocker) => (
-                        <p key={blocker.code} className="text-xs">
-                          {blocker.message}
-                        </p>
-                      ))}
+                      {transition.blockers.map((blocker) => {
+                        // #2558 — localize by blocker code from the guard's
+                        // structured params; fall back to the raw message for
+                        // codes without a translation (e.g. permission codes).
+                        const missing = blocker.parameters?.missing_required;
+                        return (
+                          <p key={blocker.code} className="text-xs">
+                            {t(`workflow.blocker.${blocker.code}`, {
+                              defaultValue: blocker.message,
+                              ...blocker.parameters,
+                              missing: Array.isArray(missing) ? missing.join(', ') : '',
+                            })}
+                          </p>
+                        );
+                      })}
                     </TooltipContent>
                   </Tooltip>
                 );

--- a/apps/admin/src/lib/workflow/api.ts
+++ b/apps/admin/src/lib/workflow/api.ts
@@ -12,7 +12,12 @@ export interface WorkflowTransitionOption {
   name: string;
   to: string;
   enabled: boolean;
-  blockers: { code: string; message: string }[];
+  /**
+   * #2558 — `parameters` carries the guard's structured data (e.g.
+   * `missing_required`, `min_completeness_pct`) so the UI can render a
+   * localized tooltip instead of the raw English `message`.
+   */
+  blockers: { code: string; message: string; parameters?: Record<string, unknown> }[];
 }
 
 /** #2521 — the recipient a review task will land on (role or a person). */

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -4073,6 +4073,10 @@
       "published": "Published",
       "archived": "Archived"
     },
+    "blocker": {
+      "completeness_gate": "Completeness below the publish gate (min {{min_completeness_pct}}%). Fill the required fields: {{missing}}.",
+      "missing_required": "To submit for review, fill the required fields: {{missing}}."
+    },
     "transition": {
       "submit_for_review": "Submit for review",
       "publish": "Publish",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -4093,6 +4093,10 @@
       "published": "Opublikowany",
       "archived": "Zarchiwizowany"
     },
+    "blocker": {
+      "completeness_gate": "Kompletność poniżej progu publikacji (min. {{min_completeness_pct}}%). Uzupełnij wymagane pola: {{missing}}.",
+      "missing_required": "Aby zgłosić do przeglądu, uzupełnij wymagane pola: {{missing}}."
+    },
     "transition": {
       "submit_for_review": "Zgłoś do przeglądu",
       "publish": "Opublikuj",

--- a/apps/api/src/Catalog/Infrastructure/Workflow/CompletenessGateGuard.php
+++ b/apps/api/src/Catalog/Infrastructure/Workflow/CompletenessGateGuard.php
@@ -27,6 +27,13 @@ final readonly class CompletenessGateGuard implements EventSubscriberInterface
     public const string BLOCKER_CODE = 'completeness_gate';
 
     /**
+     * #2558 — submit-time required-fields blocker. Distinct from the numeric
+     * publish gate: a product missing required attributes cannot be published,
+     * so it must not enter the review queue.
+     */
+    public const string BLOCKER_MISSING_REQUIRED = 'missing_required';
+
+    /**
      * @var list<string>
      */
     private const array GATED_TRANSITIONS = [
@@ -45,6 +52,24 @@ final readonly class CompletenessGateGuard implements EventSubscriberInterface
     {
         $subject = $event->getSubject();
         if (!$subject instanceof CatalogObject) {
+            return;
+        }
+
+        // #2558 — a product missing its ObjectType's required attributes cannot
+        // be published, so it must not be submittable for review either (else
+        // it strands a reviewer who can never approve it). This required-fields
+        // rule is independent of the numeric publish gate below and applies
+        // whenever the type declares required attributes.
+        if (ObjectEditorialWorkflow::TRANSITION_SUBMIT_FOR_REVIEW === $event->getTransition()->getName()) {
+            $missing = $this->missingRequiredCodes($subject);
+            if ([] !== $missing) {
+                $event->addTransitionBlocker(new TransitionBlocker(
+                    \sprintf('Fill the required fields before review: %s.', \implode(', ', $missing)),
+                    self::BLOCKER_MISSING_REQUIRED,
+                    ['missing_required' => $missing],
+                ));
+            }
+
             return;
         }
 
@@ -103,6 +128,12 @@ final readonly class CompletenessGateGuard implements EventSubscriberInterface
                 [] === $missing ? '' : ' Missing required: '.\implode(', ', $missing).'.',
             ),
             self::BLOCKER_CODE,
+            // #2558 — structured params so the SPA can render a localized
+            // message instead of the raw English blocker text.
+            [
+                'min_completeness_pct' => $minPct,
+                'missing_required' => $missing,
+            ],
         ));
     }
 

--- a/apps/api/src/Catalog/Presentation/Controller/ObjectWorkflowController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ObjectWorkflowController.php
@@ -261,7 +261,14 @@ final class ObjectWorkflowController
 
             $blockers = [];
             foreach ($workflow->buildTransitionBlockerList($object, $transition->getName()) as $blocker) {
-                $blockers[] = ['code' => $blocker->getCode(), 'message' => $blocker->getMessage()];
+                // #2558 — expose the guard's structured parameters (e.g.
+                // missing_required, min_completeness_pct) so the SPA renders a
+                // localized tooltip instead of the raw English message.
+                $blockers[] = [
+                    'code' => $blocker->getCode(),
+                    'message' => $blocker->getMessage(),
+                    'parameters' => $blocker->getParameters(),
+                ];
             }
 
             $described[] = [

--- a/apps/api/tests/Api/Catalog/ObjectWorkflowCompletenessGateApiTest.php
+++ b/apps/api/tests/Api/Catalog/ObjectWorkflowCompletenessGateApiTest.php
@@ -108,6 +108,57 @@ final class ObjectWorkflowCompletenessGateApiTest extends CatalogApiTestCase
     }
 
     #[Test]
+    public function submitForReviewBlockedWhenRequiredFieldsMissing(): void
+    {
+        // #2558 — a product missing required attributes must not enter review.
+        $this->setRequired(['ean']);
+        $id = $this->seedProduct('WFL-SUBMIT-BLOCK', completenessPct: 40);
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/objects/'.$id.'/workflow/transitions/submit_for_review');
+        self::assertResponseStatusCodeSame(409);
+        self::assertStringContainsString('ean', $response->getContent(false), '409 lists the missing required attribute');
+
+        // Discovery mirrors the blocker with its machine code + structured
+        // params (for the localized tooltip).
+        $body = $client->request('GET', '/api/objects/'.$id.'/workflow')->toArray();
+        $submit = null;
+        $transitions = $body['transitions'] ?? [];
+        self::assertIsArray($transitions);
+        foreach ($transitions as $transition) {
+            self::assertIsArray($transition);
+            if ('submit_for_review' === $transition['name']) {
+                $submit = $transition;
+            }
+        }
+        self::assertNotNull($submit);
+        self::assertFalse($submit['enabled']);
+        $blockers = $submit['blockers'];
+        self::assertIsArray($blockers);
+        $first = $blockers[0] ?? null;
+        self::assertIsArray($first);
+        self::assertSame('missing_required', $first['code'] ?? null);
+        $parameters = $first['parameters'] ?? null;
+        self::assertIsArray($parameters);
+        $missing = $parameters['missing_required'] ?? [];
+        self::assertIsArray($missing);
+        self::assertContains('ean', $missing);
+    }
+
+    #[Test]
+    public function submitForReviewAllowedWhenRequiredFieldsPresent(): void
+    {
+        // Same required rule, but the product now carries the value — submit
+        // proceeds (the numeric publish gate still applies later, at approve).
+        $this->setRequired(['ean']);
+        $id = $this->seedProduct('WFL-SUBMIT-OK', completenessPct: 40, indexed: ['ean' => '5901234123457']);
+
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/objects/'.$id.'/workflow/transitions/submit_for_review');
+        self::assertResponseIsSuccessful();
+    }
+
+    #[Test]
     public function malformedGateConfigIsRejectedWith422(): void
     {
         $client = $this->authenticatedClient();
@@ -159,13 +210,15 @@ final class ObjectWorkflowCompletenessGateApiTest extends CatalogApiTestCase
     }
 
     /**
-     * @param array<string, int> $perChannel
+     * @param array<string, int>   $perChannel
+     * @param array<string, mixed> $indexed    #2558 — denormalised attribute values to pin
      */
     private function seedProduct(
         string $code,
         int $completenessPct,
         array $perChannel = [],
         string $status = CatalogObject::STATUS_DRAFT,
+        array $indexed = [],
     ): string {
         $em = $this->em();
         $object = new CatalogObject($this->productType(), $code);
@@ -177,14 +230,20 @@ final class ObjectWorkflowCompletenessGateApiTest extends CatalogApiTestCase
 
         // The sync rebuild listener recomputes completeness on flush, so
         // the fixture value is pinned with raw SQL AFTER the flush (same
-        // pattern as the DASH attributes_indexed lesson).
+        // pattern as the DASH attributes_indexed lesson). The attribute
+        // index is pinned the same way so the required-fields guard sees it.
         $completeness = ['global' => $completenessPct];
         if ([] !== $perChannel) {
             $completeness['per_channel'] = $perChannel;
         }
         $em->getConnection()->executeStatement(
-            'UPDATE objects SET completeness = :c, completeness_pct = :pct WHERE id = :id',
-            ['c' => \json_encode($completeness, JSON_THROW_ON_ERROR), 'pct' => $completenessPct, 'id' => $object->getId()->toRfc4122()],
+            'UPDATE objects SET completeness = :c, completeness_pct = :pct, attributes_indexed = :ai WHERE id = :id',
+            [
+                'c' => \json_encode($completeness, JSON_THROW_ON_ERROR),
+                'pct' => $completenessPct,
+                'ai' => \json_encode($indexed, JSON_THROW_ON_ERROR),
+                'id' => $object->getId()->toRfc4122(),
+            ],
         );
         $em->clear();
 


### PR DESCRIPTION
## Summary
Naprawia dwa problemy zgłoszone przez operatora na produkcie w „W przeglądzie":
1. **Tooltip blockera po angielsku** — surowy `blocker.message` z backendu.
2. **Głębszy: pusty produkt wchodził do recenzji i zakleszczał się** — bramka completeness była tylko na `approve`/`publish`, nie na `submit_for_review`, więc produkt z niewypełnionymi wymaganymi polami trafiał do kolejki, a reviewer nie mógł go zatwierdzić.

Closes #2558.

## Backend changes
- `CompletenessGateGuard`: **gate `submit_for_review`** — blokuje gdy `ObjectType.completeness_rules.required` ma niewypełnione pola (blocker `missing_required`, param `missing_required`). Niezależne od % gate (dot. wymaganych pól). Wzbogaca też blocker `completeness_gate` o parametry (`min_completeness_pct`, `missing_required`).
- `ObjectWorkflowController`: serializuje `parameters` blockera w discovery.

## Frontend changes
- `lib/workflow/api.ts`: blocker type + `parameters?`.
- `workflow-modal.tsx`: tooltip przez `t('workflow.blocker.{code}', {defaultValue: message, ...params, missing})` — fallback na message dla kodów bez tłumaczenia (np. permission).
- i18n `workflow.blocker.completeness_gate` + `missing_required` (pl+en).

## e2e (świadomy wpływ)
- `wfl-p3-01`, `wfl-p3-02`, `wfl-p6-02`, `wfl-dashboard` tworzyły puste produkty i submitowały → teraz uzupełniają `sku/name/description/price` przed submitem. `wfl-p5-03` NIE submituje (bezpieczny), `wfl-p3-04` mockuje endpoint (bezpieczny).

## Blast radius (zweryfikowany)
- BE ApiTests submitujące (`WorkflowTasks/Security/Endpoints/Notifications`) używają built-in product type BEZ required rules (`BuiltInObjectTypeSeeder`), więc gate ich nie blokuje. `ObjectWorkflowCompletenessGateApiTest` używa `forceStatus` (nie submituje). required rules `[sku,name,description,price]` są tylko z `DemoCatalogSeeder` (demo/e2e).

## Quality gates
- PHPStan max 0, cs-fixer czysto, deptrac 0. tsc 0, Biome 0, i18n-parity OK (+2 klucze), max-lines bez regresji. OpenAPI: brak driftu (kształt blockera nie jest w spec). ApiTest: submit incomplete→409 `missing_required`+params, complete→200.

## Live-smoke (dev stack) — PROOF
- Pusty produkt → `submit_for_review` → **409** „Fill the required fields before review: sku, name, description, price."
- Discovery: `submit_for_review` `enabled:false`, blocker `{code: missing_required, parameters: {missing_required: [sku,name,description,price]}}`.
- Produkt z wypełnionymi `sku/name/description/price` → submit → **200**.

## Smoke test plan (operator)
1. Login. Weź pusty produkt (draft) → modal Workflow → „Zgłoś do przeglądu" jest teraz **wyłączony**, tooltip po polsku: „Aby zgłosić do przeglądu, uzupełnij wymagane pola: sku, name, description, price."
2. Uzupełnij wymagane pola → „Zgłoś do przeglądu" się odblokowuje.
3. Produkt w recenzji z brakami → tooltip „Zatwierdź" po polsku (kompletność + brakujące pola).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
