### PR TITLE
fix(catalog): thumb variant w PDF — obrazowe katalogi nie OOM-ują (regresja #2597)

### DIFF
--- a/apps/api/src/Asset/Infrastructure/Service/StorageAssetInliner.php
+++ b/apps/api/src/Asset/Infrastructure/Service/StorageAssetInliner.php
@@ -16,8 +16,15 @@ use Symfony\Component\Uid\Uuid;
 /**
  * Reads an asset's bytes straight from storage and base64-encodes them into a
  * `data:` URI (CPDF #2569/#2570). Mirrors {@see \App\Asset\Presentation\Controller\PreviewAssetController}
- * variant selection, but prefers the medium (800px) variant — a print-friendly
- * size that keeps the PDF small without the thumbnail's loss of detail.
+ * variant selection, but prefers the THUMB (200px) variant.
+ *
+ * Why thumb, not medium: Dompdf (the default in-process renderer) decodes every
+ * embedded image to a raw bitmap and holds the whole document in PHP memory. An
+ * 800px JPEG expands to ~1.9 MB raw; a few hundred of them blow past the worker's
+ * 256 MB ceiling and the render dies with an OOM Fatal — so a catalog with images
+ * would not generate at all. A 200px thumb is ~16× smaller raw, keeping a
+ * full-cap (CATALOG_PDF_MAX_ITEMS) catalog inside the budget. Higher-fidelity
+ * output is the job of the Gotenberg sidecar (streams, no in-memory cap).
  *
  * Resolutions are memoised per instance: a catalog render resolves the same
  * logo once per document instead of once per product row.
@@ -90,10 +97,11 @@ final class StorageAssetInliner implements AssetInliner
             $variants[$variant->getVariantCode()] = [$variant->getStoragePath(), $variant->getMimeType()];
         }
 
-        // Print prefers medium (800) → thumb (200) → original when thumbnails
-        // are ready; falls back to the original blob otherwise.
+        // Memory-first order thumb (200) → medium (800) → original: the smallest
+        // variant that exists keeps the in-process renderer under its budget
+        // (see the class docblock). Only used when thumbnails are ready.
         if (ThumbnailsStatus::Ready === $asset->getThumbnailsStatus()) {
-            foreach ([AssetVariant::CODE_MEDIUM, AssetVariant::CODE_THUMB, AssetVariant::CODE_ORIGINAL] as $code) {
+            foreach ([AssetVariant::CODE_THUMB, AssetVariant::CODE_MEDIUM, AssetVariant::CODE_ORIGINAL] as $code) {
                 if (isset($variants[$code])) {
                     return $variants[$code];
                 }

--- a/apps/api/tests/Unit/Asset/StorageAssetInlinerTest.php
+++ b/apps/api/tests/Unit/Asset/StorageAssetInlinerTest.php
@@ -17,20 +17,21 @@ use Symfony\Component\Uid\Uuid;
 final class StorageAssetInlinerTest extends TestCase
 {
     #[Test]
-    public function inlinesBareUuidAsDataUriPreferringMediumVariant(): void
+    public function inlinesBareUuidAsDataUriPreferringThumbVariant(): void
     {
         $id = Uuid::v7();
         $repo = $this->createStub(AssetRepositoryInterface::class);
         $repo->method('findById')->willReturn($this->readyAssetWithVariants($id));
 
         $storage = $this->createMock(FilesystemOperator::class);
-        // Medium (800) is preferred over thumb/original for print.
-        $storage->expects(self::once())->method('read')->with('demo/medium.jpg')->willReturn('MEDIUM-BYTES');
+        // Thumb (200) is preferred over medium/original to keep the in-process
+        // renderer under its memory budget (a full catalog of 800px images OOMs).
+        $storage->expects(self::once())->method('read')->with('demo/thumb.jpg')->willReturn('THUMB-BYTES');
 
         $inliner = new StorageAssetInliner($repo, $storage);
 
         self::assertSame(
-            'data:image/jpeg;base64,'.base64_encode('MEDIUM-BYTES'),
+            'data:image/jpeg;base64,'.base64_encode('THUMB-BYTES'),
             $inliner->toDataUri($id->toRfc4122()),
         );
     }


### PR DESCRIPTION
## Summary

Regresja z #2597: **duże katalogi z obrazami wisiały w „pending" i nie generowały się** (operator: „generowanie trwa już 2 minuty").

## Root cause

#2597 osadzał wariant **medium (800px)**. Dompdf dekoduje każdy osadzony obraz do surowej bitmapy i trzyma cały dokument w pamięci PHP: 800px JPEG → ~1.9 MB surowego × kilkaset produktów >> limit **256 MB** workera → **Fatal `Allowed memory size exhausted`** w `Cpdf.php` → run wisi w „pending" (worker crash-loop). Przed #2597 katalogi generowały się bez obrazów (415 KB) — więc de facto zamieniłem „obrazy się nie ładują" na „duży katalog z obrazami w ogóle nie generuje".

## Fix

Inliner preferuje teraz **thumb (200px)** zamiast medium: ~16× mniej surowej pamięci → pełen katalog (do cap `CATALOG_PDF_MAX_ITEMS=500`) mieści się w budżecie. Wysoka rozdzielczość to zadanie sidecara **Gotenberg** (strumieniuje, bez limitu in-memory) — architektura już to wspiera (`CATALOG_PDF_RENDERER=gotenberg`).

## Verification (live, `https://pim.localhost`)

Ten sam katalog 305 produktów z obrazami:
- **Przed:** Fatal OOM w logach workera, run „pending" w nieskończoność.
- **Po:** `done` w **~13 s**, PDF **3.0 MB** (było 34 MB), **185 osadzonych `/Image` XObject** (obrazy nadal w środku), zero OOM.

## Backend changes

- `Asset/Infrastructure/Service/StorageAssetInliner.php` — kolejność wariantów thumb → medium → original (memory-first) + docstring z uzasadnieniem.
- `tests/Unit/Asset/StorageAssetInlinerTest.php` — asercja preferencji thumb.

## Quality gates

- PHPStan max: 0 · deptrac: 0 · PHPUnit `StorageAssetInlinerTest` 7/7.
- Live end-to-end: pobrany PDF 3 MB, 185 obrazów, ~13 s, brak OOM.

## Uwaga operacyjna

Trade-off: 200px zamiast 800px (miniatura zamiast pełnej rozdzielczości). Dla katalogu produktowego akceptowalne; dla druku wysokiej jakości / bardzo dużych katalogów → włączyć Gotenberg (`docker compose --profile gotenberg`, `CATALOG_PDF_RENDERER=gotenberg`).

Refs #2569 #2570

🤖 Generated with [Claude Code](https://claude.com/claude-code)