### PR TITLE
feat(cpdf): mapowanie pól przez dropdown atrybutów

### DIFF
--- a/apps/admin/e2e/cpdf-wizard.spec.ts
+++ b/apps/admin/e2e/cpdf-wizard.spec.ts
@@ -27,8 +27,21 @@ test('CPDF-P5-02 — catalog wizard: steps, generate, navigate back, a11y', asyn
       json: { member: [{ id: PRODUCT_OT_ID, code: 'product', kind: 'product', builtIn: true }] },
     }),
   );
-  // Attribute catalog for the filter panel — keep it empty + deterministic.
-  await page.route('**/api/attributes**', (route) => route.fulfill({ json: { member: [] } }));
+  // Attribute catalog for the filter panel + the field-mapping pickers (#2570).
+  // Includes the default mapping targets so the prefilled slots resolve.
+  await page.route('**/api/attributes**', (route) =>
+    route.fulfill({
+      json: {
+        member: [
+          { id: 'a-name', code: 'name', label: { pl: 'Nazwa', en: 'Name' } },
+          { id: 'a-sku', code: 'sku', label: { pl: 'SKU', en: 'SKU' } },
+          { id: 'a-image', code: 'main_image', label: { pl: 'Zdjęcie', en: 'Image' } },
+          { id: 'a-desc', code: 'description', label: { pl: 'Opis', en: 'Description' } },
+          { id: 'a-price', code: 'price', label: { pl: 'Cena', en: 'Price' } },
+        ],
+      },
+    }),
+  );
 
   const previewCalls: unknown[] = [];
   await page.route('**/api/catalogs/preview', async (route) => {
@@ -80,8 +93,11 @@ test('CPDF-P5-02 — catalog wizard: steps, generate, navigate back, a11y', asyn
   await page.getByLabel(/nazwa firmy|company name/i).fill('Acme');
   await next.click();
 
-  // Step 4 — mapping: keep the prefilled defaults.
-  await expect(page.getByLabel(/nazwa produktu|product name/i)).toHaveValue('name');
+  // Step 4 — mapping: the attribute picker (#2570) is prefilled with the
+  // template default; the "title" slot resolves to the `name` attribute.
+  await expect(page.getByRole('button', { name: /nazwa produktu|product name/i })).toContainText(
+    'name',
+  );
   await next.click();
 
   // Step 5 — preview: refresh renders the mocked HTML sample.

--- a/apps/admin/src/components/catalog/attribute-picker.tsx
+++ b/apps/admin/src/components/catalog/attribute-picker.tsx
@@ -61,6 +61,11 @@ export interface AttributePickerProps {
    */
   systemFields?: ReadonlyArray<{ code: string; name: string; type?: string }>;
   placeholder?: string;
+  /**
+   * Accessible name for the trigger button when several pickers share the
+   * same placeholder (e.g. the catalog field-mapping step, #2570).
+   */
+  ariaLabel?: string;
   className?: string;
 }
 
@@ -77,6 +82,7 @@ export function AttributePicker({
   filterableOnly,
   systemFields,
   placeholder,
+  ariaLabel,
   className,
 }: AttributePickerProps) {
   const { t, i18n } = useTranslation();
@@ -219,6 +225,7 @@ export function AttributePicker({
         onClick={() => setOpen((prev) => !prev)}
         aria-haspopup="listbox"
         aria-expanded={open}
+        aria-label={ariaLabel}
         className="h-9 w-full inline-flex items-center justify-between gap-2 rounded-lg border border-zinc-200 bg-white px-3 text-[12.5px] hover:border-zinc-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900"
       >
         <span className="truncate text-left">{triggerLabel}</span>

--- a/apps/admin/src/features/catalogs-pdf/wizard/steps/StepMapping.tsx
+++ b/apps/admin/src/features/catalogs-pdf/wizard/steps/StepMapping.tsx
@@ -1,14 +1,16 @@
 import { useTranslation } from 'react-i18next';
 
+import { AttributePicker } from '@/components/catalog/attribute-picker';
+
 import { SHEET_SLOTS } from '../types';
 import { useCatalogWizard } from '../wizard-store';
 
 /**
  * CPDF-P5-02 step 4 — field mapping. For each `sheet` slot (title/sku/image/
- * description/price) a labelled attribute-code input, prefilled with the
- * template defaults (title→name, sku→sku, image→main_image, …). MVP keeps
- * this as free-text inputs — a full attribute picker is deferred; the BE
- * treats each ref as an attribute code. Empty inputs drop from the payload.
+ * description/price) an attribute picker (#2570 — replaced the free-text code
+ * input), prefilled with the template defaults (title→name, sku→sku,
+ * image→main_image, …). The BE treats each ref as an attribute code; an empty
+ * slot drops from the payload.
  */
 export function StepMapping() {
   const { t } = useTranslation();
@@ -23,24 +25,18 @@ export function StepMapping() {
 
       <div className="mt-5 space-y-3">
         {SHEET_SLOTS.map((slot) => {
-          const inputId = `catalog-mapping-${slot}`;
+          const slotLabel = t(`catalogs_pdf.wizard.slot.${slot}`);
           return (
             <div
               key={slot}
               className="grid grid-cols-1 items-center gap-2 sm:grid-cols-[180px_1fr]"
             >
-              <label htmlFor={inputId} className="text-[13px] font-medium text-ink">
-                {t(`catalogs_pdf.wizard.slot.${slot}`)}
-              </label>
-              <input
-                id={inputId}
-                type="text"
-                value={state.fieldMappings[slot]}
-                onChange={(event) =>
-                  dispatch({ type: 'SET_MAPPING', slot, ref: event.target.value })
-                }
+              <span className="text-[13px] font-medium text-ink">{slotLabel}</span>
+              <AttributePicker
+                value={state.fieldMappings[slot] || null}
+                onChange={(next) => dispatch({ type: 'SET_MAPPING', slot, ref: next?.code ?? '' })}
+                ariaLabel={slotLabel}
                 placeholder={t('catalogs_pdf.wizard.mapping_placeholder')}
-                className="focus-ring h-10 w-full rounded-xl border border-zinc-200 bg-surface px-3 font-mono text-[13px]"
               />
             </div>
           );

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1099,8 +1099,8 @@
       "branding_logo_label": "Logo URL",
       "branding_logo_hint": "A direct link to an image file (PNG/SVG).",
       "mapping_title": "Field mapping",
-      "mapping_subtitle": "Map the template slots to attribute codes. Defaults are prefilled — change them if needed.",
-      "mapping_placeholder": "attribute code",
+      "mapping_subtitle": "Map the template slots to attributes. Defaults are prefilled — change them if needed.",
+      "mapping_placeholder": "Choose attribute",
       "mapping_hint": "Empty slots are skipped during rendering.",
       "slot": {
         "title": "Product name",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1109,8 +1109,8 @@
       "branding_logo_label": "URL logo",
       "branding_logo_hint": "Bezpośredni odnośnik do pliku graficznego (PNG/SVG).",
       "mapping_title": "Mapowanie pól",
-      "mapping_subtitle": "Przypisz sloty szablonu do kodów atrybutów. Wartości domyślne są uzupełnione — możesz je zmienić.",
-      "mapping_placeholder": "kod atrybutu",
+      "mapping_subtitle": "Przypisz sloty szablonu do atrybutów. Wartości domyślne są uzupełnione — możesz je zmienić.",
+      "mapping_placeholder": "Wybierz atrybut",
       "mapping_hint": "Puste sloty zostaną pominięte podczas renderowania.",
       "slot": {
         "title": "Nazwa produktu",


### PR DESCRIPTION
## Summary
Krok „Mapowanie pól" kreatora katalogu miał wolne pola tekstowe, w które trzeba było **wpisać kod atrybutu**. Teraz każdy slot to **`AttributePicker`** (searchable dropdown atrybutów z `/api/attributes`, z ulubionymi) — zgodnie z #2570.

## Zmiany
- `StepMapping`: input → `AttributePicker` (value=kod, onChange→SET_MAPPING). Prefill defaultów (name/sku/main_image/description/price) rozwiązuje się na etykiety.
- `attribute-picker`: dodany opcjonalny prop `ariaLabel` (5 pickerów z tym samym placeholderem → rozróżnialne dla czytników ekranu).
- Locale: placeholder „kod atrybutu" → „Wybierz atrybut" (pl/en), subtitle „kodów atrybutów" → „atrybutów".
- `cpdf-wizard` spec: mock `/api/attributes` zwraca defaulty; asercja przez rolę przycisku pickera.

## Quality gates
- Biome 0, tsc 0. Playwright `cpdf-wizard` zielony lokalnie (walk do kroku mapowania + a11y).

Closes #2570

🤖 Generated with [Claude Code](https://claude.com/claude-code)