### PR TITLE
fix(assets): skeleton przełączenia folderu dopasowany do wysokości (rezydualny przeskok)

### DIFF
--- a/apps/admin/e2e/2572-assets-folder-flicker.spec.ts
+++ b/apps/admin/e2e/2572-assets-folder-flicker.spec.ts
@@ -3,13 +3,18 @@ import { expect, test } from '@playwright/test';
 import { loginAsAdmin } from './helpers/auth';
 
 /**
- * #2572 — entering a folder must not flash the previous (all-assets) grid.
- * With `keepPreviousData` the stale cards used to stay on screen until the
- * folder's set arrived; now a skeleton (aria-hidden placeholder, rendered
- * only while `isPlaceholderData` is true) covers the switch. We delay the
- * folder request and assert the skeleton — not the old cards — is shown.
+ * #2572 — entering a folder must not flash the previous (all-assets) grid, and
+ * must not jump the page height. `keepPreviousData` used to leave the stale
+ * cards on screen; a skeleton (aria-hidden, rendered only while
+ * `isPlaceholderData` is true) now covers the switch, and it is sized to the
+ * OUTGOING grid so the height is held until the new content settles in one
+ * motion (no 102→10→N double jump). We delay the folder request and assert
+ * both: the skeleton — not the old cards — shows, and it matches the outgoing
+ * card count.
  */
-test('entering a folder shows a skeleton, not the previous folder cards', async ({ page }) => {
+test('entering a folder shows a height-matched skeleton, not the previous cards', async ({
+  page,
+}) => {
   await loginAsAdmin(page);
   await page.goto('/assets');
 
@@ -17,6 +22,10 @@ test('entering a folder shows a skeleton, not the previous folder cards', async 
   await expect(page.getByRole('button', { name: /prześlij|upload/i }).first()).toBeVisible();
   const skeleton = page.locator('ul[aria-hidden="true"]');
   await expect(skeleton).toHaveCount(0);
+
+  // The real grid carries an aria-label; the skeleton is aria-hidden. Capture
+  // the outgoing card count so we can assert the skeleton matches it.
+  const outgoing = await page.locator('ul[aria-label] > li').count();
 
   // Hold the next assets request so the switch stays visible long enough.
   let armed = false;
@@ -36,6 +45,14 @@ test('entering a folder shows a skeleton, not the previous folder cards', async 
 
   // While the folder loads the skeleton is shown (proves stale cards are hidden).
   await expect(skeleton).toBeVisible();
+
+  // The skeleton holds the outgoing height (sized to the previous grid, capped
+  // at 120) instead of a fixed handful — this is what removes the residual jump.
+  if (outgoing > 12) {
+    await expect(page.locator('ul[aria-hidden="true"] > li')).toHaveCount(Math.min(outgoing, 120));
+  } else {
+    await expect(page.locator('ul[aria-hidden="true"] > li').first()).toBeVisible();
+  }
 
   // After the request resolves the real grid returns and the skeleton is gone.
   await expect(skeleton).toHaveCount(0, { timeout: 5000 });

--- a/apps/admin/src/features/asset/assets/list.tsx
+++ b/apps/admin/src/features/asset/assets/list.tsx
@@ -158,6 +158,12 @@ export function AssetsListPage() {
   // (folder/filter change) is shown; render a skeleton then instead of the
   // wrong cards. Background thumbnail polls (same query key) don't trip it.
   const isSwitching = query.isPlaceholderData;
+  // #2572 — size the skeleton to the OUTGOING grid so switching a folder does
+  // not collapse the page height the instant the skeleton appears (a 102→10→N
+  // double jump). While `isPlaceholderData` is true `assets` still holds the
+  // previous folder's set (keepPreviousData), so its length is the height to
+  // hold until the new content settles in one motion.
+  const skeletonCount = isSwitching && assets.length > 0 ? Math.min(assets.length, 120) : 12;
   const showFolderTiles = currentFolder === null && !debouncedSearch;
   const currentFolderEntry =
     currentFolder !== null && currentFolder !== 'root'
@@ -373,7 +379,7 @@ export function AssetsListPage() {
         </div>
 
         {isLoading || isSwitching ? (
-          <AssetGridSkeleton view={view} />
+          <AssetGridSkeleton view={view} count={skeletonCount} />
         ) : assets.length === 0 ? (
           <div className="rounded-2xl border border-dashed border-zinc-200 px-6 py-16 text-center text-[13px] text-zinc-500">
             {t('assets.empty')}
@@ -626,17 +632,20 @@ function FolderRow({ name, count, warning = false, onOpen }: FolderTileProps) {
 
 /**
  * #2572 — stable placeholder shown while a folder switch is in flight, so the
- * previous folder's thumbnails never flash on screen. Mirrors the real grid /
- * list dimensions to avoid a layout jump.
+ * previous folder's thumbnails never flash on screen. `count` sizes it to the
+ * outgoing grid so the page height is held until the new content settles,
+ * avoiding the residual layout jump.
  */
-// Stable keys for the fixed-length placeholder grid (biome noArrayIndexKey).
-const SKELETON_KEYS = Array.from({ length: 10 }, (_, i) => `asset-skeleton-${i}`);
+// Stable keys for the placeholder grid (biome noArrayIndexKey); sliced to count.
+const MAX_SKELETON = 120;
+const SKELETON_KEYS = Array.from({ length: MAX_SKELETON }, (_, i) => `asset-skeleton-${i}`);
 
-function AssetGridSkeleton({ view }: { view: 'grid' | 'list' }) {
+function AssetGridSkeleton({ view, count = 12 }: { view: 'grid' | 'list'; count?: number }) {
+  const keys = SKELETON_KEYS.slice(0, Math.max(1, Math.min(count, MAX_SKELETON)));
   if (view === 'grid') {
     return (
       <ul aria-hidden="true" className="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-3">
-        {SKELETON_KEYS.map((key) => (
+        {keys.map((key) => (
           <li
             key={key}
             className="overflow-hidden rounded-2xl border border-zinc-100 bg-white shadow-sm"
@@ -657,7 +666,7 @@ function AssetGridSkeleton({ view }: { view: 'grid' | 'list' }) {
       className="overflow-hidden rounded-2xl border border-zinc-100 bg-white shadow-sm"
     >
       <div className="divide-y divide-zinc-50">
-        {SKELETON_KEYS.map((key) => (
+        {keys.map((key) => (
           <div key={key} className="flex items-center gap-3 px-4 py-2.5">
             <div className="size-8 animate-pulse rounded-md bg-zinc-100" />
             <div className="h-3 flex-1 animate-pulse rounded bg-zinc-100" />


### PR DESCRIPTION
## Summary

Domknięcie rezydualnego „przeskoku" przy wejściu do folderu na `/assets` (operator: „dużo dużo lepiej, ale na ułamek sekundy wciąż widać przeskok").

## Root cause

Skeleton z #2596 miał **sztywno 10 kart**. Wejście do folderu z dużego gridu (np. „Wszystkie zasoby" = 102 karty) kurczyło wysokość strony DWA razy: 102 → 10 (skeleton pojawia się) → N (realna zawartość). Ten natychmiastowy skok 102→10 to był rezydualny „przeskok".

## Fix

Skeleton jest teraz **rozmiaru wychodzącego gridu**: podczas przełączania `assets` wciąż trzyma poprzedni zestaw (`keepPreviousData` + `isPlaceholderData`), więc `assets.length` = liczba kart do utrzymania (cap 120). Dzięki temu wysokość strony NIE zmienia się w momencie kliknięcia — trzyma się aż realna zawartość osiądzie w jednym ruchu.

## Frontend changes

- `features/asset/assets/list.tsx` — `skeletonCount = isSwitching && assets.length > 0 ? min(assets.length,120) : 12`; `AssetGridSkeleton` przyjmuje `count`.
- `e2e/2572-assets-folder-flicker.spec.ts` — asercja że skeleton ma `min(outgoing,120)` kart (dopasowanie wysokości), robustna wobec seedu.

## Quality gates

- Biome strict: 0 · tsc: 0.
- Playwright (dev): spec zielony — przy 102 wychodzących assetach skeleton renderuje 102 karty (wysokość utrzymana), potem realna zawartość.

## Smoke test (operator)

`/assets` → dwuklik na folder z widoku „Wszystkie zasoby": grid nie kurczy się natychmiast do kilku kart; wysokość trzyma się do momentu pojawienia się zawartości folderu. Bez skoku „na ułamek sekundy".

🤖 Generated with [Claude Code](https://claude.com/claude-code)