### PR TITLE
fix(api-configurator): domyślnie otwieraj zakładkę „Połączenia”

### DIFF
--- a/apps/admin/e2e/1796-api-producer-hub.spec.ts
+++ b/apps/admin/e2e/1796-api-producer-hub.spec.ts
@@ -73,7 +73,9 @@ test('APIC-P4-06 — producer hub: profiles / keys / webhooks tabs', async ({ pa
     }),
   );
 
-  await page.goto('/integrations/api-configurator');
+  // #2576 — the producer hub moved off the configurator landing (which now
+  // redirects to the Połączenia tab) to its own /producer path.
+  await page.goto('/integrations/api-configurator/producer');
 
   await expect(page.getByRole('heading', { name: /moje api|my api/i })).toBeVisible();
 

--- a/apps/admin/e2e/1798-api-shell-unify.spec.ts
+++ b/apps/admin/e2e/1798-api-shell-unify.spec.ts
@@ -31,19 +31,21 @@ test('APIC-P4-08 — unified shell: navigate across producer / consumer / monito
     );
   }
 
-  // Producer hub is the configurator landing.
+  // #2576 — the configurator landing redirects to the Połączenia (connections)
+  // tab, the configured first face.
   await page.goto('/integrations/api-configurator');
-  await expect(page.getByRole('heading', { name: /moje api|my api/i })).toBeVisible();
+  await expect(page).toHaveURL(/\/connections$/);
+  await expect(page.getByRole('heading', { name: /^połączenia$|^connections$/i })).toBeVisible();
 
   // a11y on the unified shell at rest (each face is audited in its own E2E;
   // here we check the shell landing before exercising cross-face navigation).
   const a11y = await new AxeBuilder({ page }).analyze();
   expect(a11y.violations).toEqual([]);
 
-  // → Consumer side (Połączenia).
-  await page.getByRole('tab', { name: /^połączenia$|^connections$/i }).click();
-  await expect(page).toHaveURL(/\/connections$/);
-  await expect(page.getByRole('heading', { name: /^połączenia$|^connections$/i })).toBeVisible();
+  // → Producer face (Moje API), now on its own /producer path.
+  await page.getByRole('tab', { name: /^moje api$|^my api$/i }).click();
+  await expect(page).toHaveURL(/\/producer$/);
+  await expect(page.getByRole('heading', { name: /moje api|my api/i })).toBeVisible();
 
   // → Monitor.
   await page.getByRole('tab', { name: /^monitor$/i }).click();
@@ -52,8 +54,8 @@ test('APIC-P4-08 — unified shell: navigate across producer / consumer / monito
     page.getByRole('heading', { name: /monitor synchronizacji|sync monitor/i }),
   ).toBeVisible();
 
-  // → back to the producer face.
-  await page.getByRole('tab', { name: /^moje api$|^my api$/i }).click();
-  await expect(page).toHaveURL(/\/api-configurator$/);
-  await expect(page.getByRole('heading', { name: /moje api|my api/i })).toBeVisible();
+  // → back to Połączenia.
+  await page.getByRole('tab', { name: /^połączenia$|^connections$/i }).click();
+  await expect(page).toHaveURL(/\/connections$/);
+  await expect(page.getByRole('heading', { name: /^połączenia$|^connections$/i })).toBeVisible();
 });

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -766,7 +766,16 @@ function App() {
                   <Route path="/integrations/imports/new" element={<ImportWizardPage />} />
                   <Route path="/integrations/imports/:id" element={<ImportShowPage />} />
                   <Route element={<KonfiguratorApiLayout />}>
-                    <Route path="/integrations/api-configurator" element={<ProducerHubPage />} />
+                    {/* #2576 — the configurator opens on the Połączenia
+                        (connections) tab; the producer hub gets its own path. */}
+                    <Route
+                      path="/integrations/api-configurator"
+                      element={<Navigate to="/integrations/api-configurator/connections" replace />}
+                    />
+                    <Route
+                      path="/integrations/api-configurator/producer"
+                      element={<ProducerHubPage />}
+                    />
                     <Route
                       path="/integrations/api-configurator/create"
                       element={<ApiProfileCreatePage />}

--- a/apps/admin/src/features/api-configurator/layout/KonfiguratorApiLayout.tsx
+++ b/apps/admin/src/features/api-configurator/layout/KonfiguratorApiLayout.tsx
@@ -37,7 +37,9 @@ export function KonfiguratorApiLayout() {
         ariaLabel={t('api_configurator.shell.tabs_aria')}
         activeId={activeId}
         onChange={(id) => {
-          void navigate(id === 'producer' ? BASE : `${BASE}/${id}`);
+          // #2576 — the configurator landing (BASE) redirects to the
+          // connections tab, so the producer face has its own /producer path.
+          void navigate(`${BASE}/${id}`);
         }}
         items={[
           { id: 'connections', label: t('api_configurator.shell.tabs.connections') },


### PR DESCRIPTION
## Summary
Po kliknięciu w menu `Konfigurator API` (`/integrations/api-configurator`) otwierał się hub producenta („Moje API"). Teraz landing przekierowuje na **„Połączenia"** (pierwsza zakładka shella), a hub producenta dostaje własną trasę `/producer`.

## Zmiany
- `App.tsx`: `/integrations/api-configurator` → `<Navigate to=".../connections" replace />`; dodana trasa `/integrations/api-configurator/producer` → `ProducerHubPage`.
- `KonfiguratorApiLayout`: `onChange` producenta nawiguje do `/producer` (BASE przekierowuje). Highlight w sidebarze bez zmian (matchuje prefix `/api-configurator`).
- Specy: `1796` (goto `/producer`), `1798` (flow: landing = Połączenia → Moje API `/producer` → Monitor → Połączenia).

## Quality gates
- Biome 0, tsc 0. Lokalny smoke: menu → `/connections`, aktywna zakładka „Połączenia".

Closes #2576

🤖 Generated with [Claude Code](https://claude.com/claude-code)