### PR TITLE
fix(assets): skeleton na przełączeniu folderu zamiast migających starych miniatur

### DIFF
--- a/apps/admin/e2e/2572-assets-folder-flicker.spec.ts
+++ b/apps/admin/e2e/2572-assets-folder-flicker.spec.ts
@@ -28,11 +28,10 @@ test('entering a folder shows a skeleton, not the previous folder cards', async 
   });
   armed = true;
 
-  // Double-click the first folder tile (Explorer semantics, #2320).
-  const firstFolder = page
-    .locator('button[title]')
-    .filter({ hasText: /produkt|product/i })
-    .first();
+  // Double-click the first folder tile (Explorer semantics, #2320). The
+  // "Bez przypisania" tile is always present, so this is data-independent.
+  const firstFolder = page.getByTestId('folder-tile').first();
+  await expect(firstFolder).toBeVisible();
   await firstFolder.dblclick();
 
   // While the folder loads the skeleton is shown (proves stale cards are hidden).

--- a/apps/admin/e2e/2572-assets-folder-flicker.spec.ts
+++ b/apps/admin/e2e/2572-assets-folder-flicker.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * #2572 — entering a folder must not flash the previous (all-assets) grid.
+ * With `keepPreviousData` the stale cards used to stay on screen until the
+ * folder's set arrived; now a skeleton (aria-hidden placeholder, rendered
+ * only while `isPlaceholderData` is true) covers the switch. We delay the
+ * folder request and assert the skeleton — not the old cards — is shown.
+ */
+test('entering a folder shows a skeleton, not the previous folder cards', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/assets');
+
+  // Wait for the initial "all assets" grid to settle (real cards, no skeleton).
+  await expect(page.getByRole('button', { name: /prześlij|upload/i }).first()).toBeVisible();
+  const skeleton = page.locator('ul[aria-hidden="true"]');
+  await expect(skeleton).toHaveCount(0);
+
+  // Hold the next assets request so the switch stays visible long enough.
+  let armed = false;
+  await page.route('**/api/assets?**', async (route) => {
+    if (armed) {
+      await new Promise((r) => setTimeout(r, 1200));
+    }
+    await route.continue();
+  });
+  armed = true;
+
+  // Double-click the first folder tile (Explorer semantics, #2320).
+  const firstFolder = page
+    .locator('button[title]')
+    .filter({ hasText: /produkt|product/i })
+    .first();
+  await firstFolder.dblclick();
+
+  // While the folder loads the skeleton is shown (proves stale cards are hidden).
+  await expect(skeleton).toBeVisible();
+
+  // After the request resolves the real grid returns and the skeleton is gone.
+  await expect(skeleton).toHaveCount(0, { timeout: 5000 });
+});

--- a/apps/admin/src/features/asset/assets/list.tsx
+++ b/apps/admin/src/features/asset/assets/list.tsx
@@ -557,6 +557,7 @@ function FolderTile({ name, count, warning = false, onOpen }: FolderTileProps) {
   return (
     <button
       type="button"
+      data-testid="folder-tile"
       // #2320 — open on double-click (Windows Explorer behaviour); a single
       // click no longer navigates. Keyboard users still open with Enter/Space.
       onDoubleClick={onOpen}

--- a/apps/admin/src/features/asset/assets/list.tsx
+++ b/apps/admin/src/features/asset/assets/list.tsx
@@ -151,6 +151,13 @@ export function AssetsListPage() {
 
   const assets = useMemo(() => (result?.data ?? []).map(toAssetMeta), [result?.data]);
   const isLoading = query.isLoading;
+  // #2572 — `keepPreviousData` keeps the grid mounted across a folder switch,
+  // but it also keeps the PREVIOUS folder's thumbnails on screen until the new
+  // set lands — the "all files outside the folder flash up then vanish" bug.
+  // `isPlaceholderData` is true exactly while stale data from a different query
+  // (folder/filter change) is shown; render a skeleton then instead of the
+  // wrong cards. Background thumbnail polls (same query key) don't trip it.
+  const isSwitching = query.isPlaceholderData;
   const showFolderTiles = currentFolder === null && !debouncedSearch;
   const currentFolderEntry =
     currentFolder !== null && currentFolder !== 'root'
@@ -365,7 +372,9 @@ export function AssetsListPage() {
           ) : null}
         </div>
 
-        {assets.length === 0 && !isLoading ? (
+        {isLoading || isSwitching ? (
+          <AssetGridSkeleton view={view} />
+        ) : assets.length === 0 ? (
           <div className="rounded-2xl border border-dashed border-zinc-200 px-6 py-16 text-center text-[13px] text-zinc-500">
             {t('assets.empty')}
           </div>
@@ -611,6 +620,51 @@ function FolderRow({ name, count, warning = false, onOpen }: FolderTileProps) {
           : ''}
       </span>
     </button>
+  );
+}
+
+/**
+ * #2572 — stable placeholder shown while a folder switch is in flight, so the
+ * previous folder's thumbnails never flash on screen. Mirrors the real grid /
+ * list dimensions to avoid a layout jump.
+ */
+// Stable keys for the fixed-length placeholder grid (biome noArrayIndexKey).
+const SKELETON_KEYS = Array.from({ length: 10 }, (_, i) => `asset-skeleton-${i}`);
+
+function AssetGridSkeleton({ view }: { view: 'grid' | 'list' }) {
+  if (view === 'grid') {
+    return (
+      <ul aria-hidden="true" className="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-3">
+        {SKELETON_KEYS.map((key) => (
+          <li
+            key={key}
+            className="overflow-hidden rounded-2xl border border-zinc-100 bg-white shadow-sm"
+          >
+            <div className="aspect-square animate-pulse bg-zinc-100" />
+            <div className="space-y-1.5 px-2.5 py-2">
+              <div className="h-3 w-3/4 animate-pulse rounded bg-zinc-100" />
+              <div className="h-2.5 w-1/2 animate-pulse rounded bg-zinc-100" />
+            </div>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+  return (
+    <div
+      aria-hidden="true"
+      className="overflow-hidden rounded-2xl border border-zinc-100 bg-white shadow-sm"
+    >
+      <div className="divide-y divide-zinc-50">
+        {SKELETON_KEYS.map((key) => (
+          <div key={key} className="flex items-center gap-3 px-4 py-2.5">
+            <div className="size-8 animate-pulse rounded-md bg-zinc-100" />
+            <div className="h-3 flex-1 animate-pulse rounded bg-zinc-100" />
+            <div className="h-3 w-16 animate-pulse rounded bg-zinc-100" />
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Naprawa flickera przy wejściu do folderu na `/assets` (operator: „przez chwilę widać wszystkie pliki które są poza folderem", „ikony podjeżdżają do góry i znikają").

## Root cause

Poprzedni fix #2572 (`placeholderData: keepPreviousData`) utrzymywał grid zamontowany, ale **pokazywał miniatury poprzedniego folderu** (albo pełnej listy „wszystkie assety") aż do przyjścia nowego zestawu — dokładnie ten flash. Dodatkowo sekcja „Foldery" znika wewnątrz folderu (`showFolderTiles=false`), więc grid podskakiwał do góry pod stare karty.

## Fix

Gdy `query.isPlaceholderData` jest `true` (czyli pokazywane są stale dane z INNEGO zapytania — zmiana folderu/filtra), renderujemy **skeleton** o wymiarach gridu zamiast błędnych kart. Background-poll miniatur (to samo query key) NIE ustawia `isPlaceholderData`, więc nie miga.

## Frontend changes

- `features/asset/assets/list.tsx` — `isSwitching = query.isPlaceholderData`; render `AssetGridSkeleton` (grid/list) gdy `isLoading || isSwitching`; nowy komponent skeletonu.
- `e2e/2572-assets-folder-flicker.spec.ts` — deterministyczny test: opóźnia request folderu, asertuje że pojawia się skeleton (nie stare 102 karty), po czym wraca prawdziwy grid.

## Quality gates

- Biome strict: 0.
- tsc `--noEmit`: 0.
- Playwright (lokalny dev-stack): `2572-assets-folder-flicker` zielony (skeleton widoczny podczas przełączania folderu, brak starych kart).

## Smoke test plan (dla operatora)

1. `/assets` (widok „Wszystkie zasoby", 102 pliki).
2. Dwuklik na dowolny folder.
3. Zamiast błysku wszystkich plików — krótki skeleton, potem zawartość folderu. Bez „podjeżdżania i znikania".

🤖 Generated with [Claude Code](https://claude.com/claude-code)