### PR TITLE
fix(workflow): pokaż „Workflow” w breadcrumbie /workflow

### DIFF
--- a/apps/admin/e2e/wfl-p3-02-review-queue.spec.ts
+++ b/apps/admin/e2e/wfl-p3-02-review-queue.spec.ts
@@ -60,6 +60,9 @@ test('review queue lists a submitted object and approve clears it', async ({ pag
 
   await page.goto('/workflow');
   await expect(page.getByTestId('review-queue-page')).toBeVisible();
+  // #2575 — the topbar breadcrumb reads "Workflow" on /workflow (was the bare
+  // "Workspace" root before the route crumb was added).
+  await expect(page.getByRole('navigation', { name: 'breadcrumb' })).toContainText('Workflow');
 
   const row = page.getByTestId('review-queue-row').filter({ hasText: sku });
   await expect(row).toBeVisible();

--- a/apps/admin/src/layout/topbar-v2.tsx
+++ b/apps/admin/src/layout/topbar-v2.tsx
@@ -33,6 +33,7 @@ const ROUTE_CRUMBS: RouteCrumb[] = [
   },
   { match: /^\/integrations/, segments: [{ key: 'nav.integrations' }] },
   { match: /^\/products/, segments: [{ key: 'nav.products' }] },
+  { match: /^\/workflow/, segments: [{ key: 'nav.workflow' }] },
   { match: /^\/modeling/, segments: [{ key: 'nav.modeling' }] },
   { match: /^\/assets/, segments: [{ key: 'nav.multimedia' }] },
   { match: /^\/catalogs-pdf/, segments: [{ key: 'nav.catalogsPdf' }] },


### PR DESCRIPTION
## Summary
Na `/workflow` breadcrumb pokazywał tylko goły root **„Workspace"** (brak wpisu w `ROUTE_CRUMBS`). Dodany crumb → **„Workspace / Workflow"**, spójnie z każdą inną sekcją.

## Zmiana
- `topbar-v2` ROUTE_CRUMBS: `{ match: /^\/workflow/, segments: [{ key: 'nav.workflow' }] }` (klucz `nav.workflow` = „Workflow" już istnieje pl+en).
- `wfl-p3-02-review-queue`: asercja breadcrumbu zawiera „Workflow".

## Quality gates
- Biome 0. Lokalny smoke: breadcrumb `/workflow` = „Workspace / Workflow".

Closes #2575

🤖 Generated with [Claude Code](https://claude.com/claude-code)