### PR TITLE
fix(catalog): obrazy w PDF — inline assetów jako data URI (logo + zdjęcia produktów)

### DIFF
--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -414,6 +414,14 @@ services:
         arguments:
             $assetsStorage: '@assets.storage'
 
+    # CPDF #2569/#2570 — the catalog PDF inliner reads asset bytes from the
+    # named storage (same reason as the uploader: multiple FilesystemOperator
+    # services, autowire can't pick) and is the AssetInliner seam impl.
+    App\Asset\Infrastructure\Service\StorageAssetInliner:
+        arguments:
+            $assetsStorage: '@assets.storage'
+    App\Asset\Contracts\Service\AssetInliner: '@App\Asset\Infrastructure\Service\StorageAssetInliner'
+
     # IMP-02 (#443) — rules-based mapping dictionary loader. Cached for
     # 5 min in `cache.app` (see MappingDictionaryService). The dictionary
     # path lives under config/ so it ships with the container and never

--- a/apps/api/src/Asset/Contracts/Service/AssetInliner.php
+++ b/apps/api/src/Asset/Contracts/Service/AssetInliner.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Asset\Contracts\Service;
+
+/**
+ * Resolves an asset reference to an inline `data:` URI so an offline renderer
+ * — Dompdf runs with `isRemoteEnabled=false` (see {@see \App\Export\Catalog\Infrastructure\Renderer\DompdfRenderer})
+ * — can embed the image without fetching an authenticated or remote URL.
+ *
+ * The catalog PDF pipeline feeds product image slots and the branding logo
+ * through this seam (CPDF #2569/#2570): product images arrive as a bare asset
+ * UUID (the export builder flattens the media envelope to its `asset_id`) and
+ * the logo as a `/api/assets/{id}/preview` URL. Both must become inline bytes
+ * before Dompdf renders them, otherwise the image is silently dropped.
+ */
+interface AssetInliner
+{
+    /**
+     * @param string $reference a bare asset UUID or a `/api/assets/{id}/preview` URL
+     *
+     * @return string|null a `data:<mime>;base64,<payload>` URI, or null when the
+     *                     reference is not a resolvable tenant asset
+     */
+    public function toDataUri(string $reference): ?string;
+}

--- a/apps/api/src/Asset/Infrastructure/Service/StorageAssetInliner.php
+++ b/apps/api/src/Asset/Infrastructure/Service/StorageAssetInliner.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Asset\Infrastructure\Service;
+
+use App\Asset\Contracts\Service\AssetInliner;
+use App\Asset\Domain\Entity\Asset;
+use App\Asset\Domain\Entity\AssetVariant;
+use App\Asset\Domain\Repository\AssetRepositoryInterface;
+use App\Asset\Domain\ThumbnailsStatus;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Reads an asset's bytes straight from storage and base64-encodes them into a
+ * `data:` URI (CPDF #2569/#2570). Mirrors {@see \App\Asset\Presentation\Controller\PreviewAssetController}
+ * variant selection, but prefers the medium (800px) variant — a print-friendly
+ * size that keeps the PDF small without the thumbnail's loss of detail.
+ *
+ * Resolutions are memoised per instance: a catalog render resolves the same
+ * logo once per document instead of once per product row.
+ */
+final class StorageAssetInliner implements AssetInliner
+{
+    /** @var array<string, string|null> reference => data URI (or null miss) */
+    private array $cache = [];
+
+    public function __construct(
+        private readonly AssetRepositoryInterface $assets,
+        private readonly FilesystemOperator $assetsStorage,
+    ) {
+    }
+
+    public function toDataUri(string $reference): ?string
+    {
+        if (\array_key_exists($reference, $this->cache)) {
+            return $this->cache[$reference];
+        }
+
+        return $this->cache[$reference] = $this->resolve($reference);
+    }
+
+    private function resolve(string $reference): ?string
+    {
+        $assetId = $this->extractId($reference);
+        if (null === $assetId) {
+            return null;
+        }
+
+        $asset = $this->assets->findById($assetId) ?? $this->assets->findByObjectId($assetId);
+        if (null === $asset) {
+            return null;
+        }
+
+        [$path, $mime] = $this->resolveVariant($asset);
+
+        try {
+            $bytes = $this->assetsStorage->read($path);
+        } catch (FilesystemException) {
+            return null;
+        }
+
+        return \sprintf('data:%s;base64,%s', $mime, base64_encode($bytes));
+    }
+
+    /**
+     * Accepts a bare UUID or a `/api/assets/{id}/preview` URL (with or without
+     * a query string). Returns null for anything else — an external image URL
+     * or plain text passes through untouched.
+     */
+    private function extractId(string $reference): ?Uuid
+    {
+        $candidate = $reference;
+        if (1 === preg_match('#/api/assets/([^/]+)/preview#', $reference, $matches)) {
+            $candidate = $matches[1];
+        }
+
+        return Uuid::isValid($candidate) ? Uuid::fromString($candidate) : null;
+    }
+
+    /**
+     * @return array{0: string, 1: string} [storagePath, mimeType]
+     */
+    private function resolveVariant(Asset $asset): array
+    {
+        $variants = [];
+        foreach ($asset->getVariants() as $variant) {
+            $variants[$variant->getVariantCode()] = [$variant->getStoragePath(), $variant->getMimeType()];
+        }
+
+        // Print prefers medium (800) → thumb (200) → original when thumbnails
+        // are ready; falls back to the original blob otherwise.
+        if (ThumbnailsStatus::Ready === $asset->getThumbnailsStatus()) {
+            foreach ([AssetVariant::CODE_MEDIUM, AssetVariant::CODE_THUMB, AssetVariant::CODE_ORIGINAL] as $code) {
+                if (isset($variants[$code])) {
+                    return $variants[$code];
+                }
+            }
+        }
+
+        if (isset($variants[AssetVariant::CODE_ORIGINAL])) {
+            return $variants[AssetVariant::CODE_ORIGINAL];
+        }
+
+        return [$asset->getStoragePath(), $asset->getMimeType()];
+    }
+}

--- a/apps/api/src/Benchmark/Export/CatalogPdfBenchmarkCommand.php
+++ b/apps/api/src/Benchmark/Export/CatalogPdfBenchmarkCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Benchmark\Export;
 
+use App\Asset\Contracts\Service\AssetInliner;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
 use App\Export\Catalog\Application\CatalogRenderService;
@@ -158,6 +159,14 @@ final class CatalogPdfBenchmarkCommand extends Command
                 new HtmlValueSanitizer(),
                 $this->twig,
                 new DompdfRenderer(),
+                // Synthetic products carry no real assets — a no-op inliner keeps
+                // the benchmark measuring the render path only.
+                new class implements AssetInliner {
+                    public function toDataUri(string $reference): ?string
+                    {
+                        return null;
+                    }
+                },
                 maxInMemoryItems: PHP_INT_MAX, // the benchmark measures past the cap on purpose
             );
 

--- a/apps/api/src/Export/Catalog/Application/CatalogRenderService.php
+++ b/apps/api/src/Export/Catalog/Application/CatalogRenderService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Export\Catalog\Application;
 
+use App\Asset\Contracts\Service\AssetInliner;
 use App\Export\Catalog\Domain\Entity\CatalogProfile;
 use App\Export\Catalog\Domain\HtmlSlotPolicy;
 use App\Export\Catalog\Domain\Mapping\CatalogFieldMapping;
@@ -31,9 +32,13 @@ use Twig\Environment;
  * so renderers that answer false to {@see PdfRenderer::supportsLargeDocuments()}
  * get a product cap ($maxInMemoryItems, env CATALOG_PDF_MAX_ITEMS — decision A,
  * CPDF-P6-04): exceeding it raises {@see CatalogTooLargeException} with an
- * actionable "enable Gotenberg" message instead of an OOM'd worker. Image
- * embedding stays URL-based (decision B, CPDF-P6-03) — the resolved image
- * value is passed straight through and the sidecar fetches it itself.
+ * actionable "enable Gotenberg" message instead of an OOM'd worker.
+ *
+ * Images (#2569/#2570): the default Dompdf renderer runs with remote fetching
+ * off, so image-slot values (a bare asset UUID) and the branding logo (a
+ * `/api/assets/{id}/preview` URL) are inlined as `data:` URIs through the
+ * {@see AssetInliner} seam before rendering — otherwise the renderer silently
+ * drops every image. Non-asset URLs pass through untouched.
  */
 final class CatalogRenderService
 {
@@ -47,6 +52,7 @@ final class CatalogRenderService
         private readonly HtmlValueSanitizer $sanitizer,
         private readonly Environment $twig,
         private readonly PdfRenderer $renderer,
+        private readonly AssetInliner $imageInliner,
         private readonly int $maxInMemoryItems = 500,
     ) {
     }
@@ -95,9 +101,14 @@ final class CatalogRenderService
                     continue; // built below from the leftover attributes
                 }
                 $value = $slots[$name] ?? '';
-                if ('richtext' === ($slotFormats[$name] ?? '')) {
+                $format = $slotFormats[$name] ?? '';
+                if ('richtext' === $format) {
                     // Template prints this slot with `|raw` — sanitise here.
                     $value = $this->sanitizer->sanitize($value, HtmlSlotPolicy::RichText);
+                } elseif ('url' === $format && '' !== $value) {
+                    // #2570 — image slots hold a bare asset UUID; inline the bytes
+                    // as a data: URI so the offline renderer embeds them.
+                    $value = $this->imageInliner->toDataUri($value) ?? $value;
                 }
                 // Text / url slots stay raw strings; Twig autoescape handles them.
                 $product[$name] = $value;
@@ -113,7 +124,7 @@ final class CatalogRenderService
         }
 
         $html = $this->twig->render($template->twig, [
-            'branding' => $profile->getBranding(),
+            'branding' => $this->inlineBrandingLogo($profile->getBranding()),
             'products' => $products,
             // Grid cover/TOC heading; sheet and pricelist ignore it.
             'title' => $profile->getName(),
@@ -127,6 +138,24 @@ final class CatalogRenderService
             byteSize: \strlen($pdf),
             itemCount: \count($products),
         );
+    }
+
+    /**
+     * Inline the branding logo (a `/api/assets/{id}/preview` URL) as a data:
+     * URI so the offline renderer embeds it; a non-asset value passes through.
+     *
+     * @param array<mixed, mixed> $branding
+     *
+     * @return array<mixed, mixed>
+     */
+    private function inlineBrandingLogo(array $branding): array
+    {
+        $logo = $branding['logo'] ?? null;
+        if (\is_string($logo) && '' !== $logo) {
+            $branding['logo'] = $this->imageInliner->toDataUri($logo) ?? $logo;
+        }
+
+        return $branding;
     }
 
     /**

--- a/apps/api/src/Export/Catalog/Application/Preview/CatalogPreviewService.php
+++ b/apps/api/src/Export/Catalog/Application/Preview/CatalogPreviewService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Export\Catalog\Application\Preview;
 
+use App\Asset\Contracts\Service\AssetInliner;
 use App\Export\Catalog\Application\HtmlValueSanitizer;
 use App\Export\Catalog\Domain\Enum\CatalogTemplateKind;
 use App\Export\Catalog\Domain\HtmlSlotPolicy;
@@ -44,6 +45,7 @@ final class CatalogPreviewService
         private readonly CatalogTemplateCatalog $templates,
         private readonly HtmlValueSanitizer $sanitizer,
         private readonly Environment $twig,
+        private readonly AssetInliner $imageInliner,
     ) {
     }
 
@@ -96,9 +98,14 @@ final class CatalogPreviewService
                     continue; // built below from the leftover attributes
                 }
                 $value = $slots[$name] ?? '';
-                if ('richtext' === ($slotFormats[$name] ?? '')) {
+                $format = $slotFormats[$name] ?? '';
+                if ('richtext' === $format) {
                     // Template prints this slot with `|raw` — sanitise here.
                     $value = $this->sanitizer->sanitize($value, HtmlSlotPolicy::RichText);
+                } elseif ('url' === $format && '' !== $value) {
+                    // #2570 — inline image-slot assets as data: URIs (mirrors
+                    // CatalogRenderService so the preview matches the PDF).
+                    $value = $this->imageInliner->toDataUri($value) ?? $value;
                 }
                 // Text / url slots stay raw strings; Twig autoescape handles them.
                 $product[$name] = $value;
@@ -113,7 +120,7 @@ final class CatalogPreviewService
         }
 
         $html = $this->twig->render($template->twig, [
-            'branding' => $branding,
+            'branding' => $this->inlineBrandingLogo($branding),
             'products' => $products,
         ]);
 
@@ -121,6 +128,24 @@ final class CatalogPreviewService
             'sample_count' => \count($products),
             'html' => $html,
         ];
+    }
+
+    /**
+     * Inline the branding logo as a data: URI (mirrors
+     * {@see \App\Export\Catalog\Application\CatalogRenderService::inlineBrandingLogo()}).
+     *
+     * @param array<mixed, mixed> $branding
+     *
+     * @return array<mixed, mixed>
+     */
+    private function inlineBrandingLogo(array $branding): array
+    {
+        $logo = $branding['logo'] ?? null;
+        if (\is_string($logo) && '' !== $logo) {
+            $branding['logo'] = $this->imageInliner->toDataUri($logo) ?? $logo;
+        }
+
+        return $branding;
     }
 
     /**

--- a/apps/api/tests/Integration/Export/Catalog/CatalogRenderServiceTest.php
+++ b/apps/api/tests/Integration/Export/Catalog/CatalogRenderServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration\Export\Catalog;
 
+use App\Asset\Contracts\Service\AssetInliner;
 use App\Catalog\Application\Filter\FilterDslResolver;
 use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
@@ -244,6 +245,7 @@ final class CatalogRenderServiceTest extends KernelTestCase
             // PdfRenderer alias has no consumer yet (DI removes it) — the default
             // in-process Dompdf adapter is constructor-less, use it directly.
             $renderer ?? new DompdfRenderer(),
+            $container->get(AssetInliner::class),
             $maxInMemoryItems,
         );
     }

--- a/apps/api/tests/Integration/Export/Catalog/GenerateCatalogHandlerTest.php
+++ b/apps/api/tests/Integration/Export/Catalog/GenerateCatalogHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration\Export\Catalog;
 
+use App\Asset\Contracts\Service\AssetInliner;
 use App\Catalog\Application\Filter\FilterDslResolver;
 use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
@@ -138,6 +139,7 @@ final class GenerateCatalogHandlerTest extends KernelTestCase
             new HtmlValueSanitizer(),
             $container->get('twig'),
             new DompdfRenderer(),
+            $container->get(AssetInliner::class),
         );
 
         $regenerator = new CatalogRegenerator(

--- a/apps/api/tests/Unit/Asset/StorageAssetInlinerTest.php
+++ b/apps/api/tests/Unit/Asset/StorageAssetInlinerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Asset;
+
+use App\Asset\Domain\Entity\Asset;
+use App\Asset\Domain\Entity\AssetVariant;
+use App\Asset\Domain\Repository\AssetRepositoryInterface;
+use App\Asset\Infrastructure\Service\StorageAssetInliner;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\UnableToReadFile;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class StorageAssetInlinerTest extends TestCase
+{
+    #[Test]
+    public function inlinesBareUuidAsDataUriPreferringMediumVariant(): void
+    {
+        $id = Uuid::v7();
+        $repo = $this->createStub(AssetRepositoryInterface::class);
+        $repo->method('findById')->willReturn($this->readyAssetWithVariants($id));
+
+        $storage = $this->createMock(FilesystemOperator::class);
+        // Medium (800) is preferred over thumb/original for print.
+        $storage->expects(self::once())->method('read')->with('demo/medium.jpg')->willReturn('MEDIUM-BYTES');
+
+        $inliner = new StorageAssetInliner($repo, $storage);
+
+        self::assertSame(
+            'data:image/jpeg;base64,'.base64_encode('MEDIUM-BYTES'),
+            $inliner->toDataUri($id->toRfc4122()),
+        );
+    }
+
+    #[Test]
+    public function extractsIdFromPreviewUrl(): void
+    {
+        $id = Uuid::v7();
+        $repo = $this->createStub(AssetRepositoryInterface::class);
+        $repo->method('findById')->willReturn($this->readyAssetWithVariants($id));
+
+        $storage = $this->createStub(FilesystemOperator::class);
+        $storage->method('read')->willReturn('BYTES');
+
+        $inliner = new StorageAssetInliner($repo, $storage);
+
+        $result = $inliner->toDataUri(\sprintf('/api/assets/%s/preview', $id->toRfc4122()));
+        self::assertNotNull($result);
+        self::assertStringStartsWith('data:image/jpeg;base64,', $result);
+    }
+
+    #[Test]
+    public function fallsBackToOriginalWhenThumbnailsPending(): void
+    {
+        $id = Uuid::v7();
+        // Pending thumbnails → the variant loop is skipped; only the original
+        // blob is used.
+        $asset = new Asset('code', 'f.jpg', 'image/jpeg', 10, 'demo/original.jpg', $id);
+        $asset->addVariant(new AssetVariant($asset, AssetVariant::CODE_ORIGINAL, 'demo/original.jpg', 'image/jpeg', 10));
+
+        $repo = $this->createStub(AssetRepositoryInterface::class);
+        $repo->method('findById')->willReturn($asset);
+
+        $storage = $this->createMock(FilesystemOperator::class);
+        $storage->expects(self::once())->method('read')->with('demo/original.jpg')->willReturn('ORIG');
+
+        $inliner = new StorageAssetInliner($repo, $storage);
+
+        self::assertSame('data:image/jpeg;base64,'.base64_encode('ORIG'), $inliner->toDataUri($id->toRfc4122()));
+    }
+
+    #[Test]
+    public function returnsNullForNonAssetReference(): void
+    {
+        $repo = $this->createMock(AssetRepositoryInterface::class);
+        $repo->expects(self::never())->method('findById');
+        $storage = $this->createStub(FilesystemOperator::class);
+
+        $inliner = new StorageAssetInliner($repo, $storage);
+
+        self::assertNull($inliner->toDataUri('https://example.com/logo.png'));
+        self::assertNull($inliner->toDataUri(''));
+        self::assertNull($inliner->toDataUri('not-a-uuid'));
+    }
+
+    #[Test]
+    public function returnsNullWhenAssetMissing(): void
+    {
+        $repo = $this->createStub(AssetRepositoryInterface::class);
+        $repo->method('findById')->willReturn(null);
+        $repo->method('findByObjectId')->willReturn(null);
+        $storage = $this->createStub(FilesystemOperator::class);
+
+        $inliner = new StorageAssetInliner($repo, $storage);
+
+        self::assertNull($inliner->toDataUri(Uuid::v7()->toRfc4122()));
+    }
+
+    #[Test]
+    public function returnsNullWhenBlobMissing(): void
+    {
+        $id = Uuid::v7();
+        $repo = $this->createStub(AssetRepositoryInterface::class);
+        $repo->method('findById')->willReturn($this->readyAssetWithVariants($id));
+
+        $storage = $this->createStub(FilesystemOperator::class);
+        $storage->method('read')->willThrowException(UnableToReadFile::fromLocation('demo/medium.jpg'));
+
+        $inliner = new StorageAssetInliner($repo, $storage);
+
+        self::assertNull($inliner->toDataUri($id->toRfc4122()));
+    }
+
+    #[Test]
+    public function memoisesResolutionPerReference(): void
+    {
+        $id = Uuid::v7();
+        $repo = $this->createMock(AssetRepositoryInterface::class);
+        // The same logo repeats across every product row — resolve it once.
+        $repo->expects(self::once())->method('findById')->willReturn($this->readyAssetWithVariants($id));
+
+        $storage = $this->createMock(FilesystemOperator::class);
+        $storage->expects(self::once())->method('read')->willReturn('BYTES');
+
+        $inliner = new StorageAssetInliner($repo, $storage);
+
+        $ref = $id->toRfc4122();
+        $first = $inliner->toDataUri($ref);
+        $second = $inliner->toDataUri($ref);
+        self::assertSame($first, $second);
+    }
+
+    private function readyAssetWithVariants(Uuid $id): Asset
+    {
+        $asset = new Asset('code', 'f.jpg', 'image/jpeg', 100, 'demo/original.jpg', $id);
+        $asset->addVariant(new AssetVariant($asset, AssetVariant::CODE_ORIGINAL, 'demo/original.jpg', 'image/jpeg', 100));
+        $asset->addVariant(new AssetVariant($asset, AssetVariant::CODE_THUMB, 'demo/thumb.jpg', 'image/jpeg', 20));
+        $asset->addVariant(new AssetVariant($asset, AssetVariant::CODE_MEDIUM, 'demo/medium.jpg', 'image/jpeg', 50));
+        $asset->markThumbnailsReady(800, 600, null);
+
+        return $asset;
+    }
+}


### PR DESCRIPTION
## Summary

Naprawa: **żadne zdjęcie nie ładowało się do PDF-a katalogu** (ani logo, ani zdjęcia produktów).

## Root cause

Domyślny renderer to **Dompdf z `isRemoteEnabled=false`**. Wartości slotów obrazu to **goły UUID asseta** (ExportBuilder spłaszcza envelope media do `asset_id`), a logo to URL `/api/assets/{id}/preview` (za auth). Dompdf nie pobiera zdalnych/autoryzowanych URL-i → każdy obraz cicho znikał. Udokumentowana w kodzie „decision B" (data URI) **nigdy nie została zaimplementowana**.

## Fix

Nowy seam `App\Asset\Contracts\Service\AssetInliner` (impl `StorageAssetInliner`): rozwiązuje referencję asseta (goły UUID **lub** `/api/assets/{id}/preview`) → czyta bajty ze storage (preferuje wariant *medium*/800px dla druku) → koduje base64 → `data:<mime>;base64,…`. Memoizacja per render (to samo logo raz na dokument, nie raz na produkt).

`CatalogRenderService` **oraz** `CatalogPreviewService` przepuszczają sloty formatu `url` i logo brandingu przez inliner przed renderem. URL-e nie-assetowe przechodzą bez zmian; assety bez dostępnego bloba wracają do oryginalnej referencji (nieszkodliwie).

Deptrac: `Export_Catalog_Internals → Asset_Contracts` już dozwolone — bez zmian granic.

## Backend changes

- `Asset/Contracts/Service/AssetInliner.php` — nowy port.
- `Asset/Infrastructure/Service/StorageAssetInliner.php` — impl (mirror `PreviewAssetController` variant selection, medium-first).
- `Export/Catalog/Application/CatalogRenderService.php` + `Preview/CatalogPreviewService.php` — inline slotów url + logo.
- `config/services.yaml` — bind `$assetsStorage` + alias interfejsu.
- Testy: `StorageAssetInlinerTest` (7 przypadków) + fix konstrukcji w 2 testach integracyjnych.

## Quality gates

- PHPStan max: 0 (zmienione pliki).
- deptrac: 0 violations.
- PHPUnit: `StorageAssetInlinerTest` 7/7 (extract UUID/preview URL, wybór wariantu, memoizacja, null gdy brak asseta/bloba/nie-asset).
- **Live preview smoke** (`https://pim.localhost`): `POST /api/catalogs/preview` z mapowaniem `image→main_image` + logo z ready-asseta → `<img src>` to teraz `data:image/jpeg;base64,…` (37 KB) dla logo **i** zdjęć produktów; assety bez blobów (pending, demo placeholdery) zostają nietknięte.

## ⚠️ Smoke test — wymaga potwierdzenia operatora

Live preview inline'owania **przetestowany end-to-end** (data URI w HTML). Pełnej **asynchronicznej generacji binarki PDF nie udało mi się dokończyć na lokalnym dev-stacku** — worker nie drenował kolejki `import` (2 wiadomości `available_at` w przyszłości / mismatch queue — problem infrastruktury dev, nie kodu obrazów). Ścieżka renderu (CatalogRenderService) używa tego samego inlinera co preview i jest pokryta testem integracyjnym w CI. **Proszę potwierdzić po merge**: wygeneruj katalog z logo + `main_image` i pobierz PDF — obrazy powinny być osadzone.

Refs #2569 #2570

🤖 Generated with [Claude Code](https://claude.com/claude-code)