### PR TITLE
fix(worker): clear compiled container on boot so code changes apply

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -243,7 +243,15 @@ services:
     # fires its daily cron; without a consumer the schedule is inert.
     # APIC-P3-09 — `scheduler_integration_sync` drains the SyncSchedule per-minute
     # tick that fires due sync bindings (integration:sync:dispatch-due).
-    command: php bin/console messenger:consume import scheduler_maintenance scheduler_integration_sync --time-limit=3600 --memory-limit=256M
+    # #2597 follow-up — the worker runs APP_DEBUG=0, so Symfony does NOT rebuild
+    # the compiled container when source changes. After a pull that touches DI
+    # wiring (e.g. a new constructor arg) the stale container instantiates
+    # services with the old signature and every message dead-letters with a
+    # TypeError. A boot-time cache:clear rebuilds the container so a restart
+    # always picks up the new code; it clears only APP_CACHE_DIR
+    # (/app/var/cache-worker), never the api's tree, so it cannot corrupt live
+    # requests (the reason the old boot clear was removed — GOLIVE #2179).
+    command: sh -c "php bin/console cache:clear --no-warmup && php bin/console messenger:consume import scheduler_maintenance scheduler_integration_sync --time-limit=3600 --memory-limit=256M"
     environment:
       APP_ENV: ${APP_ENV:-dev}
       # WFL-P5-01 - the bulk change_status handler resolves the workflow


### PR DESCRIPTION
## Summary

To jest root cause zgłoszenia operatora „generowanie PDF trwa kilka minut i nic się nie generuje".

Worker dev działa z `APP_DEBUG=0` (żeby bulk joby nie OOM-owały pod debug-cache'ami), więc Symfony **nie przebudowuje skompilowanego kontenera DI przy zmianie kodu**. Po `git pull` zmiany dotykającej wiringu DI (np. #2597 dodało argument `AssetInliner` do konstruktora `CatalogRenderService`) stały kontener instancjonował serwis ze STARĄ sygnaturą → każda wiadomość katalogu dead-letterowała z `TypeError` (`Argument #7 ($imageInliner) must be of type AssetInliner, int given`), a generacja PDF cicho wisiała.

## Fix

Prefiks `cache:clear` przed `messenger:consume`. Worker ma własny `APP_CACHE_DIR=/app/var/cache-worker` (od GOLIVE #2179), więc `cache:clear` czyści TYLKO drzewo workera — nie może już zepsuć żywego cache api (to był powód usunięcia starego boot-clear). Restart workera zawsze podnosi nowy kod. Prod definiuje własny command workera (`messenger:consume async import`) i jest nietknięty.

## Verification (live, `https://pim.localhost`)

- Boot workera po zmianie: log `Clearing the cache for the dev environment with debug false` → `[OK] Cache cleared` → `Consuming messages`.
- Generacja katalogu przez worker: `done | 8 stron | 305 produktów` (pricelist) oraz `done | 305 stron | 34 MB` (sheet z obrazami).
- **Obrazy w PDF potwierdzone** (walidacja #2597): pobrany PDF 34 MB, **184 `/Image` XObject** osadzone (logo + zdjęcia produktów) — vs historyczne katalogi bez obrazów max 415 KB.

## Uwaga operacyjna

Na już (zanim to się zmerguje): na swoim stacku zrób raz
`docker compose exec worker php bin/console cache:clear && docker compose restart worker`
— potem generacja PDF z obrazami zadziała. Po merge tego PR restart workera wystarczy przy każdej przyszłej zmianie DI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)