### PR TITLE
fix(admin): rename Pulpit→Workspace on home topbar + menu, drop disabled history icon

### DIFF
--- a/apps/admin/e2e/1420-sidebar-settings-subtree.spec.ts
+++ b/apps/admin/e2e/1420-sidebar-settings-subtree.spec.ts
@@ -45,7 +45,8 @@ test.describe('NUI-01 — settings subtree in main sidebar', () => {
     await page.goto('/dashboard');
 
     const nav = page.locator('nav').first();
-    await expect(nav.getByRole('link', { name: /dashboard|pulpit/i })).toBeVisible();
+    // The dashboard entry was renamed "Pulpit" → "Workspace" (#2561).
+    await expect(nav.getByRole('link', { name: 'Workspace', exact: true })).toBeVisible();
 
     // No CUSTOM tag anywhere in the sidebar — holds in every environment.
     await expect(nav.getByText('CUSTOM', { exact: true })).toHaveCount(0);

--- a/apps/admin/e2e/2561-home-topbar-workspace.spec.ts
+++ b/apps/admin/e2e/2561-home-topbar-workspace.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * #2561 — home page polish: the "Pulpit" concept is renamed to
+ * "Workspace" and the topbar loses its disabled "history soon"
+ * placeholder icon.
+ *
+ * Locks in three operator-requested changes on `/dashboard`:
+ *   1. the topbar breadcrumb reads just "Workspace" (the redundant
+ *      "/ Pulpit" segment was dropped from ROUTE_CRUMBS),
+ *   2. the left nav's first item (link → /dashboard) is labelled
+ *      "Workspace", not "Pulpit",
+ *   3. the greyed-out disabled history button is gone — the active
+ *      BulkSessionsPopover already covers the rollback/history surface
+ *      (it self-hides under webdriver, so we only assert the removal).
+ */
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    // Seed the i18next detector so the app resolves to `pl` regardless of
+    // the Playwright profile locale (default en-US renders EN labels).
+    window.localStorage.setItem('i18nextLng', 'pl');
+  });
+});
+
+test('#2561 — home topbar shows Workspace breadcrumb, no Pulpit, no disabled history icon', async ({
+  page,
+}) => {
+  await loginAsAdmin(page);
+
+  // Attach the listener only AFTER login: the unauthenticated login screen
+  // legitimately probes /api/auth/refresh (HttpOnly cookie is invisible
+  // client-side) and that bootstrap 401 is out of scope (see #2199). We
+  // also drop "Failed to load resource" lines — those are browser network
+  // logs (the auth-bootstrap 401 race), not JS/React errors, which is what
+  // this smoke assertion actually guards.
+  const consoleErrors: string[] = [];
+  page.on('console', (message) => {
+    if (message.type() !== 'error') return;
+    if (message.text().includes('Failed to load resource')) return;
+    consoleErrors.push(message.text());
+  });
+
+  await page.goto('/dashboard');
+
+  // 1. Breadcrumb — single "Workspace" segment, no "Pulpit".
+  const breadcrumb = page.getByRole('navigation', { name: 'breadcrumb' });
+  await expect(breadcrumb).toBeVisible();
+  await expect(breadcrumb).toHaveText('Workspace');
+  await expect(breadcrumb.getByText('Pulpit')).toHaveCount(0);
+
+  // 2. Left menu — the dashboard entry is now "Workspace"; "Pulpit" is gone.
+  const menuLink = page.getByRole('link', { name: 'Workspace', exact: true });
+  await expect(menuLink.first()).toBeVisible();
+  await expect(menuLink.first()).toHaveAttribute('href', '/dashboard');
+  await expect(page.getByRole('link', { name: 'Pulpit' })).toHaveCount(0);
+
+  // 3. No disabled "history soon" placeholder button in the topbar.
+  await expect(page.getByRole('button', { name: 'Historia', exact: true })).toHaveCount(0);
+
+  expect(consoleErrors).toEqual([]);
+});

--- a/apps/admin/e2e/golive-2126-browser-matrix.spec.ts
+++ b/apps/admin/e2e/golive-2126-browser-matrix.spec.ts
@@ -13,7 +13,7 @@ import { expect, test } from '@playwright/test';
 import { loginAsAdmin } from './helpers/auth';
 
 const CRITICAL_VIEWS: Array<{ name: string; path: string; expect: RegExp }> = [
-  { name: 'dashboard', path: '/dashboard', expect: /pulpit|dashboard|witaj|welcome/i },
+  { name: 'dashboard', path: '/dashboard', expect: /workspace|pulpit|dashboard|witaj|welcome/i },
   { name: 'products', path: '/products', expect: /produkt|product/i },
   { name: 'modeling', path: '/modeling', expect: /modelowanie|modeling|atrybut|attribute/i },
   { name: 'imports', path: '/integrations/imports', expect: /import/i },

--- a/apps/admin/e2e/modeling-shell.spec.ts
+++ b/apps/admin/e2e/modeling-shell.spec.ts
@@ -54,7 +54,7 @@ test('Modeling shell + Dashboard mock — full handoff smoke', async ({ page }) 
   await expect(sidebar).toBeVisible();
 
   for (const label of [
-    /^dashboard$|^pulpit$/i,
+    /^workspace$/i,
     /^products$|^produkty$/i,
     /^pdf catalogs$|^katalogi pdf$/i,
     /^multimedia$/i,
@@ -63,7 +63,10 @@ test('Modeling shell + Dashboard mock — full handoff smoke', async ({ page }) 
     /^settings$|^ustawienia$/i,
     /^modeling$|^modelowanie$/i,
   ]) {
-    await expect(sidebar.getByText(label)).toBeVisible();
+    // `.first()` — after the Pulpit→Workspace rename (#2561) the sidebar has
+    // both a "Workspace" section header and the "Workspace" dashboard leaf;
+    // the loop only needs to confirm the entry renders.
+    await expect(sidebar.getByText(label).first()).toBeVisible();
   }
 
   // VIEW-08 (#427): Services removed from default sidebar seed (operator
@@ -231,7 +234,7 @@ test('Modeling shell + Dashboard mock — full handoff smoke', async ({ page }) 
   await expect(settingsRow.getByRole('button', { name: /ukryj|hide/i })).toHaveCount(0);
   const dashboardRow = visibleList
     .locator('> div')
-    .filter({ has: page.locator('span.flex-1', { hasText: /^(pulpit|dashboard)$/i }) });
+    .filter({ has: page.locator('span.flex-1', { hasText: /^workspace$/i }) });
   await expect(dashboardRow.getByRole('button', { name: /ukryj|hide/i })).toBeVisible();
 
   // Asset toggle is locked on its detail page.

--- a/apps/admin/src/layout/topbar-v2.tsx
+++ b/apps/admin/src/layout/topbar-v2.tsx
@@ -1,7 +1,5 @@
-import { History } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { type BreadcrumbItem, PageHeader } from '@/components/ui-v2/page-header';
 
 import { BulkSessionsPopover } from './bulk-sessions-popover';
@@ -34,7 +32,6 @@ const ROUTE_CRUMBS: RouteCrumb[] = [
     segments: [{ key: 'nav.integrations', href: '/integrations' }, { key: 'nav.api_configurator' }],
   },
   { match: /^\/integrations/, segments: [{ key: 'nav.integrations' }] },
-  { match: /^\/dashboard/, segments: [{ key: 'nav.dashboard' }] },
   { match: /^\/products/, segments: [{ key: 'nav.products' }] },
   { match: /^\/modeling/, segments: [{ key: 'nav.modeling' }] },
   { match: /^\/assets/, segments: [{ key: 'nav.multimedia' }] },
@@ -45,8 +42,10 @@ const ROUTE_CRUMBS: RouteCrumb[] = [
 /**
  * Global topbar v2 (EXR-03): ui-v2 PageHeader breadcrumb + per-page
  * action slot (PageActionsContext) + fixed actions (language switcher,
- * disabled history icon, notifications). The audit-log status pill was
- * removed in VIEW-13 (#2143) per operator decision.
+ * bulk-sessions rollback, notifications). The audit-log status pill was
+ * removed in VIEW-13 (#2143) per operator decision; the disabled
+ * "history soon" placeholder icon was removed once BulkSessionsPopover
+ * covered the same rollback/history surface.
  */
 export function TopbarV2() {
   const { t } = useTranslation();
@@ -67,19 +66,6 @@ export function TopbarV2() {
         <>
           {pageActions}
           <LanguageSwitcher />
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                disabled
-                aria-label={t('topbar.history', { defaultValue: 'Historia' })}
-                className="grid h-9 w-9 cursor-not-allowed place-items-center rounded-xl text-zinc-300"
-              >
-                <History className="size-4" aria-hidden />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>{t('ui_v2.soon_tooltip')}</TooltipContent>
-          </Tooltip>
           <BulkSessionsPopover />
           <NotificationsBell />
         </>

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -88,7 +88,7 @@
     }
   },
   "nav": {
-    "dashboard": "Dashboard",
+    "dashboard": "Workspace",
     "products": "Products",
     "services": "Services",
     "catalogsPdf": "PDF Catalogs",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -88,7 +88,7 @@
     }
   },
   "nav": {
-    "dashboard": "Pulpit",
+    "dashboard": "Workspace",
     "products": "Produkty",
     "services": "Usługi",
     "catalogsPdf": "Katalogi PDF",


### PR DESCRIPTION
## Summary

Trzy drobne poprawki UI strony głównej (`/dashboard`) — koncept „Pulpit" przemianowany na „Workspace":

1. Breadcrumb górnej belki pokazuje samo **„Workspace"** (usunięto zbędny segment „/ Pulpit").
2. Pozycja w lewym menu (link → `/dashboard`) to teraz **„Workspace"**, nie „Pulpit".
3. Usunięto **zaszarzoną, nieaktywną ikonę zegarka‑wstecz** (placeholder „Historia — wkrótce") — aktywny `BulkSessionsPopover` pełni tę samą funkcję (rollback/historia sesji bulk).

## Root cause

Zbędny/niedokończony UI, nie regresja. `topbar-v2.tsx` doklejał segment `nav.dashboard` na `/dashboard` do zawsze‑obecnego „Workspace"; pozycja menu używała `nav.dashboard` = „Pulpit"; górna belka renderowała `disabled` przycisk `History` obok działającego popovera.

## Backend changes

Brak — zmiana czysto frontendowa.

## Frontend changes

- `topbar-v2.tsx`: usunięta reguła `/dashboard` z `ROUTE_CRUMBS`; usunięty wyłączony przycisk `History` + nieużywane importy (`History`, `Tooltip*`); zaktualizowany docblock.
- `locales/pl.json` + `locales/en.json`: `nav.dashboard` → „Workspace" (spójnie obejmuje też etykietę Cmd+K).
- `e2e/2561-home-topbar-workspace.spec.ts`: nowy spec (breadcrumb „Workspace" bez „Pulpit", link menu „Workspace" → `/dashboard`, brak przycisku „Historia").

## Quality gates

- Biome strict: 0 błędów.
- `tsc -b --noEmit`: 0 błędów.
- Vite build: OK.
- Playwright: `2561-home-topbar-workspace.spec.ts` zielony lokalnie (live stack).

## Smoke test plan

- [ ] Login `admin@demo.localhost / changeme` → `/dashboard`.
- [ ] Górna belka: breadcrumb = „Workspace" (bez „/ Pulpit").
- [ ] Lewe menu: pierwsza pozycja „Workspace".
- [ ] Górna belka: brak zaszarzonej ikony zegarka‑wstecz; aktywna ikona rollbacku obecna gdy są sesje.
- [ ] DevTools Console: brak czerwonych errorów.

Smoke-test lokalny przez Playwright na żywym stacku przeszedł; manualny smoke na `https://pim.localhost` wykonam po merge (per SMOKE TEST RULE).

## Świadome odejścia

- Klucz i18n `topbar.history` staje się osierocony — zostawiony w locales (nieszkodliwy). Ewentualne sprzątanie osobno.
- Zmiana `nav.dashboard` obejmuje też etykietę w Cmd+K — spójne „Workspace", zamierzone.

Closes #2561

🤖 Generated with [Claude Code](https://claude.com/claude-code)
