### PR TITLE
fix(catalog): keep grid TOC entries on one line

### DIFF
--- a/apps/api/templates/catalog/grid.html.twig
+++ b/apps/api/templates/catalog/grid.html.twig
@@ -75,6 +75,12 @@
             border-bottom: 0.75px dotted #d9dce1;
             padding: 4px 0;
             font-size: 9.5px;
+            {# Exactly ONE line per entry — the batch maths assumes constant
+               row height; long titles are ellipsised in Twig and any residue
+               must clip, not wrap (a wrapped column re-opens the taller-than-
+               a-page cell bug this section works around). #}
+            white-space: nowrap;
+            overflow: hidden;
         }
         .toc-entry a {
             color: #16181d;
@@ -173,17 +179,19 @@
                 <tr>
                     <td class="toc-col toc-col-left">
                         {% for product in batch[:batch_half] %}
+                            {% set toc_title = product.title|default('') %}
                             <div class="toc-entry">
-                                <a href="#product-{{ batch_offset + loop.index }}">{{ product.title|default('') }}<span class="toc-page"></span></a>
                                 <span class="toc-sku">{{ product.sku|default('') }}</span>
+                                <a href="#product-{{ batch_offset + loop.index }}">{{ toc_title|length > 50 ? toc_title[:47] ~ '…' : toc_title }}<span class="toc-page"></span></a>
                             </div>
                         {% endfor %}
                     </td>
                     <td class="toc-col toc-col-right">
                         {% for product in batch[batch_half:] %}
+                            {% set toc_title = product.title|default('') %}
                             <div class="toc-entry">
-                                <a href="#product-{{ batch_offset + batch_half + loop.index }}">{{ product.title|default('') }}<span class="toc-page"></span></a>
                                 <span class="toc-sku">{{ product.sku|default('') }}</span>
+                                <a href="#product-{{ batch_offset + batch_half + loop.index }}">{{ toc_title|length > 50 ? toc_title[:47] ~ '…' : toc_title }}<span class="toc-page"></span></a>
                             </div>
                         {% endfor %}
                     </td>

--- a/apps/api/tests/Integration/Export/Catalog/GridTemplateRenderTest.php
+++ b/apps/api/tests/Integration/Export/Catalog/GridTemplateRenderTest.php
@@ -95,11 +95,14 @@ final class GridTemplateRenderTest extends KernelTestCase
     {
         // Live-smoke regression (#2608) — Dompdf clips a table cell taller
         // than one page, so a 305-product TOC must chunk into ceil(305/72) = 5
-        // two-column tables (max 36 entries per cell) instead of one giant cell.
+        // two-column tables (max 36 entries per cell) instead of one giant
+        // cell, and every entry must stay ONE line: long real-world titles
+        // wrapped to two lines and re-opened the oversized-cell clipping.
+        $longTitle = 'Torebka damska na telefon nosowana pikowana z klapą i odpinanym paskiem w kolorze czarnym';
         $products = [];
         for ($i = 1; $i <= 305; ++$i) {
             $products[] = [
-                'title' => \sprintf('Produkt %d', $i),
+                'title' => 0 === $i % 2 ? \sprintf('%s %d', $longTitle, $i) : \sprintf('Produkt %d', $i),
                 'sku' => \sprintf('SKU-%03d', $i),
                 'image' => '',
                 'price' => '9,00 zł',
@@ -114,6 +117,10 @@ final class GridTemplateRenderTest extends KernelTestCase
         // Anchor numbering stays global across batches.
         self::assertStringContainsString('href="#product-305"', $html);
         self::assertStringContainsString('id="product-305"', $html);
+        // TOC entries are ellipsised to a single line (47 chars + '…') — the
+        // full long title never appears inside a TOC anchor.
+        self::assertStringContainsString(mb_substr($longTitle, 0, 47).'…', $html);
+        self::assertSame(0, substr_count($html, 'href="#product-2">'.$longTitle));
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Druga odsłona buga TOC z live smoke #2608: batchowanie po 72 (#2610) zakładało stałą wysokość wpisu, ale realne nazwy produktów operatora (60-90 znaków) łamały się na 2 linie — kolumna znów przekraczała wysokość strony i Dompdf produkował puste strony TOC.

## Fix

Wpis TOC jest twardo jednoliniowy: elipsa w Twig (>50 znaków → 47 + „…") + `white-space: nowrap; overflow: hidden` jako bezpiecznik. Kolumna = zawsze dokładnie 36 linii. SKU przeniesione przed tekst (float-right przed treścią — poprawny float w jednej linii).

## Weryfikacja

- Spike w kontenerze na 305 produktach z długimi tytułami: 5 czystych stron TOC (wpisy z elipsą, SKU po prawej), zero pustych stron, 32 strony total.
- `GridTemplateRenderTest` rozszerzony: długie tytuły w fixtures; asercja elipsy i braku pełnego tytułu w kotwicy TOC. 18/18 zielone w kontenerze.

## Smoke test plan

Po merge: regeneracja TMP-audit-grid na żywym stacku → pdftoppm stron TOC → proof w komentarzu zamykającym #2608.

Refs #2608

🤖 Generated with [Claude Code](https://claude.com/claude-code)