### PR TITLE
feat(cpdf): edycja istniejącego katalogu

### DIFF
--- a/apps/admin/e2e/2566-catalog-edit.spec.ts
+++ b/apps/admin/e2e/2566-catalog-edit.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * #2566 — edit an existing catalog. `/catalogs-pdf/:id/edit` opens the wizard
+ * prefilled from GET /api/catalogs/{id}; the final step PATCHes the config
+ * (no regeneration) and returns to the hub. All endpoints mocked.
+ */
+
+const CATALOG_ID = '019f0000-0000-7000-8000-0000000000ed';
+
+test('#2566 — edit catalog: prefilled wizard + PATCH on save', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('i18nextLng', 'pl');
+  });
+
+  await page.route('**/api/object_types', (route) =>
+    route.fulfill({
+      json: {
+        member: [{ id: '11111111-1111-4111-8111-111111111111', code: 'product', kind: 'product' }],
+      },
+    }),
+  );
+  await page.route('**/api/attributes**', (route) =>
+    route.fulfill({ json: { member: [{ id: 'a1', code: 'name', label: { pl: 'Nazwa' } }] } }),
+  );
+  await page.route('**/api/search/products**', (route) =>
+    route.fulfill({
+      json: {
+        hits: [],
+        totalHits: 5,
+        facetDistribution: {},
+        processingTimeMs: 1,
+        page: 1,
+        perPage: 1,
+      },
+    }),
+  );
+  await page.route('**/api/catalogs/preview', (route) =>
+    route.fulfill({ json: { sample_count: 1, html: '<div>x</div>' } }),
+  );
+
+  let patched: { name?: string } | null = null;
+  await page.route(`**/api/catalogs/${CATALOG_ID}`, (route) => {
+    if (route.request().method() === 'PATCH') {
+      patched = route.request().postDataJSON() as { name?: string };
+      return route.fulfill({ json: { id: CATALOG_ID, name: patched.name } });
+    }
+    // GET — the config the edit wizard prefills from.
+    return route.fulfill({
+      json: {
+        id: CATALOG_ID,
+        name: 'Katalog wiosna',
+        template_kind: 'sheet',
+        branding: { color: '#123456', company_name: 'Acme', logo: '' },
+        field_mappings: [{ slot: 'title', source: { kind: 'attribute', ref: 'name' } }],
+        filter: null,
+        locale: null,
+      },
+    });
+  });
+
+  await loginAsAdmin(page);
+  await page.goto(`/catalogs-pdf/${CATALOG_ID}/edit`);
+
+  // Edit mode header.
+  await expect(
+    page.getByRole('heading', { level: 1, name: /edytuj katalog|edit catalog/i }),
+  ).toBeVisible();
+
+  const next = page.getByRole('button', { name: /^dalej$|^next$/i });
+  await next.click(); // scope → archetype
+  await next.click(); // archetype (sheet prefilled) → branding
+
+  // Branding prefilled from the catalog.
+  await expect(page.getByLabel(/nazwa firmy|company name/i)).toHaveValue('Acme');
+  await next.click(); // → mapping
+  await next.click(); // → preview
+  await page.getByRole('button', { name: /odśwież podgląd|refresh preview/i }).click();
+  await next.click(); // → generate
+
+  // Generate step: name prefilled + edit CTA (no "generate").
+  await expect(page.getByLabel(/nazwa katalogu|catalog name/i)).toHaveValue('Katalog wiosna');
+  const save = page.getByRole('button', { name: /zapisz zmiany|save changes/i });
+  await expect(save).toBeVisible();
+  await save.click();
+
+  // PATCH fired and the wizard returned to the hub.
+  await expect(page).toHaveURL(/\/catalogs-pdf$/);
+  expect(patched).not.toBeNull();
+  expect((patched as { name?: string } | null)?.name).toBe('Katalog wiosna');
+});

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -626,6 +626,15 @@ function App() {
                       </PermissionRoute>
                     }
                   />
+                  {/* #2566 — edit an existing catalog (wizard prefilled). */}
+                  <Route
+                    path="/catalogs-pdf/:id/edit"
+                    element={
+                      <PermissionRoute anyOf={['exports.view_own', 'exports.view_all']}>
+                        <CatalogWizardPage />
+                      </PermissionRoute>
+                    }
+                  />
                   {/* AUD-076 (W3-5.5) — gate the whole settings tree with the
                     same permission set the sidebar uses to show the entry
                     (MENU_PERMISSIONS.settings). A user with no settings

--- a/apps/admin/src/features/catalogs-pdf/hub/CatalogCard.tsx
+++ b/apps/admin/src/features/catalogs-pdf/hub/CatalogCard.tsx
@@ -1,7 +1,8 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { Check, Download, FileText, Link2, RefreshCw, Trash2 } from 'lucide-react';
+import { Check, Download, FileText, Link2, Pencil, RefreshCw, Trash2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
 import { useToast } from '@/components/ui/toast';
 import { StatusPill } from '@/components/ui-v2/status-pill';
 import { httpErrorDetail } from '@/lib/http';
@@ -194,6 +195,13 @@ export function CatalogCard({ catalog }: { catalog: CatalogProfileRow }) {
           />
           {t('catalogs_pdf.card.regenerate')}
         </button>
+        <Link
+          to={`/catalogs-pdf/${catalog.id}/edit`}
+          className="flex h-8 items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-2.5 text-[12px] font-medium text-zinc-700 transition hover:bg-zinc-50"
+        >
+          <Pencil className="h-3.5 w-3.5" aria-hidden />
+          {t('catalogs_pdf.card.edit', { defaultValue: 'Edytuj' })}
+        </Link>
         <button
           type="button"
           onClick={onShare}

--- a/apps/admin/src/features/catalogs-pdf/wizard/CatalogWizardPage.tsx
+++ b/apps/admin/src/features/catalogs-pdf/wizard/CatalogWizardPage.tsx
@@ -1,6 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router';
 
 import { WizardStepper } from '@/components/ui-v2/wizard-stepper';
+import { jsonFetch } from '@/lib/http';
 
 import { useDefaultObjectType } from '../../catalog/products/use-default-object-type';
 import { StepArchetype } from './steps/StepArchetype';
@@ -9,6 +12,7 @@ import { StepGenerate } from './steps/StepGenerate';
 import { StepMapping } from './steps/StepMapping';
 import { StepPreview } from './steps/StepPreview';
 import { StepScope } from './steps/StepScope';
+import { type CatalogResponse, catalogResponseToWizardState } from './use-generate-catalog';
 import { WizardFooter } from './WizardFooter';
 import { CatalogWizardProvider, useCatalogWizard } from './wizard-store';
 
@@ -19,6 +23,11 @@ import { CatalogWizardProvider, useCatalogWizard } from './wizard-store';
  * (WizardStepper + step components + a context store + footer nav).
  */
 export function CatalogWizardPage(): React.ReactElement {
+  // #2566 — /catalogs-pdf/:id/edit opens the wizard prefilled for editing.
+  const { id } = useParams<{ id: string }>();
+  if (id !== undefined) {
+    return <EditCatalogWizard catalogId={id} />;
+  }
   return (
     <CatalogWizardProvider>
       <WizardContent />
@@ -26,9 +35,40 @@ export function CatalogWizardPage(): React.ReactElement {
   );
 }
 
+function EditCatalogWizard({ catalogId }: { catalogId: string }): React.ReactElement {
+  const { t } = useTranslation();
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['catalog', catalogId],
+    queryFn: () => jsonFetch<CatalogResponse>(`/api/catalogs/${catalogId}`),
+  });
+
+  if (isLoading) {
+    return (
+      <p className="mx-auto max-w-5xl px-6 py-12 text-[13px] text-zinc-500">{t('app.loading')}</p>
+    );
+  }
+  if (isError || data === undefined) {
+    return (
+      <p className="mx-auto max-w-5xl px-6 py-12 text-[13px] text-brick-600">
+        {t('catalogs_pdf.wizard.edit_load_error', {
+          defaultValue: 'Nie udało się wczytać katalogu.',
+        })}
+      </p>
+    );
+  }
+  return (
+    <CatalogWizardProvider
+      initialState={catalogResponseToWizardState(data)}
+      editCatalogId={catalogId}
+    >
+      <WizardContent />
+    </CatalogWizardProvider>
+  );
+}
+
 function WizardContent() {
   const { t } = useTranslation();
-  const { state, dispatch } = useCatalogWizard();
+  const { state, dispatch, editCatalogId } = useCatalogWizard();
   // The wizard targets products — the built-in product ObjectType id is
   // auto-resolved (same seam the product create page uses; no picker yet).
   const { objectTypeId } = useDefaultObjectType('product');
@@ -50,7 +90,9 @@ function WizardContent() {
     <div className="mx-auto max-w-5xl space-y-6">
       <header>
         <h1 className="display text-[24px] font-semibold tracking-tight text-ink">
-          {t('catalogs_pdf.wizard.title')}
+          {editCatalogId !== null
+            ? t('catalogs_pdf.wizard.edit_title', { defaultValue: 'Edytuj katalog' })
+            : t('catalogs_pdf.wizard.title')}
         </h1>
         <p className="mt-1 text-[13px] text-zinc-500">{t('catalogs_pdf.wizard.lead')}</p>
       </header>

--- a/apps/admin/src/features/catalogs-pdf/wizard/steps/StepGenerate.tsx
+++ b/apps/admin/src/features/catalogs-pdf/wizard/steps/StepGenerate.tsx
@@ -22,12 +22,15 @@ interface StepGenerateProps {
 export function StepGenerate({ objectTypeId }: StepGenerateProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { state, dispatch } = useCatalogWizard();
-  const { createAndGenerate, isRunning } = useGenerateCatalog();
+  const { state, dispatch, editCatalogId } = useCatalogWizard();
+  const { createAndGenerate, updateCatalog, isRunning } = useGenerateCatalog();
   const [error, setError] = useState<string | null>(null);
+  const isEdit = editCatalogId !== null;
 
   const nameValid = state.name.trim() !== '';
-  const canSubmit = nameValid && objectTypeId !== null && !isRunning;
+  // Editing PATCHes the existing catalog and does not need the product
+  // ObjectType id (that seam is only used to POST a new catalog + generate).
+  const canSubmit = nameValid && (isEdit || objectTypeId !== null) && !isRunning;
 
   const summaryRows: Array<{ label: string; value: string }> = [
     { label: t('catalogs_pdf.wizard.summary_name'), value: state.name.trim() || '—' },
@@ -53,13 +56,19 @@ export function StepGenerate({ objectTypeId }: StepGenerateProps) {
   ];
 
   const handleFinish = async () => {
-    if (objectTypeId === null) {
-      setError(t('catalogs_pdf.wizard.error_no_object_type'));
-      return;
-    }
     setError(null);
     try {
-      await createAndGenerate(state, objectTypeId);
+      // #2566 — edit mode PATCHes the config (regeneration stays a separate
+      // hub action); create mode POSTs a new catalog + generates.
+      if (editCatalogId !== null) {
+        await updateCatalog(editCatalogId, state);
+      } else {
+        if (objectTypeId === null) {
+          setError(t('catalogs_pdf.wizard.error_no_object_type'));
+          return;
+        }
+        await createAndGenerate(state, objectTypeId);
+      }
       void navigate('/catalogs-pdf');
     } catch (err) {
       setError(httpErrorDetail(err) ?? t('catalogs_pdf.wizard.generate_error'));
@@ -135,7 +144,9 @@ export function StepGenerate({ objectTypeId }: StepGenerateProps) {
       >
         {isRunning
           ? t('catalogs_pdf.wizard.generate_running')
-          : t('catalogs_pdf.wizard.generate_cta')}
+          : isEdit
+            ? t('catalogs_pdf.wizard.edit_save_cta', { defaultValue: 'Zapisz zmiany' })
+            : t('catalogs_pdf.wizard.generate_cta')}
       </button>
     </div>
   );

--- a/apps/admin/src/features/catalogs-pdf/wizard/use-generate-catalog.ts
+++ b/apps/admin/src/features/catalogs-pdf/wizard/use-generate-catalog.ts
@@ -2,7 +2,13 @@ import { useState } from 'react';
 
 import { jsonFetch } from '@/lib/http';
 
-import { type CatalogWizardState, SHEET_SLOTS } from './types';
+import {
+  type CatalogTemplateKind,
+  type CatalogWizardState,
+  INITIAL_CATALOG_WIZARD_STATE,
+  SHEET_SLOTS,
+  type SheetSlot,
+} from './types';
 
 /** One field-mapping entry in the BE contract shape. */
 export interface FieldMappingPayload {
@@ -68,6 +74,45 @@ export function buildCreatePayload(
     payload.locale = state.locale;
   }
   return payload;
+}
+
+/** Shape of GET /api/catalogs/{id} that the edit flow reads (#2566). */
+export interface CatalogResponse {
+  name?: string;
+  template_kind?: string;
+  branding?: { color?: string; company_name?: string; logo?: string } | null;
+  field_mappings?: Array<{ slot?: string; source?: { ref?: string } }> | null;
+  filter?: CatalogWizardState['filterDsl'];
+  locale?: string | null;
+}
+
+/**
+ * #2566 — map a GET /api/catalogs/{id} response back into the wizard draft so
+ * the edit flow opens prefilled. Field mappings come back as {slot, source:
+ * {ref}} and collapse to the store's {slot: ref} shape.
+ */
+export function catalogResponseToWizardState(res: CatalogResponse): CatalogWizardState {
+  const branding = res.branding ?? {};
+  const fieldMappings = { ...INITIAL_CATALOG_WIZARD_STATE.fieldMappings };
+  for (const entry of res.field_mappings ?? []) {
+    if (typeof entry.slot === 'string' && entry.slot in fieldMappings) {
+      fieldMappings[entry.slot as SheetSlot] = entry.source?.ref ?? '';
+    }
+  }
+  return {
+    ...INITIAL_CATALOG_WIZARD_STATE,
+    name: res.name ?? '',
+    templateKind: (res.template_kind as CatalogTemplateKind | undefined) ?? 'sheet',
+    branding: {
+      color: branding.color ?? INITIAL_CATALOG_WIZARD_STATE.branding.color,
+      company_name: branding.company_name ?? '',
+      logo: branding.logo ?? '',
+    },
+    fieldMappings,
+    filterDsl: res.filter ?? null,
+    locale: res.locale ?? null,
+    dirty: false,
+  };
 }
 
 /** Build the POST /api/catalogs/preview body from the wizard draft. */
@@ -144,5 +189,30 @@ export function useGenerateCatalog() {
     }
   };
 
-  return { preview, createAndGenerate, isRunning };
+  /**
+   * #2566 — persist edits to an existing catalog. PATCH the config (name,
+   * template, branding, mappings, filter, locale); regeneration stays a
+   * separate explicit action (the hub's "Regeneruj" button).
+   */
+  const updateCatalog = async (id: string, state: CatalogWizardState): Promise<void> => {
+    setIsRunning(true);
+    try {
+      await jsonFetch(`/api/catalogs/${id}`, {
+        method: 'PATCH',
+        accept: 'application/json',
+        body: {
+          name: state.name.trim(),
+          template_kind: state.templateKind,
+          branding: buildBranding(state),
+          field_mappings: buildFieldMappings(state),
+          filter: state.filterDsl,
+          locale: state.locale !== null && state.locale !== '' ? state.locale : null,
+        },
+      });
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  return { preview, createAndGenerate, updateCatalog, isRunning };
 }

--- a/apps/admin/src/features/catalogs-pdf/wizard/wizard-store.tsx
+++ b/apps/admin/src/features/catalogs-pdf/wizard/wizard-store.tsx
@@ -45,14 +45,28 @@ export function catalogWizardReducer(
 interface CatalogWizardContextValue {
   state: CatalogWizardState;
   dispatch: Dispatch<CatalogWizardAction>;
+  /** #2566 — the catalog id being edited, or null when creating. */
+  editCatalogId: string | null;
 }
 
 const CatalogWizardContext = createContext<CatalogWizardContextValue | null>(null);
 
-export function CatalogWizardProvider({ children }: { children: ReactNode }) {
-  const [state, dispatch] = useReducer(catalogWizardReducer, INITIAL_CATALOG_WIZARD_STATE);
+export function CatalogWizardProvider({
+  children,
+  initialState,
+  editCatalogId = null,
+}: {
+  children: ReactNode;
+  /** #2566 — prefilled state for the edit flow; defaults to a blank draft. */
+  initialState?: CatalogWizardState;
+  editCatalogId?: string | null;
+}) {
+  const [state, dispatch] = useReducer(
+    catalogWizardReducer,
+    initialState ?? INITIAL_CATALOG_WIZARD_STATE,
+  );
   return (
-    <CatalogWizardContext.Provider value={{ state, dispatch }}>
+    <CatalogWizardContext.Provider value={{ state, dispatch, editCatalogId }}>
       {children}
     </CatalogWizardContext.Provider>
   );

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1052,6 +1052,7 @@
     "card": {
       "download": "Download",
       "regenerate": "Regenerate",
+      "edit": "Edit",
       "share": "Share",
       "share_copied": "Copied",
       "delete": "Delete",
@@ -1068,6 +1069,9 @@
     "wizard": {
       "title": "New PDF catalog",
       "lead": "Build and generate a catalog in six steps: scope, layout, branding, field mapping, preview, generate.",
+      "edit_title": "Edit catalog",
+      "edit_save_cta": "Save changes",
+      "edit_load_error": "Could not load the catalog.",
       "step_indicator": "step {{step}} of {{total}} · {{title}}",
       "cancel": "Cancel",
       "back": "Back",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1062,6 +1062,7 @@
     "card": {
       "download": "Pobierz",
       "regenerate": "Regeneruj",
+      "edit": "Edytuj",
       "share": "Udostępnij",
       "share_copied": "Skopiowano",
       "delete": "Usuń",
@@ -1078,6 +1079,9 @@
     "wizard": {
       "title": "Nowy katalog PDF",
       "lead": "Zbuduj i wygeneruj katalog w sześciu krokach: zakres, układ, branding, mapowanie pól, podgląd, generowanie.",
+      "edit_title": "Edytuj katalog",
+      "edit_save_cta": "Zapisz zmiany",
+      "edit_load_error": "Nie udało się wczytać katalogu.",
       "step_indicator": "krok {{step}} z {{total}} · {{title}}",
       "cancel": "Anuluj",
       "back": "Wstecz",


### PR DESCRIPTION
## Summary
Katalog można było tylko **dodać lub usunąć** — brak edycji (#2566). Dodany flow edycji: akcja **„Edytuj"** na karcie katalogu → `/catalogs-pdf/:id/edit`, który pobiera katalog (GET) i **prefilluje wizard**. Ostatni krok robi **PATCH** konfiguracji (zamiast POST+generate); regeneracja zostaje osobną akcją „Regeneruj".

## Zmiany
- `wizard-store`: `CatalogWizardProvider` przyjmuje `initialState` + `editCatalogId` (context).
- `use-generate-catalog`: `catalogResponseToWizardState` (mapper GET→state; field_mappings `[{slot,source:{ref}}]`→`{slot:ref}`) + `updateCatalog(id,state)` (PATCH).
- `CatalogWizardPage`: tryb edit (fetch GET → loading/error → prefilled Provider), tytuł „Edytuj katalog".
- `StepGenerate`: branch PATCH vs POST+generate; CTA „Zapisz zmiany"; edycja nie wymaga objectTypeId.
- `App.tsx`: trasa `/catalogs-pdf/:id/edit`. `CatalogCard`: akcja „Edytuj". Locale (pl+en).

## Quality gates
- Biome 0, tsc 0. Nowy spec `2566-catalog-edit` (prefill przez wizard + PATCH na zapisie) zielony; cpdf-wizard/shell/hub bez regresji.
- Live smoke: PATCH `/api/catalogs/{id}` → HTTP 200; `/edit` renderuje „Edytuj katalog".

Closes #2566

🤖 Generated with [Claude Code](https://claude.com/claude-code)