### PR TITLE
fix(assets): brak migotania ikon przy wejściu w katalog

### DIFF
--- a/apps/admin/src/features/asset/assets/list.tsx
+++ b/apps/admin/src/features/asset/assets/list.tsx
@@ -1,4 +1,5 @@
 import { useList } from '@refinedev/core';
+import { keepPreviousData } from '@tanstack/react-query';
 import {
   ArrowUp,
   Check,
@@ -136,6 +137,10 @@ export function AssetsListPage() {
     pagination: { mode: 'off' },
     filters: filterParams,
     queryOptions: {
+      // #2572 — keep the previous folder's thumbnails on screen while the new
+      // folder loads instead of flashing an empty grid (the "icons slide up
+      // and disappear, then reappear" flicker when entering a folder).
+      placeholderData: keepPreviousData,
       refetchInterval: (q) => {
         const data = q.state.data?.data as AssetEntry[] | undefined;
         return data?.some((item) => toAssetMeta(item).thumbnailsPending) ? POLL_INTERVAL_MS : false;


### PR DESCRIPTION
## Summary
Na `/assets` wejście w katalog powodowało migotanie — ikony zdjęć „podjeżdżały do góry i znikały", a dopiero potem pojawiała się zawartość folderu.

## Root cause
`useList` (Refine) refetchuje listę assetów przy zmianie folderu; podczas ładowania grid pokazywał pustkę (`assets = []`), więc stare miniatury znikały zanim nowe się załadowały (flash pustej listy + skok layoutu).

## Zmiana
- `assets/list.tsx`: `queryOptions.placeholderData: keepPreviousData` (`@tanstack/react-query`) — poprzedni grid zostaje na ekranie do przyjścia nowych assetów, płynna podmiana zamiast pustego flasha.

## Quality gates
- Biome 0, tsc 0. Playwright `1427-multimedia-explorer` (nawigacja folderów) zielony.
- Wizualna płynność (brak migotania) do potwierdzenia w manualnym smoke — zmiana timingu, trudna do deterministycznego E2E.

Closes #2572

🤖 Generated with [Claude Code](https://claude.com/claude-code)