### PR TITLE
fix(agent): wyjaśnij stan czatu 'Twoja kolej' zamiast pustego panelu po akcji zbiorczej

### DIFF
--- a/apps/admin/src/features/agent/chat/AgentChatSheet.tsx
+++ b/apps/admin/src/features/agent/chat/AgentChatSheet.tsx
@@ -256,6 +256,36 @@ export function AgentChatSheet() {
               </Link>
             </div>
           )}
+          {/* #2605 — awaiting_input with no assistant message is a dead-end for a
+              bulk run (it proposed nothing): explain instead of a blank panel
+              that reads like a hang. Interactive runs just get the "your turn"
+              nudge; the composer below is enabled either way. */}
+          {run?.status === 'awaiting_input' &&
+            run.messages.filter((message) => message.role !== 'user').length === 0 && (
+              <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+                {run.context.bulk_content ? (
+                  <>
+                    <p className="font-medium">
+                      {t('agent.chat.bulk_no_proposals_title', {
+                        defaultValue: 'Agent nie przygotował żadnych propozycji.',
+                      })}
+                    </p>
+                    <p className="mt-1 text-amber-800">
+                      {t('agent.chat.bulk_no_proposals_hint', {
+                        defaultValue:
+                          'Wybrane produkty prawdopodobnie nie mają danych źródłowych (nazwa, opis, marka…) wymaganych przez przepis. Uzupełnij je i spróbuj ponownie.',
+                      })}
+                    </p>
+                  </>
+                ) : (
+                  <p>
+                    {t('agent.chat.awaiting_input_hint', {
+                      defaultValue: 'Twoja kolej — napisz poniżej, co agent ma zrobić dalej.',
+                    })}
+                  </p>
+                )}
+              </div>
+            )}
           {run?.status === 'error' && run.error_message !== null && (
             <p className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-900">
               {run.error_message}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -3924,7 +3924,7 @@
     },
     "status": {
       "planning": "Planning…",
-      "awaiting_input": "Awaiting your reply",
+      "awaiting_input": "Your turn",
       "awaiting_approval": "Awaiting approval",
       "committing": "Committing…",
       "done": "Done",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -3946,7 +3946,7 @@
     },
     "status": {
       "planning": "Planuję…",
-      "awaiting_input": "Czekam na odpowiedź",
+      "awaiting_input": "Twoja kolej",
       "awaiting_approval": "Czeka na akceptację",
       "committing": "Zapisuję…",
       "done": "Zakończony",


### PR DESCRIPTION
## Summary

Naprawa mylącego czatu agenta po akcji zbiorczej „Generuj treść AI" (operator: „run zawiesza się — agent nic nie generuje").

## Root cause (zweryfikowany na żywo)

Bulk-generate **DZIAŁA** — 3/3 testowych runów utworzyło propozycję (~30-60 s) w skrzynce agenta (`/agent/inbox`; 13 oczekujących teraz). Problem był w UI:
1. Gdy bulk generuje 0 propozycji (grounding gate — wybrane produkty bez danych źródłowych), run kończy w `awaiting_input`, a czat renderował **pusty body** pod badgem „Czekam na odpowiedź" — wyglądało jak zawieszenie.
2. Etykieta `awaiting_input` = „Czekam na odpowiedź" myląca (brzmi jakby user czekał na agenta; to agent czeka na usera).

## Frontend changes

- `locales/pl.json` / `en.json` — `awaiting_input`: „Czekam na odpowiedź" → **„Twoja kolej"** / „Your turn".
- `features/agent/chat/AgentChatSheet.tsx` — w `awaiting_input` bez wiadomości asystenta: bulk-run (`context.bulk_content`) pokazuje „Agent nie przygotował żadnych propozycji — produkty prawdopodobnie nie mają danych źródłowych…"; interaktywny run — „Twoja kolej, napisz co dalej". Composer pozostaje aktywny.

Propozycje bulk bez zmian — trafiają do `/agent/inbox`, a czat już linkuje tam przy `awaiting_approval`.

## Quality gates

- Biome strict: 0 · tsc: 0.

## Live smoke (`https://pim.localhost`)

- 3× `POST /api/agent/content/bulk-generate` → każdy `awaiting_approval` + pending change (~30-60 s). Skrzynka: 13 propozycji oczekuje.
- Diagnoza: operatora runy skończyły cancelled/rolled_back/awaiting_input z 0 zmian → mylący pusty czat, nie realny hang.

## Smoke test (operator)

1. `/agent/inbox` — zobacz oczekujące propozycje (są tam teraz).
2. Zaznacz produkty **z danymi** (nazwa/opis/marka) → „Generuj treść AI" → wybierz przepis → poczekaj ~30-60 s → propozycje w skrzynce.
3. Jeśli agent nic nie zaproponuje, czat pokaże teraz czytelne wyjaśnienie zamiast pustego „Czekam na odpowiedź".

Closes #2605

🤖 Generated with [Claude Code](https://claude.com/claude-code)