### PR TITLE
feat(cpdf): włącz typy katalogu Grid i Cennik w kreatorze

### DIFF
--- a/apps/admin/e2e/cpdf-shell.spec.ts
+++ b/apps/admin/e2e/cpdf-shell.spec.ts
@@ -40,7 +40,8 @@ test('CPDF-P5-01 — catalogs shell: tabs, empty state, templates, a11y', async 
   // Switch to the Szablony tab — the sheet archetype is available.
   await templatesTab.click();
   await expect(page.getByRole('radio', { name: /karta produktu|product sheet/i })).toBeVisible();
-  // The grid/pricelist archetypes are disabled "Wkrótce" cards.
+  // Grid/pricelist are selectable in the wizard (#2568) but stay muted in this
+  // informational shell tab.
   await expect(
     page.getByRole('radio', { name: /katalog \(grid\)|catalog \(grid\)/i }),
   ).toHaveAttribute('aria-disabled', 'true');

--- a/apps/admin/src/features/catalogs-pdf/TemplatesTab.tsx
+++ b/apps/admin/src/features/catalogs-pdf/TemplatesTab.tsx
@@ -5,11 +5,11 @@ import { SelectableCard, SelectableCardGroup } from '@/components/ui-v2/selectab
 import { StatusPill } from '@/components/ui-v2/status-pill';
 
 /**
- * CPDF-P5-01 — Templates tab. Lists the built-in catalog archetypes. The
- * `sheet` archetype (CatalogTemplateCatalog #2370) is the only one shipped in
- * the MVP; `grid` and `pricelist` render as disabled "Wkrótce" cards (module
- * M6). The cards are informational for the shell — selection is wired into the
- * create wizard in CPDF-P5-02.
+ * CPDF-P5-01 — Templates tab. Lists the built-in catalog archetypes. Cards are
+ * informational here; all three (sheet / grid / pricelist) are selectable in
+ * the create wizard (#2568). Grid/pricelist stay visually muted in this tab
+ * (aligning the shell display is a follow-up — see the SelectableCard
+ * enabled-state contrast).
  */
 export function TemplatesTab() {
   const { t } = useTranslation();

--- a/apps/admin/src/features/catalogs-pdf/wizard/CatalogWizardPage.tsx
+++ b/apps/admin/src/features/catalogs-pdf/wizard/CatalogWizardPage.tsx
@@ -82,9 +82,9 @@ function WizardContent() {
     { id: 'generate', label: t('catalogs_pdf.wizard.steps.generate') },
   ];
 
-  // Step 2 (archetype) gates "Dalej" until a renderable archetype is chosen;
-  // only `sheet` is renderable in the MVP.
-  const nextDisabled = state.step === 1 && state.templateKind !== 'sheet';
+  // All three archetypes (sheet / grid / pricelist) are renderable (#2568),
+  // and a kind is always selected — no step gates the wizard here.
+  const nextDisabled = false;
 
   return (
     <div className="mx-auto max-w-5xl space-y-6">

--- a/apps/admin/src/features/catalogs-pdf/wizard/steps/StepArchetype.tsx
+++ b/apps/admin/src/features/catalogs-pdf/wizard/steps/StepArchetype.tsx
@@ -7,9 +7,11 @@ import type { CatalogTemplateKind } from '../types';
 import { useCatalogWizard } from '../wizard-store';
 
 /**
- * CPDF-P5-02 step 2 — archetype pick. Only `sheet` is renderable in the MVP
- * (CatalogTemplateCatalog); `grid` and `pricelist` show as disabled "Wkrótce"
- * cards (module M6). Mirrors the shell's TemplatesTab card set.
+ * CPDF-P5-02 step 2 — archetype pick. All three archetypes are renderable
+ * (CatalogTemplateCatalog: sheet / grid / pricelist, backends CPDF-P6-01/02).
+ * The mapping step exposes the shared sheet slots; kind-specific slots (e.g.
+ * the grid `specs`) fall back to the template defaults — a per-kind mapping UI
+ * is a follow-up (#2568). Mirrors the shell's TemplatesTab card set.
  */
 export function StepArchetype() {
   const { t } = useTranslation();
@@ -43,13 +45,15 @@ export function StepArchetype() {
           icon={<LayoutGrid className="size-5" aria-hidden />}
           title={t('catalogs_pdf.template_grid_name')}
           description={t('catalogs_pdf.template_grid_description')}
-          disabled
+          selected={state.templateKind === 'grid'}
+          onSelect={() => select('grid')}
         />
         <SelectableCard
           icon={<Table className="size-5" aria-hidden />}
           title={t('catalogs_pdf.template_pricelist_name')}
           description={t('catalogs_pdf.template_pricelist_description')}
-          disabled
+          selected={state.templateKind === 'pricelist'}
+          onSelect={() => select('pricelist')}
         />
       </SelectableCardGroup>
     </div>

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1094,7 +1094,7 @@
       "scope_locale_default": "Tenant default language",
       "scope_locale_hint": "Controls attribute value resolution during rendering.",
       "archetype_title": "Choose a layout",
-      "archetype_subtitle": "The \"Product sheet\" layout is ready in the MVP. Grid and price list arrive in module M6.",
+      "archetype_subtitle": "Choose a catalog layout: Product sheet, Grid or Price list.",
       "archetype_group_aria": "Catalog layouts",
       "branding_title": "Branding",
       "branding_subtitle": "The brand color, company name and logo appear in the catalog header. All fields are optional.",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1106,7 +1106,7 @@
       "scope_locale_default": "Domyślny języka tenanta",
       "scope_locale_hint": "Steruje rozwiązywaniem wartości atrybutów podczas renderowania.",
       "archetype_title": "Wybierz układ",
-      "archetype_subtitle": "Układ „Karta produktu” jest gotowy w MVP. Grid i cennik dochodzą w module M6.",
+      "archetype_subtitle": "Wybierz układ katalogu: Karta produktu, Grid lub Cennik.",
       "archetype_group_aria": "Układy katalogu",
       "branding_title": "Branding",
       "branding_subtitle": "Kolor marki, nazwa firmy i logo pojawią się w nagłówku katalogu. Wszystkie pola są opcjonalne.",


### PR DESCRIPTION
## Summary
Backend już renderuje wszystkie trzy archetypy (**sheet / grid / pricelist**, CPDF-P6-01/02), ale kreator pozwalał wybrać tylko „Karta produktu". Grid i Cennik są teraz **wybieralne** w kroku Archetyp; zdjęty gate „tylko sheet".

## Weryfikacja backendu
- `POST /api/catalogs/preview` z `template_kind=grid` → HTTP 200, HTML (~3.6k znaków); `pricelist` → HTTP 200 (~2.6k). Renderery gotowe.

## Zmiany
- `StepArchetype`: grid/pricelist `selected` + `onSelect` (usunięte `disabled`).
- `CatalogWizardPage`: `nextDisabled = false` (wszystkie archetypy renderowalne).
- `archetype_subtitle` (pl+en): usunięte „dochodzą w module M6".

## Świadome odejścia
- **Mapping UI per-kind** (np. slot `specs` dla grid) — follow-up; teraz backend template-defaults dla slotów kind-specific.
- **Shell TemplatesTab** trzyma grid/pricelist wizualnie wyciszone (informacyjne) — wyrównanie displayu to follow-up (enabled-state contrast w `SelectableCard` — poza zakresem). Tworzenie grid/cennik działa przez kreator.

## Quality gates
- Biome 0, tsc 0. Playwright cpdf-shell + cpdf-wizard zielone.
- Live smoke: karta „Katalog (grid)" wybieralna (aria-checked=true), kreator przechodzi dalej z grid.

Closes #2568

🤖 Generated with [Claude Code](https://claude.com/claude-code)