### PR TITLE
feat(modeling): usuń wybór ikon i kolorów przy definiowaniu wpisów

### DIFF
--- a/apps/admin/e2e/2578-remove-icon-color-pickers.spec.ts
+++ b/apps/admin/e2e/2578-remove-icon-color-pickers.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * #2578 — the icon/color selection was removed from the entry-definition
+ * forms (ObjectType wizard, Category create) and the Smart Preset modal.
+ * Defaults are sent silently so the BE contracts stay satisfied; the UI
+ * simply no longer exposes a picker. This spec asserts the pickers are gone
+ * on the two modeling forms (the Smart Preset save path is covered by
+ * ptr-01, which now saves without touching an icon field).
+ */
+test('2578: ObjectType wizard no longer shows icon/color pickers', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/modeling/object-types/new');
+
+  // Wizard step 1 renders inline (progressbar step indicator).
+  await expect(page.getByRole('progressbar')).toBeVisible();
+
+  // The identification step keeps Name + Code but no icon/color fields.
+  await expect(page.getByText(/^Ikona$/)).toHaveCount(0);
+  await expect(page.getByText(/^Kolor$/)).toHaveCount(0);
+});
+
+test('2578: Category create no longer shows the visualization (icon) section', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/modeling/categories/new');
+
+  // The create form renders; the "Wizualizacja" (icon picker) section is gone.
+  await expect(page.getByText(/Nowa kategoria/i).first()).toBeVisible();
+  await expect(page.getByText(/Wizualizacja/i)).toHaveCount(0);
+});

--- a/apps/admin/src/components/catalog/save-as-smart-preset-modal.tsx
+++ b/apps/admin/src/components/catalog/save-as-smart-preset-modal.tsx
@@ -8,7 +8,6 @@ import type { FilterDsl } from '@/lib/filters/filter-dsl';
 import type { SmartFilterPreset } from '@/lib/filters/use-smart-presets';
 import type { GridColumnOverride } from '@/lib/grid/types';
 import { httpErrorDetail } from '@/lib/http';
-import { cn } from '@/lib/utils';
 
 const ICON_CHOICES = ['🔧', '⚙️', '⚡', '🛠️', '🏷️', '📦', '🔍', '🌟', '🚀', '🎯', '💡', '📊'];
 
@@ -40,7 +39,8 @@ interface SaveAsSmartPresetModalProps {
  * PTR-01 — preset absorbuje rolę "widoku kolumn": zapisuje bieżący filtr
  * (może być pusty) ORAZ układ kolumn. Można zapisać preset bez żadnego
  * warunku (sam układ kolumn). Nazwa multilingual {pl, en} zgodnie z
- * CLAUDE.md punkt 8. Icon picker z 12 emoji presetów.
+ * CLAUDE.md punkt 8. #2578 — bez wyboru ikony; preset dostaje domyślną
+ * ikonę cicho (kontrakt BE wymaga `icon`).
  */
 export function SaveAsSmartPresetModal({
   query,
@@ -52,13 +52,15 @@ export function SaveAsSmartPresetModal({
   const { t } = useTranslation();
   const [namePl, setNamePl] = useState('');
   const [nameEn, setNameEn] = useState('');
-  const [icon, setIcon] = useState(ICON_CHOICES[0] ?? '🔧');
+  // #2578 — the icon is no longer user-pickable; keep a default so the BE
+  // contract (icon required) stays satisfied without any UI.
+  const icon = ICON_CHOICES[0] ?? '🔧';
   const [isPending, setIsPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // PTR-01 — a preset may carry only a column layout, so an empty filter is
-  // allowed; the name + icon are the only hard requirements.
-  const canSubmit = namePl.trim().length >= 3 && nameEn.trim().length >= 3 && icon !== '';
+  // allowed; the name is the only hard requirement.
+  const canSubmit = namePl.trim().length >= 3 && nameEn.trim().length >= 3;
 
   const handleSubmit = async (event: React.FormEvent): Promise<void> => {
     event.preventDefault();
@@ -128,37 +130,6 @@ export function SaveAsSmartPresetModal({
               maxLength={60}
               placeholder="e.g. Festo low stock"
             />
-          </div>
-
-          <div className="space-y-2">
-            <span className="text-sm font-medium">
-              {t('products.smart_filters.save_as_preset_icon_label', { defaultValue: 'Ikona' })}
-              <span className="ml-1 text-rose-600">*</span>
-            </span>
-            <fieldset className="grid grid-cols-6 gap-2 border-0 p-0">
-              <legend className="sr-only">Icon</legend>
-              {ICON_CHOICES.map((choice) => (
-                <label
-                  key={choice}
-                  className={cn(
-                    'h-10 w-10 rounded-xl border text-[18px] grid place-items-center cursor-pointer focus-within:ring-2 focus-within:ring-zinc-900',
-                    icon === choice
-                      ? 'bg-zinc-900 text-white border-zinc-900'
-                      : 'bg-white text-zinc-700 border-zinc-200 hover:border-zinc-300',
-                  )}
-                >
-                  <input
-                    type="radio"
-                    name="smart-preset-icon"
-                    value={choice}
-                    checked={icon === choice}
-                    onChange={() => setIcon(choice)}
-                    className="sr-only"
-                  />
-                  <span aria-hidden="true">{choice}</span>
-                </label>
-              ))}
-            </fieldset>
           </div>
 
           <div className="rounded-md border bg-muted/40 p-3 text-xs">

--- a/apps/admin/src/components/modeling/object-type-wizard.tsx
+++ b/apps/admin/src/components/modeling/object-type-wizard.tsx
@@ -6,12 +6,12 @@ import { Link, useNavigate } from 'react-router';
 
 import { AddAttributesToObjectTypeDialog } from '@/components/modeling/add-attributes-to-object-type-dialog';
 import { AuditLogIndicator } from '@/components/modeling/audit-log-indicator';
-import { ColorPicker, DEFAULT_WIZARD_COLORS } from '@/components/modeling/color-picker';
+import { DEFAULT_WIZARD_COLORS } from '@/components/modeling/color-picker';
 import { CreateAttributeForObjectTypeDialog } from '@/components/modeling/create-attribute-for-object-type-dialog';
 import { CreateGroupInlineDialog } from '@/components/modeling/create-group-inline-dialog';
 import { DeclareObjectTypeAttributeGroupDialog } from '@/components/modeling/declare-object-type-attribute-group-dialog';
 import { DisplayModeSegmented } from '@/components/modeling/group-card';
-import { DEFAULT_WIZARD_ICONS, IconPicker } from '@/components/modeling/icon-picker';
+import { DEFAULT_WIZARD_ICONS } from '@/components/modeling/icon-picker';
 import { LocaleTabsField } from '@/components/modeling/locale-tabs-field';
 import { ObjectTypeIcon } from '@/components/modeling/object-type-icon';
 import { SettingToggleRow } from '@/components/modeling/setting-toggle-row';
@@ -80,8 +80,10 @@ export function ObjectTypeWizard() {
   const [step, setStep] = useState<number>(1);
   const [label, setLabel] = useState<Record<string, string>>({});
   const [code, setCode] = useState<string>('');
-  const [icon, setIcon] = useState<string>(DEFAULT_WIZARD_ICONS[0]);
-  const [color, setColor] = useState<string>(DEFAULT_WIZARD_COLORS[0]);
+  // #2578 — icon/color are no longer user-pickable; keep sensible defaults so
+  // the badge stays consistent and the payload contract is unchanged.
+  const icon = DEFAULT_WIZARD_ICONS[0];
+  const color = DEFAULT_WIZARD_COLORS[0];
   const [hasVariants, setHasVariants] = useState(false);
   const [hasMultimedia, setHasMultimedia] = useState(false);
   const [isCategorizable, setIsCategorizable] = useState(false);
@@ -463,32 +465,18 @@ export function ObjectTypeWizard() {
                     onChange={setLabel}
                   />
                 </div>
-                <div className="grid grid-cols-1 gap-x-8 gap-y-4 sm:grid-cols-2">
-                  <div>
-                    <div className="mb-1.5 text-[11.5px] font-medium text-zinc-500">
-                      {t('object_type_wizard.field_code', { defaultValue: 'Code' })}
-                    </div>
-                    <Input
-                      value={code}
-                      onChange={(e) =>
-                        setCode(e.target.value.toLowerCase().replace(/[^a-z0-9_]/g, ''))
-                      }
-                      placeholder="subscription"
-                      className="font-mono"
-                    />
+                <div>
+                  <div className="mb-1.5 text-[11.5px] font-medium text-zinc-500">
+                    {t('object_type_wizard.field_code', { defaultValue: 'Code' })}
                   </div>
-                  <div>
-                    <div className="mb-1.5 text-[11.5px] font-medium text-zinc-500">
-                      {t('object_type_wizard.field_icon', { defaultValue: 'Ikona' })}
-                    </div>
-                    <IconPicker selected={icon} onSelect={setIcon} />
-                  </div>
-                  <div className="sm:col-span-2">
-                    <div className="mb-1.5 text-[11.5px] font-medium text-zinc-500">
-                      {t('object_type_wizard.field_color', { defaultValue: 'Kolor' })}
-                    </div>
-                    <ColorPicker selected={color} onSelect={setColor} />
-                  </div>
+                  <Input
+                    value={code}
+                    onChange={(e) =>
+                      setCode(e.target.value.toLowerCase().replace(/[^a-z0-9_]/g, ''))
+                    }
+                    placeholder="subscription"
+                    className="font-mono"
+                  />
                 </div>
               </>
             ) : null}
@@ -775,18 +763,6 @@ export function ObjectTypeWizard() {
                       {t('object_type_wizard.field_code', { defaultValue: 'Code' })}:
                     </span>{' '}
                     <span className="font-mono">{code || '—'}</span>
-                  </div>
-                  <div>
-                    <span className="text-zinc-500">
-                      {t('object_type_wizard.field_icon', { defaultValue: 'Ikona' })}:
-                    </span>{' '}
-                    {icon}
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <span className="text-zinc-500">
-                      {t('object_type_wizard.field_color', { defaultValue: 'Kolor' })}:
-                    </span>
-                    <span aria-hidden className="size-4 rounded" style={{ background: color }} />
                   </div>
                   <div className="sm:col-span-2">
                     <span className="text-zinc-500">

--- a/apps/admin/src/features/catalog/categories/new.tsx
+++ b/apps/admin/src/features/catalog/categories/new.tsx
@@ -5,13 +5,11 @@ import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useSearchParams } from 'react-router';
 
-import { IconPicker } from '@/components/modeling/icon-picker';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
-import { CATEGORY_ICONS } from '@/lib/category-icons';
 import { HttpError, jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
@@ -39,8 +37,6 @@ const CODE_RE = /^[a-z][a-z0-9_]*$/;
  *     for MVP the BE accepts it inside the create payload only when an
  *     `attributes` upserter is wired; here we keep it form-local and
  *     persist after redirect via the Show page)
- *   - Icon (emoji from CATEGORY_ICONS; stored in attributes.icon when
- *     attribute upserter ships)
  *   - Live ltree path preview
  *
  * Pixel-perfect of the Create flow + Save-on-create attributes mirroring
@@ -61,7 +57,6 @@ export function CategoryCreatePage() {
   const [namePl, setNamePl] = useState('');
   const [nameEn, setNameEn] = useState('');
   const [descPl, setDescPl] = useState('');
-  const [icon, setIcon] = useState<string>(CATEGORY_ICONS[0]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -290,17 +285,6 @@ export function CategoryCreatePage() {
               className="rounded-xl"
             />
           </div>
-        </section>
-
-        <section className="space-y-3">
-          <div className="text-[11px] font-medium uppercase tracking-wider text-zinc-500">
-            {t('categories.fields.section_visualization', { defaultValue: 'Wizualizacja' })}
-          </div>
-          <IconPicker
-            selected={icon}
-            onSelect={(value) => setIcon(value)}
-            options={[...CATEGORY_ICONS]}
-          />
         </section>
 
         <section className="space-y-2 rounded-xl bg-zinc-50 px-4 py-3">

--- a/apps/admin/src/features/catalog/object-types/show.tsx
+++ b/apps/admin/src/features/catalog/object-types/show.tsx
@@ -26,7 +26,6 @@ import { AddAttributesToObjectTypeDialog } from '@/components/modeling/add-attri
 import { AuditLogIndicator } from '@/components/modeling/audit-log-indicator';
 import { AuditTrailCompact } from '@/components/modeling/audit-trail-compact';
 import { BuiltInLockBadge } from '@/components/modeling/built-in-lock-badge';
-import { ColorPicker } from '@/components/modeling/color-picker';
 import { CreateAttributeForObjectTypeDialog } from '@/components/modeling/create-attribute-for-object-type-dialog';
 import { CreateGroupInlineDialog } from '@/components/modeling/create-group-inline-dialog';
 import { DangerZoneCard } from '@/components/modeling/danger-zone-card';
@@ -37,7 +36,6 @@ import {
   GroupCard,
   type GroupDisplayMode,
 } from '@/components/modeling/group-card';
-import { IconPicker } from '@/components/modeling/icon-picker';
 import { LocaleTabsField } from '@/components/modeling/locale-tabs-field';
 import { ObjectTypeIcon } from '@/components/modeling/object-type-icon';
 import { SettingToggleRow } from '@/components/modeling/setting-toggle-row';
@@ -208,7 +206,8 @@ export function ObjectTypeShowPage() {
     staleTime: 30_000,
   });
 
-  const [editingField, setEditingField] = useState<'name' | 'icon' | 'color' | null>(null);
+  // #2578 — icon/color are no longer editable; only the name stays inline-editable.
+  const [editingField, setEditingField] = useState<'name' | null>(null);
   const [draftLabel, setDraftLabel] = useState<Record<string, string> | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [declareGroupOpen, setDeclareGroupOpen] = useState(false);
@@ -541,56 +540,15 @@ export function ObjectTypeShowPage() {
               <div className="mb-1.5 text-[11.5px] font-medium text-zinc-500">
                 {t('object_types.field_icon', { defaultValue: 'Ikona' })}
               </div>
-              {editingField === 'icon' ? (
-                <IconPicker
-                  selected={objectType.icon ?? ''}
-                  onSelect={async (icon) => {
-                    const ok = await handlePatch({ icon });
-                    if (ok) setEditingField(null);
-                  }}
+              {/* #2578 — icon/color are display-only now (no picker). */}
+              <div className="flex h-10 items-center gap-2 rounded-xl border border-zinc-100 bg-zinc-50 px-3 text-[13px]">
+                <ObjectTypeIcon
+                  icon={objectType.icon}
+                  color={objectType.color}
+                  kind={objectType.kind}
+                  size="sm"
                 />
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => setEditingField('icon')}
-                  className="flex h-10 items-center gap-2 rounded-xl border border-zinc-200 bg-white px-3 text-[13px] hover:bg-zinc-50"
-                >
-                  <ObjectTypeIcon
-                    icon={objectType.icon}
-                    color={objectType.color}
-                    kind={objectType.kind}
-                    size="sm"
-                  />
-                  <Pencil className="ml-auto size-3.5 text-zinc-500" />
-                </button>
-              )}
-            </div>
-            <div>
-              <div className="mb-1.5 text-[11.5px] font-medium text-zinc-500">
-                {t('object_types.field_color', { defaultValue: 'Kolor (badge)' })}
               </div>
-              {editingField === 'color' ? (
-                <ColorPicker
-                  selected={objectType.color ?? '#6366f1'}
-                  onSelect={async (color) => {
-                    const ok = await handlePatch({ color });
-                    if (ok) setEditingField(null);
-                  }}
-                />
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => setEditingField('color')}
-                  className="flex h-10 items-center gap-2 rounded-xl border border-zinc-200 bg-white px-3 text-[13px] hover:bg-zinc-50"
-                >
-                  <span
-                    className="size-4 rounded"
-                    style={{ background: objectType.color ?? '#a1a1aa' }}
-                  />
-                  <span className="font-mono text-[12px]">{objectType.color ?? '—'}</span>
-                  <Pencil className="ml-auto size-3.5 text-zinc-500" />
-                </button>
-              )}
             </div>
             <FieldDisplay
               label={t('object_types.field_tenant', { defaultValue: 'Tenant' })}


### PR DESCRIPTION
## Summary

Usunięto wybór **ikon i kolorów** z formularzy definicji wpisów oraz z modalu Smart Preset. Zgodnie z ticketem: gdzie pole było wymagane, zamiast UI zostaje sensowny default wysyłany cicho — kontrakty API bez zmian, znika tylko picker.

Powierzchnie objęte:
- **Kreator ObjectType** (`/modeling/object-types/new`) — usunięte `IconPicker` + `ColorPicker` z kroku 1 i z podsumowania; `icon`/`color` to teraz stałe (`DEFAULT_WIZARD_ICONS[0]` / `DEFAULT_WIZARD_COLORS[0]`) w payloadzie. Badge podglądu (read-only) zostaje.
- **Tworzenie kategorii** (`/modeling/categories/new`) — usunięta sekcja „Wizualizacja" (`IconPicker`). Uwaga: `icon` i tak **nigdy nie był wysyłany** w body create (capture-only, jak niedokończony upserter z #1358) → zero wpływu na dane.
- **Detal ObjectType** (`/modeling/object-types/:id`) — edytowalne pola Ikona/Kolor zamienione na read-only badge (Ikona) i usunięte (Kolor). Nazwa dalej edytowalna inline.
- **Modal „Zapisz jako Smart Preset"** — usunięty grid 12 emoji; `icon` to stała `ICON_CHOICES[0]` w payloadzie (BE wymaga `icon`); `canSubmit` nie wymaga już wyboru ikony.

## Frontend changes

- `components/modeling/object-type-wizard.tsx` — usunięte pickery + wiersze podsumowania + nieużywane importy; `icon`/`color` jako stałe.
- `features/catalog/object-types/show.tsx` — read-only ikona, usunięte pole koloru, zawężony typ `editingField` do `'name' | null`, usunięte importy.
- `features/catalog/categories/new.tsx` — usunięta sekcja „Wizualizacja" + stan `icon` + importy `IconPicker`/`CATEGORY_ICONS`.
- `components/catalog/save-as-smart-preset-modal.tsx` — usunięty fieldset ikony, `icon` jako stała, relaksacja `canSubmit`, usunięty import `cn`.
- `e2e/2578-remove-icon-color-pickers.spec.ts` — nowy spec: brak pickerów na kreatorze ObjectType i formularzu kategorii.

## Quality gates

- Biome strict: 0.
- tsc `--noEmit`: 0 błędów.
- Playwright (lokalny dev-stack, form-login):
  - `2578-remove-icon-color-pickers` — 2/2 zielone (wizard + kategoria bez pickerów).
  - `ptr-01-preset-columns-merge` — zielony (modal presetu zapisuje bez pola ikony, default w payloadzie).
  - smoke detalu ObjectType — ikona read-only, brak pola „Kolor (badge)".

## Smoke test plan (dla operatora po merge)

1. Login (admin@demo.localhost / changeme).
2. `Modelowanie → Typy obiektów → Stwórz nowy` — krok 1 pokazuje tylko Nazwę + Code, **bez** Ikony/Koloru. Utwórz typ → zapisuje się (dostaje domyślną ikonę/kolor).
3. `Modelowanie → Kategorie → Nowa kategoria` — brak sekcji „Wizualizacja".
4. Detal dowolnego typu obiektu — badge ikony read-only, brak edycji koloru; edycja nazwy działa.
5. `Produkty` → panel filtrów → **Własny preset** → modal „Zapisz jako Smart Preset" **bez** wyboru ikony; zapis z samą nazwą działa.
6. DevTools Console — brak czerwonych errorów z tych widoków.

## Świadome odejścia

- Pickery ikon/kolorów przy **opcjach atrybutów** (`attributes/values`, `attribute-groups/create`) **zostają** — to swatche opcji/organizacja grup, nie „definiowanie wpisów", i poza kryteriami akceptacji ticketu.
- Nieużywane klucze i18n (`field_icon`, `field_color`, `section_visualization`, `save_as_preset_icon_label`) zostawione w locales (usunięcie dotknęłoby współdzielonych plików bez korzyści funkcjonalnej).

Closes #2578

🤖 Generated with [Claude Code](https://claude.com/claude-code)