### PR TITLE
fix(admin): zakładka Ustawienia w sidebarze zwijalna/rozwijalna jak Integracje

### DIFF
--- a/apps/admin/e2e/1420-sidebar-settings-subtree.spec.ts
+++ b/apps/admin/e2e/1420-sidebar-settings-subtree.spec.ts
@@ -9,6 +9,9 @@ import { loginAsAdmin } from './helpers/auth';
  *      active (deep links included), and disappears outside /settings.
  *   2. Custom ObjectTypes render like built-in items — no CUSTOM badge,
  *      no violet dashed treatment.
+ *   3. #2616 — the "Ustawienia" parent is a toggle button (like
+ *      "Integracje"): clicking it collapses/expands the subtree without
+ *      navigating.
  */
 
 test.describe('NUI-01 — settings subtree in main sidebar', () => {
@@ -38,6 +41,34 @@ test.describe('NUI-01 — settings subtree in main sidebar', () => {
     // Outside /settings the subtree unmounts.
     await page.goto('/dashboard');
     await expect(page.getByTestId('nav-settings-subtree')).toHaveCount(0);
+  });
+
+  test('clicking "Ustawienia" toggles the subtree without navigating (#2616)', async ({ page }) => {
+    await loginAsAdmin(page);
+
+    await page.goto('/settings/users');
+    const subtree = page.getByTestId('nav-settings-subtree');
+    await expect(subtree).toBeVisible();
+
+    // Scope to the sidebar nav — topbar/user-menu buttons could also match.
+    const parent = page
+      .locator('nav')
+      .first()
+      .getByRole('button', { name: /^(ustawienia|settings)$/i });
+    await expect(parent).toHaveAttribute('aria-expanded', 'true');
+
+    // First click collapses — the original bug: a second click on the same
+    // entry did nothing because visibility was derived from the route alone.
+    await parent.click();
+    await expect(page.getByTestId('nav-settings-subtree')).toHaveCount(0);
+    await expect(parent).toHaveAttribute('aria-expanded', 'false');
+    await expect(page).toHaveURL(/\/settings\/users/);
+
+    // Second click re-expands, still without navigating.
+    await parent.click();
+    await expect(page.getByTestId('nav-settings-subtree')).toBeVisible();
+    await expect(parent).toHaveAttribute('aria-expanded', 'true');
+    await expect(page).toHaveURL(/\/settings\/users/);
   });
 
   test('custom ObjectType renders without CUSTOM badge or violet treatment', async ({ page }) => {

--- a/apps/admin/src/layout/sidebar-nav.tsx
+++ b/apps/admin/src/layout/sidebar-nav.tsx
@@ -213,6 +213,15 @@ export function SidebarNav({ onNavigate }: SidebarNavProps) {
     }
   }, [integrationsRouteActive]);
 
+  const settingsRouteActive = pathname.startsWith('/settings');
+  const [settingsOpen, setSettingsOpen] = useState(settingsRouteActive);
+  useEffect(() => {
+    // Deep link onto /settings/users etc. opens the parent (#2616).
+    if (settingsRouteActive) {
+      setSettingsOpen(true);
+    }
+  }, [settingsRouteActive]);
+
   const countSources: NavCountSource[] = [
     ...items
       .filter((item) => item.kind === 'object_type' && item.route !== null)
@@ -315,31 +324,45 @@ export function SidebarNav({ onNavigate }: SidebarNavProps) {
 
   /**
    * NUI-01 (#1420) — settings sub-navigation lives in the MAIN sidebar as an
-   * indented subtree under "Ustawienia" (design `settings/page.jsx`), shown
-   * while any /settings/* route is active. Replaces the second sidebar that
-   * `SettingsLayout` used to render.
+   * indented subtree under "Ustawienia" (design `settings/page.jsx`). Since
+   * #2616 the parent is a toggle button mirroring "Integracje": click
+   * expands/collapses, a deep link onto /settings/* opens it automatically.
    */
   const renderSettingsParent = (item: EffectiveMenuItem) => {
     const Icon = ICON_MAP[item.icon] ?? Cog;
     const labelText = renderLabel(item);
-    const settingsActive = pathname.startsWith('/settings');
     return (
       <div key={item.id}>
-        <NavLink
-          to={item.route ?? '/settings'}
-          onClick={onNavigate}
-          className={leafLinkClass}
-          end={false}
-        >
-          {({ isActive }) => (
-            <>
-              <Icon className={cn('size-4', isActive ? 'text-white/90' : 'text-zinc-500')} />
-              <span className="flex-1">{labelText}</span>
-            </>
+        <button
+          type="button"
+          aria-expanded={settingsOpen}
+          aria-controls="nav-settings-children"
+          onClick={() => setSettingsOpen((open) => !open)}
+          className={cn(
+            baseLeafClass,
+            settingsRouteActive && !settingsOpen
+              ? 'bg-zinc-900 text-white'
+              : 'text-zinc-700 hover:bg-zinc-100',
           )}
-        </NavLink>
-        {settingsActive && (
+        >
+          <Icon
+            className={cn(
+              'size-4',
+              settingsRouteActive && !settingsOpen ? 'text-white/90' : 'text-zinc-500',
+            )}
+          />
+          <span className="flex-1 text-left">{labelText}</span>
+          <ChevronDown
+            aria-hidden="true"
+            className={cn(
+              'size-3.5 text-zinc-500 transition-transform',
+              settingsOpen && 'rotate-180',
+            )}
+          />
+        </button>
+        {settingsOpen && (
           <div
+            id="nav-settings-children"
             className="my-1 ml-[18px] space-y-2.5 border-l border-zinc-200 pb-1 pl-3"
             data-testid="nav-settings-subtree"
           >


### PR DESCRIPTION
## Summary
Pozycja „Ustawienia" w lewym menu rozwijała podmenu, ale ponowne kliknięcie go nie zwijało — trzeba było kliknąć inną pozycję. Teraz zachowuje się identycznie jak „Integracje": przycisk toggle z chevronem, rozwijanie/zwijanie klikiem, auto-otwarcie przy deep-linku na `/settings/*`.

## Root cause
`renderSettingsParent` renderował parent jako `NavLink` do `/settings`, a widoczność podmenu wynikała wyłącznie z `pathname.startsWith('/settings')` — brak lokalnego stanu open/close (niedokończony wzorzec z NUI-01 #1420).

## Backend changes
- Brak (FE-only).

## Frontend changes
- `apps/admin/src/layout/sidebar-nav.tsx` — stan `settingsOpen` + effect deep-link (wzorzec EXR-03 z Integracji); parent = `<button aria-expanded aria-controls>` z `ChevronDown` (rotate przy open); highlight `bg-zinc-900` gdy route `/settings/*` aktywny a podmenu zwinięte. Klik NIE nawiguje (czysty toggle, jak Integracje) — `/settings` redirect pozostaje dostępny z URL.
- `apps/admin/e2e/1420-sidebar-settings-subtree.spec.ts` — nowy test: klik zwija (oryginalny bug), drugi klik rozwija, URL bez zmian, `aria-expanded` się przełącza.

## Quality gates
- Biome strict: 0 errors (5 pre-existing warnings poza zmienionymi plikami).
- `tsc -b --noEmit`: 0. `pnpm build`: zielony.
- Playwright: `1420-sidebar-settings-subtree` (3 passed, 1 skipped — environment-dependent custom OT test, pre-existing) + `dp-03` regresja zielona.
- pnpm audit: 0 nie-ignorowanych high/critical.

## Smoke test plan
1. Login `admin@demo.localhost / changeme`.
2. `/dashboard` → klik „Ustawienia" → podmenu się rozwija, URL bez zmian.
3. Klik „Ustawienia" ponownie → podmenu się zwija (bug fix).
4. Deep-link `/settings/users` → podmenu auto-otwarte, „Użytkownicy" aktywne.
5. DevTools Console — brak czerwonych errorów.

Zweryfikowane Playwright E2E na lokalnym stacku; manualny live smoke po merge'u przed zamknięciem issue (per CLOSED MEANS CLOSED).

## Świadome odejścia
- „Ustawienia" przestaje nawigować na `/settings` (redirect do `/settings/security`) — zamierzone, parytet z „Integracje"; strony dostępne z podmenu.
- Wspólny komponent `CollapsibleNavParent` dla obu parentów — kosmetyczny refactor poza zakresem bug fixa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)