### PR TITLE
feat(workflow): przenieś edytor definicji workflow do /workflow + przycisk konfiguracji

### DIFF
--- a/apps/admin/e2e/wfl-flow-settings.spec.ts
+++ b/apps/admin/e2e/wfl-flow-settings.spec.ts
@@ -29,6 +29,13 @@ test('flow settings: pick an approver and save enables the asset definition', as
     await loginAsAdmin(page);
     await page.goto('/workflow');
 
+    // #2574 — the hub exposes both CTAs to a manager: custom definitions and
+    // the flow-settings page. The definitions CTA points at the moved route.
+    await expect(page.getByTestId('workflow-definitions-cta')).toHaveAttribute(
+      'href',
+      '/workflow/definitions',
+    );
+
     await page.getByTestId('workflow-settings-cta').click();
     await expect(page).toHaveURL(/\/workflow\/settings$/);
     await expect(page.getByTestId('workflow-settings-page')).toBeVisible();

--- a/apps/admin/e2e/wfl-p5-03-definition-builder.spec.ts
+++ b/apps/admin/e2e/wfl-p5-03-definition-builder.spec.ts
@@ -27,7 +27,9 @@ test('definition builder: custom place shows up on the product without a deploy'
   const definitionName = `E2E builder ${Date.now().toString(36)}`;
 
   try {
-    await page.goto('/settings/workflow');
+    // #2574 — the definition builder moved out of Settings into the Workflow
+    // hub. The old /settings/workflow path still redirects here.
+    await page.goto('/workflow/definitions');
     await expect(page.getByTestId('workflow-definitions-page')).toBeVisible();
 
     // Accessibility gate on the list page (serious/critical only, per DoD).

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -36,6 +36,12 @@ function lazyPage<K extends string, T extends Record<K, ComponentType<never>>>(
   return lazy(() => loader().then((m) => ({ default: m[exportName] as ComponentType<unknown> })));
 }
 
+/** #2574 — preserve the definition id when redirecting the old settings path. */
+function WorkflowDefinitionEditRedirect(): React.ReactElement {
+  const { id } = useParams<{ id: string }>();
+  return <Navigate to={`/workflow/definitions/${id}/edit`} replace />;
+}
+
 const AgentInboxPage = lazyPage(
   () => import('@/features/agent/inbox/AgentInboxPage'),
   'AgentInboxPage',
@@ -610,6 +616,33 @@ function App() {
                       </PermissionRoute>
                     }
                   />
+                  {/* #2574 — custom workflow definitions moved out of Settings
+                      into the Workflow hub. Old /settings/workflow* paths
+                      redirect below. */}
+                  <Route
+                    path="/workflow/definitions"
+                    element={
+                      <PermissionRoute anyOf={['workflow.manage_definitions']}>
+                        <WorkflowSettingsPage />
+                      </PermissionRoute>
+                    }
+                  />
+                  <Route
+                    path="/workflow/definitions/new"
+                    element={
+                      <PermissionRoute anyOf={['workflow.manage_definitions']}>
+                        <WorkflowDefinitionEditorRoute />
+                      </PermissionRoute>
+                    }
+                  />
+                  <Route
+                    path="/workflow/definitions/:id/edit"
+                    element={
+                      <PermissionRoute anyOf={['workflow.manage_definitions']}>
+                        <WorkflowDefinitionEditorRoute />
+                      </PermissionRoute>
+                    }
+                  />
                   <Route
                     path="/catalogs-pdf"
                     element={
@@ -681,33 +714,17 @@ function App() {
                     <Route path="tenant" element={<TenantSettingsPage />} />
                     <Route path="ai" element={<AiSettingsPage />} />
                     <Route path="sso" element={<SsoSettingsPage />} />
-                    {/* WFL-P5-03 (#2433) — definition builder; the page is
-                      additionally hidden by the workflow_custom_definitions
-                      feature flag (sidebar + FeatureRoute below). */}
+                    {/* #2574 — the definition builder moved to /workflow/
+                      definitions*; keep the old settings paths as redirects. */}
                     <Route
                       path="workflow"
-                      element={
-                        <PermissionRoute anyOf={['workflow.manage_definitions']}>
-                          <WorkflowSettingsPage />
-                        </PermissionRoute>
-                      }
+                      element={<Navigate to="/workflow/definitions" replace />}
                     />
                     <Route
                       path="workflow/new"
-                      element={
-                        <PermissionRoute anyOf={['workflow.manage_definitions']}>
-                          <WorkflowDefinitionEditorRoute />
-                        </PermissionRoute>
-                      }
+                      element={<Navigate to="/workflow/definitions/new" replace />}
                     />
-                    <Route
-                      path="workflow/:id/edit"
-                      element={
-                        <PermissionRoute anyOf={['workflow.manage_definitions']}>
-                          <WorkflowDefinitionEditorRoute />
-                        </PermissionRoute>
-                      }
-                    />
+                    <Route path="workflow/:id/edit" element={<WorkflowDefinitionEditRedirect />} />
                   </Route>
                   {/* RBAC-P5-019 (#709) — Super Admin operator panel.
                     Lives under /admin/* inside the existing app until

--- a/apps/admin/src/features/settings/workflow/DefinitionEditorPage.tsx
+++ b/apps/admin/src/features/settings/workflow/DefinitionEditorPage.tsx
@@ -95,7 +95,7 @@ export function DefinitionEditorPage() {
           toast.error(
             t('settings.workflow.not_found', { defaultValue: 'Nie znaleziono definicji.' }),
           );
-          void navigate('/settings/workflow');
+          void navigate('/workflow/definitions');
           return;
         }
         setOriginal(found);
@@ -132,7 +132,7 @@ export function DefinitionEditorPage() {
     request
       .then(() => {
         toast.success(t('settings.workflow.saved', { defaultValue: 'Definicja zapisana.' }));
-        void navigate('/settings/workflow');
+        void navigate('/workflow/definitions');
       })
       .catch((error: unknown) => {
         const violations = extractViolations(error);
@@ -172,7 +172,7 @@ export function DefinitionEditorPage() {
   return (
     <div className="space-y-6" data-testid="workflow-definition-editor">
       <header className="flex items-center gap-3">
-        <Button variant="ghost" size="icon" onClick={() => void navigate('/settings/workflow')}>
+        <Button variant="ghost" size="icon" onClick={() => void navigate('/workflow/definitions')}>
           <ArrowLeft className="size-4" />
           <span className="sr-only">{t('common.back', { defaultValue: 'Wstecz' })}</span>
         </Button>

--- a/apps/admin/src/features/settings/workflow/DefinitionsListView.tsx
+++ b/apps/admin/src/features/settings/workflow/DefinitionsListView.tsx
@@ -74,7 +74,7 @@ export function DefinitionsListView() {
           </p>
         </div>
         <Button
-          onClick={() => void navigate('/settings/workflow/new')}
+          onClick={() => void navigate('/workflow/definitions/new')}
           data-testid="definition-create"
         >
           <Plus className="mr-1 size-4" />
@@ -143,7 +143,7 @@ export function DefinitionsListView() {
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={() => void navigate(`/settings/workflow/${definition.id}/edit`)}
+                onClick={() => void navigate(`/workflow/definitions/${definition.id}/edit`)}
                 data-testid={`definition-edit-${definition.name}`}
               >
                 <Pencil className="mr-1 size-3.5" />

--- a/apps/admin/src/features/settings/workflow/index.tsx
+++ b/apps/admin/src/features/settings/workflow/index.tsx
@@ -2,8 +2,8 @@ import { DefinitionEditorPage } from './DefinitionEditorPage';
 import { DefinitionsListView } from './DefinitionsListView';
 
 /**
- * WFL-P5-03 (#2433) — entry points for `/settings/workflow` (list) and
- * `/settings/workflow/{new,:id/edit}` (form editor). Follows the roles
+ * WFL-P5-03 (#2433) — entry points for `/workflow/definitions` (list) and
+ * `/workflow/definitions/{new,:id/edit}` (form editor). Follows the roles
  * module layout so helpers can grow next to their pages.
  */
 export function WorkflowSettingsPage() {

--- a/apps/admin/src/features/workflow/WorkflowPage.tsx
+++ b/apps/admin/src/features/workflow/WorkflowPage.tsx
@@ -1,11 +1,11 @@
-import { SlidersHorizontal } from 'lucide-react';
+import { GitBranch, SlidersHorizontal } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 
 import { PillTabs } from '@/components/ui-v2/pill-tabs';
 import { usePageActions } from '@/layout/page-actions-context';
-import { useIdentity } from '@/lib/identity';
+import { hasFeature, useIdentity } from '@/lib/identity';
 
 import { ReviewQueuePage } from './ReviewQueuePage';
 import { TasksPanel } from './TasksPanel';
@@ -22,22 +22,38 @@ export function WorkflowPage() {
   const { identity } = useIdentity();
   const canDecide = identity?.permissions.has('workflow.approve_reject') ?? false;
   const canManageDefinitions = identity?.permissions.has('workflow.manage_definitions') ?? false;
+  // #2574 — custom definitions live in the hub now, gated by the same flag the
+  // old Settings entry used.
+  const showDefinitions =
+    canManageDefinitions && hasFeature(identity, 'workflow_custom_definitions');
   const [tab, setTab] = useState('review');
 
   usePageActions(
     useMemo(
       () =>
         canManageDefinitions ? (
-          <Link
-            to="/workflow/settings"
-            data-testid="workflow-settings-cta"
-            className="focus-ring inline-flex h-9 items-center gap-1.5 rounded-xl bg-zinc-900 px-3.5 text-[13px] font-semibold text-white transition hover:bg-zinc-800"
-          >
-            <SlidersHorizontal className="size-4" aria-hidden="true" />
-            {t('workflow.settings_cta', { defaultValue: 'Ustawienia przepływu' })}
-          </Link>
+          <div className="flex items-center gap-2">
+            {showDefinitions ? (
+              <Link
+                to="/workflow/definitions"
+                data-testid="workflow-definitions-cta"
+                className="focus-ring inline-flex h-9 items-center gap-1.5 rounded-xl border border-zinc-200 bg-white px-3.5 text-[13px] font-semibold text-zinc-700 transition hover:bg-zinc-50"
+              >
+                <GitBranch className="size-4" aria-hidden="true" />
+                {t('workflow.definitions_cta', { defaultValue: 'Definicje przepływu' })}
+              </Link>
+            ) : null}
+            <Link
+              to="/workflow/settings"
+              data-testid="workflow-settings-cta"
+              className="focus-ring inline-flex h-9 items-center gap-1.5 rounded-xl bg-zinc-900 px-3.5 text-[13px] font-semibold text-white transition hover:bg-zinc-800"
+            >
+              <SlidersHorizontal className="size-4" aria-hidden="true" />
+              {t('workflow.settings_cta', { defaultValue: 'Ustawienia przepływu' })}
+            </Link>
+          </div>
         ) : null,
-      [canManageDefinitions, t],
+      [canManageDefinitions, showDefinitions, t],
     ),
   );
 

--- a/apps/admin/src/layout/settings-nav-data.ts
+++ b/apps/admin/src/layout/settings-nav-data.ts
@@ -1,7 +1,6 @@
 import {
   Building2,
   CreditCard,
-  GitBranch,
   Globe,
   Key,
   KeyRound,
@@ -64,15 +63,9 @@ export const SETTINGS_NAV_GROUPS: readonly SettingsNavGroup[] = [
       // DP-03 (#2033): Locales + Channels moved to Modeling (/modeling/locales,
       // /modeling/channels) — they are data-model dimensions, not settings.
       { to: '/settings/ai', icon: Sparkles, labelKey: 'settings.nav.ai' },
-      // WFL-P5-03 (#2433) — definition builder; deployment-flagged and
-      // gated by workflow.manage_definitions (Owner/Admin).
-      {
-        to: '/settings/workflow',
-        icon: GitBranch,
-        labelKey: 'settings.nav.workflow',
-        permission: 'workflow.manage_definitions',
-        featureFlag: 'workflow_custom_definitions',
-      },
+      // WFL-P5-03 (#2433) — definition builder moved out of Settings into the
+      // Workflow hub (#2574): /workflow/definitions, reachable from the
+      // WorkflowPage "Definicje przepływu" CTA.
     ],
   },
   {


### PR DESCRIPTION
## Summary

Edytor własnych definicji workflow (builder z placami i przejściami) siedział pod Ustawieniami (`/settings/workflow`) — jego naturalne miejsce jest w hubie Workflow, obok kolejki do przeglądu i ustawień przepływu. Ten PR:

- Dodaje CTA **„Definicje przepływu"** na `WorkflowPage` (obok istniejącego „Ustawienia przepływu"), gated przez `workflow.manage_definitions` + flagę `workflow_custom_definitions`.
- Montuje listę + edytor pod nowymi ścieżkami: `/workflow/definitions`, `/workflow/definitions/new`, `/workflow/definitions/:id/edit` (reużywa `WorkflowSettingsPage` / `WorkflowDefinitionEditorRoute` — bez duplikacji kodu).
- Przekierowuje stare `/settings/workflow*` na nowe (zakładki i linki nie giną); `/settings/workflow/:id/edit` zachowuje `id` przez mały `WorkflowDefinitionEditRedirect`.
- Usuwa wpis Workflow z nawigacji Ustawień (`settings-nav-data.ts`) i nieużywany import ikony.
- Przełącza wewnętrzne `navigate()` w `DefinitionsListView` / `DefinitionEditorPage` na `/workflow/definitions`.

Breadcrumb topbaru dla `/workflow/definitions` pokazuje teraz „Workspace / Workflow" (wcześniej pod Ustawieniami było „Workspace / Ustawienia") — bardziej trafnie, bez dodatkowego mapowania (reguła `/^\/workflow/`).

## Frontend changes

- `features/workflow/WorkflowPage.tsx` — nowy CTA „Definicje przepływu" (GitBranch), obok „Ustawienia przepływu", oba w jednym `flex` gapie.
- `App.tsx` — trasy `/workflow/definitions*` + `WorkflowDefinitionEditRedirect` + redirecty starych `/settings/workflow*`.
- `features/settings/workflow/{DefinitionsListView,DefinitionEditorPage,index}.tsx` — linki `/settings/workflow*` → `/workflow/definitions*`.
- `layout/settings-nav-data.ts` — usunięty wpis Workflow + nieużywany import `GitBranch`.
- `e2e/wfl-p5-03-definition-builder.spec.ts` — nawigacja do kanonicznego `/workflow/definitions`.
- `e2e/wfl-flow-settings.spec.ts` — asercja że CTA „Definicje przepływu" linkuje do `/workflow/definitions`.

## Quality gates

- Biome strict: 0 (auto-fix zastosowany).
- tsc `--noEmit`: 0 błędów.
- Playwright (lokalny dev-stack, browser-only smoke): login → `/workflow` → CTA widoczny z `href=/workflow/definitions` → klik ląduje na `/workflow/definitions` z listą definicji → stary `/settings/workflow` przekierowuje na `/workflow/definitions`. **Zielony.**

## Smoke test plan (dla operatora po merge)

1. Login (admin@demo.localhost / changeme).
2. Menu → **Workflow**. W prawym górnym rogu widoczne dwa przyciski: **Definicje przepływu** (białe, ikona gałęzi) i **Ustawienia przepływu** (czarne).
3. Klik **Definicje przepływu** → URL `/workflow/definitions`, lista definicji się renderuje. Breadcrumb: „Workspace / Workflow".
4. Otwórz stary link `https://pim.localhost/settings/workflow` → przekierowanie na `/workflow/definitions`.
5. W Ustawieniach (koło zębate) **nie ma już** pozycji „Workflow".
6. DevTools Console — brak czerwonych errorów.

## Świadome odejścia

- Brak. Pełen scope ticketu (przeniesienie + przycisk + redirecty + czyszczenie nav) dostarczony.

Closes #2574

🤖 Generated with [Claude Code](https://claude.com/claude-code)