### PR TITLE
chore(channels): usuń pustą zakładkę „Podgląd” z detalu kanału

### DIFF
--- a/apps/admin/src/features/channel/channels/show.tsx
+++ b/apps/admin/src/features/channel/channels/show.tsx
@@ -18,9 +18,10 @@ interface ChannelDetail {
   categoryTreeRootId?: string | null;
 }
 
-type TabKey = 'overview' | 'channelTree' | 'categoryMapping' | 'preview';
+type TabKey = 'overview' | 'channelTree' | 'categoryMapping';
 
-const TABS: TabKey[] = ['overview', 'channelTree', 'categoryMapping', 'preview'];
+// #2577 — the empty "Podgląd" (preview) placeholder tab was removed.
+const TABS: TabKey[] = ['overview', 'channelTree', 'categoryMapping'];
 
 export function ChannelShowPage() {
   const { t } = useTranslation();
@@ -89,11 +90,7 @@ export function ChannelShowPage() {
       ) : (
         <Card>
           <CardContent className="pt-6">
-            {activeTab === 'overview' ? (
-              <OverviewTab channel={channel} />
-            ) : (
-              <PlaceholderTab tab="preview" />
-            )}
+            <OverviewTab channel={channel} />
           </CardContent>
         </Card>
       )}
@@ -115,11 +112,6 @@ function OverviewTab({ channel }: { channel: ChannelDetail }) {
       ) : null}
     </dl>
   );
-}
-
-function PlaceholderTab({ tab }: { tab: 'preview' }) {
-  const { t } = useTranslation();
-  return <p className="text-sm text-muted-foreground">{t(`channels.show.placeholder.${tab}`)}</p>;
 }
 
 function Row({ label, children }: { label: string; children: React.ReactNode }) {


### PR DESCRIPTION
## Summary
Zakładka **„Podgląd"** (preview) na detalu kanału (`/modeling/channels/{id}`) renderowała pusty placeholder bez funkcji. Usunięta — zostają: Przegląd / Drzewo kanału / Mapowanie kategorii.

## Zmiana
- `channel/channels/show.tsx`: usunięty `'preview'` z `TabKey` + `TABS`, uproszczony render (else = Overview), usunięta funkcja `PlaceholderTab`.
- Osierocone klucze i18n (`channels.show.tabs.preview`, `.placeholder.preview`) zostawione, żeby nie kolidować z równoległym PR #2571 (locale) — nieszkodliwe, do sprzątnięcia osobno.

## Quality gates
- Biome 0, tsc 0. Brak speców asertujących zakładkę „Podgląd" kanału (zweryfikowane grepem). Trywialne usunięcie martwego placeholdera.

Closes #2577

🤖 Generated with [Claude Code](https://claude.com/claude-code)