### PR TITLE
fix(ui): kursor łapki na przyciskach, wyjaśnienie tokenów API, badge ikony w podglądzie

### DIFF
--- a/apps/admin/e2e/smoke-ui-polish-2.spec.ts
+++ b/apps/admin/e2e/smoke-ui-polish-2.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * Post-smoke UI polish (operator round 2): the API-tokens page now explains
+ * what tokens are for (#2573), the ObjectType wizard preview no longer shows
+ * an icon/color badge (#2578 follow-up), and interactive buttons carry a
+ * pointer cursor (#2567 UX — the shared Button base).
+ */
+test('api-tokens page explains its purpose', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/settings/api-tokens');
+  await expect(page.getByText(/Authorization: Token cortex/)).toBeVisible();
+});
+
+test('ObjectType wizard preview shows no icon/color badge', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/modeling/object-types/new');
+  await expect(page.getByRole('progressbar')).toBeVisible();
+  await expect(page.getByText(/^Ikona$/)).toHaveCount(0);
+  await expect(page.getByText(/^Kolor$/)).toHaveCount(0);
+});
+
+test('primary buttons carry a pointer cursor', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/settings/api-tokens');
+  // The "create token" CTA is a shared <Button>; the base now sets the cursor.
+  const cta = page.getByRole('button', { name: /token/i }).first();
+  await expect(cta).toBeVisible();
+  await expect(cta).toHaveCSS('cursor', 'pointer');
+});

--- a/apps/admin/src/components/modeling/object-type-wizard.tsx
+++ b/apps/admin/src/components/modeling/object-type-wizard.tsx
@@ -13,7 +13,6 @@ import { DeclareObjectTypeAttributeGroupDialog } from '@/components/modeling/dec
 import { DisplayModeSegmented } from '@/components/modeling/group-card';
 import { DEFAULT_WIZARD_ICONS } from '@/components/modeling/icon-picker';
 import { LocaleTabsField } from '@/components/modeling/locale-tabs-field';
-import { ObjectTypeIcon } from '@/components/modeling/object-type-icon';
 import { SettingToggleRow } from '@/components/modeling/setting-toggle-row';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -844,21 +843,20 @@ export function ObjectTypeWizard() {
               <div className="text-[11px] font-medium uppercase tracking-wider text-zinc-500">
                 {t('object_type_wizard.preview_label', { defaultValue: 'Podgląd' })}
               </div>
-              <div className="flex items-center gap-3">
-                <ObjectTypeIcon icon={icon} color={color} size="sm" />
-                <div>
-                  <div className="text-[14px] font-semibold tracking-tight">
-                    {namePrimary ||
-                      t('object_type_wizard.preview_default_name', {
-                        defaultValue: 'Nowy typ',
-                      })}
-                  </div>
-                  <div className="font-mono text-[11.5px] text-zinc-500">
-                    {code ||
-                      t('object_type_wizard.preview_default_code', {
-                        defaultValue: 'code…',
-                      })}
-                  </div>
+              {/* #2578 follow-up — no icon/color badge; the preview shows just
+                  the name + code (icon/color are not user-chosen anymore). */}
+              <div>
+                <div className="text-[14px] font-semibold tracking-tight">
+                  {namePrimary ||
+                    t('object_type_wizard.preview_default_name', {
+                      defaultValue: 'Nowy typ',
+                    })}
+                </div>
+                <div className="font-mono text-[11.5px] text-zinc-500">
+                  {code ||
+                    t('object_type_wizard.preview_default_code', {
+                      defaultValue: 'code…',
+                    })}
                 </div>
               </div>
             </CardContent>

--- a/apps/admin/src/components/ui/button.tsx
+++ b/apps/admin/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {

--- a/apps/admin/src/features/settings/api-tokens/index.tsx
+++ b/apps/admin/src/features/settings/api-tokens/index.tsx
@@ -81,6 +81,26 @@ export function ApiTokensSettingsPage() {
         </Button>
       </header>
 
+      {/* #2573 — spell out what API tokens are for; the page title alone left
+          operators unsure whether the feature does anything. */}
+      <div className="flex gap-3 rounded-lg border border-zinc-200 bg-zinc-50/70 px-4 py-3 text-[13px] text-zinc-600">
+        <KeyRound className="mt-0.5 size-4 shrink-0 text-zinc-500" aria-hidden="true" />
+        <div className="space-y-1.5">
+          <p>
+            {t('settings.api_tokens.help_purpose', {
+              defaultValue:
+                'Tokeny API pozwalają integracjom, skryptom i systemom zewnętrznym wywoływać to samo API co panel — bez logowania e-mailem. Każdy token ma własne uprawnienia (scopes) i można go w każdej chwili unieważnić.',
+            })}
+          </p>
+          <p className="text-zinc-500">
+            {t('settings.api_tokens.help_usage', { defaultValue: 'Użycie w nagłówku żądania:' })}{' '}
+            <code className="rounded bg-white px-1.5 py-0.5 font-mono text-[12px] text-zinc-700 ring-1 ring-zinc-200">
+              Authorization: Token cortex_…
+            </code>
+          </p>
+        </div>
+      </div>
+
       <div className="inline-flex rounded-md border bg-background p-0.5">
         <ScopeButton
           active={scope === 'own'}


### PR DESCRIPTION
## Summary

Poprawki po smoke-teście operatora (runda 2) — trzy drobne, spójne polerki UI:

- **#1 (część UX #2567)** — bazowy `Button` (shadcn) nie miał `cursor-pointer` → aktywne przyciski nie zamieniały kursora na „łapkę", a przycisk „Zastosuj filtr" sprawiał wrażenie martwego. Dodane `cursor-pointer` + `disabled:cursor-not-allowed` w bazie — działa globalnie, disabled ma teraz czytelny stan.
- **#4 (#2573)** — strona `/settings/api-tokens` wyjaśnia teraz **do czego służą tokeny** (dostęp programistyczny do API bez logowania) i **jak ich użyć** (`Authorization: Token cortex_…`). Feature JEST funkcjonalny (zweryfikowane na żywo: `Token cortex_…` → `GET /api/products` 200) — nie usuwam, tylko objaśniam.
- **#6 (follow-up #2578)** — kreator ObjectType w bloczku „Podgląd" nie pokazuje już badge ikony/koloru (ikona/kolor nie są wybierane przez użytkownika).

## Frontend changes

- `components/ui/button.tsx` — `cursor-pointer` + `disabled:cursor-not-allowed` w bazowych wariantach.
- `features/settings/api-tokens/index.tsx` — callout z przeznaczeniem + przykładem użycia.
- `components/modeling/object-type-wizard.tsx` — usunięty `ObjectTypeIcon` z podglądu (+ nieużywany import).
- `e2e/smoke-ui-polish-2.spec.ts` — 3 asercje (help tokenów, brak badge w podglądzie, `cursor: pointer` na CTA).

## Quality gates

- Biome strict: 0.
- tsc `--noEmit`: 0.
- Playwright (lokalny dev-stack): `smoke-ui-polish-2` 3/3 zielone (help widoczny, brak Ikona/Kolor w podglądzie, `cursor: pointer` na przycisku).

## Smoke test plan (dla operatora)

1. `/settings/api-tokens` — pod tytułem widać wyjaśnienie + `Authorization: Token cortex_…`.
2. `/modeling/object-types/new` — bloczek „Podgląd" pokazuje tylko nazwę + code, bez ikony.
3. Najedź na dowolny przycisk (np. „Utwórz token") → kursor „łapka"; przycisk `disabled` → kursor „nie wolno".

## Uwaga (osobne PR-y w toku)

To jest część rundy poprawek po smoke. Pozostałe (osobne PR-y): obrazy w PDF (Dompdf data-URI), flicker assetów przy wejściu do folderu. „Zastosuj filtr" nic nie robi wizualnie poza licznikiem — pełniejszy feedback w PR obrazów/filtra jeśli potrzeba.

🤖 Generated with [Claude Code](https://claude.com/claude-code)