### PR TITLE
feat(cpdf): rename module Katalogi PDF → Web To Print

### DIFF
--- a/apps/admin/e2e/cpdf-shell.spec.ts
+++ b/apps/admin/e2e/cpdf-shell.spec.ts
@@ -25,7 +25,7 @@ test('CPDF-P5-01 — catalogs shell: tabs, empty state, templates, a11y', async 
   await page.goto('/catalogs-pdf');
 
   // Header + both pill tabs render (bilingual-tolerant).
-  await expect(page.getByRole('heading', { name: /katalogi pdf|pdf catalogs/i })).toBeVisible();
+  await expect(page.getByRole('heading', { name: /web to print/i })).toBeVisible();
   const catalogsTab = page.getByRole('tab', { name: /^katalogi$|^catalogs$/i });
   const templatesTab = page.getByRole('tab', { name: /^szablony$|^templates$/i });
   await expect(catalogsTab).toBeVisible();

--- a/apps/admin/e2e/modeling-shell.spec.ts
+++ b/apps/admin/e2e/modeling-shell.spec.ts
@@ -56,7 +56,7 @@ test('Modeling shell + Dashboard mock — full handoff smoke', async ({ page }) 
   for (const label of [
     /^workspace$/i,
     /^products$|^produkty$/i,
-    /^pdf catalogs$|^katalogi pdf$/i,
+    /^web to print$/i,
     /^multimedia$/i,
     /^workflow$/i,
     /^integrations$|^integracje$/i,

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -91,7 +91,7 @@
     "dashboard": "Workspace",
     "products": "Products",
     "services": "Services",
-    "catalogsPdf": "PDF Catalogs",
+    "catalogsPdf": "Web To Print",
     "multimedia": "Multimedia",
     "workflow": "Workflow",
     "integrations": "Integrations",
@@ -1008,7 +1008,7 @@
     }
   },
   "catalogs_pdf": {
-    "page_title": "PDF Catalogs",
+    "page_title": "Web To Print",
     "placeholder_title": "Coming soon",
     "placeholder_description": "PDF catalog generation is in the backlog. Scope will be defined in a separate ticket.",
     "tabs_aria": "PDF catalog sections",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -91,7 +91,7 @@
     "dashboard": "Workspace",
     "products": "Produkty",
     "services": "Usługi",
-    "catalogsPdf": "Katalogi PDF",
+    "catalogsPdf": "Web To Print",
     "multimedia": "Multimedia",
     "workflow": "Workflow",
     "integrations": "Integracje",
@@ -1018,7 +1018,7 @@
     }
   },
   "catalogs_pdf": {
-    "page_title": "Katalogi PDF",
+    "page_title": "Web To Print",
     "placeholder_title": "W przygotowaniu",
     "placeholder_description": "Generowanie katalogów PDF jest na liście backlogu. Scope ustalimy w osobnym tickecie.",
     "tabs_aria": "Sekcje katalogów PDF",


### PR DESCRIPTION
## Summary
Zmiana nazwy modułu **Katalogi PDF** → **Web To Print** wszędzie w UI (sidebar, nagłówek strony, breadcrumb), pl + en. „Web To Print" to nazwa brandowa — ten sam string w obu locale.

## Zakres
- `nav.catalogsPdf` (label w menu + breadcrumb `/catalogs-pdf`) → „Web To Print".
- `catalogs_pdf.page_title` (H1) → „Web To Print".
- Indywidualne „katalog"/„Nowy katalog" bez zmian (odnoszą się do pojedynczego katalogu, nie modułu).
- Route `/catalogs-pdf` i API bez zmian.
- Specy: `cpdf-shell` (asercja nagłówka) + `modeling-shell` (leaf sidebara) zaktualizowane.

## Quality gates
- Biome: 0. Playwright `cpdf-shell` zielony lokalnie.

Closes #2565

🤖 Generated with [Claude Code](https://claude.com/claude-code)