### PR TITLE
fix(agent): modal bulk 'Generuj treść AI' oferuje wszystkie przepisy (w tym custom)

### DIFF
--- a/apps/admin/e2e/aicg-p5-bulk-generate.spec.ts
+++ b/apps/admin/e2e/aicg-p5-bulk-generate.spec.ts
@@ -7,10 +7,37 @@ import { loginAsAdmin } from './helpers/auth';
  * the dedicated bulk path (POST /api/agent/content/bulk-generate, 202).
  * The agent content API is intercepted (CI has no BYOK key — the 2246/P5a
  * convention).
+ *
+ * #2603 — the modal now offers EVERY content recipe (built-in + custom), so a
+ * custom recipe is selectable and its id reaches the backend.
  */
 
 const RUN_ID = '019f0000-0000-7000-8000-0000000b1b1b';
 const BATCH_ID = '019f0000-0000-7000-8000-0000000ba7c1';
+
+const RECIPES = [
+  {
+    id: 'r-seo',
+    code: 'meta_seo',
+    name: 'Meta SEO',
+    targetAttribute: 'meta_description',
+    builtIn: true,
+  },
+  {
+    id: 'r-custom',
+    code: 'ext_desc',
+    name: 'Opis Rozbudowany',
+    targetAttribute: 'description_html',
+    builtIn: false,
+  },
+  {
+    id: 'r-desc',
+    code: 'product_description',
+    name: 'Opis produktu',
+    targetAttribute: 'description',
+    builtIn: true,
+  },
+];
 
 function estimateBody(count: number) {
   return {
@@ -28,9 +55,16 @@ test.beforeEach(async ({ page }) => {
   await page.addInitScript(() => {
     window.localStorage.setItem('i18nextLng', 'pl');
   });
+  await page.route('**/api/content-recipes', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ member: RECIPES }),
+    }),
+  );
 });
 
-test('bulk generate previews the cost and starts one run via the bulk path', async ({ page }) => {
+test('bulk generate offers every recipe and sends the chosen recipe id', async ({ page }) => {
   let capturedPreview: Record<string, unknown> | null = null;
   let capturedGenerate: Record<string, unknown> | null = null;
 
@@ -94,22 +128,30 @@ test('bulk generate previews the cost and starts one run via the bulk path', asy
 
   await page.getByTestId('bulk-generate-content').click();
   await expect(page.getByTestId('bulk-generate-count')).toContainText('2');
-  // The backend preview drives the estimate line.
-  await expect(page.getByTestId('bulk-generate-estimate')).toContainText('USD');
-  await expect.poll(() => capturedPreview !== null).toBeTruthy();
-  expect((capturedPreview as { product_count?: number })?.product_count).toBe(2);
 
-  // Switch to SEO mode and start via the bulk-generate endpoint.
-  await page.getByRole('button', { name: /meta seo/i }).click();
+  // #2603 — the custom recipe is now a selectable option (was invisible before).
+  const recipes = page.getByTestId('bulk-generate-recipes');
+  await expect(recipes.getByRole('button', { name: /Opis Rozbudowany/ })).toBeVisible();
+  await expect(recipes.getByRole('button', { name: /Meta SEO/ })).toBeVisible();
+  await expect(recipes.getByRole('button', { name: /Opis produktu/ })).toBeVisible();
+
+  // Pick the custom recipe; the cost preview refetches with its id.
+  await recipes.getByRole('button', { name: /Opis Rozbudowany/ }).click();
+  await expect(page.getByTestId('bulk-generate-estimate')).toContainText('USD');
+  await expect.poll(() => (capturedPreview as { recipe_id?: string })?.recipe_id).toBe('r-custom');
+
   await page.getByRole('button', { name: /^generuj$/i }).click();
 
   await expect.poll(() => capturedGenerate !== null).toBeTruthy();
   const body = capturedGenerate as unknown as {
     mode: string;
+    recipe_id: string;
     selected_ids: string[];
     object_type_code: string;
   };
-  expect(body.mode).toBe('seo');
+  // A description-target recipe uses the description tool (mode) and carries its id.
+  expect(body.mode).toBe('descriptions');
+  expect(body.recipe_id).toBe('r-custom');
   expect(body.selected_ids).toHaveLength(2);
   expect(body.object_type_code).toBe('product');
 

--- a/apps/admin/src/components/catalog/bulk-actions/generate-content-modal.tsx
+++ b/apps/admin/src/components/catalog/bulk-actions/generate-content-modal.tsx
@@ -10,7 +10,17 @@ import {
   previewContentCost,
 } from '@/features/agent/api';
 import { OPEN_AGENT_CHAT_EVENT } from '@/features/agent/chat/AgentChatSheet';
+import { useContentRecipes } from '@/features/agent/hooks/use-content-recipes';
 import { cn } from '@/lib/utils';
+
+/**
+ * The SEO tool (generate_seo_text) applies title/meta length rules; everything
+ * else uses the general description writer. The backend picks the tool from
+ * `mode`, so derive it from the recipe's target attribute.
+ */
+function modeForTarget(targetAttribute: string): BulkContentMode {
+  return targetAttribute === 'meta_description' ? 'seo' : 'descriptions';
+}
 
 /**
  * AICG-P5-03 (#2341) / AICG-P6-03 (#2346) — bulk "Generuj opisy /
@@ -34,21 +44,30 @@ export function BulkGenerateContentModal({
   onStarted: () => void;
 }) {
   const { t } = useTranslation();
-  const [mode, setMode] = useState<BulkContentMode>('descriptions');
+  const { recipes, isLoading: recipesLoading } = useContentRecipes();
+  // #2603 — the modal offers every content recipe (built-in + custom), not two
+  // hardcoded modes; a custom recipe was invisible here even though it showed
+  // in Settings → AI content. Default to the first recipe once they load.
+  const [selectedId, setSelectedId] = useState<string | null>(null);
   const [isStarting, setIsStarting] = useState(false);
 
   const count = selectedIds.length;
+  const selectedRecipe = recipes.find((recipe) => recipe.id === selectedId) ?? recipes[0] ?? null;
+  const mode: BulkContentMode = selectedRecipe
+    ? modeForTarget(selectedRecipe.targetAttribute)
+    : 'descriptions';
+  const recipeId = selectedRecipe?.id;
 
   const { data: estimate, isLoading: isEstimating } = useQuery({
-    queryKey: ['content-cost-preview', count, mode],
-    queryFn: () => previewContentCost(count, mode),
-    enabled: count > 0,
+    queryKey: ['content-cost-preview', count, mode, recipeId],
+    queryFn: () => previewContentCost(count, mode, recipeId),
+    enabled: count > 0 && recipeId !== undefined,
   });
 
   const start = async () => {
     setIsStarting(true);
     try {
-      const result = await bulkGenerateContent({ objectTypeCode, mode, selectedIds });
+      const result = await bulkGenerateContent({ objectTypeCode, mode, selectedIds, recipeId });
       window.dispatchEvent(
         new CustomEvent(OPEN_AGENT_CHAT_EVENT, { detail: { runId: result.run_id } }),
       );
@@ -104,34 +123,47 @@ export function BulkGenerateContentModal({
             <span className="text-[11px] font-semibold uppercase tracking-wider text-zinc-500">
               {t('aicg.bulk.mode_label', { defaultValue: 'Co wygenerować' })}
             </span>
-            <div className="mt-2 grid grid-cols-2 gap-2">
-              <button
-                type="button"
-                onClick={() => setMode('descriptions')}
-                aria-pressed={mode === 'descriptions'}
-                className={cn(
-                  'h-10 rounded-lg border px-3 text-[12px] font-medium',
-                  mode === 'descriptions'
-                    ? 'border-zinc-900 bg-zinc-900 text-white'
-                    : 'border-zinc-200 bg-white text-zinc-700 hover:border-zinc-300',
-                )}
-              >
-                {t('aicg.bulk.mode_descriptions', { defaultValue: 'Opisy produktów' })}
-              </button>
-              <button
-                type="button"
-                onClick={() => setMode('seo')}
-                aria-pressed={mode === 'seo'}
-                className={cn(
-                  'h-10 rounded-lg border px-3 text-[12px] font-medium',
-                  mode === 'seo'
-                    ? 'border-zinc-900 bg-zinc-900 text-white'
-                    : 'border-zinc-200 bg-white text-zinc-700 hover:border-zinc-300',
-                )}
-              >
-                {t('aicg.bulk.mode_seo', { defaultValue: 'Meta SEO' })}
-              </button>
-            </div>
+            {recipesLoading ? (
+              <div className="mt-2 text-[12.5px] text-zinc-500">
+                {t('aicg.bulk.recipes_loading', { defaultValue: 'Wczytuję przepisy…' })}
+              </div>
+            ) : recipes.length === 0 ? (
+              <div className="mt-2 text-[12.5px] text-zinc-500">
+                {t('aicg.bulk.recipes_empty', {
+                  defaultValue: 'Brak przepisów treści — dodaj je w Ustawienia → AI content.',
+                })}
+              </div>
+            ) : (
+              <div className="mt-2 grid gap-2" data-testid="bulk-generate-recipes">
+                {recipes.map((recipe) => {
+                  const active = selectedRecipe?.id === recipe.id;
+                  return (
+                    <button
+                      key={recipe.id}
+                      type="button"
+                      onClick={() => setSelectedId(recipe.id)}
+                      aria-pressed={active}
+                      className={cn(
+                        'flex flex-col items-start rounded-lg border px-3 py-2 text-left',
+                        active
+                          ? 'border-zinc-900 bg-zinc-900 text-white'
+                          : 'border-zinc-200 bg-white text-zinc-700 hover:border-zinc-300',
+                      )}
+                    >
+                      <span className="text-[12.5px] font-medium">{recipe.name}</span>
+                      <span
+                        className={cn(
+                          'font-mono text-[11px]',
+                          active ? 'text-zinc-300' : 'text-zinc-500',
+                        )}
+                      >
+                        → {recipe.targetAttribute}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
           </div>
 
           <div
@@ -167,7 +199,10 @@ export function BulkGenerateContentModal({
             <Button variant="ghost" onClick={onClose} disabled={isStarting}>
               {t('app.cancel', { defaultValue: 'Anuluj' })}
             </Button>
-            <Button onClick={() => void start()} disabled={isStarting || count === 0}>
+            <Button
+              onClick={() => void start()}
+              disabled={isStarting || count === 0 || recipeId === undefined}
+            >
               {t('aicg.bulk.start', { defaultValue: 'Generuj' })}
             </Button>
           </div>

--- a/apps/admin/src/features/agent/api.ts
+++ b/apps/admin/src/features/agent/api.ts
@@ -105,11 +105,12 @@ export type BulkContentMode = 'descriptions' | 'seo';
 export function previewContentCost(
   productCount: number,
   mode: BulkContentMode,
+  recipeId?: string,
 ): Promise<ContentCostEstimate> {
   return jsonFetch<ContentCostEstimate>('/api/agent/content/cost-preview', {
     ...JSON_OPTS,
     method: 'POST',
-    body: { product_count: productCount, mode },
+    body: { product_count: productCount, mode, ...(recipeId ? { recipe_id: recipeId } : {}) },
   });
 }
 
@@ -121,6 +122,7 @@ export function bulkGenerateContent(input: {
   objectTypeCode: string;
   mode: BulkContentMode;
   selectedIds: string[];
+  recipeId?: string;
 }): Promise<BulkGenerateContentResult> {
   return jsonFetch<BulkGenerateContentResult>('/api/agent/content/bulk-generate', {
     ...JSON_OPTS,
@@ -129,6 +131,7 @@ export function bulkGenerateContent(input: {
       object_type_code: input.objectTypeCode,
       mode: input.mode,
       selected_ids: input.selectedIds,
+      ...(input.recipeId ? { recipe_id: input.recipeId } : {}),
     },
   });
 }


### PR DESCRIPTION
## Summary

Naprawa: modal **Akcja zbiorcza · Generuj treść AI** (z listy produktów) pokazywał tylko 2 sztywne opcje („Opisy produktów", „Meta SEO") — custom przepis treści (np. „Opis Rozbudowany" → `description_html`) był tam niewidoczny, mimo że pojawiał się na liście „Przepisy treści".

## Root cause

`BulkGenerateContentModal` miał zahardkodowane 2 tryby i nigdy nie czytał przepisów ani nie wysyłał `recipe_id`. Backend (`AgentContentController::resolveMode`) **już** przyjmuje `recipe_id`, a tool używa `recipe->getTargetAttribute()` — gap był wyłącznie w FE.

## Frontend changes

- `components/catalog/bulk-actions/generate-content-modal.tsx` — ładuje przepisy przez `useContentRecipes`, renderuje przycisk per przepis (built-in + custom); wybór → `recipe_id` + `mode` z target attribute (`seo` dla `meta_description`, inaczej `descriptions`).
- `features/agent/api.ts` — `previewContentCost` i `bulkGenerateContent` przekazują opcjonalny `recipe_id`.
- `e2e/aicg-p5-bulk-generate.spec.ts` — mock 3 przepisów; asercja że custom „Opis Rozbudowany" jest widoczny i że jego `recipe_id` + `mode=descriptions` trafiają do backendu.

## Quality gates

- Biome strict: 0 · tsc: 0.
- Playwright (dev): `aicg-p5-bulk-generate` 2/2 zielone (modal oferuje 3 przepisy, custom wybieralny, `recipe_id` wysłany).

## Live smoke (`https://pim.localhost`)

- `GET /api/content-recipes` → 3 przepisy: Meta SEO (`meta_description`, built-in), **Opis Rozbudowany (`description_html`, custom)**, Opis produktu (`description`, built-in).
- `POST /api/agent/content/bulk-generate` z `recipe_id` custom przepisu → **HTTP 202**, run dispatched dla 2 produktów.

## Smoke test (operator)

Zaznacz produkty → „Generuj treść AI" → w „Co wygenerować" widzisz teraz **wszystkie 3 przepisy** (w tym „Opis Rozbudowany"). Wybór custom → propozycja `description_html` w skrzynce agenta.

Closes #2603

🤖 Generated with [Claude Code](https://claude.com/claude-code)