### PR TITLE
fix(catalog): chunk the grid TOC so Dompdf renders full-size catalogs

### DIFF
--- a/apps/api/templates/catalog/grid.html.twig
+++ b/apps/api/templates/catalog/grid.html.twig
@@ -55,6 +55,10 @@
         .toc-columns {
             width: 100%;
             border-collapse: collapse;
+            margin-bottom: 14px;
+            {# One single-row table per TOC batch — keep it atomic: a row
+               split near the page edge makes Dompdf emit blank pages. #}
+            page-break-inside: avoid;
         }
         .toc-columns > tr > td,
         .toc-columns td.toc-col {
@@ -153,31 +157,39 @@
     {% include 'catalog/_chrome/footer.html.twig' %}
     {% include 'catalog/_chrome/cover.html.twig' %}
 
-    {% set half = ((products|length + 1) / 2)|round(0, 'ceil') %}
+    {# The TOC is chunked into comfortably sub-page two-column tables: Dompdf
+       CLIPS a table cell taller than one page (an unchunked 150-entry column
+       vanished on a 305-product catalog) and emits blank pages when a
+       single-row table lands too close to the page height — 36 entries per
+       column (~700px) keeps every batch safely inside one page. #}
     <div class="toc">
         <div class="eyebrow">{{ branding.company_name|default('') }}</div>
         <h2 class="toc-heading">{{ l.toc|default('Contents') }}</h2>
         <div class="toc-rule"></div>
-        <table class="toc-columns">
-            <tr>
-                <td class="toc-col toc-col-left">
-                    {% for product in products[:half] %}
-                        <div class="toc-entry">
-                            <a href="#product-{{ loop.index }}">{{ product.title|default('') }}<span class="toc-page"></span></a>
-                            <span class="toc-sku">{{ product.sku|default('') }}</span>
-                        </div>
-                    {% endfor %}
-                </td>
-                <td class="toc-col toc-col-right">
-                    {% for product in products[half:] %}
-                        <div class="toc-entry">
-                            <a href="#product-{{ half + loop.index }}">{{ product.title|default('') }}<span class="toc-page"></span></a>
-                            <span class="toc-sku">{{ product.sku|default('') }}</span>
-                        </div>
-                    {% endfor %}
-                </td>
-            </tr>
-        </table>
+        {% for batch in products|batch(72) %}
+            {% set batch_offset = loop.index0 * 72 %}
+            {% set batch_half = ((batch|length + 1) / 2)|round(0, 'ceil') %}
+            <table class="toc-columns">
+                <tr>
+                    <td class="toc-col toc-col-left">
+                        {% for product in batch[:batch_half] %}
+                            <div class="toc-entry">
+                                <a href="#product-{{ batch_offset + loop.index }}">{{ product.title|default('') }}<span class="toc-page"></span></a>
+                                <span class="toc-sku">{{ product.sku|default('') }}</span>
+                            </div>
+                        {% endfor %}
+                    </td>
+                    <td class="toc-col toc-col-right">
+                        {% for product in batch[batch_half:] %}
+                            <div class="toc-entry">
+                                <a href="#product-{{ batch_offset + batch_half + loop.index }}">{{ product.title|default('') }}<span class="toc-page"></span></a>
+                                <span class="toc-sku">{{ product.sku|default('') }}</span>
+                            </div>
+                        {% endfor %}
+                    </td>
+                </tr>
+            </table>
+        {% endfor %}
     </div>
 
     <table class="grid">

--- a/apps/api/tests/Integration/Export/Catalog/GridTemplateRenderTest.php
+++ b/apps/api/tests/Integration/Export/Catalog/GridTemplateRenderTest.php
@@ -91,6 +91,32 @@ final class GridTemplateRenderTest extends KernelTestCase
     }
 
     #[Test]
+    public function fullSizeTocChunksIntoPageSizedTables(): void
+    {
+        // Live-smoke regression (#2608) — Dompdf clips a table cell taller
+        // than one page, so a 305-product TOC must chunk into ceil(305/72) = 5
+        // two-column tables (max 36 entries per cell) instead of one giant cell.
+        $products = [];
+        for ($i = 1; $i <= 305; ++$i) {
+            $products[] = [
+                'title' => \sprintf('Produkt %d', $i),
+                'sku' => \sprintf('SKU-%03d', $i),
+                'image' => '',
+                'price' => '9,00 zł',
+            ];
+        }
+
+        $html = $this->twig()->render('catalog/grid.html.twig', self::context($products));
+
+        self::assertSame(5, substr_count($html, 'class="toc-columns"'));
+        self::assertSame(305, substr_count($html, 'href="#product-'));
+        self::assertSame(305, substr_count($html, 'class="card" id="product-'));
+        // Anchor numbering stays global across batches.
+        self::assertStringContainsString('href="#product-305"', $html);
+        self::assertStringContainsString('id="product-305"', $html);
+    }
+
+    #[Test]
     public function premiumPagedMediaIsGatedBehindTheFlag(): void
     {
         $twig = $this->twig();


### PR DESCRIPTION
## Summary

Follow-up do #2609 wykryty w live-stack smoke #2608 na PEŁNYCH danych (305 produktów): dwukolumnowy spis treści gridu wkładał do jednej komórki tabeli do połowy katalogu — Dompdf tnie komórki wyższe niż strona i emituje puste strony, więc sekcja „Spis treści" renderowała się pusta (nagłówek + 3 puste strony). Fixtures testowe miały max 30 produktów i się mieściły — stąd zielone testy przy realnym bugu.

## Root cause

Dompdf-quirk: (1) komórka > wysokość strony = obcięta zawartość, (2) jednowierszowa tabela lądująca przy krawędzi strony = puste strony przeskoku.

## Fix

TOC chunk'owany na tabele per strona: `batch(72)` = 2 kolumny × 36 wpisów (~700px, komfortowo pod-stronowe), `page-break-inside: avoid` per tabela, globalna numeracja kotwic zachowana. Zweryfikowane wizualnie w kontenerze na 305 produktach (strona 2: wpisy 001-072, strona 3: 073-144, zero pustych; 32 strony vs 38 z pustymi).

## Quality gates

- GridTemplateRenderTest + CatalogTemplateCssGuardTest: 18/18 w kontenerze, w tym nowy test regresyjny (305 produktów → 5 tabel, 305 kotwic).
- Zmiana wyłącznie w szablonie Twig + teście.

## Smoke test plan

Po merge: regeneracja TMP-audit-grid (305 produktów) na żywym stacku → inspekcja pdftoppm stron TOC. Wynik dołączę do proofu zamykającego #2608.

Refs #2608

🤖 Generated with [Claude Code](https://claude.com/claude-code)